### PR TITLE
feat: Enable Windows OpenJTalk support with C++17 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,18 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
+
+# Set runtime library BEFORE project() to ensure it's applied globally
+if(MSVC)
+  # Use dynamic runtime library to match ONNX Runtime
+  # This is required for compatibility with pre-built ONNX Runtime binaries
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL$<$<CONFIG:Debug>:Debug>" CACHE STRING "MSVC Runtime Library" FORCE)
+  # Ensure new CMake policy for MSVC runtime library selection
+  cmake_policy(SET CMP0091 NEW)
+endif()
 
 project(piper C CXX)
 
 file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" piper_version)
+string(STRIP "${piper_version}" piper_version)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -11,7 +21,19 @@ if(MSVC)
   # Force compiler to use UTF-8 for IPA constants
   add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
   add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
-elseif(NOT APPLE)
+  
+  # Additional Windows-specific flags
+  add_compile_options(/EHsc)  # Enable C++ exceptions
+  add_compile_options(/W3)    # Warning level 3
+  
+  # Define Windows version macros
+  add_compile_definitions(WIN32_LEAN_AND_MEAN)
+  add_compile_definitions(_WIN32_WINNT=0x0601)  # Windows 7 and later
+elseif(APPLE)
+  # macOS flags
+  string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra")
+  string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
+else()
   # Linux flags
   string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wl,-rpath,'$ORIGIN'")
   string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
@@ -19,6 +41,57 @@ endif()
 
 add_executable(piper src/cpp/main.cpp src/cpp/piper.cpp)
 add_executable(test_piper src/cpp/test.cpp src/cpp/piper.cpp)
+
+
+# Testing support
+option(BUILD_TESTS "Build unit tests" OFF)
+if(BUILD_TESTS)
+  enable_testing()
+  
+  # Use FetchContent for Google Test
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+  )
+  # For Windows: Prevent overriding the parent project's compiler/linker settings
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(googletest)
+  
+  # Only add tests directory if it exists
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/tests")
+    add_subdirectory(src/cpp/tests)
+  endif()
+endif()
+
+# Add OpenJTalk support on all platforms
+target_sources(piper PRIVATE
+  src/cpp/openjtalk_phonemize.cpp
+  src/cpp/openjtalk_wrapper.c
+  src/cpp/openjtalk_dictionary_manager.c
+)
+target_sources(test_piper PRIVATE
+  src/cpp/openjtalk_phonemize.cpp
+  src/cpp/openjtalk_wrapper.c
+  src/cpp/openjtalk_dictionary_manager.c
+)
+
+
+# Configure RPATH for macOS
+if(APPLE)
+  set_target_properties(piper PROPERTIES
+    MACOSX_RPATH TRUE
+    INSTALL_RPATH "@executable_path/../lib;@loader_path/../lib;${PIPER_PHONEMIZE_DIR}/lib"
+    BUILD_WITH_INSTALL_RPATH FALSE
+    BUILD_RPATH "${PIPER_PHONEMIZE_DIR}/lib"
+  )
+  set_target_properties(test_piper PROPERTIES
+    MACOSX_RPATH TRUE
+    INSTALL_RPATH "@executable_path/../lib;@loader_path/../lib;${PIPER_PHONEMIZE_DIR}/lib"
+    BUILD_WITH_INSTALL_RPATH FALSE
+    BUILD_RPATH "${PIPER_PHONEMIZE_DIR}/lib"
+  )
+endif()
 
 # NOTE: external project prefix are shortened because of path length restrictions on Windows
 # NOTE: onnxruntime is pulled from piper-phonemize
@@ -30,12 +103,33 @@ if(NOT DEFINED FMT_DIR)
   set(FMT_DIR "${CMAKE_CURRENT_BINARY_DIR}/fi")
 
   include(ExternalProject)
+  # Pass architecture settings to external projects
+  if(APPLE AND CMAKE_OSX_ARCHITECTURES)
+    set(EXTERNAL_CMAKE_ARGS -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES})
+  else()
+    set(EXTERNAL_CMAKE_ARGS "")
+  endif()
+  
+  # Ensure MSVC runtime library is propagated to all external projects
+  if(MSVC)
+    list(APPEND EXTERNAL_CMAKE_ARGS
+      -DCMAKE_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}
+      -DCMAKE_POLICY_DEFAULT_CMP0091=NEW
+      -DCMAKE_CXX_FLAGS_RELEASE=/MD
+      -DCMAKE_CXX_FLAGS_DEBUG=/MDd
+      -DCMAKE_C_FLAGS_RELEASE=/MD
+      -DCMAKE_C_FLAGS_DEBUG=/MDd
+    )
+  endif()
+
   ExternalProject_Add(
     fmt_external
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/f"
     URL "https://github.com/fmtlib/fmt/archive/refs/tags/${FMT_VERSION}.zip"
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${FMT_DIR}
-    CMAKE_ARGS -DFMT_TEST:BOOL=OFF  # Don't build all the tests
+               -DFMT_TEST:BOOL=OFF  # Don't build all the tests
+               -DBUILD_SHARED_LIBS:BOOL=OFF  # Build static libraries
+               ${EXTERNAL_CMAKE_ARGS}
   )
   add_dependencies(piper fmt_external)
   add_dependencies(test_piper fmt_external)
@@ -51,6 +145,8 @@ if(NOT DEFINED SPDLOG_DIR)
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/s"
     URL "https://github.com/gabime/spdlog/archive/refs/tags/v${SPDLOG_VERSION}.zip"
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${SPDLOG_DIR}
+               -DSPDLOG_BUILD_SHARED:BOOL=OFF  # Build static libraries
+               ${EXTERNAL_CMAKE_ARGS}
   )
   add_dependencies(piper spdlog_external)
   add_dependencies(test_piper spdlog_external)
@@ -60,19 +156,157 @@ endif()
 
 if(NOT DEFINED PIPER_PHONEMIZE_DIR)
   set(PIPER_PHONEMIZE_DIR "${CMAKE_CURRENT_BINARY_DIR}/pi")
