### PR TITLE
前処理にプログレスバーの表示

### DIFF
--- a/src/python/piper_train/preprocess.py
+++ b/src/python/piper_train/preprocess.py
@@ -348,9 +348,9 @@ def phonemize_batch_espeak(
     try:
         # Suppress C-level warnings from pyopenjtalk/OpenJTalk to keep output clean
         if not getattr(args, "debug", False):
-            import os
             devnull_fd = os.open(os.devnull, os.O_RDWR)
             os.dup2(devnull_fd, 2)
+            os.dup2(devnull_fd, 1)
 
         casing = get_text_casing(args.text_casing)
         silence_detector = make_silence_detector()
@@ -402,9 +402,9 @@ def phonemize_batch_text(
 ):
     try:
         if not getattr(args, "debug", False):
-            import os
             devnull_fd = os.open(os.devnull, os.O_RDWR)
             os.dup2(devnull_fd, 2)
+            os.dup2(devnull_fd, 1)
 
         casing = get_text_casing(args.text_casing)
         silence_detector = make_silence_detector()
@@ -456,9 +456,9 @@ def phonemize_batch_openjtalk(
 ):
     try:
         if not getattr(args, "debug", False):
-            import os
             devnull_fd = os.open(os.devnull, os.O_RDWR)
             os.dup2(devnull_fd, 2)
+            os.dup2(devnull_fd, 1)
 
         casing = get_text_casing(args.text_casing)
         silence_detector = make_silence_detector()

--- a/src/python/piper_train/preprocess.py
+++ b/src/python/piper_train/preprocess.py
@@ -263,6 +263,19 @@ def main() -> None:
     _LOGGER.info(
         "Processing %s utterance(s) with %s worker(s)", num_utterances, args.max_workers
     )
+    # プログレスバーを表示（stdoutに表示し、早めに初期化）
+    print(f"Starting to process {num_utterances} utterances...", file=sys.stdout, flush=True)
+    pbar = tqdm(
+        total=num_utterances,
+        desc="Preprocessing",
+        unit="utt",
+        file=sys.stdout,
+        leave=True,
+        dynamic_ncols=True,
+        ascii=True,
+        disable=False,
+    )
+
     with open(args.output_dir / "dataset.jsonl", "w", encoding="utf-8") as dataset_file:
         for utt_batch in batched(
             make_dataset(args),
@@ -271,21 +284,6 @@ def main() -> None:
             queue_in.put(utt_batch)
 
         _LOGGER.debug("Waiting for jobs to finish")
-        # プログレスバーを表示
-        print(f"Starting to process {num_utterances} utterances...", file=sys.stderr, flush=True)
-        pbar = tqdm(
-            total=num_utterances, 
-            desc="Preprocessing", 
-            unit="utt",
-            file=sys.stderr,
-            leave=True,
-            dynamic_ncols=True,
-            disable=False,
-            mininterval=0.1,
-            maxinterval=1.0,
-            ncols=80
-        )
-        pbar.set_description("Processing utterances")
         missing_phonemes: "Counter[str]" = Counter()
         for _ in range(num_utterances):
             utt = queue_out.get()

--- a/src/python/piper_train/preprocess.py
+++ b/src/python/piper_train/preprocess.py
@@ -350,7 +350,6 @@ def phonemize_batch_espeak(
         if not getattr(args, "debug", False):
             devnull_fd = os.open(os.devnull, os.O_RDWR)
             os.dup2(devnull_fd, 2)
-            os.dup2(devnull_fd, 1)
 
         casing = get_text_casing(args.text_casing)
         silence_detector = make_silence_detector()
@@ -404,7 +403,6 @@ def phonemize_batch_text(
         if not getattr(args, "debug", False):
             devnull_fd = os.open(os.devnull, os.O_RDWR)
             os.dup2(devnull_fd, 2)
-            os.dup2(devnull_fd, 1)
 
         casing = get_text_casing(args.text_casing)
         silence_detector = make_silence_detector()
@@ -458,7 +456,6 @@ def phonemize_batch_openjtalk(
         if not getattr(args, "debug", False):
             devnull_fd = os.open(os.devnull, os.O_RDWR)
             os.dup2(devnull_fd, 2)
-            os.dup2(devnull_fd, 1)
 
         casing = get_text_casing(args.text_casing)
         silence_detector = make_silence_detector()

--- a/src/python/piper_train/preprocess.py
+++ b/src/python/piper_train/preprocess.py
@@ -307,6 +307,8 @@ def main() -> None:
 
             # プログレスバーを最後に更新（処理済みかどうかに関わらず）
             pbar.update(1)
+            if (pbar.n % 500) == 0:
+                pbar.refresh()
 
         pbar.close()
         if missing_phonemes:
@@ -344,6 +346,12 @@ def phonemize_batch_espeak(
     args: argparse.Namespace, queue_in: JoinableQueue, queue_out: Queue
 ):
     try:
+        # Suppress C-level warnings from pyopenjtalk/OpenJTalk to keep output clean
+        if not getattr(args, "debug", False):
+            import os
+            devnull_fd = os.open(os.devnull, os.O_RDWR)
+            os.dup2(devnull_fd, 2)
+
         casing = get_text_casing(args.text_casing)
         silence_detector = make_silence_detector()
 
@@ -393,6 +401,11 @@ def phonemize_batch_text(
     args: argparse.Namespace, queue_in: JoinableQueue, queue_out: Queue
 ):
     try:
+        if not getattr(args, "debug", False):
+            import os
+            devnull_fd = os.open(os.devnull, os.O_RDWR)
+            os.dup2(devnull_fd, 2)
+
         casing = get_text_casing(args.text_casing)
         silence_detector = make_silence_detector()
 
@@ -442,6 +455,11 @@ def phonemize_batch_openjtalk(
     args: argparse.Namespace, queue_in: JoinableQueue, queue_out: Queue
 ):
     try:
+        if not getattr(args, "debug", False):
+            import os
+            devnull_fd = os.open(os.devnull, os.O_RDWR)
+            os.dup2(devnull_fd, 2)
+
         casing = get_text_casing(args.text_casing)
         silence_detector = make_silence_detector()
 


### PR DESCRIPTION
* openjtalkのwaringの停止
* 前処理のプログレスバーの表示(500件で強制再描画)

実行すると以下のようになります

```sh
python3 -m piper_train.preprocess   --language ja   --input-dir ${MOE_DATASET_DIR}   --output-dir ${PREPROCESSED_MOE_SINGLE_DIR}   --dataset-format ljspeech   --sample-rate 22050   --single-speaker   --max-workers 45
INFO:preprocess:Using pyopenjtalk for Japanese phonemization (53 symbols)
INFO:preprocess:Single speaker dataset
INFO:preprocess:Wrote dataset config
INFO:preprocess:Processing 395170 utterance(s) with 45 worker(s)
Starting to process 395170 utterances...
Preprocessing:   0%|                                                                                                                                                                           | 0/395170 [00:00<?, ?utt/s]

```