### PR TITLE
日本語の音素処理も一文字音素対応に変更

### DIFF
--- a/src/python/piper_train/phonemize/japanese.py
+++ b/src/python/piper_train/phonemize/japanese.py
@@ -2,6 +2,7 @@ import re
 from typing import List
 
 import pyopenjtalk
+from .token_mapper import map_sequence
 
 __all__ = ["phonemize_japanese"]
 
@@ -109,4 +110,5 @@ def phonemize_japanese(text: str) -> List[str]:
         if (a2 == 1) and (a2_next == 2):
             tokens.append("[")
 
-    return tokens 
+    # 多文字トークンを1コードポイントへ変換
+    return map_sequence(tokens) 

--- a/src/python/piper_train/phonemize/jp_id_map.py
+++ b/src/python/piper_train/phonemize/jp_id_map.py
@@ -1,4 +1,5 @@
 from typing import Dict, List
+from .token_mapper import register
 
 __all__ = ["get_japanese_id_map", "JAPANESE_PHONEMES", "SPECIAL_TOKENS"]
 
@@ -72,7 +73,8 @@ def get_japanese_id_map() -> Dict[str, List[int]]:
     padding symbol, mirroring the convention used in Piper's English mapping.
     """
 
-    symbols: List[str] = SPECIAL_TOKENS + JAPANESE_PHONEMES
+    # 各トークンを1文字へ写像
+    symbols: List[str] = [register(s) for s in (SPECIAL_TOKENS + JAPANESE_PHONEMES)]
     id_map: Dict[str, List[int]] = {}
     for idx, symbol in enumerate(symbols):
         id_map[symbol] = [idx]

--- a/src/python/piper_train/phonemize/token_mapper.py
+++ b/src/python/piper_train/phonemize/token_mapper.py
@@ -1,0 +1,31 @@
+# 新規追加ファイル: 多文字音素→1文字(コードポイント) 変換を共通提供
+TOKEN2CHAR = {}
+CHAR2TOKEN = {}
+
+# Private Use Area 開始位置
+_PUA_START = 0xE000
+_next = _PUA_START
+
+def register(token: str) -> str:
+    """Register *token* and return its single-codepoint replacement."""
+    global _next
+    if token in TOKEN2CHAR:
+        return TOKEN2CHAR[token]
+
+    # 既に1コードポイントの場合はそのまま流用
+    if len(token) == 1:
+        TOKEN2CHAR[token] = token
+        CHAR2TOKEN[token] = token
+        return token
+
+    # 割り当て
+    ch = chr(_next)
+    _next += 1
+    TOKEN2CHAR[token] = ch
+    CHAR2TOKEN[ch] = token
+    return ch
+
+
+def map_sequence(seq):
+    """seq は List[str]。各要素を1文字に置換したリストを返す"""
+    return [register(t) for t in seq] 

--- a/src/python/piper_train/preprocess.py
+++ b/src/python/piper_train/preprocess.py
@@ -238,7 +238,7 @@ def main() -> None:
                 "piper_version": _VERSION,
             },
             config_file,
-            ensure_ascii=False,
+            ensure_ascii=True,
             indent=4,
         )
     _LOGGER.info("Wrote dataset config")
@@ -307,7 +307,7 @@ def main() -> None:
                 json.dump(
                     utt_dict,
                     dataset_file,
-                    ensure_ascii=False,
+                    ensure_ascii=True,
                     cls=PathEncoder,
                 )
                 print("", file=dataset_file)


### PR DESCRIPTION
元々日本語の音素対応に 二文字で対応していたが、C++側がに文字対応されていないので日本語も一文字で対応する
ただし C++側の処理でエラーが出るので、別途対応する

以下は動作確認済み
* Pythonで日本語モデルをonnxに変換したものを推論できる
* macのバイナリーで推論はできる(ただし C++側のphenomena mapが対応していないところでwaringが出る)