+  # On Windows, we need espeak-ng as a shared library for proper functioning
+  if(WIN32)
+    set(PIPER_PHONEMIZE_SHARED_LIBS ON)
+  else()
+    set(PIPER_PHONEMIZE_SHARED_LIBS OFF)
+  endif()
+  
   ExternalProject_Add(
     piper_phonemize_external
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/p"
     URL "https://github.com/rhasspy/piper-phonemize/archive/refs/heads/master.zip"
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${PIPER_PHONEMIZE_DIR}
+    CMAKE_ARGS -DBUILD_SHARED_LIBS:BOOL=${PIPER_PHONEMIZE_SHARED_LIBS}
+    CMAKE_ARGS -DESPEAK_NG_BUILD_SHARED:BOOL=${PIPER_PHONEMIZE_SHARED_LIBS}
+    CMAKE_ARGS -DCMAKE_MSVC_RUNTIME_LIBRARY:STRING=${CMAKE_MSVC_RUNTIME_LIBRARY}
+    CMAKE_ARGS ${EXTERNAL_CMAKE_ARGS}
   )
   add_dependencies(piper piper_phonemize_external)
   add_dependencies(test_piper piper_phonemize_external)
 endif()
 
+# Runtime library is already set globally via CMAKE_MSVC_RUNTIME_LIBRARY
+# No need to set per-target properties
+
+# ---- ONNX Runtime for Windows ---
+if(WIN32)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/find_onnxruntime_windows.cmake)
+endif()
+
+# ---- HTSEngine ---
+
+# Build HTSEngine on all platforms
+if(NOT DEFINED HTS_ENGINE_DIR)
+    set(HTS_ENGINE_DIR "${CMAKE_CURRENT_BINARY_DIR}/he")
+    set(HTS_ENGINE_VERSION "1.10")
+
+    if(WIN32)
+      # Use CMake build for Windows
+      ExternalProject_Add(
+        hts_engine_external
+        PREFIX "${CMAKE_CURRENT_BINARY_DIR}/h"
+        URL "https://downloads.sourceforge.net/project/hts-engine/hts_engine%20API/hts_engine_API-${HTS_ENGINE_VERSION}/hts_engine_API-${HTS_ENGINE_VERSION}.tar.gz"
+        CMAKE_ARGS 
+          -DCMAKE_INSTALL_PREFIX:PATH=${HTS_ENGINE_DIR}
+          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+          -DBUILD_SHARED_LIBS:BOOL=OFF
+          -DHTS_EMBEDDED:BOOL=OFF
+          -DCMAKE_MSVC_RUNTIME_LIBRARY:STRING=${CMAKE_MSVC_RUNTIME_LIBRARY}
+          ${EXTERNAL_CMAKE_ARGS}
+        PATCH_COMMAND ${CMAKE_COMMAND} -E copy 
+          ${CMAKE_CURRENT_SOURCE_DIR}/cmake/HTSEngine_CMakeLists.txt 
+          <SOURCE_DIR>/CMakeLists.txt
+        BUILD_BYPRODUCTS ${HTS_ENGINE_DIR}/lib/HTSEngine.lib
+      )
+    else()
+      # Use autotools for Unix platforms
+      # Set architecture flags for configure scripts
+      if(APPLE AND CMAKE_OSX_ARCHITECTURES)
+        if(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+          set(CONFIGURE_HOST "--host=x86_64-apple-darwin")
+        elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+          set(CONFIGURE_HOST "--host=aarch64-apple-darwin")
+        else()
+          set(CONFIGURE_HOST "")
+        endif()
+        set(CONFIGURE_ENV "CFLAGS=-arch ${CMAKE_OSX_ARCHITECTURES}" "CXXFLAGS=-arch ${CMAKE_OSX_ARCHITECTURES}" "LDFLAGS=-arch ${CMAKE_OSX_ARCHITECTURES}")
+      else()
+        set(CONFIGURE_HOST "")
+        set(CONFIGURE_ENV "")
+      endif()
+
+      ExternalProject_Add(
+        hts_engine_external
+        PREFIX "${CMAKE_CURRENT_BINARY_DIR}/h"
+        URL "https://downloads.sourceforge.net/project/hts-engine/hts_engine%20API/hts_engine_API-${HTS_ENGINE_VERSION}/hts_engine_API-${HTS_ENGINE_VERSION}.tar.gz"
+        CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${CONFIGURE_ENV} ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./configure --prefix=${HTS_ENGINE_DIR} ${CONFIGURE_HOST}
+        BUILD_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make install
+        BUILD_IN_SOURCE 1
+        BUILD_BYPRODUCTS ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
+      )
+    endif()
+  endif()
+
+  # ---- OpenJTalk ---
+
+  if(NOT DEFINED OPENJTALK_DIR)
+    set(OPENJTALK_DIR "${CMAKE_CURRENT_BINARY_DIR}/oj")
+    set(OPENJTALK_VERSION "1.11")
+
+    if(WIN32)
+      # Use CMake build for Windows
+      ExternalProject_Add(
+        openjtalk_external
+        PREFIX "${CMAKE_CURRENT_BINARY_DIR}/o"
+        URL "https://downloads.sourceforge.net/project/open-jtalk/Open%20JTalk/open_jtalk-${OPENJTALK_VERSION}/open_jtalk-${OPENJTALK_VERSION}.tar.gz"
+        CMAKE_ARGS 
+          -DCMAKE_INSTALL_PREFIX:PATH=${OPENJTALK_DIR}
+          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+          -DBUILD_SHARED_LIBS:BOOL=OFF
+          -DHTS_ENGINE_INCLUDE_DIR:PATH=${HTS_ENGINE_DIR}/include
+          -DHTS_ENGINE_LIB:FILEPATH=${HTS_ENGINE_DIR}/lib/HTSEngine.lib
+          -DCMAKE_MSVC_RUNTIME_LIBRARY:STRING=${CMAKE_MSVC_RUNTIME_LIBRARY}
+          ${EXTERNAL_CMAKE_ARGS}
+        PATCH_COMMAND 
+          ${CMAKE_COMMAND} -E copy 
+            ${CMAKE_CURRENT_SOURCE_DIR}/cmake/OpenJTalk_CMakeLists.txt 
+            <SOURCE_DIR>/CMakeLists.txt
+          COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_CURRENT_SOURCE_DIR}/cmake/apply_openjtalk_patch.ps1
+            <SOURCE_DIR>/apply_patch.ps1
+          COMMAND powershell -ExecutionPolicy Bypass -File <SOURCE_DIR>/apply_patch.ps1 -SourceDir <SOURCE_DIR>
+        BUILD_BYPRODUCTS
+          ${OPENJTALK_DIR}/bin/open_jtalk.exe
+        DEPENDS hts_engine_external
+      )
+    else()
+      # Use autotools for Unix platforms
+      ExternalProject_Add(
+        openjtalk_external
+        PREFIX "${CMAKE_CURRENT_BINARY_DIR}/o"
+        URL "https://downloads.sourceforge.net/project/open-jtalk/Open%20JTalk/open_jtalk-${OPENJTALK_VERSION}/open_jtalk-${OPENJTALK_VERSION}.tar.gz"
+        PATCH_COMMAND ""
+        CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${CONFIGURE_ENV} ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./configure
+          --prefix=${OPENJTALK_DIR}
+          --with-hts-engine-header-path=${HTS_ENGINE_DIR}/include
+          --with-hts-engine-library-path=${HTS_ENGINE_DIR}/lib
+          --with-charset=UTF-8
+          ${CONFIGURE_HOST}
+        BUILD_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make install
+        BUILD_IN_SOURCE 1
+        BUILD_BYPRODUCTS
+          ${OPENJTALK_DIR}/bin/open_jtalk
+        DEPENDS hts_engine_external
+      )
+    endif()
+  endif()
+
 # ---- Declare executable ----
 
