### PR TITLE
前処理時の破損ファイルの扱いの変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Piper is used in a [variety of projects](#people-using-piper).
   * Linux (amd64, arm64)
   * macOS (x64, arm64)
   * Windows (x64)
+* 前処理済み .pt ファイルが破損していても学習時に自動スキップして継続できるように改善
+* DataLoader に `pin_memory=True` を設定し GPU 転送を最適化
 
 ## 関連記事
 * [LJSpeechを使って英語のpiperの事前学習モデルを作成する](https://ayousanz.hatenadiary.jp/entry/2025/05/26/230341)

--- a/src/python/piper_train/vits/lightning.py
+++ b/src/python/piper_train/vits/lightning.py
@@ -162,6 +162,7 @@ class VitsModel(pl.LightningModule):
             ),
             num_workers=self.hparams.num_workers,
             batch_size=self.hparams.batch_size,
+            pin_memory=True,
         )
 
     def val_dataloader(self):
@@ -173,6 +174,7 @@ class VitsModel(pl.LightningModule):
             ),
             num_workers=self.hparams.num_workers,
             batch_size=self.hparams.batch_size,
+            pin_memory=True,
         )
 
     def test_dataloader(self):


### PR DESCRIPTION
* 前処理済み .pt ファイルが破損していても学習時に自動スキップして継続できるように改善
* DataLoader に `pin_memory=True` を設定し GPU 転送を最適化