### PR TITLE
devブランチでビルドが安定しない対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,19 +27,17 @@ RUN apt-get update && \
         make \
         ninja-build \
         python3 && \
-    # アーキテクチャに応じたクロスコンパイルツールのインストール
-    if [ "$TARGETARCH" = "arm64" ]; then \
+    # --- クロスコンパイルツール ----
+    # buildx/QEMU ではビルド用コンテナ自体がターゲットと同じアーキテクチャになる。
+    # その場合追加ツールは不要で、Debian arm リポジトリには crossbuild-essential-* が存在しない。
+    #   ・ホスト = amd64 かつ TARGETARCH が異なるときだけインストールする。
+    HOST_ARCH=$(dpkg --print-architecture); \
+    if [ "$HOST_ARCH" = "amd64" ] && [ "$TARGETARCH" = "arm64" ]; then \
         apt-get install --yes --no-install-recommends \
-            gcc-aarch64-linux-gnu \
-            g++-aarch64-linux-gnu \
-            binutils-aarch64-linux-gnu \
-            crossbuild-essential-arm64; \
-    elif [ "$TARGETARCH" = "arm" ] && [ "$TARGETVARIANT" = "v7" ]; then \
+            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu; \
+    elif [ "$HOST_ARCH" = "amd64" ] && [ "$TARGETARCH" = "arm" ] && [ "$TARGETVARIANT" = "v7" ]; then \
         apt-get install --yes --no-install-recommends \
-            gcc-arm-linux-gnueabihf \
-            g++-arm-linux-gnueabihf \
-            binutils-arm-linux-gnueabihf \
-            crossbuild-essential-armhf; \
+            gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf; \
     fi && \
     # クリーンアップ
     apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Piper is used in a [variety of projects](#people-using-piper).
 
 ## 追加機能
 * 日本語の事前学習及び追加学習/推論対応
-* GitHub ActionsによるLinuxのビルドおよびバイナリー配布の自動化
+* GitHub Actionsによる以下のプラットフォームのビルドおよびバイナリー配布の自動化
+  * Linux (amd64, arm64)
+  * macOS (x64, arm64)
 
 ## 関連記事
 * [LJSpeechを使って英語のpiperの事前学習モデルを作成する](https://ayousanz.hatenadiary.jp/entry/2025/05/26/230341)


### PR DESCRIPTION
# 概要
*  PRのブランチではビルドが成功するがdevブランチだとビルドが失敗する問題の対応

# 内容

以下らしい

> 原因と対策のポイント
GitHub Actions のキャンセル
The operation was canceled と表示される arm64 側は
直後のコミット/push により同じブランチのワークフローが再実行され
先行ジョブが自動キャンセルされた可能性が高いです。
── pull-request 時は単発実行なので発生しませんでした。
対策: concurrency.group: ${{ github.workflow }}-${{ matrix.target }}
を設定して “古いジョブを残す/残さない” を明示すると挙動が安定します。
arm/v7 の apt install 失敗
crossbuild-essential-armhf 等は armv7 コンテナでは不要 かつ
Debian bullseye armv7 リポジトリには存在しないため
apt が 100 で落ちます。
PR ブランチで通ったのは、タイミング良くミラーに
パッケージが残っていた／キャッシュが効いていた可能性があります。