-if((NOT MSVC) AND (NOT APPLE))
+if(APPLE)
+  # macOS-specific settings
+  set(PIPER_EXTRA_LIBRARIES "pthread")
+  # Find Homebrew-installed espeak-ng
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set(HOMEBREW_PREFIX "/usr/local")
+  else()
+    set(HOMEBREW_PREFIX "/opt/homebrew")
+  endif()
+elseif(NOT MSVC)
   # Linux flags
   string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wl,-rpath,'$ORIGIN'")
   string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
@@ -81,14 +315,55 @@ if((NOT MSVC) AND (NOT APPLE))
   set(PIPER_EXTRA_LIBRARIES "pthread")
 endif()
 
-target_link_libraries(piper
-  fmt
-  spdlog
-  espeak-ng
-  piper_phonemize
-  onnxruntime
-  ${PIPER_EXTRA_LIBRARIES}
-)
+# Platform-specific library linking
+if(WIN32)
+  # Windows: Link libraries directly with generator expressions for debug/release
+  target_link_libraries(piper
+    optimized ${FMT_DIR}/lib/fmt.lib
+    debug ${FMT_DIR}/lib/fmtd.lib
+    optimized ${SPDLOG_DIR}/lib/spdlog.lib
+    debug ${SPDLOG_DIR}/lib/spdlogd.lib
+    ${PIPER_PHONEMIZE_DIR}/lib/piper_phonemize.lib
+    ${PIPER_PHONEMIZE_DIR}/lib/espeak-ng.lib
+    ${ONNXRUNTIME_LIB}
+    ${PIPER_EXTRA_LIBRARIES}
+  )
+else()
+  # Unix: Use standard library names
+  target_link_libraries(piper
+    fmt
+    spdlog
+    piper_phonemize
+    espeak-ng
+    onnxruntime
+    ${PIPER_EXTRA_LIBRARIES}
+  )
+endif()
+
+# Link OpenJTalk and HTS_Engine libraries
+if(TRUE)  # HTSEngine and OpenJTalk are built on all platforms
+  # Ensure libraries are built before linking
+  add_dependencies(piper openjtalk_external hts_engine_external)
+  add_dependencies(test_piper openjtalk_external hts_engine_external)
+
+  # Link libraries with absolute paths
+  # Note: OpenJTalk doesn't create a single library, we need to link individual components
+  if(WIN32)
+    target_link_libraries(piper
+      ${CMAKE_CURRENT_BINARY_DIR}/he/lib/HTSEngine.lib
+    )
+    target_link_libraries(test_piper
+      ${CMAKE_CURRENT_BINARY_DIR}/he/lib/HTSEngine.lib
+    )
+  else()
+    target_link_libraries(piper
+      ${CMAKE_CURRENT_BINARY_DIR}/he/lib/libHTSEngine.a
+    )
+    target_link_libraries(test_piper
+      ${CMAKE_CURRENT_BINARY_DIR}/he/lib/libHTSEngine.a
+    )
+  endif()
+endif()
 
 target_link_directories(piper PUBLIC
   ${FMT_DIR}/lib
@@ -96,20 +371,56 @@ target_link_directories(piper PUBLIC
   ${PIPER_PHONEMIZE_DIR}/lib
 )
 
+# Note: We don't need Homebrew paths for espeak-ng on macOS
+# because we're using the custom build from piper_phonemize
+
 target_include_directories(piper PUBLIC
   ${FMT_DIR}/include
   ${SPDLOG_DIR}/include
   ${PIPER_PHONEMIZE_DIR}/include
 )
 
+# Add ONNX Runtime include directory for Windows
+if(WIN32 AND ONNXRUNTIME_INCLUDE_DIR)
+  target_include_directories(piper PUBLIC ${ONNXRUNTIME_INCLUDE_DIR})
+  target_include_directories(test_piper PUBLIC ${ONNXRUNTIME_INCLUDE_DIR})
+endif()
+
+# Include OpenJTalk and HTSEngine headers
+if(TRUE)  # HTSEngine and OpenJTalk are built on all platforms
+  target_include_directories(piper PUBLIC
+    ${OPENJTALK_DIR}/include
+    ${HTS_ENGINE_DIR}/include
+  )
+  target_include_directories(test_piper PUBLIC
+    ${OPENJTALK_DIR}/include
+    ${HTS_ENGINE_DIR}/include
+  )
+endif()
+
+# OpenJTalk is used via binary execution, includes not needed
+
 target_compile_definitions(piper PUBLIC _PIPER_VERSION=${piper_version})
+
+# Add OpenJTalk dictionary path definition
+if(TRUE)  # HTSEngine and OpenJTalk are built
+  # Dictionary will be downloaded by CI/CD or provided by user
+  # Use relative path from binary location for better portability
+  if(WIN32)
+    target_compile_definitions(piper PUBLIC OPENJTALK_DIC_PATH="..\\\\share\\\\open_jtalk\\\\dic")
+    target_compile_definitions(test_piper PUBLIC OPENJTALK_DIC_PATH="${CMAKE_CURRENT_BINARY_DIR}\\\\naist-jdic")
+  else()
+    target_compile_definitions(piper PUBLIC OPENJTALK_DIC_PATH="../share/open_jtalk/dic")
+    target_compile_definitions(test_piper PUBLIC OPENJTALK_DIC_PATH="${CMAKE_CURRENT_BINARY_DIR}/naist-jdic")
+  endif()
+endif()
 
 # ---- Declare test ----
 include(CTest)
 enable_testing()
 add_test(
   NAME test_piper
-  COMMAND test_piper "${CMAKE_SOURCE_DIR}/etc/test_voice.onnx" "${PIPER_PHONEMIZE_DIR}/share/espeak-ng-data" "${CMAKE_CURRENT_BINARY_DIR}/test.wav"
+  COMMAND test_piper "${CMAKE_SOURCE_DIR}/etc/test_voice.onnx" "$<TARGET_FILE_DIR:test_piper>/espeak-ng-data" "${CMAKE_CURRENT_BINARY_DIR}/test.wav"
 )
 
 target_compile_features(test_piper PUBLIC cxx_std_17)
@@ -128,24 +439,42 @@ target_link_directories(
   ${PIPER_PHONEMIZE_DIR}/lib
 )
 
-target_link_libraries(test_piper PUBLIC
-  fmt
-  spdlog
-  espeak-ng
-  piper_phonemize
-  onnxruntime
-)
+# Platform-specific library linking for test_piper
+if(WIN32)
+  # Windows: Link libraries directly with generator expressions for debug/release
+  target_link_libraries(test_piper
+    optimized ${FMT_DIR}/lib/fmt.lib
+    debug ${FMT_DIR}/lib/fmtd.lib
+    optimized ${SPDLOG_DIR}/lib/spdlog.lib
+    debug ${SPDLOG_DIR}/lib/spdlogd.lib
+    ${PIPER_PHONEMIZE_DIR}/lib/piper_phonemize.lib
+    ${PIPER_PHONEMIZE_DIR}/lib/espeak-ng.lib
+    ${ONNXRUNTIME_LIB}
+    ${PIPER_EXTRA_LIBRARIES}
+  )
+else()
+  target_link_libraries(test_piper
+    fmt
+    spdlog
+    espeak-ng
+    piper_phonemize
+    onnxruntime
+    ${PIPER_EXTRA_LIBRARIES}
+  )
+endif()
+
+# OpenJTalk is used via binary execution for test_piper, not linked
 
 # ---- Declare install targets ----
 
 install(
   TARGETS piper
-  DESTINATION ${CMAKE_INSTALL_PREFIX})
+  DESTINATION bin)
 
 # Dependencies
 install(
   DIRECTORY ${PIPER_PHONEMIZE_DIR}/bin/
-  DESTINATION ${CMAKE_INSTALL_PREFIX}
+  DESTINATION bin
   USE_SOURCE_PERMISSIONS  # keep +x
   FILES_MATCHING
   PATTERN "piper_phonemize"
@@ -155,18 +484,152 @@ install(
 
 install(
   DIRECTORY ${PIPER_PHONEMIZE_DIR}/lib/
-  DESTINATION ${CMAKE_INSTALL_PREFIX}
+  DESTINATION lib
   FILES_MATCHING
   PATTERN "*.dll"
   PATTERN "*.so*"
+  PATTERN "*.dylib"
 )
 
 install(
   DIRECTORY ${PIPER_PHONEMIZE_DIR}/share/espeak-ng-data
-  DESTINATION ${CMAKE_INSTALL_PREFIX}
+  DESTINATION share
 )
 
 install(
   FILES ${PIPER_PHONEMIZE_DIR}/share/libtashkeel_model.ort
-  DESTINATION ${CMAKE_INSTALL_PREFIX}
+  DESTINATION share
 )
+
+# Install OpenJTalk for Japanese TTS support
+if(TRUE)  # HTSEngine and OpenJTalk are built
+  # Install OpenJTalk binary
+  if(WIN32)
+    install(
+      PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/oj/bin/open_jtalk.exe
+      DESTINATION bin
+      OPTIONAL  # Don't fail if not built
+    )
+  else()
+    install(
+      PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/oj/bin/open_jtalk
+      DESTINATION bin
+      OPTIONAL  # Don't fail if not built
+    )
+  endif()
+
+  # Install OpenJTalk dictionary
+  install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/share/open_jtalk
+    DESTINATION share
+    OPTIONAL  # Don't fail if not present
+  )
+endif()
+
+# Note: We don't need to copy espeak-ng library on macOS separately
+# because piper_phonemize builds and installs its own custom fork
+# of espeak-ng that includes the required espeak_TextToPhonemesWithTerminator
+# function. The library is already installed by the piper_phonemize
+# external project.
+
+# ---- Windows-specific DLL handling ----
+if(WIN32)
+  # Helper function to copy DLLs
+  function(copy_dlls_to_target target_name)
+    # Create bin and lib subdirectories for better organization
+    add_custom_command(TARGET ${target_name} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${target_name}>/lib"
+      COMMENT "Creating lib directory for ${target_name}..."
+    )
+    
+    # Copy ONNX Runtime DLLs
+    if(ONNXRUNTIME_DLL)
+      add_custom_command(TARGET ${target_name} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "${ONNXRUNTIME_DLL}"
+          "$<TARGET_FILE_DIR:${target_name}>/onnxruntime.dll"
+        COMMENT "Copying ONNX Runtime DLL..."
+      )
+      
+      # Also copy ONNX Runtime providers DLL if it exists
+      get_filename_component(ONNX_DIR "${ONNXRUNTIME_DLL}" DIRECTORY)
+      file(GLOB ONNX_PROVIDER_DLLS "${ONNX_DIR}/onnxruntime_providers*.dll")
+      foreach(dll ${ONNX_PROVIDER_DLLS})
+        add_custom_command(TARGET ${target_name} POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${dll}"
+            "$<TARGET_FILE_DIR:${target_name}>/"
+          COMMENT "Copying ONNX Runtime provider DLL: ${dll}..."
+        )
+      endforeach()
+    endif()
+  endfunction()
+  
+  # Apply DLL copying to both targets
+  copy_dlls_to_target(piper)
+  copy_dlls_to_target(test_piper)
+  
+  # Install ONNX Runtime DLL
+  if(ONNXRUNTIME_DLL)
+    install(FILES ${ONNXRUNTIME_DLL} DESTINATION bin)
+    get_filename_component(ONNX_DIR "${ONNXRUNTIME_DLL}" DIRECTORY)
+    file(GLOB ONNX_PROVIDER_DLLS "${ONNX_DIR}/onnxruntime_providers*.dll")
+    if(ONNX_PROVIDER_DLLS)
+      install(FILES ${ONNX_PROVIDER_DLLS} DESTINATION bin)
+    endif()
+  endif()
+  
+  # Copy piper-phonemize DLLs
+  # First, copy specific DLLs we know we need
+  set(PIPER_PHONEMIZE_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/p/src/piper_phonemize_external-build")
+  
+  # Copy DLLs from installed locations
+  # Both espeak-ng.dll and piper_phonemize.dll should be installed to ${PIPER_PHONEMIZE_DIR}/bin
+  
+  add_custom_command(TARGET piper POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo "Copying DLLs for piper..."
+    # Copy from installed location
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+      "${PIPER_PHONEMIZE_DIR}/bin"
+      "$<TARGET_FILE_DIR:piper>/"
+    COMMENT "Copying piper-phonemize DLLs..."
+  )
+  
+  add_custom_command(TARGET test_piper POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo "Copying DLLs for test_piper..."
+    # Copy from installed location
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+      "${PIPER_PHONEMIZE_DIR}/bin"
+      "$<TARGET_FILE_DIR:test_piper>/"
+    COMMENT "Copying piper-phonemize DLLs for tests..."
+  )
+  
+  
+  # Copy Microsoft C++ runtime redistributables if needed
+  # Required for dynamic runtime linking (/MD)
+  set(CMAKE_INSTALL_UCRT_LIBRARIES TRUE)
+  set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION bin)
+  set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP FALSE)
+  include(InstallRequiredSystemLibraries)
+  
+  # Copy runtime DLLs only for piper target to avoid conflicts
+  # test_piper will use the same directory structure in CI
+  if(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS)
+    foreach(lib ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS})
+      add_custom_command(TARGET piper POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "${lib}"
+          "$<TARGET_FILE_DIR:piper>/"
+        COMMENT "Copying runtime library ${lib}..."
+      )
+    endforeach()
+  endif()
+  
+  # Also copy espeak-ng data for test
+  add_custom_command(TARGET test_piper POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+      "${PIPER_PHONEMIZE_DIR}/share/espeak-ng-data"
+      "$<TARGET_FILE_DIR:test_piper>/espeak-ng-data"
+    COMMENT "Copying espeak-ng data for tests..."
+  )
+endif()

