### PR TITLE
前処理時の破損ファイルの扱いの変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Piper is used in a [variety of projects](#people-using-piper).
   * Windows (x64)
 * 前処理済み .pt ファイルが破損していても学習時に自動スキップして継続できるように改善
 * DataLoader に `pin_memory=True` を設定し GPU 転送を最適化
+* `preprocess.py` に `--timeout-seconds` を追加し、ハングする発話を自動タイムアウト/スキップ
 
 ## 関連記事
 * [LJSpeechを使って英語のpiperの事前学習モデルを作成する](https://ayousanz.hatenadiary.jp/entry/2025/05/26/230341)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Piper is used in a [variety of projects](#people-using-piper).
 * 前処理済み .pt ファイルが破損していても学習時に自動スキップして継続できるように改善
 * DataLoader に `pin_memory=True` を設定し GPU 転送を最適化
 * `preprocess.py` に `--timeout-seconds` を追加し、ハングする発話を自動タイムアウト/スキップ
+* `piper_train` に `--num-workers` を追加し、DataLoader のワーカー数をコマンドラインから指定可能に
 
 ## 関連記事
 * [LJSpeechを使って英語のpiperの事前学習モデルを作成する](https://ayousanz.hatenadiary.jp/entry/2025/05/26/230341)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Piper is used in a [variety of projects](#people-using-piper).
   * Linux (amd64, arm64)
   * macOS (x64, arm64)
   * Windows (x64)
+* 前処理済み .pt ファイルが破損していても学習時に自動スキップして継続できるように改善
+* DataLoader に `pin_memory=True` を設定し GPU 転送を最適化
 
 ## 関連記事
 * [LJSpeechを使って英語のpiperの事前学習モデルを作成する](https://ayousanz.hatenadiary.jp/entry/2025/05/26/230341)

--- a/TRAINING.md
+++ b/TRAINING.md
@@ -177,7 +177,8 @@ python3 -m piper_train \
     --max_epochs 10000 \
     --resume_from_checkpoint /path/to/lessac/epoch=2164-step=1355540.ckpt \
     --checkpoint-epochs 1 \
-    --precision 32
+    --precision 32 \
+    --num-workers 48
 ```
 
 Use `--quality high` to train a [larger voice model](https://github.com/rhasspy/piper/blob/master/src/python/piper_train/vits/config.py#L45) (sounds better, but is much slower).
@@ -243,3 +244,19 @@ If the export is successful, you can now use your voice with Piper:
 echo 'This is a test.' | \
   piper -m /path/to/model.onnx --output_file test.wav
 ```
+
+### DataLoader ワーカー数 (`--num-workers`)
+
+`DataLoader` が使用するワーカー数はデフォルトで `min(16, CPU コア数)` に設定されています。
+必要に応じて学習コマンドに `--num-workers <N>` を追加することで変更できます。
+
+```sh
+python3 -m piper_train \
+  --dataset-dir /path/to/training_dir/ \
+  --accelerator 'gpu' \
+  --devices 1 \
+  --batch-size 32 \
+  --num-workers 48   # 例: 48 スレッドを使用
+```
+
+ワーカー数を増やしすぎると、ディスク I/O や CPU ボトルネックによって逆に遅くなることがあります。マシンのコア数や負荷を確認しながら調整してください。

--- a/src/python/piper_train/vits/lightning.py
+++ b/src/python/piper_train/vits/lightning.py
@@ -162,6 +162,7 @@ class VitsModel(pl.LightningModule):
             ),
             num_workers=self.hparams.num_workers,
             batch_size=self.hparams.batch_size,
+            pin_memory=True,
         )
 
     def val_dataloader(self):
@@ -173,6 +174,7 @@ class VitsModel(pl.LightningModule):
             ),
             num_workers=self.hparams.num_workers,
             batch_size=self.hparams.batch_size,
+            pin_memory=True,
         )
 
     def test_dataloader(self):

--- a/src/python/piper_train/vits/lightning.py
+++ b/src/python/piper_train/vits/lightning.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
@@ -350,5 +351,11 @@ class VitsModel(pl.LightningModule):
         parser.add_argument("--filter-channels", type=int, default=768)
         parser.add_argument("--n-layers", type=int, default=6)
         parser.add_argument("--n-heads", type=int, default=2)
+        parser.add_argument(
+            "--num-workers",
+            type=int,
+            default=min(16, os.cpu_count()),
+            help="Number of workers for DataLoader",
+        )
         #
         return parent_parser


### PR DESCRIPTION
* 前処理済み .pt ファイルが破損していても学習時に自動スキップして継続できるように改善
* DataLoader に `pin_memory=True` を設定し GPU 転送を最適化
 * 引数からデータロード時のスレッド数を指定できるように変更