### PR TITLE
feat: 日本語TTS向けPUA音素マッピングとOpenJTalk統合 (#34)

### DIFF
--- a/.github/workflows/dev-daily-release.yml
+++ b/.github/workflows/dev-daily-release.yml
@@ -364,10 +364,12 @@ jobs:
           echo "::group::Install dependencies"
           if [ "${{ matrix.arch }}" = "x64" ]; then
             # x64用の依存関係（Rosetta 2を使用）
-            arch -x86_64 brew install cmake espeak-ng ninja autoconf automake libtool
+            # Note: We don't install espeak-ng from brew as piper_phonemize builds its own fork
+            arch -x86_64 brew install cmake ninja autoconf automake libtool
           else
             # arm64用の依存関係
-            brew install cmake espeak-ng ninja autoconf automake libtool
+            # Note: We don't install espeak-ng from brew as piper_phonemize builds its own fork
+            brew install cmake ninja autoconf automake libtool
           fi
           echo "::endgroup::"
       - name: Configure build
@@ -449,6 +451,61 @@ jobs:
             echo "::error::Failed to set executable permissions"
             exit 1
           fi
+          
+          # Check library dependencies
+          echo "Checking library dependencies..."
+          otool -L _install/piper/bin/piper
+          
+          echo "Checking piper_phonemize dependencies..."
+          otool -L _install/piper/lib/libpiper_phonemize*.dylib | head -20
+          
+          # Check if libraries are installed
+          echo "Checking installed libraries..."
+          ls -la _install/piper/lib/ || echo "No lib directory found"
+          
+          # Check RPATH
+          echo "Checking RPATH settings..."
+          otool -l _install/piper/bin/piper | grep -A2 LC_RPATH || echo "No RPATH found"
+          
+          # Fix library dependencies on macOS
+          echo "Fixing library dependencies..."
+          
+          # Update library paths for all executables and libraries
+          for binary in _install/piper/bin/*; do
+            if [ -f "$binary" ] && [ -x "$binary" ]; then
+              echo "Updating dependencies for: $binary"
+              # Update espeak-ng library path
+              install_name_tool -change "@rpath/libespeak-ng.dylib" "@loader_path/../lib/libespeak-ng.dylib" "$binary" || true
+              install_name_tool -change "@rpath/libespeak-ng.1.dylib" "@loader_path/../lib/libespeak-ng.1.dylib" "$binary" || true
+              # Update piper_phonemize library path
+              install_name_tool -change "@rpath/libpiper_phonemize.dylib" "@loader_path/../lib/libpiper_phonemize.dylib" "$binary" || true
+              install_name_tool -change "@rpath/libpiper_phonemize.1.dylib" "@loader_path/../lib/libpiper_phonemize.1.dylib" "$binary" || true
+            fi
+          done
+          
+          # Fix library dependencies for the libraries themselves
+          for lib in _install/piper/lib/*.dylib; do
+            if [ -f "$lib" ]; then
+              echo "Updating dependencies for library: $lib"
+              # Update espeak-ng references
+              install_name_tool -change "@rpath/libespeak-ng.dylib" "@loader_path/libespeak-ng.dylib" "$lib" || true
+              install_name_tool -change "@rpath/libespeak-ng.1.dylib" "@loader_path/libespeak-ng.1.dylib" "$lib" || true
+              # Fix the library ID if it's espeak-ng
+              if [[ "$lib" == *"libespeak-ng"* ]]; then
+                lib_name=$(basename "$lib")
+                install_name_tool -id "@loader_path/$lib_name" "$lib" || true
+              fi
+            fi
+          done
+          
+          echo "Final library check:"
+          ls -la _install/piper/lib/
+          
+          echo "Final dependency check for piper:"
+          otool -L _install/piper/bin/piper
+          
+          echo "Final dependency check for libpiper_phonemize:"
+          otool -L _install/piper/lib/libpiper_phonemize*.dylib | head -20
       - name: Verify macOS package
         run: |
           # バイナリの存在確認
@@ -468,10 +525,11 @@ jobs:
           lipo -info "_install/piper/bin/piper"
           
           # アーキテクチャに応じたテスト実行
+          echo "Testing piper binary..."
           if [ "${{ matrix.arch }}" = "x64" ]; then
-            /usr/bin/arch -x86_64 echo "Testing piper binary..." | _install/piper/bin/piper --help
+            /usr/bin/arch -x86_64 _install/piper/bin/piper --help
           else
-            /usr/bin/arch -arm64 echo "Testing piper binary..." | _install/piper/bin/piper --help
+            /usr/bin/arch -arm64 _install/piper/bin/piper --help
           fi || {
             echo "::error::piper binary test failed"
             exit 1
@@ -623,7 +681,8 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install espeak-ng
+          # Note: espeak-ng is bundled with piper, no need to install separately
+          echo "Using bundled espeak-ng from piper build"
           
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
@@ -688,9 +747,9 @@ jobs:
                 Write-Host "Creating piper directory structure..."
                 New-Item -ItemType Directory -Force -Path piper | Out-Null
                 Move-Item -Path "bin" -Destination "piper/" -Force
-                Move-Item -Path "espeak-ng-data" -Destination "piper/" -Force -ErrorAction SilentlyContinue
-                Move-Item -Path "*.dll" -Destination "piper/" -Force -ErrorAction SilentlyContinue
-                Move-Item -Path "*.ort" -Destination "piper/" -Force -ErrorAction SilentlyContinue
+                Move-Item -Path "share/espeak-ng-data" -Destination "piper/" -Force -ErrorAction SilentlyContinue
+                Move-Item -Path "lib/*.dll" -Destination "piper/" -Force -ErrorAction SilentlyContinue
+                Move-Item -Path "share/*.ort" -Destination "piper/" -Force -ErrorAction SilentlyContinue
               }
             }
           } else {
@@ -711,16 +770,30 @@ jobs:
         run: |
           echo "Testing Japanese TTS..."
           
+          # Download Japanese dictionary for OpenJTalk
+          echo "Downloading NAIST Japanese Dictionary..."
+          mkdir -p piper/share/naist-jdic
+          curl -L -o dict.tar.gz "https://sourceforge.net/projects/open-jtalk/files/Dictionary/open_jtalk_dic-1.11/open_jtalk_dic_utf_8-1.11.tar.gz/download"
+          tar -xzf dict.tar.gz --strip-components=1 -C piper/share/naist-jdic
+          rm dict.tar.gz
+          export OPENJTALK_DICTIONARY_DIR=$PWD/piper/share/naist-jdic
+          echo "Dictionary downloaded to: $OPENJTALK_DICTIONARY_DIR"
+          
           # Set library path for Linux
           if [ "${{ runner.os }}" = "Linux" ]; then
             export LD_LIBRARY_PATH=$PWD/piper/lib:$LD_LIBRARY_PATH
             echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
           fi
           
-          # Create test input
-          echo "こんにちは、音声合成のテストです。" > test_input.txt
-          echo "日本語の音声が正しく生成されることを確認しています。" >> test_input.txt
-          echo "本日は晴天なり。" >> test_input.txt
+          # Set library path for macOS
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            export DYLD_LIBRARY_PATH=$PWD/piper/lib:$DYLD_LIBRARY_PATH
+            echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH"
+          fi
+          
+          # Create test input (use English for test model)
+          echo "Hello, this is a test of the text to speech system." > test_input.txt
+          echo "Testing the piper voice synthesis." >> test_input.txt
           
           # Test binary exists and is executable
           if [ ! -f "${{ matrix.binary_path }}" ]; then
@@ -760,8 +833,13 @@ jobs:
               export ESPEAK_DATA_PATH=$PWD/piper/espeak-ng-data
             fi
             
-            # Try simple TTS without model (will fail but shows binary works)
-            echo "Testing" | "${{ matrix.binary_path }}" --output_file test_output.wav 2>&1 | grep -E "(model|help|usage)" || true
+            # Try to use the test voice from the repository
+            if [ -f "etc/test_voice.onnx" ]; then
+              echo "Using test voice from repository"
+              echo "Testing" | "${{ matrix.binary_path }}" --model etc/test_voice.onnx --output_file test_output.wav || echo "Test voice failed"
+            else
+              echo "No test model available, skipping TTS test"
+            fi
             
             echo "✅ Binary test completed (model test skipped)"
           fi
@@ -786,9 +864,8 @@ jobs:
           Write-Host "Testing Japanese TTS..."
           
           # Create test input
-          "こんにちは、音声合成のテストです。" | Out-File -FilePath test_input.txt -Encoding UTF8
-          "日本語の音声が正しく生成されることを確認しています。" | Add-Content -Path test_input.txt -Encoding UTF8
-          "本日は晴天なり。" | Add-Content -Path test_input.txt -Encoding UTF8
+          "Hello, this is a test of the text to speech system." | Out-File -FilePath test_input.txt -Encoding UTF8
+          "Testing the piper voice synthesis." | Add-Content -Path test_input.txt -Encoding UTF8
           
           # Test binary exists
           if (!(Test-Path "${{ matrix.binary_path }}")) {
@@ -843,8 +920,16 @@ jobs:
               Write-Host "Version check failed with exit code $versionExitCode"
             }
             
-            # Try simple TTS without model (will fail but shows binary works)
-            "Testing" | & "${{ matrix.binary_path }}" --output_file test_output.wav 2>&1 | Select-String -Pattern "model|help|usage"
+            # Try to use the test voice from the repository
+            if (Test-Path "etc\test_voice.onnx") {
+              Write-Host "Using test voice from repository"
+              "Testing" | & "${{ matrix.binary_path }}" --model etc\test_voice.onnx --output_file test_output.wav
+              if ($LASTEXITCODE -ne 0) {
+                Write-Host "Test voice failed with exit code $LASTEXITCODE"
+              }
+            } else {
+              Write-Host "No test model available, skipping TTS test"
+            }
             
             Write-Host "✅ Binary test completed (model test skipped)"
           }

--- a/.github/workflows/dev-daily-release.yml
+++ b/.github/workflows/dev-daily-release.yml
@@ -676,12 +676,13 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libespeak-ng1
+          sudo apt-get install -y libespeak-ng1 open-jtalk open-jtalk-mecab-naist-jdic
           
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          # Note: espeak-ng is bundled with piper, no need to install separately
+          # Install open-jtalk for Japanese TTS
+          brew install open-jtalk
           echo "Using bundled espeak-ng from piper build"
           
       - name: Install dependencies (Windows)
@@ -770,14 +771,25 @@ jobs:
         run: |
           echo "Testing Japanese TTS..."
           
-          # Download Japanese dictionary for OpenJTalk
-          echo "Downloading NAIST Japanese Dictionary..."
-          mkdir -p piper/share/naist-jdic
-          curl -L -o dict.tar.gz "https://sourceforge.net/projects/open-jtalk/files/Dictionary/open_jtalk_dic-1.11/open_jtalk_dic_utf_8-1.11.tar.gz/download"
-          tar -xzf dict.tar.gz --strip-components=1 -C piper/share/naist-jdic
-          rm dict.tar.gz
-          export OPENJTALK_DICTIONARY_DIR=$PWD/piper/share/naist-jdic
-          echo "Dictionary downloaded to: $OPENJTALK_DICTIONARY_DIR"
+          # Setup OpenJTalk for Japanese TTS
+          if [ -f "test/models/ja_JP-test-medium.onnx" ]; then
+            echo "Setting up OpenJTalk for Japanese TTS..."
+            
+            # For Ubuntu, dictionary is already installed via apt
+            if [ "${{ runner.os }}" = "Linux" ]; then
+              export OPENJTALK_DICTIONARY_DIR=/var/lib/mecab/dic/open-jtalk/naist-jdic
+              echo "Using system OpenJTalk dictionary: $OPENJTALK_DICTIONARY_DIR"
+            else
+              # For macOS, download dictionary
+              echo "Downloading NAIST Japanese Dictionary..."
+              mkdir -p piper/share/naist-jdic
+              curl -L -o dict.tar.gz "https://sourceforge.net/projects/open-jtalk/files/Dictionary/open_jtalk_dic-1.11/open_jtalk_dic_utf_8-1.11.tar.gz/download"
+              tar -xzf dict.tar.gz --strip-components=1 -C piper/share/naist-jdic
+              rm dict.tar.gz
+              export OPENJTALK_DICTIONARY_DIR=$PWD/piper/share/naist-jdic
+              echo "Dictionary downloaded to: $OPENJTALK_DICTIONARY_DIR"
+            fi
+          fi
           
           # Set library path for Linux
           if [ "${{ runner.os }}" = "Linux" ]; then
@@ -791,9 +803,16 @@ jobs:
             echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH"
           fi
           
-          # Create test input (use English for test model)
-          echo "Hello, this is a test of the text to speech system." > test_input.txt
-          echo "Testing the piper voice synthesis." >> test_input.txt
+          # Create test input
+          # For Japanese model, use Japanese text
+          if [ -f "test/models/ja_JP-test-medium.onnx" ]; then
+            echo "こんにちは、音声合成のテストです。" > test_input.txt
+            echo "日本語の音声合成をテストしています。" >> test_input.txt
+          else
+            # For English model, use English text
+            echo "Hello, this is a test of the text to speech system." > test_input.txt
+            echo "Testing the piper voice synthesis." >> test_input.txt
+          fi
           
           # Test binary exists and is executable
           if [ ! -f "${{ matrix.binary_path }}" ]; then
@@ -819,15 +838,18 @@ jobs:
           "${{ matrix.binary_path }}" --help || echo "Warning: Help command failed"
           
           # Run TTS
-          # Always use English model for CI testing to avoid OpenJTalk dependency
-          if [ -f "etc/test_voice.onnx" ]; then
+          # Prefer Japanese model for testing PUA phoneme mapping
+          if [ -f "test/models/ja_JP-test-medium.onnx" ]; then
+            echo "Using Japanese model with Japanese text"
+            cat test_input.txt | "${{ matrix.binary_path }}" --model test/models/ja_JP-test-medium.onnx --output_file test_output.wav
+            if [ $? -ne 0 ]; then
+              echo "Japanese TTS failed, trying with debug output"
+              cat test_input.txt | "${{ matrix.binary_path }}" --model test/models/ja_JP-test-medium.onnx --output_file test_output.wav --debug
+              exit 1
+            fi
+          elif [ -f "etc/test_voice.onnx" ]; then
             echo "Using test voice from repository (English model)"
-            # Use English text for English model to avoid PUA mapping errors
-            echo "Hello world" | "${{ matrix.binary_path }}" --model etc/test_voice.onnx --output_file test_output.wav || echo "Test voice failed"
-          elif [ -f "test/models/ja_JP-test-medium.onnx" ]; then
-            echo "Warning: Japanese model requires OpenJTalk, using English text as fallback"
-            # For Japanese model, still use English text to avoid crash
-            echo "Hello world" | "${{ matrix.binary_path }}" --model test/models/ja_JP-test-medium.onnx --output_file test_output.wav || echo "Japanese model test failed"
+            cat test_input.txt | "${{ matrix.binary_path }}" --model etc/test_voice.onnx --output_file test_output.wav || echo "Test voice failed"
           else
             # Fallback: just test that the binary runs
             echo "Testing binary functionality..."
@@ -856,7 +878,7 @@ jobs:
         run: |
           Write-Host "Testing Japanese TTS..."
           
-          # Create test input
+          # Create test input (Windows uses English only - no OpenJTalk support)
           "Hello, this is a test of the text to speech system." | Out-File -FilePath test_input.txt -Encoding UTF8
           "Testing the piper voice synthesis." | Add-Content -Path test_input.txt -Encoding UTF8
           

--- a/.github/workflows/dev-daily-release.yml
+++ b/.github/workflows/dev-daily-release.yml
@@ -819,28 +819,20 @@ jobs:
           "${{ matrix.binary_path }}" --help || echo "Warning: Help command failed"
           
           # Run TTS
-          if [ -f "test/models/ja_JP-test-medium.onnx" ]; then
-            cat test_input.txt | "${{ matrix.binary_path }}" --model test/models/ja_JP-test-medium.onnx --output_file test_output.wav
+          # Always use English model for CI testing to avoid OpenJTalk dependency
+          if [ -f "etc/test_voice.onnx" ]; then
+            echo "Using test voice from repository (English model)"
+            # Use English text for English model to avoid PUA mapping errors
+            echo "Hello world" | "${{ matrix.binary_path }}" --model etc/test_voice.onnx --output_file test_output.wav || echo "Test voice failed"
+          elif [ -f "test/models/ja_JP-test-medium.onnx" ]; then
+            echo "Warning: Japanese model requires OpenJTalk, using English text as fallback"
+            # For Japanese model, still use English text to avoid crash
+            echo "Hello world" | "${{ matrix.binary_path }}" --model test/models/ja_JP-test-medium.onnx --output_file test_output.wav || echo "Japanese model test failed"
           else
             # Fallback: just test that the binary runs
             echo "Testing binary functionality..."
             # Test with --version command
             "${{ matrix.binary_path }}" --version || echo "Version check failed"
-            
-            # Check if espeak-ng data is available
-            if [ -d "piper/espeak-ng-data" ]; then
-              echo "Found espeak-ng data directory"
-              export ESPEAK_DATA_PATH=$PWD/piper/espeak-ng-data
-            fi
-            
-            # Try to use the test voice from the repository
-            if [ -f "etc/test_voice.onnx" ]; then
-              echo "Using test voice from repository (English model)"
-              # Use English text for English model to avoid PUA mapping errors
-              echo "Hello world" | "${{ matrix.binary_path }}" --model etc/test_voice.onnx --output_file test_output.wav || echo "Test voice failed"
-            else
-              echo "No test model available, skipping TTS test"
-            fi
             
             echo "✅ Binary test completed (model test skipped)"
           fi

--- a/.github/workflows/dev-daily-release.yml
+++ b/.github/workflows/dev-daily-release.yml
@@ -777,8 +777,23 @@ jobs:
             
             # For Ubuntu, dictionary is already installed via apt
             if [ "${{ runner.os }}" = "Linux" ]; then
-              export OPENJTALK_DICTIONARY_DIR=/var/lib/mecab/dic/open-jtalk/naist-jdic
-              echo "Using system OpenJTalk dictionary: $OPENJTALK_DICTIONARY_DIR"
+              # Find the correct dictionary path
+              DICT_PATH=$(find /usr/share /var/lib -name "naist-jdic" -type d 2>/dev/null | head -1)
+              if [ -z "$DICT_PATH" ]; then
+                echo "Dictionary not found, downloading..."
+                mkdir -p piper/share/naist-jdic
+                curl -L -o dict.tar.gz "https://sourceforge.net/projects/open-jtalk/files/Dictionary/open_jtalk_dic-1.11/open_jtalk_dic_utf_8-1.11.tar.gz/download"
+                tar -xzf dict.tar.gz --strip-components=1 -C piper/share/naist-jdic
+                rm dict.tar.gz
+                export OPENJTALK_DICTIONARY_DIR=$PWD/piper/share/naist-jdic
+              else
+                export OPENJTALK_DICTIONARY_DIR=$DICT_PATH
+              fi
+              echo "Using OpenJTalk dictionary: $OPENJTALK_DICTIONARY_DIR"
+              
+              # Check OpenJTalk binary location
+              which open_jtalk || echo "open_jtalk not in PATH"
+              ls -la /usr/bin/open_jtalk || echo "open_jtalk not in /usr/bin"
             else
               # For macOS, download dictionary
               echo "Downloading NAIST Japanese Dictionary..."
@@ -841,10 +856,19 @@ jobs:
           # Prefer Japanese model for testing PUA phoneme mapping
           if [ -f "test/models/ja_JP-test-medium.onnx" ]; then
             echo "Using Japanese model with Japanese text"
-            cat test_input.txt | "${{ matrix.binary_path }}" --model test/models/ja_JP-test-medium.onnx --output_file test_output.wav
+            echo "Environment variables:"
+            echo "OPENJTALK_DICTIONARY_DIR=$OPENJTALK_DICTIONARY_DIR"
+            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+            echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH"
+            
+            # Run with debug output from the start
+            echo "Running TTS with debug output..."
+            cat test_input.txt | "${{ matrix.binary_path }}" --model test/models/ja_JP-test-medium.onnx --output_file test_output.wav --debug
             if [ $? -ne 0 ]; then
-              echo "Japanese TTS failed, trying with debug output"
-              cat test_input.txt | "${{ matrix.binary_path }}" --model test/models/ja_JP-test-medium.onnx --output_file test_output.wav --debug
+              echo "Japanese TTS failed!"
+              # Try to get more information
+              echo "Checking for core dump..."
+              ls -la core* || echo "No core dump found"
               exit 1
             fi
           elif [ -f "etc/test_voice.onnx" ]; then

--- a/.github/workflows/dev-daily-release.yml
+++ b/.github/workflows/dev-daily-release.yml
@@ -775,6 +775,16 @@ jobs:
           if [ -f "test/models/ja_JP-test-medium.onnx" ]; then
             echo "Setting up OpenJTalk for Japanese TTS..."
             
+            # Download HTS voice model (required for command-line OpenJTalk)
+            echo "Downloading HTS voice model..."
+            mkdir -p piper/share/hts-voice
+            curl -L -o voice.tar.gz "https://sourceforge.net/projects/open-jtalk/files/HTS%20voice/hts_voice_nitech_jp_atr503_m001-1.05/hts_voice_nitech_jp_atr503_m001-1.05.tar.gz/download"
+            tar -xzf voice.tar.gz
+            cp hts_voice_nitech_jp_atr503_m001-1.05/*.htsvoice piper/share/hts-voice/
+            rm -rf voice.tar.gz hts_voice_nitech_jp_atr503_m001-1.05
+            export OPENJTALK_VOICE=$PWD/piper/share/hts-voice/nitech_jp_atr503_m001.htsvoice
+            echo "HTS voice downloaded to: $OPENJTALK_VOICE"
+            
             # For Ubuntu, dictionary is already installed via apt
             if [ "${{ runner.os }}" = "Linux" ]; then
               # Find the correct dictionary path
@@ -858,6 +868,7 @@ jobs:
             echo "Using Japanese model with Japanese text"
             echo "Environment variables:"
             echo "OPENJTALK_DICTIONARY_DIR=$OPENJTALK_DICTIONARY_DIR"
+            echo "OPENJTALK_VOICE=$OPENJTALK_VOICE"
             echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
             echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH"
             

--- a/.github/workflows/dev-daily-release.yml
+++ b/.github/workflows/dev-daily-release.yml
@@ -835,8 +835,9 @@ jobs:
             
             # Try to use the test voice from the repository
             if [ -f "etc/test_voice.onnx" ]; then
-              echo "Using test voice from repository"
-              echo "Testing" | "${{ matrix.binary_path }}" --model etc/test_voice.onnx --output_file test_output.wav || echo "Test voice failed"
+              echo "Using test voice from repository (English model)"
+              # Use English text for English model to avoid PUA mapping errors
+              echo "Hello world" | "${{ matrix.binary_path }}" --model etc/test_voice.onnx --output_file test_output.wav || echo "Test voice failed"
             else
               echo "No test model available, skipping TTS test"
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ htmlcov
 .venv/
 lightning_logs/
 
+# Test artifacts
+test_japanese_tts.sh
+test_piper/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,13 +185,24 @@ target_link_libraries(piper espeak-ng)
 
 # Link OpenJTalk and HTS_Engine libraries
 if(NOT WIN32 AND NOT MSVC)
+  # Add library directories
+  target_link_directories(piper PUBLIC 
+    ${OPENJTALK_DIR}/lib
+    ${HTS_ENGINE_DIR}/lib
+  )
+  target_link_directories(test_piper PUBLIC 
+    ${OPENJTALK_DIR}/lib
+    ${HTS_ENGINE_DIR}/lib
+  )
+  
+  # Link libraries
   target_link_libraries(piper 
-    ${OPENJTALK_DIR}/lib/libOpenJTalk.a
-    ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
+    OpenJTalk
+    HTSEngine
   )
   target_link_libraries(test_piper 
-    ${OPENJTALK_DIR}/lib/libOpenJTalk.a
-    ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
+    OpenJTalk
+    HTSEngine
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,6 @@ if(NOT WIN32 AND NOT MSVC)
       INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make install
       BUILD_IN_SOURCE 1
       BUILD_BYPRODUCTS 
-        ${OPENJTALK_DIR}/lib/libopenjtalk.a
         ${OPENJTALK_DIR}/bin/open_jtalk
       DEPENDS hts_engine_external
     )
@@ -186,12 +185,11 @@ if(NOT WIN32 AND NOT MSVC)
   add_dependencies(test_piper openjtalk_external hts_engine_external)
   
   # Link libraries with absolute paths
+  # Note: OpenJTalk doesn't create a single library, we need to link individual components
   target_link_libraries(piper 
-    ${CMAKE_CURRENT_BINARY_DIR}/oj/lib/libopenjtalk.a
     ${CMAKE_CURRENT_BINARY_DIR}/he/lib/libHTSEngine.a
   )
   target_link_libraries(test_piper 
-    ${CMAKE_CURRENT_BINARY_DIR}/oj/lib/libopenjtalk.a
     ${CMAKE_CURRENT_BINARY_DIR}/he/lib/libHTSEngine.a
   )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,8 +119,6 @@ if(NOT WIN32 AND NOT MSVC)
       BUILD_IN_SOURCE 1
       BUILD_BYPRODUCTS ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
     )
-    add_dependencies(piper hts_engine_external)
-    add_dependencies(test_piper hts_engine_external)
   endif()
 
   # ---- OpenJTalk ---
@@ -147,8 +145,6 @@ if(NOT WIN32 AND NOT MSVC)
         ${OPENJTALK_DIR}/bin/open_jtalk
       DEPENDS hts_engine_external
     )
-    add_dependencies(piper openjtalk_external)
-    add_dependencies(test_piper openjtalk_external)
   endif()
 endif()
 
@@ -185,24 +181,29 @@ target_link_libraries(piper espeak-ng)
 
 # Link OpenJTalk and HTS_Engine libraries
 if(NOT WIN32 AND NOT MSVC)
-  # Add library directories
-  target_link_directories(piper PUBLIC 
-    ${OPENJTALK_DIR}/lib
-    ${HTS_ENGINE_DIR}/lib
-  )
-  target_link_directories(test_piper PUBLIC 
-    ${OPENJTALK_DIR}/lib
-    ${HTS_ENGINE_DIR}/lib
+  # Create imported library targets
+  add_library(openjtalk_lib STATIC IMPORTED)
+  set_target_properties(openjtalk_lib PROPERTIES
+    IMPORTED_LOCATION ${OPENJTALK_DIR}/lib/libopenjtalk.a
   )
   
-  # Link libraries (use full paths since library names may vary)
+  add_library(hts_engine_lib STATIC IMPORTED)
+  set_target_properties(hts_engine_lib PROPERTIES
+    IMPORTED_LOCATION ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
+  )
+  
+  # Ensure libraries are built before linking
+  add_dependencies(piper openjtalk_external hts_engine_external)
+  add_dependencies(test_piper openjtalk_external hts_engine_external)
+  
+  # Link libraries
   target_link_libraries(piper 
-    ${OPENJTALK_DIR}/lib/libopenjtalk.a
-    ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
+    openjtalk_lib
+    hts_engine_lib
   )
   target_link_libraries(test_piper 
-    ${OPENJTALK_DIR}/lib/libopenjtalk.a
-    ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
+    openjtalk_lib
+    hts_engine_lib
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,18 +22,9 @@ else()
   string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
 endif()
 
-add_executable(piper src/cpp/main.cpp src/cpp/piper.cpp)
-add_executable(test_piper src/cpp/test.cpp src/cpp/piper.cpp)
+add_executable(piper src/cpp/main.cpp src/cpp/piper.cpp src/cpp/openjtalk_phonemize.cpp src/cpp/openjtalk_wrapper.c)
+add_executable(test_piper src/cpp/test.cpp src/cpp/piper.cpp src/cpp/openjtalk_phonemize.cpp src/cpp/openjtalk_wrapper.c)
 
-# Add OpenJTalk support on Unix platforms (not Windows)
-if(NOT WIN32 AND NOT MSVC)
-  target_sources(piper PRIVATE 
-    src/cpp/openjtalk_wrapper.c
-  )
-  target_sources(test_piper PRIVATE 
-    src/cpp/openjtalk_wrapper.c
-  )
-endif()
 
 # Configure RPATH for macOS
 if(APPLE)
@@ -180,7 +171,17 @@ target_link_libraries(piper
 # Link espeak-ng
 target_link_libraries(piper espeak-ng)
 
-# OpenJTalk is used via binary execution, not linked
+# Link OpenJTalk and HTS_Engine libraries
+if(NOT WIN32 AND NOT MSVC)
+  target_link_libraries(piper 
+    ${OPENJTALK_DIR}/lib/libOpenJTalk.a
+    ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
+  )
+  target_link_libraries(test_piper 
+    ${OPENJTALK_DIR}/lib/libOpenJTalk.a
+    ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
+  )
+endif()
 
 target_link_directories(piper PUBLIC
   ${FMT_DIR}/lib
@@ -196,6 +197,17 @@ target_include_directories(piper PUBLIC
   ${SPDLOG_DIR}/include
   ${PIPER_PHONEMIZE_DIR}/include
 )
+
+if(NOT WIN32 AND NOT MSVC)
+  target_include_directories(piper PUBLIC
+    ${OPENJTALK_DIR}/include
+    ${HTS_ENGINE_DIR}/include
+  )
+  target_include_directories(test_piper PUBLIC
+    ${OPENJTALK_DIR}/include
+    ${HTS_ENGINE_DIR}/include
+  )
+endif()
 
 # OpenJTalk is used via binary execution, includes not needed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,8 +227,8 @@ target_compile_definitions(piper PUBLIC _PIPER_VERSION=${piper_version})
 # Add OpenJTalk dictionary path definition on Unix platforms
 if(NOT WIN32 AND NOT MSVC)
   # Dictionary will be downloaded by CI/CD or provided by user
-  # For testing, use build directory path
-  target_compile_definitions(piper PUBLIC OPENJTALK_DIC_PATH="${CMAKE_INSTALL_PREFIX}/share/open_jtalk/dic")
+  # Use relative path from binary location for better portability
+  target_compile_definitions(piper PUBLIC OPENJTALK_DIC_PATH="../share/open_jtalk/dic")
   target_compile_definitions(test_piper PUBLIC OPENJTALK_DIC_PATH="${CMAKE_CURRENT_BINARY_DIR}/naist-jdic")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ if(NOT WIN32 AND NOT MSVC)
       INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make install
       BUILD_IN_SOURCE 1
       BUILD_BYPRODUCTS 
-        ${OPENJTALK_DIR}/lib/libOpenJTalk.a
+        ${OPENJTALK_DIR}/lib/libopenjtalk.a
         ${OPENJTALK_DIR}/bin/open_jtalk
       DEPENDS hts_engine_external
     )
@@ -195,14 +195,14 @@ if(NOT WIN32 AND NOT MSVC)
     ${HTS_ENGINE_DIR}/lib
   )
   
-  # Link libraries
+  # Link libraries (use full paths since library names may vary)
   target_link_libraries(piper 
-    OpenJTalk
-    HTSEngine
+    ${OPENJTALK_DIR}/lib/libopenjtalk.a
+    ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
   )
   target_link_libraries(test_piper 
-    OpenJTalk
-    HTSEngine
+    ${OPENJTALK_DIR}/lib/libopenjtalk.a
+    ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,20 @@ else()
   string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
 endif()
 
-add_executable(piper src/cpp/main.cpp src/cpp/piper.cpp src/cpp/openjtalk_phonemize.cpp src/cpp/openjtalk_wrapper.c)
-add_executable(test_piper src/cpp/test.cpp src/cpp/piper.cpp src/cpp/openjtalk_phonemize.cpp src/cpp/openjtalk_wrapper.c)
+add_executable(piper src/cpp/main.cpp src/cpp/piper.cpp)
+add_executable(test_piper src/cpp/test.cpp src/cpp/piper.cpp)
+
+# Add OpenJTalk support on Unix platforms (not Windows)
+if(NOT WIN32 AND NOT MSVC)
+  target_sources(piper PRIVATE 
+    src/cpp/openjtalk_phonemize.cpp
+    src/cpp/openjtalk_wrapper.c
+  )
+  target_sources(test_piper PRIVATE 
+    src/cpp/openjtalk_phonemize.cpp
+    src/cpp/openjtalk_wrapper.c
+  )
+endif()
 
 
 # Configure RPATH for macOS
@@ -131,7 +143,7 @@ if(NOT WIN32 AND NOT MSVC)
       INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make install
       BUILD_IN_SOURCE 1
       BUILD_BYPRODUCTS 
-        ${OPENJTALK_DIR}/lib/libopenjtalk.a
+        ${OPENJTALK_DIR}/lib/libOpenJTalk.a
         ${OPENJTALK_DIR}/bin/open_jtalk
       DEPENDS hts_engine_external
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,23 @@ install(
   DESTINATION share
 )
 
+# Install OpenJTalk for Japanese TTS support
+if(NOT WIN32 AND NOT MSVC)
+  # Install OpenJTalk binary
+  install(
+    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/oj/bin/open_jtalk
+    DESTINATION bin
+    OPTIONAL  # Don't fail if not built
+  )
+  
+  # Install OpenJTalk dictionary
+  install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/share/open_jtalk
+    DESTINATION share
+    OPTIONAL  # Don't fail if not present
+  )
+endif()
+
 # Note: We don't need to copy espeak-ng library on macOS separately
 # because piper_phonemize builds and installs its own custom fork
 # of espeak-ng that includes the required espeak_TextToPhonemesWithTerminator

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,29 +181,18 @@ target_link_libraries(piper espeak-ng)
 
 # Link OpenJTalk and HTS_Engine libraries
 if(NOT WIN32 AND NOT MSVC)
-  # Create imported library targets
-  add_library(openjtalk_lib STATIC IMPORTED)
-  set_target_properties(openjtalk_lib PROPERTIES
-    IMPORTED_LOCATION ${OPENJTALK_DIR}/lib/libopenjtalk.a
-  )
-  
-  add_library(hts_engine_lib STATIC IMPORTED)
-  set_target_properties(hts_engine_lib PROPERTIES
-    IMPORTED_LOCATION ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
-  )
-  
   # Ensure libraries are built before linking
   add_dependencies(piper openjtalk_external hts_engine_external)
   add_dependencies(test_piper openjtalk_external hts_engine_external)
   
-  # Link libraries
+  # Link libraries with absolute paths
   target_link_libraries(piper 
-    openjtalk_lib
-    hts_engine_lib
+    ${CMAKE_CURRENT_BINARY_DIR}/oj/lib/libopenjtalk.a
+    ${CMAKE_CURRENT_BINARY_DIR}/he/lib/libHTSEngine.a
   )
   target_link_libraries(test_piper 
-    openjtalk_lib
-    hts_engine_lib
+    ${CMAKE_CURRENT_BINARY_DIR}/oj/lib/libopenjtalk.a
+    ${CMAKE_CURRENT_BINARY_DIR}/he/lib/libHTSEngine.a
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.13)
 project(piper C CXX)
 
 file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" piper_version)
-# 末尾の改行がコンパイラ定義に混入しないようにトリム
 string(STRIP "${piper_version}" piper_version)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -13,87 +12,42 @@ if(MSVC)
   # Force compiler to use UTF-8 for IPA constants
   add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
   add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
-  
-  # Windows固有の定義
-  add_definitions(-DWIN32_LEAN_AND_MEAN)
-  add_definitions(-DNOMINMAX)
-  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-  add_definitions(-D_WIN32_WINNT=0x0601)  # Windows 7 or later
-  
-  # ONNX Runtimeのヘッダーファイルの問題を解決
-  add_definitions(-D_Frees_ptr_opt_=)
-  add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
-  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-  add_definitions(-DWIN32)
-  add_definitions(-D_WINDOWS)
-  add_definitions(-D_UNICODE)
-  add_definitions(-DUNICODE)
-  add_definitions(-D_USE_MATH_DEFINES)
-  add_definitions(-D_WIN32_WINNT=0x0601)
-  add_definitions(-DWINVER=0x0601)
-  add_definitions(-D_WIN32_IE=0x0601)
-  add_definitions(-D_WIN32_WINDOWS=0x0601)
-  
-  # MSVC固有のコンパイラオプション
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /MP /bigobj")
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /O2 /GL")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Od /Zi /RTC1")
-  
-  # コンパイルオプションの修正
-  add_compile_options(/W4 /WX /wd4100 /wd4505 /wd4996 /wd4005)
-  add_compile_options(/permissive)  # /permissive-を/permissiveに変更
-  add_compile_options(/Zc:__cplusplus)
-  add_compile_options(/Zc:inline)
-  add_compile_options(/Zc:strictStrings)
-  add_compile_options(/Zc:throwingNew)
-  add_compile_options(/Zc:referenceBinding)
-  add_compile_options(/Zc:rvalueCast)
-  add_compile_options(/bigobj)  # 大きなオブジェクトファイルをサポート
-  add_compile_options(/MP)  # マルチプロセッサコンパイルを有効化
-  add_compile_options(/wd4244)  # 型変換の警告を無視
-  add_compile_options(/wd4267)  # size_tからintへの変換の警告を無視
-  add_compile_options(/wd4996)  # 非推奨関数の警告を無視
-  
-  # ONNX Runtimeとの互換性のための追加定義
-  add_definitions(-DONNXRUNTIME_DLL)
-  add_definitions(-DONNXRUNTIME_STATIC_LIB)
-  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-  add_definitions(-D_SCL_SECURE_NO_WARNINGS)
-  
-  # Windows SDKのヘッダーを追加
-  include_directories("$ENV{WindowsSdkDir}Include\\$ENV{WindowsSDKVersion}um")
-  include_directories("$ENV{WindowsSdkDir}Include\\$ENV{WindowsSDKVersion}shared")
-  include_directories("$ENV{WindowsSdkDir}Include\\$ENV{WindowsSDKVersion}ucrt")
-  
-  # リンクライブラリを追加
-  link_libraries(winmm ws2_32 version)
-  
-  # Windows固有のソースファイルの設定
-  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/windows_console.cpp")
-    target_sources(piper PRIVATE src/cpp/windows_console.cpp)
-  endif()
-elseif(NOT APPLE)
-  # Linux flags
-  string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wl,-rpath,'$$ORIGIN'")
-  string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
 elseif(APPLE)
-  # macOS
+  # macOS flags
   string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra")
   string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
+else()
+  # Linux flags
+  string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wl,-rpath,'$ORIGIN'")
+  string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
 endif()
 
-# Define source files based on platform
-set(PIPER_SOURCES src/cpp/main.cpp src/cpp/piper.cpp)
-set(TEST_PIPER_SOURCES src/cpp/test.cpp src/cpp/piper.cpp)
+add_executable(piper src/cpp/main.cpp src/cpp/piper.cpp)
+add_executable(test_piper src/cpp/test.cpp src/cpp/piper.cpp)
 
-# Add OpenJTalk sources only on Unix platforms
+# Add OpenJTalk support on Unix platforms (not Windows)
 if(NOT WIN32 AND NOT MSVC)
-  list(APPEND PIPER_SOURCES src/cpp/openjtalk_phonemize.cpp src/cpp/openjtalk_wrapper.c)
-  list(APPEND TEST_PIPER_SOURCES src/cpp/openjtalk_phonemize.cpp src/cpp/openjtalk_wrapper.c)
+  target_sources(piper PRIVATE 
+    src/cpp/openjtalk_wrapper.c
+  )
+  target_sources(test_piper PRIVATE 
+    src/cpp/openjtalk_wrapper.c
+  )
 endif()
 
-add_executable(piper ${PIPER_SOURCES})
-add_executable(test_piper ${TEST_PIPER_SOURCES})
+# Configure RPATH for macOS
+if(APPLE)
+  set_target_properties(piper PROPERTIES
+    MACOSX_RPATH TRUE
+    INSTALL_RPATH "@executable_path/../lib"
+    BUILD_WITH_INSTALL_RPATH TRUE
+  )
+  set_target_properties(test_piper PROPERTIES
+    MACOSX_RPATH TRUE
+    INSTALL_RPATH "@executable_path/../lib"
+    BUILD_WITH_INSTALL_RPATH TRUE
+  )
+endif()
 
 # NOTE: external project prefix are shortened because of path length restrictions on Windows
 # NOTE: onnxruntime is pulled from piper-phonemize
@@ -135,172 +89,98 @@ endif()
 
 if(NOT DEFINED PIPER_PHONEMIZE_DIR)
   set(PIPER_PHONEMIZE_DIR "${CMAKE_CURRENT_BINARY_DIR}/pi")
-  
-  if(MSVC)
-    # Windows specific arguments
-    ExternalProject_Add(
-      piper_phonemize_external
-      PREFIX "${CMAKE_CURRENT_BINARY_DIR}/p"
-      URL "https://github.com/rhasspy/piper-phonemize/archive/refs/heads/master.zip"
-      CMAKE_ARGS 
-        -DCMAKE_INSTALL_PREFIX:PATH=${PIPER_PHONEMIZE_DIR}
-        -G ${CMAKE_GENERATOR}
-        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-    )
-  else()
-    # Unix specific arguments  
-    ExternalProject_Add(
-      piper_phonemize_external
-      PREFIX "${CMAKE_CURRENT_BINARY_DIR}/p"
-      URL "https://github.com/rhasspy/piper-phonemize/archive/refs/heads/master.zip"
-      CMAKE_ARGS 
-        -DCMAKE_INSTALL_PREFIX:PATH=${PIPER_PHONEMIZE_DIR}
-    )
-  endif()
-  
+  ExternalProject_Add(
+    piper_phonemize_external
+    PREFIX "${CMAKE_CURRENT_BINARY_DIR}/p"
+    URL "https://github.com/rhasspy/piper-phonemize/archive/refs/heads/master.zip"
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${PIPER_PHONEMIZE_DIR}
+  )
   add_dependencies(piper piper_phonemize_external)
   add_dependencies(test_piper piper_phonemize_external)
 endif()
 
-# ---- openjtalk (Japanese phonemizer) ----
-# Only build OpenJTalk on Unix platforms (Linux, macOS)
-# Windows doesn't support the autotools build system used by OpenJTalk
+# ---- HTSEngine (Unix platforms only) ---
 
 if(NOT WIN32 AND NOT MSVC)
-  include(ExternalProject)
-
-  if(NOT DEFINED OPENJTALK_DIR)
-    set(OPENJTALK_DIR "${CMAKE_CURRENT_BINARY_DIR}/oj")
-    set(HTS_ENGINE_DIR "${CMAKE_CURRENT_BINARY_DIR}/hts")
+  if(NOT DEFINED HTS_ENGINE_DIR)
+    set(HTS_ENGINE_DIR "${CMAKE_CURRENT_BINARY_DIR}/he")
+    set(HTS_ENGINE_VERSION "1.10")
     
-    # ---------------------------------------------------------------------------
-    # OpenJTalk は ExternalProject でビルド後に include/lib ディレクトリが生成されるが、
-    # configure 時点では存在しないため CMake 3.29 以降で
-    #   "Imported target openjtalk includes non-existent path" エラーが発生する。
-    # ここで空ディレクトリを先に生成しておくことで、後段の set_target_properties が
-    # 参照してもエラーにならないようにする。
-    # ---------------------------------------------------------------------------
-    file(MAKE_DIRECTORY "${OPENJTALK_DIR}/include")
-    file(MAKE_DIRECTORY "${OPENJTALK_DIR}/lib")
-    file(MAKE_DIRECTORY "${HTS_ENGINE_DIR}/include")
-    file(MAKE_DIRECTORY "${HTS_ENGINE_DIR}/lib")
-    
-    # Build HTS Engine first as a dependency for OpenJTalk
     ExternalProject_Add(
       hts_engine_external
       PREFIX "${CMAKE_CURRENT_BINARY_DIR}/h"
-      GIT_REPOSITORY https://github.com/r9y9/hts_engine_API.git
-      GIT_TAG v1.0.9  # latest available stable version
-      UPDATE_COMMAND ""
-      CONFIGURE_COMMAND 
-        cd <SOURCE_DIR>/src && 
-        touch ChangeLog &&
-        autoreconf -fi &&
-        ./configure --prefix=${HTS_ENGINE_DIR} --enable-static --disable-shared
-      BUILD_COMMAND cd <SOURCE_DIR>/src && make -j${CMAKE_BUILD_PARALLEL_LEVEL}
-      INSTALL_COMMAND cd <SOURCE_DIR>/src && make install
-      BUILD_BYPRODUCTS 
-        ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
-        ${HTS_ENGINE_DIR}/include/HTS_engine.h
+      URL "https://downloads.sourceforge.net/project/hts-engine/hts_engine%20API/hts_engine_API-${HTS_ENGINE_VERSION}/hts_engine_API-${HTS_ENGINE_VERSION}.tar.gz"
+      CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./configure --prefix=${HTS_ENGINE_DIR}
+      BUILD_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make
+      INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make install
+      BUILD_IN_SOURCE 1
+      BUILD_BYPRODUCTS ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
     )
+    add_dependencies(piper hts_engine_external)
+    add_dependencies(test_piper hts_engine_external)
+  endif()
+
+  # ---- OpenJTalk ---
+  
+  if(NOT DEFINED OPENJTALK_DIR)
+    set(OPENJTALK_DIR "${CMAKE_CURRENT_BINARY_DIR}/oj")
+    set(OPENJTALK_VERSION "1.11")
     
     ExternalProject_Add(
       openjtalk_external
       PREFIX "${CMAKE_CURRENT_BINARY_DIR}/o"
-      GIT_REPOSITORY https://github.com/r9y9/open_jtalk.git
-      GIT_TAG 1.11  # stable tag that matches pyopenjtalk fork
-      UPDATE_COMMAND ""
-      DEPENDS hts_engine_external
-      CONFIGURE_COMMAND 
-        cd <SOURCE_DIR>/src && 
-        touch ChangeLog &&
-        autoreconf -fi &&
-        ./configure --prefix=${OPENJTALK_DIR} --with-charset=utf-8 --enable-static --disable-shared 
-        --with-hts-engine-header-path=${HTS_ENGINE_DIR}/include 
+      URL "https://downloads.sourceforge.net/project/open-jtalk/Open%20JTalk/open_jtalk-${OPENJTALK_VERSION}/open_jtalk-${OPENJTALK_VERSION}.tar.gz"
+      PATCH_COMMAND ""
+      CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./configure 
+        --prefix=${OPENJTALK_DIR}
+        --with-hts-engine-header-path=${HTS_ENGINE_DIR}/include
         --with-hts-engine-library-path=${HTS_ENGINE_DIR}/lib
-      BUILD_COMMAND cd <SOURCE_DIR>/src && make -j${CMAKE_BUILD_PARALLEL_LEVEL}
-      INSTALL_COMMAND 
-        cd <SOURCE_DIR>/src && make install &&
-        mkdir -p ${OPENJTALK_DIR}/include &&
-        cp text2mecab/text2mecab.h ${OPENJTALK_DIR}/include/ &&
-        cp mecab/src/mecab.h ${OPENJTALK_DIR}/include/ &&
-        cp njd/njd.h ${OPENJTALK_DIR}/include/ &&
-        cp jpcommon/jpcommon.h ${OPENJTALK_DIR}/include/ &&
-        cp njd_set_pronunciation/njd_set_pronunciation.h ${OPENJTALK_DIR}/include/ &&
-        cp njd_set_digit/njd_set_digit.h ${OPENJTALK_DIR}/include/ &&
-        cp njd_set_accent_phrase/njd_set_accent_phrase.h ${OPENJTALK_DIR}/include/ &&
-        cp njd_set_accent_type/njd_set_accent_type.h ${OPENJTALK_DIR}/include/ &&
-        cp njd_set_unvoiced_vowel/njd_set_unvoiced_vowel.h ${OPENJTALK_DIR}/include/ &&
-        cp njd_set_long_vowel/njd_set_long_vowel.h ${OPENJTALK_DIR}/include/ &&
-        cp mecab2njd/mecab2njd.h ${OPENJTALK_DIR}/include/ &&
-        cp njd2jpcommon/njd2jpcommon.h ${OPENJTALK_DIR}/include/ &&
-        mkdir -p ${OPENJTALK_DIR}/lib &&
-        cp text2mecab/libtext2mecab.a ${OPENJTALK_DIR}/lib/ &&
-        cp mecab/src/libmecab.a ${OPENJTALK_DIR}/lib/ &&
-        cp njd/libnjd.a ${OPENJTALK_DIR}/lib/ &&
-        cp jpcommon/libjpcommon.a ${OPENJTALK_DIR}/lib/ &&
-        cp njd_set_pronunciation/libnjd_set_pronunciation.a ${OPENJTALK_DIR}/lib/ &&
-        cp njd_set_digit/libnjd_set_digit.a ${OPENJTALK_DIR}/lib/ &&
-        cp njd_set_accent_phrase/libnjd_set_accent_phrase.a ${OPENJTALK_DIR}/lib/ &&
-        cp njd_set_accent_type/libnjd_set_accent_type.a ${OPENJTALK_DIR}/lib/ &&
-        cp njd_set_unvoiced_vowel/libnjd_set_unvoiced_vowel.a ${OPENJTALK_DIR}/lib/ &&
-        cp njd_set_long_vowel/libnjd_set_long_vowel.a ${OPENJTALK_DIR}/lib/ &&
-        cp mecab2njd/libmecab2njd.a ${OPENJTALK_DIR}/lib/ &&
-        cp njd2jpcommon/libnjd2jpcommon.a ${OPENJTALK_DIR}/lib/
+        --with-charset=UTF-8
+      BUILD_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make
+      INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make install
+      BUILD_IN_SOURCE 1
       BUILD_BYPRODUCTS 
-        ${OPENJTALK_DIR}/lib/libtext2mecab.a
-        ${OPENJTALK_DIR}/lib/libmecab.a
-        ${OPENJTALK_DIR}/lib/libnjd.a
-        ${OPENJTALK_DIR}/lib/libjpcommon.a
-        ${OPENJTALK_DIR}/include/text2mecab.h
-        ${OPENJTALK_DIR}/include/mecab.h
-        ${OPENJTALK_DIR}/include/njd.h
-        ${OPENJTALK_DIR}/include/jpcommon.h
+        ${OPENJTALK_DIR}/lib/libopenjtalk.a
+        ${OPENJTALK_DIR}/bin/open_jtalk
+      DEPENDS hts_engine_external
     )
-
-    # For now, just create stub implementation - will implement proper OpenJTalk integration later
-    # This allows the build to succeed while we figure out library structure
-    add_library(openjtalk INTERFACE)
-  else()
-    message(STATUS "Using prebuilt OpenJTalk at ${OPENJTALK_DIR}")
-    add_library(openjtalk INTERFACE)
+    add_dependencies(piper openjtalk_external)
+    add_dependencies(test_piper openjtalk_external)
   endif()
-
-  target_link_libraries(piper PUBLIC openjtalk)
-  target_link_libraries(test_piper PUBLIC openjtalk)
-else()
-  message(STATUS "OpenJTalk is not supported on Windows - skipping Japanese phonemizer")
-  # Create empty target for compatibility
-  add_library(openjtalk INTERFACE)
 endif()
 
 # ---- Declare executable ----
 
-if((NOT MSVC) AND (NOT APPLE))
-  # Linux flags - remove duplicate since already set above
-  target_link_options(piper PRIVATE -static-libgcc -static-libstdc++)
+if(APPLE)
+  # macOS-specific settings
+  set(PIPER_EXTRA_LIBRARIES "pthread")
+  # Find Homebrew-installed espeak-ng
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set(HOMEBREW_PREFIX "/usr/local")
+  else()
+    set(HOMEBREW_PREFIX "/opt/homebrew")
+  endif()
+elseif(NOT MSVC)
+  # Linux flags
+  string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wl,-rpath,'$ORIGIN'")
+  string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
+  target_link_libraries(piper -static-libgcc -static-libstdc++)
 
   set(PIPER_EXTRA_LIBRARIES "pthread")
 endif()
 
-target_link_libraries(piper PUBLIC
+target_link_libraries(piper
   fmt
   spdlog
-  espeak-ng
   piper_phonemize
   onnxruntime
   ${PIPER_EXTRA_LIBRARIES}
 )
 
-# Windows固有のリンク設定
-if(MSVC)
-  target_link_libraries(piper PRIVATE
-    winmm
-    ws2_32
-    version
-  )
-endif()
+# Link espeak-ng
+target_link_libraries(piper espeak-ng)
+
+# OpenJTalk is used via binary execution, not linked
 
 target_link_directories(piper PUBLIC
   ${FMT_DIR}/lib
@@ -308,20 +188,33 @@ target_link_directories(piper PUBLIC
   ${PIPER_PHONEMIZE_DIR}/lib
 )
 
+# Note: We don't need Homebrew paths for espeak-ng on macOS
+# because we're using the custom build from piper_phonemize
+
 target_include_directories(piper PUBLIC
   ${FMT_DIR}/include
   ${SPDLOG_DIR}/include
   ${PIPER_PHONEMIZE_DIR}/include
 )
 
+# OpenJTalk is used via binary execution, includes not needed
+
 target_compile_definitions(piper PUBLIC _PIPER_VERSION=${piper_version})
+
+# Add OpenJTalk dictionary path definition on Unix platforms
+if(NOT WIN32 AND NOT MSVC)
+  # Dictionary will be downloaded by CI/CD or provided by user
+  # For testing, use build directory path
+  target_compile_definitions(piper PUBLIC OPENJTALK_DIC_PATH="${CMAKE_INSTALL_PREFIX}/share/open_jtalk/dic")
+  target_compile_definitions(test_piper PUBLIC OPENJTALK_DIC_PATH="${CMAKE_CURRENT_BINARY_DIR}/naist-jdic")
+endif()
 
 # ---- Declare test ----
 include(CTest)
 enable_testing()
 add_test(
   NAME test_piper
-  COMMAND test_piper "${CMAKE_SOURCE_DIR}/etc/test_voice.onnx" "auto" "${CMAKE_CURRENT_BINARY_DIR}/test.wav"
+  COMMAND test_piper "${CMAKE_SOURCE_DIR}/etc/test_voice.onnx" "${PIPER_PHONEMIZE_DIR}/share/espeak-ng-data" "${CMAKE_CURRENT_BINARY_DIR}/test.wav"
 )
 
 target_compile_features(test_piper PUBLIC cxx_std_17)
@@ -340,7 +233,7 @@ target_link_directories(
   ${PIPER_PHONEMIZE_DIR}/lib
 )
 
-target_link_libraries(test_piper PUBLIC
+target_link_libraries(test_piper
   fmt
   spdlog
   espeak-ng
@@ -348,17 +241,18 @@ target_link_libraries(test_piper PUBLIC
   onnxruntime
 )
 
+# OpenJTalk is used via binary execution for test_piper, not linked
+
 # ---- Declare install targets ----
 
 install(
   TARGETS piper
-  RUNTIME DESTINATION bin
-)
+  DESTINATION bin)
 
 # Dependencies
 install(
   DIRECTORY ${PIPER_PHONEMIZE_DIR}/bin/
-  DESTINATION ${CMAKE_INSTALL_PREFIX}
+  DESTINATION bin
   USE_SOURCE_PERMISSIONS  # keep +x
   FILES_MATCHING
   PATTERN "piper_phonemize"
@@ -368,7 +262,7 @@ install(
 
 install(
   DIRECTORY ${PIPER_PHONEMIZE_DIR}/lib/
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+  DESTINATION lib
   FILES_MATCHING
   PATTERN "*.dll"
   PATTERN "*.so*"
@@ -377,61 +271,16 @@ install(
 
 install(
   DIRECTORY ${PIPER_PHONEMIZE_DIR}/share/espeak-ng-data
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/share
+  DESTINATION share
 )
 
 install(
   FILES ${PIPER_PHONEMIZE_DIR}/share/libtashkeel_model.ort
-  DESTINATION ${CMAKE_INSTALL_PREFIX}
+  DESTINATION share
 )
 
-# Windows固有のターゲット設定
-if(MSVC)
-  target_compile_definitions(piper PRIVATE
-    _CRT_SECURE_NO_WARNINGS
-    _WINSOCK_DEPRECATED_NO_WARNINGS
-    WIN32_LEAN_AND_MEAN
-    NOMINMAX
-    _UNICODE
-    UNICODE
-    _USE_MATH_DEFINES
-    _WIN32_WINNT=0x0601
-    WINVER=0x0601
-    _WIN32_IE=0x0601
-    _WIN32_WINDOWS=0x0601
-    ONNXRUNTIME_DLL
-    ONNXRUNTIME_STATIC_LIB
-  )
-  
-  # Windows SDKのバージョン設定
-  if(NOT DEFINED CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
-    set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION "10.0.19041.0")
-  endif()
-  
-  # ONNX Runtime 用定義と SAL マクロ簡易定義
-  target_compile_definitions(piper PRIVATE
-    ONNXRUNTIME_DLL
-    ONNXRUNTIME_STATIC_LIB
-    _Frees_ptr_opt_=
-  )
-endif()
-
-install(
-  DIRECTORY ${FMT_DIR}/lib/
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-  FILES_MATCHING PATTERN "*.dylib" PATTERN "*.so*"
-)
-
-install(
-  DIRECTORY ${SPDLOG_DIR}/lib/
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-  FILES_MATCHING PATTERN "*.dylib" PATTERN "*.so*"
-)
-
-# macOS 実行時に同梱 lib を検索させる
-if(APPLE)
-  set_target_properties(piper PROPERTIES
-    INSTALL_RPATH "@loader_path/../lib")
-endif()
-
-# OpenJTalk dictionary installation is skipped for stub implementation
+# Note: We don't need to copy espeak-ng library on macOS separately
+# because piper_phonemize builds and installs its own custom fork
+# of espeak-ng that includes the required espeak_TextToPhonemesWithTerminator
+# function. The library is already installed by the piper_phonemize
+# external project.

--- a/JAPANESE_USAGE.md
+++ b/JAPANESE_USAGE.md
@@ -53,6 +53,23 @@
 
 日本語の音声合成を行うには、OpenJTalk形式の音素を使用するモデルが必要です。
 
+### 現在利用可能なモデル
+
+1. **テスト用モデル**（開発・検証用）
+   - piper-plusリポジトリの`test/models/`ディレクトリに含まれています
+   - ファイル名: `ja_JP-test-medium.onnx`と`ja_JP-test-medium.onnx.json`
+   - GitHubからダウンロード:
+     ```bash
+     # ONNXモデル（約63MB）
+     curl -L -o ja_JP-test-medium.onnx https://github.com/ayutaz/piper-plus/raw/master/test/models/ja_JP-test-medium.onnx
+     
+     # 設定ファイル
+     curl -L -o ja_JP-test-medium.onnx.json https://github.com/ayutaz/piper-plus/raw/master/test/models/ja_JP-test-medium.onnx.json
+     ```
+
+2. **自作モデル**
+   - [トレーニングガイド](TRAINING.md)を参照して独自のモデルを作成できます
+
 ### モデルの要件
 
 モデルの設定ファイル（.onnx.json）に以下の設定が必要です：
@@ -142,10 +159,15 @@ tar -xzf open_jtalk_dic.tar.gz
 curl -L -o hts_voice.tar.gz "https://sourceforge.net/projects/open-jtalk/files/HTS%20voice/hts_voice_nitech_jp_atr503_m001-1.05/hts_voice_nitech_jp_atr503_m001-1.05.tar.gz/download"
 tar -xzf hts_voice.tar.gz
 
-# 5. 日本語モデルをダウンロード（例：テストモデル）
+# 5. 日本語モデルをダウンロード
 mkdir -p models
-curl -L -o models/ja_JP-test-medium.onnx "https://example.com/path/to/model.onnx"
-curl -L -o models/ja_JP-test-medium.onnx.json "https://example.com/path/to/model.onnx.json"
+cd models
+
+# テスト用モデルをGitHubからダウンロード
+curl -L -o ja_JP-test-medium.onnx https://github.com/ayutaz/piper-plus/raw/master/test/models/ja_JP-test-medium.onnx
+curl -L -o ja_JP-test-medium.onnx.json https://github.com/ayutaz/piper-plus/raw/master/test/models/ja_JP-test-medium.onnx.json
+
+cd ..
 
 # 6. 環境変数を設定
 export ESPEAK_DATA_PATH="$(pwd)/piper/share/espeak-ng-data"

--- a/JAPANESE_USAGE.md
+++ b/JAPANESE_USAGE.md
@@ -90,13 +90,15 @@ tar -xzf hts_voice.tar.gz
 #### 2. 環境変数の設定
 
 ```bash
-# espeak-ngのデータパス
+# espeak-ngのデータパス（Piperの初期化に必要）
+# 注意：日本語の音素抽出にはespeak-ngは使用されませんが、
+# Piperの起動時に初期化が必要なため、この設定は必須です
 export ESPEAK_DATA_PATH="$(pwd)/piper/share/espeak-ng-data"
 
-# OpenJTalk辞書のパス
+# OpenJTalk辞書のパス（日本語の音素抽出に使用）
 export OPENJTALK_DICTIONARY_DIR="$(pwd)/open_jtalk_dic_utf_8-1.11"
 
-# HTSボイスモデルのパス
+# HTSボイスモデルのパス（OpenJTalkの音素抽出に必要）
 export OPENJTALK_VOICE="$(pwd)/hts_voice_nitech_jp_atr503_m001-1.05/nitech_jp_atr503_m001.htsvoice"
 ```
 

--- a/JAPANESE_USAGE.md
+++ b/JAPANESE_USAGE.md
@@ -69,24 +69,48 @@
 
 ### 重要：初回セットアップ
 
-espeak-ngのデータパスを設定する必要があります：
+日本語TTSを使用するには、以下の設定が必要です：
+
+#### 1. 必要なファイルのダウンロード
 
 ```bash
-# piperディレクトリに移動した後
-export ESPEAK_DATA_PATH="$(pwd)/piper/espeak-ng-data"
+# 作業ディレクトリを作成
+mkdir -p ~/piper-japanese
+cd ~/piper-japanese
+
+# OpenJTalk辞書をダウンロード
+curl -L -o open_jtalk_dic.tar.gz "https://sourceforge.net/projects/open-jtalk/files/Dictionary/open_jtalk_dic-1.11/open_jtalk_dic_utf_8-1.11.tar.gz/download"
+tar -xzf open_jtalk_dic.tar.gz
+
+# HTSボイスモデルをダウンロード（音素抽出に必要）
+curl -L -o hts_voice.tar.gz "https://sourceforge.net/projects/open-jtalk/files/HTS%20voice/hts_voice_nitech_jp_atr503_m001-1.05/hts_voice_nitech_jp_atr503_m001-1.05.tar.gz/download"
+tar -xzf hts_voice.tar.gz
 ```
 
-または、シェルの設定ファイル（~/.bashrc や ~/.zshrc）に追加：
+#### 2. 環境変数の設定
+
 ```bash
-export ESPEAK_DATA_PATH="/path/to/piper/espeak-ng-data"
+# espeak-ngのデータパス
+export ESPEAK_DATA_PATH="$(pwd)/piper/share/espeak-ng-data"
+
+# OpenJTalk辞書のパス
+export OPENJTALK_DICTIONARY_DIR="$(pwd)/open_jtalk_dic_utf_8-1.11"
+
+# HTSボイスモデルのパス
+export OPENJTALK_VOICE="$(pwd)/hts_voice_nitech_jp_atr503_m001-1.05/nitech_jp_atr503_m001.htsvoice"
+```
+
+シェルの設定ファイル（~/.bashrc や ~/.zshrc）に追加する場合：
+```bash
+# Piper日本語TTS設定
+export ESPEAK_DATA_PATH="$HOME/piper-japanese/piper/share/espeak-ng-data"
+export OPENJTALK_DICTIONARY_DIR="$HOME/piper-japanese/open_jtalk_dic_utf_8-1.11"
+export OPENJTALK_VOICE="$HOME/piper-japanese/hts_voice_nitech_jp_atr503_m001-1.05/nitech_jp_atr503_m001.htsvoice"
 ```
 
 ### 基本的な使い方
 
 ```bash
-# 環境変数を設定（毎回必要）
-export ESPEAK_DATA_PATH="$(pwd)/piper/espeak-ng-data"
-
 # テキストファイルから音声を生成
 ./piper/bin/piper --model path/to/model.onnx --output_file output.wav < input.txt
 
@@ -95,6 +119,42 @@ echo "こんにちは、世界" | ./piper/bin/piper --model path/to/model.onnx -
 
 # 標準出力に音声データを出力（他のプログラムにパイプ）
 echo "おはようございます" | ./piper/bin/piper --model path/to/model.onnx --output_raw | aplay -r 22050 -f S16_LE -t raw -
+```
+
+### 完全な手順例（ゼロから始める場合）
+
+```bash
+# 1. 作業ディレクトリを作成
+mkdir -p ~/piper-japanese-setup
+cd ~/piper-japanese-setup
+
+# 2. Piperバイナリをダウンロード（Apple Silicon Macの例）
+curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper_macos_aarch64.tar.gz -o piper.tar.gz
+tar -xzf piper.tar.gz
+
+# 3. OpenJTalk辞書をダウンロード
+curl -L -o open_jtalk_dic.tar.gz "https://sourceforge.net/projects/open-jtalk/files/Dictionary/open_jtalk_dic-1.11/open_jtalk_dic_utf_8-1.11.tar.gz/download"
+tar -xzf open_jtalk_dic.tar.gz
+
+# 4. HTSボイスモデルをダウンロード
+curl -L -o hts_voice.tar.gz "https://sourceforge.net/projects/open-jtalk/files/HTS%20voice/hts_voice_nitech_jp_atr503_m001-1.05/hts_voice_nitech_jp_atr503_m001-1.05.tar.gz/download"
+tar -xzf hts_voice.tar.gz
+
+# 5. 日本語モデルをダウンロード（例：テストモデル）
+mkdir -p models
+curl -L -o models/ja_JP-test-medium.onnx "https://example.com/path/to/model.onnx"
+curl -L -o models/ja_JP-test-medium.onnx.json "https://example.com/path/to/model.onnx.json"
+
+# 6. 環境変数を設定
+export ESPEAK_DATA_PATH="$(pwd)/piper/share/espeak-ng-data"
+export OPENJTALK_DICTIONARY_DIR="$(pwd)/open_jtalk_dic_utf_8-1.11"
+export OPENJTALK_VOICE="$(pwd)/hts_voice_nitech_jp_atr503_m001-1.05/nitech_jp_atr503_m001.htsvoice"
+
+# 7. 日本語音声を生成
+echo "こんにちは、音声合成のテストです" | ./piper/bin/piper --model models/ja_JP-test-medium.onnx --output_file test.wav
+
+# 8. 生成された音声を再生（macOSの場合）
+afplay test.wav
 ```
 
 ### コマンドラインオプション

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Piper is used in a [variety of projects](#people-using-piper).
 ## 追加機能
 * 日本語の事前学習及び追加学習/推論対応（OpenJTalk統合）
   * 詳細な使用方法は[日本語音声合成ガイド](JAPANESE_USAGE.md)を参照
+  * PUA音素マッピングによる日本語TTS精度向上 - [技術詳細](docs/PUA_PHONEME_MAPPING.md)を参照
 * GitHub Actionsによる以下のプラットフォームのビルドおよびバイナリー配布の自動化
 
 ### macOSユーザーへの注意事項

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Piper is used in a [variety of projects](#people-using-piper).
 * 日本語の事前学習及び追加学習/推論対応（OpenJTalk統合）
   * 詳細な使用方法は[日本語音声合成ガイド](JAPANESE_USAGE.md)を参照
   * PUA音素マッピングによる日本語TTS精度向上 - [技術詳細](docs/PUA_PHONEME_MAPPING.md)を参照
+  * **重要**: 日本語TTSを使用するには、以下の環境変数の設定が必要です：
+    - `OPENJTALK_DICTIONARY_DIR`: OpenJTalk辞書へのパス
+    - `OPENJTALK_VOICE`: HTSボイスモデル（.htsvoice）へのパス
 * GitHub Actionsによる以下のプラットフォームのビルドおよびバイナリー配布の自動化
 
 ### macOSユーザーへの注意事項

--- a/docs/PUA_PHONEME_MAPPING.md
+++ b/docs/PUA_PHONEME_MAPPING.md
@@ -1,0 +1,128 @@
+# PUA Phoneme Mapping for Japanese TTS
+
+## Overview
+
+This document explains the Private Use Area (PUA) phoneme mapping system used in Piper for Japanese text-to-speech synthesis. The system ensures consistency between Python training code and C++ inference by mapping multi-character phonemes to single Unicode characters.
+
+## Background
+
+Japanese phonemes in OpenJTalk often consist of multiple characters (e.g., "ch", "ts", "ky"). However, Piper's architecture expects each phoneme to be represented by a single Unicode character. To solve this, we use Unicode's Private Use Area (U+E000-U+F8FF) to create single-character representations of multi-character phonemes.
+
+## PUA Mapping Table
+
+The following fixed mappings are used consistently across Python and C++ code:
+
+| Phoneme | PUA Code | Character | Description |
+|---------|----------|-----------|-------------|
+| a: | U+E000 | | Long vowel 'a' |
+| i: | U+E001 | | Long vowel 'i' |
+| u: | U+E002 | | Long vowel 'u' |
+| e: | U+E003 | | Long vowel 'e' |
+| o: | U+E004 | | Long vowel 'o' |
+| cl | U+E005 | | Geminate consonant (っ) |
+| ky | U+E006 | | Palatalized 'k' (きゃ) |
+| kw | U+E007 | | Labialized 'k' (くゎ) |
+| gy | U+E008 | | Palatalized 'g' (ぎゃ) |
+| gw | U+E009 | | Labialized 'g' (ぐゎ) |
+| ty | U+E00A | | Palatalized 't' (ちゃ) |
+| dy | U+E00B | | Palatalized 'd' (ぢゃ) |
+| py | U+E00C | | Palatalized 'p' (ぴゃ) |
+| by | U+E00D | | Palatalized 'b' (びゃ) |
+| ch | U+E00E | | Affricate (ち) |
+| ts | U+E00F | | Affricate (つ) |
+| sh | U+E010 | | Fricative (し) |
+| zy | U+E011 | | Voiced fricative (じ) |
+| hy | U+E012 | | Palatalized 'h' (ひゃ) |
+| ny | U+E013 | | Palatalized 'n' (にゃ) |
+| my | U+E014 | | Palatalized 'm' (みゃ) |
+| ry | U+E015 | | Palatalized 'r' (りゃ) |
+
+## Implementation
+
+### Python Side (Training)
+
+The mapping is implemented in `src/python/piper_train/phonemize/token_mapper.py`:
+
+```python
+from piper_train.phonemize.token_mapper import TOKEN2CHAR, CHAR2TOKEN
+
+# Convert multi-character phoneme to PUA character
+pua_char = TOKEN2CHAR["ch"]  # Returns ''
+
+# Convert PUA character back to phoneme
+phoneme = CHAR2TOKEN['']  # Returns "ch"
+```
+
+### C++ Side (Inference)
+
+The mapping is implemented in `src/cpp/openjtalk_phonemize.cpp`:
+
+```cpp
+// Multi-character phoneme to PUA mapping
+static std::unordered_map<std::string, char32_t> multiCharToPUA = {
+    {"ch", 0xE00E},
+    {"ts", 0xE00F},
+    // ... etc
+};
+
+// Function to map phoneme strings
+Phoneme mapPhonemeStr(const std::string &phonemeStr);
+```
+
+## Updating Existing Models
+
+To update existing model configurations to use PUA mappings, use the provided script:
+
+```bash
+# Update a single model
+python -m piper_train.update_model_config path/to/model.onnx.json
+
+# Update multiple models
+python -m piper_train.update_model_config models/*.onnx.json
+
+# Dry run to see what would change
+python -m piper_train.update_model_config --dry-run model.onnx.json
+
+# Update without creating backups
+python -m piper_train.update_model_config --no-backup model.onnx.json
+```
+
+## Benefits
+
+1. **Consistency**: Ensures Python training and C++ inference use identical phoneme representations
+2. **Accuracy**: Preserves phonetic information that would be lost by splitting multi-character phonemes
+3. **Compatibility**: Works with existing Piper architecture without structural changes
+4. **Performance**: Reduces "Missing phoneme" warnings during synthesis
+
+## Technical Details
+
+### Why PUA?
+
+The Private Use Area is a range of Unicode codepoints (U+E000-U+F8FF) reserved for application-specific use. These characters have no predefined meaning, making them perfect for our custom phoneme mappings.
+
+### Model Configuration
+
+In model JSON files, the `phoneme_id_map` section maps phonemes to numeric IDs:
+
+```json
+"phoneme_id_map": {
+    "_": [0],
+    "a": [7],
+    "": [30],  // PUA character for "ch"
+    "": [31],  // PUA character for "ts"
+    // ... etc
+}
+```
+
+### Debugging
+
+When debugging, PUA characters may appear as boxes or question marks in text editors. Use the reverse mapping functions to convert them back to readable phonemes:
+
+- Python: `CHAR2TOKEN[pua_char]`
+- C++: `phonemeToDisplayString(phoneme)`
+
+## Future Considerations
+
+1. The current implementation uses fixed mappings starting at U+E000
+2. Dynamic allocation starts at U+E020 for any additional phonemes
+3. The system can be extended to support other languages with multi-character phonemes

--- a/scripts/download_naist_jdic.sh
+++ b/scripts/download_naist_jdic.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Download NAIST Japanese Dictionary for OpenJTalk
+
+set -e
+
+DICT_URL="https://sourceforge.net/projects/open-jtalk/files/Dictionary/open_jtalk_dic-1.11/open_jtalk_dic_utf_8-1.11.tar.gz/download"
+DICT_DIR="${1:-./naist-jdic}"
+
+echo "Downloading NAIST Japanese Dictionary..."
+mkdir -p "$DICT_DIR"
+cd "$DICT_DIR"
+
+# Download dictionary
+curl -L -o dict.tar.gz "$DICT_URL"
+
+# Extract
+tar -xzf dict.tar.gz --strip-components=1
+
+# Clean up
+rm dict.tar.gz
+
+echo "Dictionary downloaded to: $DICT_DIR"

--- a/src/cpp/openjtalk_phonemize.cpp
+++ b/src/cpp/openjtalk_phonemize.cpp
@@ -112,13 +112,9 @@ void phonemize_openjtalk(const std::string &text,
   // Use OpenJTalk to extract full-context labels
   HTS_Label_Wrapper *labels = openjtalk_extract_fullcontext(oj, text.c_str());
   if (!labels) {
-    spdlog::error("OpenJTalk failed; using fallback codepoints");
-    std::vector<Phoneme> line;
-    for (auto it = text.begin(); it != text.end(); ) {
-      auto cp = utf8::next(it, text.end());
-      line.push_back(cp);
-    }
-    sentences.push_back(line);
+    spdlog::error("OpenJTalk failed to extract phonemes");
+    // Return empty sentences to indicate failure
+    // This will prevent the crash from trying to map Japanese characters
     return;
   }
 

--- a/src/cpp/openjtalk_phonemize.cpp
+++ b/src/cpp/openjtalk_phonemize.cpp
@@ -129,6 +129,11 @@ void phonemize_openjtalk(const std::string &text,
     if (pos1 == std::string::npos || pos2 == std::string::npos || pos2 <= pos1)
       continue;
     std::string token = lab.substr(pos1 + 1, pos2 - pos1 - 1);
+    // Skip invalid tokens (e.g., error messages that might contain ">")
+    if (token.find('>') != std::string::npos) {
+      spdlog::warn("Skipping invalid token containing '>': {}", token);
+      continue;
+    }
     if (token == "sil" && i == 0) {
       currentSentence.push_back(mapPhonemeStr("^"));
       continue;

--- a/src/cpp/openjtalk_phonemize.cpp
+++ b/src/cpp/openjtalk_phonemize.cpp
@@ -103,13 +103,9 @@ void phonemize_openjtalk(const std::string &text,
                          std::vector<std::vector<Phoneme>> &sentences) {
   ensure_init();
   if (!oj) {
-    // Fallback: treat whole text as one sentence of codepoints
-    std::vector<Phoneme> line;
-    for (auto it = text.begin(); it != text.end(); ) {
-      auto cp = utf8::next(it, text.end());
-      line.push_back(cp);
-    }
-    sentences.push_back(line);
+    // OpenJTalk not available - this should only happen for English text
+    // Don't try to apply PUA mapping on regular text
+    // Just return empty to indicate phonemization failed
     return;
   }
 

--- a/src/cpp/openjtalk_wrapper.c
+++ b/src/cpp/openjtalk_wrapper.c
@@ -44,6 +44,8 @@ OpenJTalk* openjtalk_initialize() {
         "../../build/oj/bin/open_jtalk",
         "/usr/local/bin/open_jtalk",
         "/usr/bin/open_jtalk",
+        "/opt/homebrew/bin/open_jtalk",  // macOS ARM64 homebrew
+        "/opt/local/bin/open_jtalk",      // macOS MacPorts
         NULL
     };
     
@@ -158,13 +160,14 @@ HTS_Label_Wrapper* openjtalk_extract_fullcontext(OpenJTalk* oj, const char* text
     close(output_fd);
     close(trace_fd);
     
-    // Run open_jtalk with trace output
+    // Run open_jtalk with trace output only (no voice synthesis)
     pid_t pid = fork();
     if (pid == 0) {
         // Child process
+        // Note: We don't use -m (HTS voice) or -ow (output wav) options
+        // This allows phoneme extraction without requiring voice model
         execl(impl->openjtalk_bin, "open_jtalk",
               "-x", impl->dic_path,
-              "-ow", output_file,
               "-ot", trace_file,
               input_file,
               NULL);

--- a/src/cpp/openjtalk_wrapper.c
+++ b/src/cpp/openjtalk_wrapper.c
@@ -2,40 +2,347 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
 
-// Simplified stub implementation for now - will be completed later
-// This allows the build to succeed while we figure out the library structure
+#ifndef _WIN32
+
+// Real OpenJTalk implementation for Unix platforms using binary execution
+struct OpenJTalk_impl {
+    char* dic_path;
+    char* openjtalk_bin;
+    int initialized;
+};
+
+struct HTS_Label_Wrapper_impl {
+    char** labels;
+    size_t size;
+    size_t capacity;
+};
 
 OpenJTalk* openjtalk_initialize() {
-    OpenJTalk* oj = (OpenJTalk*)malloc(sizeof(OpenJTalk));
+    struct OpenJTalk_impl* oj = (struct OpenJTalk_impl*)calloc(1, sizeof(struct OpenJTalk_impl));
     if (!oj) return NULL;
     
-    memset(oj, 0, sizeof(OpenJTalk));
-    oj->initialized = 0; // Set to 0 for now, will fallback to codepoints
+    // Check if dictionary exists
+    const char* dic_path = OPENJTALK_DIC_PATH;
+    if (access(dic_path, R_OK) != 0) {
+        fprintf(stderr, "OpenJTalk dictionary not found at: %s\n", dic_path);
+        free(oj);
+        return NULL;
+    }
     
-    return oj;
+    // Find open_jtalk binary
+    const char* possible_paths[] = {
+        "./oj/bin/open_jtalk",
+        "../oj/bin/open_jtalk",
+        "../../build/oj/bin/open_jtalk",
+        "/usr/local/bin/open_jtalk",
+        "/usr/bin/open_jtalk",
+        NULL
+    };
+    
+    const char* found_bin = NULL;
+    for (int i = 0; possible_paths[i] != NULL; i++) {
+        if (access(possible_paths[i], X_OK) == 0) {
+            found_bin = possible_paths[i];
+            break;
+        }
+    }
+    
+    if (!found_bin) {
+        // Try to find it relative to build directory
+        char build_path[512];
+        snprintf(build_path, sizeof(build_path), "%s/../oj/bin/open_jtalk", dic_path);
+        if (access(build_path, X_OK) == 0) {
+            found_bin = build_path;
+        }
+    }
+    
+    if (!found_bin) {
+        fprintf(stderr, "open_jtalk binary not found\n");
+        free(oj);
+        return NULL;
+    }
+    
+    oj->dic_path = strdup(dic_path);
+    oj->openjtalk_bin = strdup(found_bin);
+    oj->initialized = 1;
+    
+    return (OpenJTalk*)oj;
 }
 
 void openjtalk_finalize(OpenJTalk* oj) {
     if (!oj) return;
+    
+    struct OpenJTalk_impl* impl = (struct OpenJTalk_impl*)oj;
+    
+    if (impl->dic_path) free(impl->dic_path);
+    if (impl->openjtalk_bin) free(impl->openjtalk_bin);
+    
     free(oj);
 }
 
-HTS_Label_Wrapper* openjtalk_extract_fullcontext(OpenJTalk* oj, const char* text) {
-    if (!oj || !text) return NULL;
+// Parse phoneme from OpenJTalk label format
+static char* extract_phoneme_from_label(const char* label) {
+    // OpenJTalk label format includes phoneme after "-" and before "+"
+    // Example: "xx^xx-sil+xx=xx/A:xx..."
+    const char* start = strchr(label, '-');
+    if (!start) return NULL;
+    start++; // Skip '-'
     
-    // Return NULL to trigger fallback behavior in phonemize function
+    const char* end = strchr(start, '+');
+    if (!end) return NULL;
+    
+    size_t len = end - start;
+    if (len == 0) return NULL;
+    
+    char* phoneme = (char*)malloc(len + 1);
+    if (!phoneme) return NULL;
+    
+    strncpy(phoneme, start, len);
+    phoneme[len] = '\0';
+    
+    return phoneme;
+}
+
+HTS_Label_Wrapper* openjtalk_extract_fullcontext(OpenJTalk* oj, const char* text) {
+    if (!oj || !text || strlen(text) == 0) return NULL;
+    
+    struct OpenJTalk_impl* impl = (struct OpenJTalk_impl*)oj;
+    if (!impl->initialized) return NULL;
+    
+    // Create temporary files
+    char input_file[] = "/tmp/openjtalk_input_XXXXXX";
+    char output_file[] = "/tmp/openjtalk_output_XXXXXX";
+    char trace_file[] = "/tmp/openjtalk_trace_XXXXXX";
+    
+    int input_fd = mkstemp(input_file);
+    if (input_fd < 0) return NULL;
+    
+    int output_fd = mkstemp(output_file);
+    if (output_fd < 0) {
+        close(input_fd);
+        unlink(input_file);
+        return NULL;
+    }
+    
+    int trace_fd = mkstemp(trace_file);
+    if (trace_fd < 0) {
+        close(input_fd);
+        close(output_fd);
+        unlink(input_file);
+        unlink(output_file);
+        return NULL;
+    }
+    
+    // Write input text
+    FILE* fp = fdopen(input_fd, "w");
+    if (!fp) {
+        close(input_fd);
+        close(output_fd);
+        close(trace_fd);
+        unlink(input_file);
+        unlink(output_file);
+        unlink(trace_file);
+        return NULL;
+    }
+    
+    fprintf(fp, "%s\n", text);
+    fclose(fp);
+    close(output_fd);
+    close(trace_fd);
+    
+    // Run open_jtalk with trace output
+    pid_t pid = fork();
+    if (pid == 0) {
+        // Child process
+        execl(impl->openjtalk_bin, "open_jtalk",
+              "-x", impl->dic_path,
+              "-ow", output_file,
+              "-ot", trace_file,
+              input_file,
+              NULL);
+        _exit(1);
+    } else if (pid < 0) {
+        // Fork failed
+        unlink(input_file);
+        unlink(output_file);
+        unlink(trace_file);
+        return NULL;
+    }
+    
+    // Wait for process
+    int status;
+    waitpid(pid, &status, 0);
+    
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        unlink(input_file);
+        unlink(output_file);
+        unlink(trace_file);
+        return NULL;
+    }
+    
+    // Read trace file for labels
+    fp = fopen(trace_file, "r");
+    if (!fp) {
+        unlink(input_file);
+        unlink(output_file);
+        unlink(trace_file);
+        return NULL;
+    }
+    
+    // Create wrapper
+    struct HTS_Label_Wrapper_impl* wrapper = (struct HTS_Label_Wrapper_impl*)calloc(1, sizeof(struct HTS_Label_Wrapper_impl));
+    if (!wrapper) {
+        fclose(fp);
+        unlink(input_file);
+        unlink(output_file);
+        unlink(trace_file);
+        return NULL;
+    }
+    
+    // Read labels
+    char line[4096];
+    size_t capacity = 64;
+    wrapper->labels = (char**)calloc(capacity, sizeof(char*));
+    if (!wrapper->labels) {
+        free(wrapper);
+        fclose(fp);
+        unlink(input_file);
+        unlink(output_file);
+        unlink(trace_file);
+        return NULL;
+    }
+    
+    wrapper->size = 0;
+    wrapper->capacity = capacity;
+    
+    while (fgets(line, sizeof(line), fp)) {
+        // Remove newline
+        size_t len = strlen(line);
+        if (len > 0 && line[len-1] == '\n') {
+            line[len-1] = '\0';
+        }
+        
+        // Skip empty lines
+        if (strlen(line) == 0) continue;
+        
+        // Check if this is a label line (contains phoneme information)
+        if (strstr(line, "-") && strstr(line, "+") && strstr(line, "/")) {
+            // Grow array if needed
+            if (wrapper->size >= wrapper->capacity) {
+                size_t new_capacity = wrapper->capacity * 2;
+                char** new_labels = (char**)realloc(wrapper->labels, new_capacity * sizeof(char*));
+                if (!new_labels) {
+                    // Cleanup on error
+                    for (size_t i = 0; i < wrapper->size; i++) {
+                        free(wrapper->labels[i]);
+                    }
+                    free(wrapper->labels);
+                    free(wrapper);
+                    fclose(fp);
+                    unlink(input_file);
+                    unlink(output_file);
+                    unlink(trace_file);
+                    return NULL;
+                }
+                wrapper->labels = new_labels;
+                wrapper->capacity = new_capacity;
+            }
+            
+            // Store the full label
+            wrapper->labels[wrapper->size] = strdup(line);
+            if (!wrapper->labels[wrapper->size]) {
+                // Cleanup on error
+                for (size_t i = 0; i < wrapper->size; i++) {
+                    free(wrapper->labels[i]);
+                }
+                free(wrapper->labels);
+                free(wrapper);
+                fclose(fp);
+                unlink(input_file);
+                unlink(output_file);
+                unlink(trace_file);
+                return NULL;
+            }
+            wrapper->size++;
+        }
+    }
+    
+    fclose(fp);
+    
+    // Cleanup temp files
+    unlink(input_file);
+    unlink(output_file);
+    unlink(trace_file);
+    
+    if (wrapper->size == 0) {
+        free(wrapper->labels);
+        free(wrapper);
+        return NULL;
+    }
+    
+    return (HTS_Label_Wrapper*)wrapper;
+}
+
+size_t HTS_Label_get_size(HTS_Label_Wrapper* label) {
+    if (!label) return 0;
+    struct HTS_Label_Wrapper_impl* impl = (struct HTS_Label_Wrapper_impl*)label;
+    return impl->size;
+}
+
+const char* HTS_Label_get_string(HTS_Label_Wrapper* label, size_t index) {
+    if (!label) return NULL;
+    struct HTS_Label_Wrapper_impl* impl = (struct HTS_Label_Wrapper_impl*)label;
+    if (index >= impl->size) return NULL;
+    return impl->labels[index];
+}
+
+void HTS_Label_clear(HTS_Label_Wrapper* label) {
+    if (!label) return;
+    struct HTS_Label_Wrapper_impl* impl = (struct HTS_Label_Wrapper_impl*)label;
+    
+    if (impl->labels) {
+        for (size_t i = 0; i < impl->size; i++) {
+            free(impl->labels[i]);
+        }
+        free(impl->labels);
+    }
+    
+    free(label);
+}
+
+#else
+
+// Windows stub implementation
+OpenJTalk* openjtalk_initialize() {
+    return NULL;
+}
+
+void openjtalk_finalize(OpenJTalk* oj) {
+    (void)oj;
+}
+
+HTS_Label_Wrapper* openjtalk_extract_fullcontext(OpenJTalk* oj, const char* text) {
+    (void)oj;
+    (void)text;
     return NULL;
 }
 
 size_t HTS_Label_get_size(HTS_Label_Wrapper* label) {
+    (void)label;
     return 0;
 }
 
 const char* HTS_Label_get_string(HTS_Label_Wrapper* label, size_t index) {
+    (void)label;
+    (void)index;
     return NULL;
 }
 
 void HTS_Label_clear(HTS_Label_Wrapper* label) {
-    if (label) free(label);
+    (void)label;
 }
+
+#endif // _WIN32

--- a/src/cpp/openjtalk_wrapper.c
+++ b/src/cpp/openjtalk_wrapper.c
@@ -39,9 +39,14 @@ OpenJTalk* openjtalk_initialize() {
     
     // Find open_jtalk binary
     const char* possible_paths[] = {
+        // Check relative to piper binary first (for packaged version)
+        "../bin/open_jtalk",              // When piper is in bin/ directory
+        "./open_jtalk",                   // Same directory as piper
+        // Build directory paths
         "./oj/bin/open_jtalk",
         "../oj/bin/open_jtalk",
         "../../build/oj/bin/open_jtalk",
+        // System paths
         "/usr/local/bin/open_jtalk",
         "/usr/bin/open_jtalk",
         "/opt/homebrew/bin/open_jtalk",  // macOS ARM64 homebrew
@@ -67,7 +72,11 @@ OpenJTalk* openjtalk_initialize() {
     }
     
     if (!found_bin) {
-        fprintf(stderr, "open_jtalk binary not found\n");
+        fprintf(stderr, "open_jtalk binary not found. Searched paths:\n");
+        for (int i = 0; possible_paths[i] != NULL; i++) {
+            fprintf(stderr, "  %s\n", possible_paths[i]);
+        }
+        fprintf(stderr, "Please ensure OpenJTalk is installed or built\n");
         free(oj);
         return NULL;
     }

--- a/src/cpp/openjtalk_wrapper.c
+++ b/src/cpp/openjtalk_wrapper.c
@@ -24,10 +24,15 @@ OpenJTalk* openjtalk_initialize() {
     struct OpenJTalk_impl* oj = (struct OpenJTalk_impl*)calloc(1, sizeof(struct OpenJTalk_impl));
     if (!oj) return NULL;
     
-    // Check if dictionary exists
-    const char* dic_path = OPENJTALK_DIC_PATH;
+    // Check if dictionary exists - prefer environment variable
+    const char* dic_path = getenv("OPENJTALK_DICTIONARY_DIR");
+    if (!dic_path) {
+        dic_path = OPENJTALK_DIC_PATH;
+    }
+    
     if (access(dic_path, R_OK) != 0) {
         fprintf(stderr, "OpenJTalk dictionary not found at: %s\n", dic_path);
+        fprintf(stderr, "Please set OPENJTALK_DICTIONARY_DIR environment variable or install dictionary at the default location\n");
         free(oj);
         return NULL;
     }

--- a/src/cpp/openjtalk_wrapper.h
+++ b/src/cpp/openjtalk_wrapper.h
@@ -7,14 +7,9 @@ extern "C" {
 
 #include <stdlib.h>
 
-// Simplified wrapper structures (stub implementation)
-typedef struct {
-    int initialized;
-} OpenJTalk;
-
-typedef struct {
-    int valid;
-} HTS_Label_Wrapper;
+// Forward declarations
+typedef struct OpenJTalk_impl OpenJTalk;
+typedef struct HTS_Label_Wrapper_impl HTS_Label_Wrapper;
 
 // Main API functions
 OpenJTalk* openjtalk_initialize();

--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -594,6 +594,13 @@ void textToAudio(PiperConfig &config, Voice &voice, std::string text,
   } else if (voice.phonemizeConfig.phonemeType == OpenJTalkPhonemes) {
     // Japanese OpenJTalk phonemizer
     phonemize_openjtalk(text, phonemes);
+    
+    // If OpenJTalk failed, fall back to codepoints to prevent crash
+    if (phonemes.empty()) {
+      spdlog::warn("OpenJTalk returned empty phonemes, falling back to codepoints");
+      CodepointsPhonemeConfig codepointsConfig;
+      phonemize_codepoints(text, codepointsConfig, phonemes);
+    }
 #endif
   } else {
     // Use UTF-8 codepoints as "phonemes"

--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -15,6 +15,7 @@
 #include "piper.hpp"
 #include "utf8.h"
 #include "wavfile.hpp"
+#include "openjtalk_phonemize.hpp"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -592,11 +593,7 @@ void textToAudio(PiperConfig &config, Voice &voice, std::string text,
 #if !defined(_WIN32) && !defined(_MSC_VER)
   } else if (voice.phonemizeConfig.phonemeType == OpenJTalkPhonemes) {
     // Japanese OpenJTalk phonemizer
-    // phonemize_openjtalk(text, phonemes); // Temporarily disabled for CI/CD
-    // Fallback to text
-    spdlog::warn("OpenJTalk temporarily disabled, falling back to text phonemes");
-    CodepointsPhonemeConfig codepointsConfig;
-    phonemize_codepoints(text, codepointsConfig, phonemes);
+    phonemize_openjtalk(text, phonemes);
 #endif
   } else {
     // Use UTF-8 codepoints as "phonemes"

--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -29,9 +29,9 @@
 #include <mach-o/dyld.h>
 #endif
 
-// Only include OpenJTalk on Unix platforms
+// Only include OpenJTalk on Unix platforms (not Windows)
 #if !defined(_WIN32) && !defined(_MSC_VER)
-#include "openjtalk_phonemize.hpp"
+// #include "openjtalk_phonemize.hpp" // Temporarily disabled for CI/CD
 #endif
 
 namespace piper {
@@ -592,7 +592,11 @@ void textToAudio(PiperConfig &config, Voice &voice, std::string text,
 #if !defined(_WIN32) && !defined(_MSC_VER)
   } else if (voice.phonemizeConfig.phonemeType == OpenJTalkPhonemes) {
     // Japanese OpenJTalk phonemizer
-    phonemize_openjtalk(text, phonemes);
+    // phonemize_openjtalk(text, phonemes); // Temporarily disabled for CI/CD
+    // Fallback to text
+    spdlog::warn("OpenJTalk temporarily disabled, falling back to text phonemes");
+    CodepointsPhonemeConfig codepointsConfig;
+    phonemize_codepoints(text, codepointsConfig, phonemes);
 #endif
   } else {
     // Use UTF-8 codepoints as "phonemes"

--- a/src/cpp/piper.hpp
+++ b/src/cpp/piper.hpp
@@ -34,7 +34,13 @@ struct PiperConfig {
   std::unique_ptr<tashkeel::State> tashkeelState;
 };
 
-enum PhonemeType { eSpeakPhonemes, TextPhonemes, OpenJTalkPhonemes };
+enum PhonemeType { 
+  eSpeakPhonemes, 
+  TextPhonemes
+#if !defined(_WIN32) && !defined(_MSC_VER)
+  , OpenJTalkPhonemes
+#endif
+};
 
 struct PhonemizeConfig {
   PhonemeType phonemeType = eSpeakPhonemes;

--- a/src/python/piper_train/phonemize/token_mapper.py
+++ b/src/python/piper_train/phonemize/token_mapper.py
@@ -1,9 +1,49 @@
 # 新規追加ファイル: 多文字音素→1文字(コードポイント) 変換を共通提供
+# This mapping must match the C++ implementation in openjtalk_phonemize.cpp
+
+# Fixed PUA mapping table to ensure consistency between Python and C++
+FIXED_PUA_MAPPING = {
+    # Long vowels
+    "a:": 0xE000,
+    "i:": 0xE001,
+    "u:": 0xE002,
+    "e:": 0xE003,
+    "o:": 0xE004,
+    # Special consonants
+    "cl": 0xE005,
+    # Palatalized consonants
+    "ky": 0xE006,
+    "kw": 0xE007,
+    "gy": 0xE008,
+    "gw": 0xE009,
+    "ty": 0xE00A,
+    "dy": 0xE00B,
+    "py": 0xE00C,
+    "by": 0xE00D,
+    # Affricates and special sounds
+    "ch": 0xE00E,
+    "ts": 0xE00F,
+    "sh": 0xE010,
+    "zy": 0xE011,
+    "hy": 0xE012,
+    # Palatalized nasals/liquids
+    "ny": 0xE013,
+    "my": 0xE014,
+    "ry": 0xE015
+}
+
+# Build bidirectional mappings
 TOKEN2CHAR = {}
 CHAR2TOKEN = {}
 
-# Private Use Area 開始位置
-_PUA_START = 0xE000
+# Initialize with fixed mappings
+for token, codepoint in FIXED_PUA_MAPPING.items():
+    ch = chr(codepoint)
+    TOKEN2CHAR[token] = ch
+    CHAR2TOKEN[ch] = token
+
+# Private Use Area for dynamic allocation (starting after fixed mappings)
+_PUA_START = 0xE020  # Start after the last fixed mapping
 _next = _PUA_START
 
 def register(token: str) -> str:
@@ -18,7 +58,7 @@ def register(token: str) -> str:
         CHAR2TOKEN[token] = token
         return token
 
-    # 割り当て
+    # 動的割り当て（固定マッピングに含まれていない場合）
     ch = chr(_next)
     _next += 1
     TOKEN2CHAR[token] = ch

--- a/src/python/piper_train/update_model_config.py
+++ b/src/python/piper_train/update_model_config.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Update existing Piper model configurations to use PUA phoneme mappings.
+
+This script modifies model JSON configuration files to replace multi-character
+phonemes with their corresponding Private Use Area (PUA) single-character
+representations, ensuring compatibility between Python training and C++ inference.
+"""
+
+import json
+import argparse
+import shutil
+from pathlib import Path
+from typing import Dict, List, Any
+from piper_train.phonemize.token_mapper import FIXED_PUA_MAPPING, TOKEN2CHAR, CHAR2TOKEN
+
+
+def update_phoneme_id_map(config: Dict[str, Any]) -> bool:
+    """
+    Update the phoneme_id_map in a model configuration to use PUA characters.
+    
+    Args:
+        config: The model configuration dictionary
+        
+    Returns:
+        bool: True if any changes were made, False otherwise
+    """
+    if "phoneme_id_map" not in config:
+        print("Warning: No phoneme_id_map found in configuration")
+        return False
+    
+    phoneme_id_map = config["phoneme_id_map"]
+    new_phoneme_id_map = {}
+    changes_made = False
+    
+    # Process each phoneme in the map
+    for phoneme, ids in phoneme_id_map.items():
+        # Check if this is a multi-character phoneme that needs PUA mapping
+        if phoneme in FIXED_PUA_MAPPING:
+            # Replace with PUA character
+            pua_char = TOKEN2CHAR[phoneme]
+            new_phoneme_id_map[pua_char] = ids
+            changes_made = True
+            print(f"  Mapped: '{phoneme}' -> U+{ord(pua_char):04X} ('{pua_char}')")
+        else:
+            # Keep single-character phonemes as-is
+            new_phoneme_id_map[phoneme] = ids
+    
+    # Replace the phoneme_id_map
+    config["phoneme_id_map"] = new_phoneme_id_map
+    
+    return changes_made
+
+
+def process_model_config(config_path: Path, backup: bool = True) -> None:
+    """
+    Process a single model configuration file.
+    
+    Args:
+        config_path: Path to the JSON configuration file
+        backup: Whether to create a backup of the original file
+    """
+    print(f"\nProcessing: {config_path}")
+    
+    # Read the configuration
+    try:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+    except Exception as e:
+        print(f"Error reading {config_path}: {e}")
+        return
+    
+    # Check if this is a Japanese model
+    phoneme_type = config.get("phoneme_type", config.get("espeak", {}).get("voice", ""))
+    if "openjtalk" not in phoneme_type.lower() and "ja" not in str(config_path).lower():
+        print("  Skipping: Not a Japanese model")
+        return
+    
+    # Create backup if requested
+    if backup:
+        backup_path = config_path.with_suffix('.json.bak')
+        shutil.copy2(config_path, backup_path)
+        print(f"  Created backup: {backup_path}")
+    
+    # Update the phoneme mappings
+    if update_phoneme_id_map(config):
+        # Write the updated configuration
+        with open(config_path, 'w', encoding='utf-8') as f:
+            json.dump(config, f, ensure_ascii=False, indent=2)
+        print("  Configuration updated successfully")
+    else:
+        print("  No changes needed")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Update Piper model configurations to use PUA phoneme mappings"
+    )
+    parser.add_argument(
+        "configs",
+        nargs="+",
+        type=Path,
+        help="Path(s) to model configuration JSON files"
+    )
+    parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Don't create backup files"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be changed without modifying files"
+    )
+    
+    args = parser.parse_args()
+    
+    print("PUA Phoneme Mapping Update Tool")
+    print("=" * 40)
+    print("\nFixed PUA mappings:")
+    for phoneme, codepoint in sorted(FIXED_PUA_MAPPING.items()):
+        print(f"  {phoneme:3s} -> U+{codepoint:04X}")
+    
+    # Process each configuration file
+    for config_path in args.configs:
+        if not config_path.exists():
+            print(f"\nError: {config_path} does not exist")
+            continue
+        
+        if not config_path.suffix == '.json':
+            print(f"\nWarning: {config_path} is not a JSON file, skipping")
+            continue
+        
+        if args.dry_run:
+            print(f"\n[DRY RUN] Would process: {config_path}")
+            # Just show what would be done
+            with open(config_path, 'r', encoding='utf-8') as f:
+                config = json.load(f)
+            phoneme_id_map = config.get("phoneme_id_map", {})
+            for phoneme in phoneme_id_map:
+                if phoneme in FIXED_PUA_MAPPING:
+                    pua_char = TOKEN2CHAR[phoneme]
+                    print(f"  Would map: '{phoneme}' -> U+{ord(pua_char):04X}")
+        else:
+            process_model_config(config_path, backup=not args.no_backup)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_japanese_tts.sh
+++ b/test_japanese_tts.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Japanese TTS test script for piper
+# This script downloads necessary files and tests Japanese TTS
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+echo "=== Japanese TTS Test Script ==="
+
+# 1. Download OpenJTalk dictionary if not exists
+if [ ! -d "build/naist-jdic" ]; then
+    echo "Downloading OpenJTalk dictionary..."
+    cd build
+    curl -L -o dict.tar.gz "https://sourceforge.net/projects/open-jtalk/files/Dictionary/open_jtalk_dic-1.11/open_jtalk_dic_utf_8-1.11.tar.gz/download"
+    tar -xzf dict.tar.gz
+    mv open_jtalk_dic_utf_8-1.11 naist-jdic
+    rm dict.tar.gz
+    cd ..
+fi
+
+# 2. Download HTS voice model if not exists
+if [ ! -f "build/nitech_jp_atr503_m001.htsvoice" ]; then
+    echo "Downloading HTS voice model..."
+    cd build
+    curl -L -o voice.tar.gz "https://sourceforge.net/projects/open-jtalk/files/HTS%20voice/hts_voice_nitech_jp_atr503_m001-1.05/hts_voice_nitech_jp_atr503_m001-1.05.tar.gz/download"
+    tar -xzf voice.tar.gz
+    cp hts_voice_nitech_jp_atr503_m001-1.05/*.htsvoice .
+    rm -rf voice.tar.gz hts_voice_nitech_jp_atr503_m001-1.05
+    cd ..
+fi
+
+# 3. Create directory structure for piper
+echo "Setting up directory structure..."
+cd build
+mkdir -p ../share/open_jtalk
+cp -r naist-jdic ../share/open_jtalk/dic
+
+# 4. Test open_jtalk directly
+echo "Testing OpenJTalk..."
+echo "こんにちは" | open_jtalk -x naist-jdic -m nitech_jp_atr503_m001.htsvoice -ot trace.txt -ow /dev/null
+if [ -f trace.txt ]; then
+    echo "OpenJTalk trace output:"
+    head -5 trace.txt
+    rm trace.txt
+fi
+
+# 5. Run piper with Japanese text
+echo "Testing piper with Japanese text..."
+export OPENJTALK_DICTIONARY_DIR=$PWD/naist-jdic
+export DYLD_LIBRARY_PATH=$PWD/pi/lib:$DYLD_LIBRARY_PATH
+export OPENJTALK_VOICE=$PWD/nitech_jp_atr503_m001.htsvoice
+
+echo "こんにちは、音声合成のテストです。" > test_ja.txt
+
+./piper --model ../test/models/ja_JP-test-medium.onnx --output_file test_output_ja.wav < test_ja.txt
+
+if [ -f test_output_ja.wav ]; then
+    echo "Success! Generated test_output_ja.wav"
+    ls -la test_output_ja.wav
+    
+    # Play if afplay is available
+    if command -v afplay &> /dev/null; then
+        echo "Playing audio..."
+        afplay test_output_ja.wav
+    fi
+else
+    echo "Error: Failed to generate audio"
+fi
+
+cd ..


### PR DESCRIPTION
## 概要
このPRは、日本語TTSにおける複数文字音素の分割問題を修正するため、Private Use Area (PUA) Unicode マッピングを実装します。Issue #34 に対応しています。

> **Note**: このPRは #38 を整理されたコミット履歴で置き換えるものです。元のPRには76件のコミットが含まれていましたが、レビューを容易にするため整理しました。

## 🎉 主な成果

### ✅ 解決した問題
1. **複数文字音素の保持**: 「ch」「ts」「sh」「ky」などが個別文字に分割される問題を解決
2. **配布パッケージの問題**: GitHub Actionsでビルドされたバイナリに必要なコンポーネントが含まれていない問題を修正
3. **クロスプラットフォーム対応**: Linux、Windows、macOSで動作確認済み

### 🚀 動作確認済み
- ローカルビルドとGitHub Actionsビルドの両方で日本語音声生成が正常に動作
- 既存の日本語モデルは**再学習不要**（設定ファイルの更新のみで対応可能）

## 変更内容

### 1. コアPUA音素マッピング実装
- 🎯 複数文字音素用のPUAマッピング（U+E000-U+E015）を実装
- 🐍 PythonとC++の実装を一致させるため、固定マッピングテーブルを追加
- 🔧 既存モデルを変換するためのモデル設定更新スクリプトを作成
- ✅ 以下の音素の保持を修正: ch, ts, sh, ky, gy, ty, dy, py, by, ch, cl, hy, ny, my, ry, kw, gw, zy

### 2. OpenJTalk統合
- 🔨 HTSEngineとOpenJTalkをCMakeの外部依存として設定
- 📦 公式SourceForgeリポジトリからダウンロード
- 🚀 バイナリ実行アプローチでOpenJTalkラッパーを実装（複雑な内部APIを回避）
- 🇯🇵 OpenJTalkによる適切な日本語音素抽出をサポート
- 🪟 Windowsはスタブ実装を維持
- 📱 **NEW**: 配布パッケージにOpenJTalkバイナリと辞書を含めるよう修正

### 3. CI/CD改善
- 🧪 日本語TTSの自動テストを追加
- ✅ Linux (amd64)、Windows (x64)、macOS (x64/aarch64)で全テスト合格
- 📚 NAIST日本語辞書の自動ダウンロード
- 🔧 macOSライブラリ依存関係の修正
- 📦 HTSボイスモデルの自動ダウンロード

### 4. ドキュメント
- 📖 PUA音素マッピングの包括的なドキュメント (`docs/PUA_PHONEME_MAPPING.md`)
- 📚 日本語使用ガイド (`JAPANESE_USAGE.md`) - 環境設定手順を含む
- 💡 使用例とモデル互換性情報
- 🔍 トラブルシューティングガイド

## テスト結果
- ✅ Windowsビルド: 成功
- ✅ Linuxビルド: 成功 (amd64)
- ✅ macOSビルド: 成功 (x64/aarch64)
- ✅ 全CI/CDテスト: 合格
- ✅ GitHub Actionsからダウンロードしたバイナリでの日本語音声生成: 成功

## 使用方法

### 日本語TTSの使用
```bash
# 環境変数の設定
export OPENJTALK_DICTIONARY_DIR=/path/to/open_jtalk_dic_utf_8-1.11
export OPENJTALK_VOICE=/path/to/nitech_jp_atr503_m001.htsvoice
export ESPEAK_DATA_PATH=/path/to/piper/share/espeak-ng-data

# 日本語モデルで実行
echo "こんにちは、音声合成のテストです" | piper --model ja_JP-model.onnx --output_file output.wav
```

詳細な設定手順は[JAPANESE_USAGE.md](JAPANESE_USAGE.md)を参照してください。

### 既存モデルの更新（再学習不要）
```bash
# PUAマッピング用にモデル設定を更新
python -m piper_train.update_model_config path/to/model.onnx.json
```

## 注意事項
- OpenJTalkは簡潔性のためライブラリリンクではなくバイナリ実行を使用
- 日本語TTSには辞書とHTSボイスモデルを別途ダウンロードする必要があります（[JAPANESE_USAGE.md](JAPANESE_USAGE.md)参照）
- ARM64 Linuxサポートは将来のリリースで追加予定（#42）

## 今後の改善（別Issueで対応）
- #40: OpenJTalkの内部API統合（ヘッダー依存の解決）
- #32: Windows向けの完全な実装
- #42: ARM64 Linuxサポートの追加
- #41: 辞書の自動ダウンロード機能
- #43: 日本語TTSチュートリアルとサンプルの追加

## 最近の修正
- ✨ OpenJTalkバイナリを配布パッケージに含めるよう修正（f46c558）
- 📝 日本語TTSモデルのダウンロード手順を追加（52ac5cb）
- 🐛 OpenJTalkの無効な音素トークンのエッジケースを修正（76a1d4e）
- 📚 環境設定ドキュメントの追加（c472d3f）

Fixes #34