--- a/cmake/HTSEngine.cmake
+++ b/cmake/HTSEngine.cmake
@@ -1,0 +1,29 @@
+# HTSEngine Windows build configuration
+# This file provides CMake-based build for HTSEngine on Windows
+
+set(HTS_ENGINE_VERSION "1.10")
+set(HTS_ENGINE_URL "https://downloads.sourceforge.net/project/hts-engine/hts_engine%20API/hts_engine_API-${HTS_ENGINE_VERSION}/hts_engine_API-${HTS_ENGINE_VERSION}.tar.gz")
+
+if(WIN32)
+  # Create a CMake-based build for HTSEngine on Windows
+  set(HTS_ENGINE_DIR "${CMAKE_CURRENT_BINARY_DIR}/he")
+  
+  # Download and extract HTSEngine
+  ExternalProject_Add(
+    hts_engine_external
+    PREFIX "${CMAKE_CURRENT_BINARY_DIR}/h"
+    URL ${HTS_ENGINE_URL}
+    CMAKE_ARGS
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+      -DCMAKE_INSTALL_PREFIX=${HTS_ENGINE_DIR}
+      -DCMAKE_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}
+      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    PATCH_COMMAND ${CMAKE_COMMAND} -E copy 
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/HTSEngine_CMakeLists.txt 
+      <SOURCE_DIR>/CMakeLists.txt
+    BUILD_BYPRODUCTS 
+      ${HTS_ENGINE_DIR}/lib/HTSEngine.lib
+      ${HTS_ENGINE_DIR}/lib/libHTSEngine.a
+  )
+endif()

--- a/cmake/HTSEngine_CMakeLists.txt
+++ b/cmake/HTSEngine_CMakeLists.txt
@@ -1,0 +1,94 @@
+cmake_minimum_required(VERSION 3.13)
+project(HTSEngine C)
+
+# HTSEngine API 1.10 - CMake build configuration for Windows
+# Based on the original autotools configuration
+
+set(CMAKE_C_STANDARD 99)
+
+# Configuration options
+option(HTS_EMBEDDED "Build for embedded devices" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+
+# Version information
+set(HTS_ENGINE_VERSION "1.10")
+set(HTS_ENGINE_VERSION_MAJOR 1)
+set(HTS_ENGINE_VERSION_MINOR 10)
+
+# Source files
+set(HTS_ENGINE_SOURCES
+  lib/HTS_audio.c
+  lib/HTS_engine.c
+  lib/HTS_gstream.c
+  lib/HTS_label.c
+  lib/HTS_misc.c
+  lib/HTS_model.c
+  lib/HTS_pstream.c
+  lib/HTS_sstream.c
+  lib/HTS_vocoder.c
+)
+
+# Header files  
+set(HTS_ENGINE_HEADERS
+  include/HTS_engine.h
+  # HTS_hidden.h is internal and should not be installed
+)
+
+# Create library
+add_library(HTSEngine ${HTS_ENGINE_SOURCES})
+
+# Include directories
+target_include_directories(HTSEngine
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib
+)
+
+# Platform-specific settings
+if(WIN32)
+  target_compile_definitions(HTSEngine PRIVATE
+    AUDIO_PLAY_NONE  # Disable audio playback on Windows to avoid SDK issues
+    _CRT_SECURE_NO_WARNINGS
+    WIN32_LEAN_AND_MEAN
+  )
+  
+  # Use same runtime library as parent project
+  if(MSVC)
+    set_property(TARGET HTSEngine PROPERTY MSVC_RUNTIME_LIBRARY ${CMAKE_MSVC_RUNTIME_LIBRARY})
+  endif()
+else()
+  # Unix/Linux settings
+  target_compile_definitions(HTSEngine PRIVATE AUDIO_PLAY_NONE)
+endif()
+
+# Embedded device settings
+if(HTS_EMBEDDED)
+  target_compile_definitions(HTSEngine PRIVATE HTS_EMBEDDED)
+endif()
+
+# Install configuration
+install(TARGETS HTSEngine
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(FILES ${HTS_ENGINE_HEADERS}
+  DESTINATION include
+)
+
+# Build executable if requested
+option(BUILD_HTS_ENGINE_EXECUTABLE "Build hts_engine executable" ON)
+if(BUILD_HTS_ENGINE_EXECUTABLE)
+  add_executable(hts_engine bin/hts_engine.c)
+  target_link_libraries(hts_engine PRIVATE HTSEngine)
+  if(NOT WIN32)
+    target_link_libraries(hts_engine PRIVATE m)
+  endif()
+  
+  install(TARGETS hts_engine
+    RUNTIME DESTINATION bin
+  )
+endif()

--- a/cmake/OpenJTalk.cmake
+++ b/cmake/OpenJTalk.cmake
@@ -1,0 +1,39 @@
+# OpenJTalk Windows build configuration
+# This file provides CMake-based build for OpenJTalk on Windows
+
+set(OPENJTALK_VERSION "1.11")
+set(OPENJTALK_URL "https://downloads.sourceforge.net/project/open-jtalk/Open%20JTalk/open_jtalk-${OPENJTALK_VERSION}/open_jtalk-${OPENJTALK_VERSION}.tar.gz")
+
+if(WIN32)
+  # Create a CMake-based build for OpenJTalk on Windows
+  set(OPENJTALK_DIR "${CMAKE_CURRENT_BINARY_DIR}/oj")
+  
+  # Ensure HTSEngine is built first
+  if(NOT TARGET hts_engine_external)
+    message(FATAL_ERROR "HTSEngine must be built before OpenJTalk")
+  endif()
+  
+  # Download and build OpenJTalk
+  ExternalProject_Add(
+    openjtalk_external
+    PREFIX "${CMAKE_CURRENT_BINARY_DIR}/o"
+    URL ${OPENJTALK_URL}
+    CMAKE_ARGS
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+      -DCMAKE_INSTALL_PREFIX=${OPENJTALK_DIR}
+      -DCMAKE_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}
+      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+      -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+      -DHTS_ENGINE_INCLUDE_DIR=${HTS_ENGINE_DIR}/include
+      -DHTS_ENGINE_LIB=${HTS_ENGINE_DIR}/lib/HTSEngine.lib
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    PATCH_COMMAND ${CMAKE_COMMAND} -E copy 
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/OpenJTalk_CMakeLists.txt 
+      <SOURCE_DIR>/CMakeLists.txt
+    BUILD_BYPRODUCTS 
+      ${OPENJTALK_DIR}/bin/open_jtalk.exe
+      ${OPENJTALK_DIR}/lib/libopenjtalk.lib
+      ${OPENJTALK_DIR}/lib/libopenjtalk.a
+    DEPENDS hts_engine_external
+  )
+endif()

--- a/cmake/OpenJTalk_CMakeLists.txt
+++ b/cmake/OpenJTalk_CMakeLists.txt
@@ -1,0 +1,292 @@
+cmake_minimum_required(VERSION 3.13)
+project(OpenJTalk C CXX)
+
+# OpenJTalk 1.11 - CMake build configuration for Windows
+# Based on the original autotools configuration
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Configuration options
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+
+# Version information
+set(OPEN_JTALK_VERSION "1.11")
+set(OPEN_JTALK_VERSION_MAJOR 1)
+set(OPEN_JTALK_VERSION_MINOR 11)
+
+# Find HTSEngine
+if(NOT HTS_ENGINE_INCLUDE_DIR OR NOT HTS_ENGINE_LIB)
+  message(FATAL_ERROR "HTSEngine not found. Please set HTS_ENGINE_INCLUDE_DIR and HTS_ENGINE_LIB")
+endif()
+
+# Source files for mecab
+set(MECAB_SOURCES
+  mecab/src/char_property.cpp
+  mecab/src/connector.cpp
+  mecab/src/context_id.cpp
+  mecab/src/dictionary.cpp
+  mecab/src/dictionary_compiler.cpp
+  mecab/src/dictionary_generator.cpp
+  mecab/src/dictionary_rewriter.cpp
+  mecab/src/eval.cpp
+  mecab/src/feature_index.cpp
+  mecab/src/iconv_utils.cpp
+  mecab/src/lbfgs.cpp
+  mecab/src/learner.cpp
+  mecab/src/learner_tagger.cpp
+  mecab/src/libmecab.cpp
+  mecab/src/nbest_generator.cpp
+  mecab/src/param.cpp
+  mecab/src/string_buffer.cpp
+  mecab/src/tagger.cpp
+  mecab/src/tokenizer.cpp
+  mecab/src/utils.cpp
+  mecab/src/viterbi.cpp
+  mecab/src/writer.cpp
+)
+
+# Source files for njd
+set(NJD_SOURCES
+  njd/njd.c
+  njd/njd_node.c
+  njd_set_accent_phrase/njd_set_accent_phrase.c
+  njd_set_accent_type/njd_set_accent_type.c
+  njd_set_digit/njd_set_digit.c
+  njd_set_long_vowel/njd_set_long_vowel.c
+  njd_set_pronunciation/njd_set_pronunciation.c
+  njd_set_unvoiced_vowel/njd_set_unvoiced_vowel.c
+)
+
+# Source files for jpcommon
+set(JPCOMMON_SOURCES
+  jpcommon/jpcommon.c
+  jpcommon/jpcommon_label.c
+  jpcommon/jpcommon_node.c
+)
+
+# Source files for text2mecab
+set(TEXT2MECAB_SOURCES
+  text2mecab/text2mecab.c
+)
+
+# Source files for mecab2njd
+set(MECAB2NJD_SOURCES
+  mecab2njd/mecab2njd.c
+)
+
+# Source files for njd2jpcommon
+set(NJD2JPCOMMON_SOURCES
+  njd2jpcommon/njd2jpcommon.c
+)
+
+# Create mecab library
+add_library(mecab STATIC ${MECAB_SOURCES})
+
+# Ensure all symbols are included on Windows
+if(WIN32 AND MSVC)
+  set_target_properties(mecab PROPERTIES
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+  )
+endif()
+target_include_directories(mecab PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/mecab/src
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Force C++14 for MeCab to avoid std::binary_function issues in C++17
+set_property(TARGET mecab PROPERTY CXX_STANDARD 14)
+set_property(TARGET mecab PROPERTY CXX_STANDARD_REQUIRED ON)
+# Windows-specific definitions for mecab
+if(WIN32)
+  target_compile_definitions(mecab PRIVATE
+    DIC_VERSION=102
+    HAVE_WINDOWS_H
+    PACKAGE="open_jtalk"
+    VERSION="${OPEN_JTALK_VERSION}"
+    MECAB_DEFAULT_RC=""
+    _CRT_SECURE_NO_WARNINGS
+  )
+  
+  # Add Windows compatibility
+  target_sources(mecab PRIVATE mecab/src/winmain.h)
+else()
+  target_compile_definitions(mecab PRIVATE
+    DIC_VERSION=102
+    HAVE_UNISTD_H
+    HAVE_DIRENT_H
+    HAVE_FCNTL_H
+    HAVE_SYS_STAT_H
+    HAVE_SYS_TYPES_H
+    HAVE_SYS_MMAN_H
+    PACKAGE="open_jtalk"
+    VERSION="${OPEN_JTALK_VERSION}"
+    MECAB_DEFAULT_RC=""
+  )
+endif()
+
+# Create OpenJTalk library
+add_library(openjtalk STATIC
+  ${NJD_SOURCES}
+  ${JPCOMMON_SOURCES}
+  ${TEXT2MECAB_SOURCES}
+  ${MECAB2NJD_SOURCES}
+  ${NJD2JPCOMMON_SOURCES}
+)
+
+target_include_directories(openjtalk PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/njd
+  ${CMAKE_CURRENT_SOURCE_DIR}/njd_set_accent_phrase
+  ${CMAKE_CURRENT_SOURCE_DIR}/njd_set_accent_type
+  ${CMAKE_CURRENT_SOURCE_DIR}/njd_set_digit
+  ${CMAKE_CURRENT_SOURCE_DIR}/njd_set_long_vowel
+  ${CMAKE_CURRENT_SOURCE_DIR}/njd_set_pronunciation
+  ${CMAKE_CURRENT_SOURCE_DIR}/njd_set_unvoiced_vowel
+  ${CMAKE_CURRENT_SOURCE_DIR}/njd2jpcommon
+  ${CMAKE_CURRENT_SOURCE_DIR}/jpcommon
+  ${CMAKE_CURRENT_SOURCE_DIR}/text2mecab
+  ${CMAKE_CURRENT_SOURCE_DIR}/mecab2njd
+  ${CMAKE_CURRENT_SOURCE_DIR}/mecab/src
+  ${HTS_ENGINE_INCLUDE_DIR}
+)
+
+target_link_libraries(openjtalk PUBLIC mecab)
+
+# Windows-specific settings
+if(WIN32)
+  target_compile_definitions(openjtalk PRIVATE
+    _CRT_SECURE_NO_WARNINGS
+    ASCII_HEADER
+    CHARSET_UTF_8
+  )
+  target_compile_definitions(mecab PRIVATE
+    CHARSET_UTF_8
+  )
+  
+  # Use same runtime library as parent project
+  if(MSVC)
+    set_property(TARGET mecab PROPERTY MSVC_RUNTIME_LIBRARY ${CMAKE_MSVC_RUNTIME_LIBRARY})
+    set_property(TARGET openjtalk PROPERTY MSVC_RUNTIME_LIBRARY ${CMAKE_MSVC_RUNTIME_LIBRARY})
+  endif()
+endif()
+
+# Apply C++17 compatibility patch for MeCab
+if(WIN32 AND CMAKE_CXX_STANDARD GREATER_EQUAL 17)
+  # Apply patch to dictionary.cpp for C++17 compatibility
+  message(STATUS "Applying C++17 compatibility patch to MeCab dictionary.cpp")
+  # Copy patch file from cmake directory
+  set(PATCH_SOURCE "${CMAKE_SOURCE_DIR}/cmake/openjtalk_dictionary_patch.txt")
+  set(PATCH_DEST "${CMAKE_CURRENT_SOURCE_DIR}/dictionary.patch")
+  
+  if(EXISTS "${PATCH_SOURCE}")
+    configure_file("${PATCH_SOURCE}" "${PATCH_DEST}" COPYONLY)
+    set(patch_copy_result 0)
+  else()
+    message(WARNING "Patch file not found at ${PATCH_SOURCE}")
+    set(patch_copy_result 1)
+  endif()
+  
+  if(NOT patch_copy_result EQUAL 0)
+    message(WARNING "Failed to copy patch file")
+  else()
+    # Try to apply the patch
+    find_program(PATCH_EXECUTABLE patch)
+    if(PATCH_EXECUTABLE)
+      execute_process(
+        COMMAND ${PATCH_EXECUTABLE} -p1 -N -s
+        INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/dictionary.patch
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        RESULT_VARIABLE patch_result
+        OUTPUT_QUIET
+        ERROR_QUIET
+      )
+      if(patch_result EQUAL 0)
+        message(STATUS "Successfully applied C++17 compatibility patch")
+      endif()
+    else()
+      message(WARNING "patch command not found, using sed fallback")
+      # Fallback: Use CMake to modify the file directly
+      file(READ "${CMAKE_CURRENT_SOURCE_DIR}/mecab/src/dictionary.cpp" DICT_CONTENT)
+      # Check if already patched
+      if(NOT DICT_CONTENT MATCHES "__cplusplus >= 201703L")
+        # Replace the struct definition
+        string(REPLACE
+          "namespace {
+template <typename T1, typename T2>
+struct pair_1st_cmp: public std::binary_function<bool, T1, T2> {
+  bool operator()(const std::pair<T1, T2> &x1,"
+          "namespace {
+template <typename T1, typename T2>
+#if __cplusplus >= 201703L
+struct pair_1st_cmp {
+  typedef T1 first_argument_type;
+  typedef T2 second_argument_type;
+  typedef bool result_type;
+#else
+struct pair_1st_cmp: public std::binary_function<bool, T1, T2> {
+#endif
+  bool operator()(const std::pair<T1, T2> &x1,"
+          DICT_CONTENT "${DICT_CONTENT}")
+        file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/mecab/src/dictionary.cpp" "${DICT_CONTENT}")
+        message(STATUS "Applied C++17 compatibility patch using CMake")
+      endif()
+    endif()
+  endif()
+endif()
+
+# Build open_jtalk executable
+add_executable(open_jtalk bin/open_jtalk.c)
+
+# Add mecab.cpp directly to the executable to ensure symbols are available
+target_sources(open_jtalk PRIVATE mecab/src/mecab.cpp)
+
+# On Windows, we need to ensure proper linking order and symbol visibility
+if(WIN32)
+  target_link_libraries(open_jtalk PRIVATE
+    openjtalk
+    mecab
+    ${HTS_ENGINE_LIB}
+  )
+else()
+  target_link_libraries(open_jtalk PRIVATE
+    openjtalk
+    mecab
+    ${HTS_ENGINE_LIB}
+  )
+endif()
+
+if(NOT WIN32)
+  target_link_libraries(open_jtalk PRIVATE m)
+endif()
+
+target_include_directories(open_jtalk PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/njd
+  ${CMAKE_CURRENT_SOURCE_DIR}/njd2jpcommon
+  ${CMAKE_CURRENT_SOURCE_DIR}/jpcommon
+  ${CMAKE_CURRENT_SOURCE_DIR}/text2mecab
+  ${CMAKE_CURRENT_SOURCE_DIR}/mecab2njd
+  ${CMAKE_CURRENT_SOURCE_DIR}/mecab/src
+  ${HTS_ENGINE_INCLUDE_DIR}
+)
+
+# Install configuration
+install(TARGETS openjtalk mecab
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS open_jtalk
+  RUNTIME DESTINATION bin
+)
+
+# Install headers
+install(FILES 
+  njd/njd.h
+  jpcommon/jpcommon.h
+  mecab/src/mecab.h
+  DESTINATION include
+)

--- a/cmake/apply_openjtalk_patch.ps1
+++ b/cmake/apply_openjtalk_patch.ps1
@@ -1,0 +1,68 @@
+param([string]$SourceDir)
+
+$filePath = Join-Path $SourceDir "mecab/src/dictionary.cpp"
+Write-Host "Patching file: $filePath"
+
+if (Test-Path $filePath) {
+    # Read content as individual lines to preserve formatting
+    $lines = Get-Content -Path $filePath
+    
+    # Check if already patched
+    $content = Get-Content -Path $filePath -Raw
+    if ($content -match 'MSVC_BINARY_FUNCTION_WORKAROUND') {
+        Write-Host "File already patched"
+        exit 0
+    }
+    
+    Write-Host "Applying C++17 compatibility patch..."
+    
+    # Build new content - insert the fix after includes
+    $newLines = @()
+    $insertDone = $false
+    
+    for ($i = 0; $i -lt $lines.Length; $i++) {
+        # Look for a good place to insert - after the last include but before namespace
+        if (-not $insertDone -and $lines[$i] -match '^\s*namespace\s+MeCab\s*\{') {
+            # Insert before the MeCab namespace
+            $newLines += ''
+            $newLines += '// MSVC_BINARY_FUNCTION_WORKAROUND'
+            $newLines += '#if defined(_MSC_VER) && _MSC_VER >= 1900'
+            $newLines += '// VS2015 and later removed std::binary_function'
+            $newLines += 'namespace std {'
+            $newLines += '  template<typename Arg1, typename Arg2, typename Result>'
+            $newLines += '  struct binary_function {'
+            $newLines += '    typedef Arg1 first_argument_type;'
+            $newLines += '    typedef Arg2 second_argument_type;'
+            $newLines += '    typedef Result result_type;'
+            $newLines += '  };'
+            $newLines += '}'
+            $newLines += '#endif'
+            $newLines += ''
+            $insertDone = $true
+        }
+        
+        # Add the original line
+        $newLines += $lines[$i]
+    }
+    
+    if (-not $insertDone) {
+        Write-Host "ERROR: Could not find appropriate insertion point"
+        exit 1
+    }
+    
+    # Write the patched content
+    Set-Content -Path $filePath -Value $newLines
+    Write-Host "Successfully applied C++17 compatibility patch"
+    
+    # Verify the patch
+    $verifyContent = Get-Content -Path $filePath -Raw
+    if ($verifyContent -match 'MSVC_BINARY_FUNCTION_WORKAROUND') {
+        Write-Host "Patch verification: SUCCESS"
+    } else {
+        Write-Host "Patch verification: FAILED"
+        exit 1
+    }
+} else {
+    Write-Host "ERROR: File not found: $filePath"
+    exit 1
+}

--- a/cmake/binary_function_fix.h
+++ b/cmake/binary_function_fix.h
@@ -1,0 +1,18 @@
+// Compatibility header for C++17 and later
+// Provides std::binary_function which was deprecated in C++11 and removed in C++17
+
+#ifndef BINARY_FUNCTION_FIX_H
+#define BINARY_FUNCTION_FIX_H
+
+#if __cplusplus >= 201703L
+namespace std {
+    template <typename Arg1, typename Arg2, typename Result>
+    struct binary_function {
+        typedef Arg1 first_argument_type;
+        typedef Arg2 second_argument_type;
+        typedef Result result_type;
+    };
+}
+#endif
+
+#endif // BINARY_FUNCTION_FIX_H

--- a/cmake/dictionary_patch.txt
+++ b/cmake/dictionary_patch.txt
@@ -1,0 +1,18 @@
+--- dictionary.cpp.orig	2025-07-01 12:00:00.000000000 -0500
++++ dictionary.cpp	2025-07-01 12:00:01.000000000 -0500
+@@ -71,7 +71,15 @@
+ 
+ namespace {
+ template <typename T1, typename T2>
++#if __cplusplus >= 201703L
++struct pair_1st_cmp {
++  typedef T1 first_argument_type;
++  typedef T2 second_argument_type;
++  typedef bool result_type;
++#else
+ struct pair_1st_cmp: public std::binary_function<bool, T1, T2> {
++#endif
++
+   bool operator()(const std::pair<T1, T2> &x1,
+                   const std::pair<T1, T2> &x2) {
+     return x1.first < x2.first;

--- a/cmake/openjtalk_binary_function.patch
+++ b/cmake/openjtalk_binary_function.patch
@@ -1,0 +1,16 @@
+--- a/mecab/src/dictionary.cpp
++++ b/mecab/src/dictionary.cpp
+@@ -65,8 +65,13 @@
+ 
+ namespace {
+ template <typename T1, typename T2>
++#if __cplusplus >= 201703L
++struct pair_1st_cmp {
++  typedef T1 first_argument_type;
++#else
+ struct pair_1st_cmp: public std::binary_function<bool, T1, T2> {
+   bool operator()(const std::pair<T1, T2> &x1,
++#endif
+                   const std::pair<T1, T2> &x2) {
+     return x1.first < x2.first;
+   }

--- a/src/cpp/piper.hpp
+++ b/src/cpp/piper.hpp
@@ -34,7 +34,11 @@ struct PiperConfig {
   std::unique_ptr<tashkeel::State> tashkeelState;
 };
 
-enum PhonemeType { eSpeakPhonemes, TextPhonemes };
+enum PhonemeType { 
+  eSpeakPhonemes, 
+  TextPhonemes,
+  OpenJTalkPhonemes
+};
 
 struct PhonemizeConfig {
   PhonemeType phonemeType = eSpeakPhonemes;


### PR DESCRIPTION
- Add CMake configurations for HTSEngine and OpenJTalk builds on all platforms
- Implement PowerShell patch script for std::binary_function C++17 compatibility
- Add binary function compatibility header for MSVC
- Remove platform conditionals to enable OpenJTalk on Windows
- Configure proper library linking and include paths for Windows builds