### PR TITLE
fix: GitHub Actionsのdev releaseワークフローを修正

### DIFF
--- a/.github/workflows/create-dev-release.yml
+++ b/.github/workflows/create-dev-release.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   # First, trigger the build workflow
@@ -24,7 +25,7 @@ jobs:
     name: Trigger Build
     runs-on: ubuntu-latest
     outputs:
-      workflow-run-id: ${{ steps.trigger.outputs.run-id }}
+      workflow-run-id: ${{ steps.get-run-id.outputs.run-id }}
     steps:
       - uses: actions/checkout@v4
       
@@ -40,24 +41,49 @@ jobs:
               ref: context.ref
             });
             
-            // Wait for workflow to start
-            await new Promise(resolve => setTimeout(resolve, 5000));
+            console.log('Workflow dispatch triggered');
             
-            // Get the workflow run
+      - name: Wait and get workflow run ID
+        id: get-run-id
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Wait for workflow to start
+            await new Promise(resolve => setTimeout(resolve, 10000));
+            
+            // Get the workflow runs triggered in the last minute
             const runs = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'build-all-platforms.yml',
-              per_page: 1
+              branch: context.ref.replace('refs/heads/', ''),
+              event: 'workflow_dispatch',
+              per_page: 5
             });
             
-            return runs.data.workflow_runs[0].id;
+            // Find the most recent run
+            const recentRuns = runs.data.workflow_runs.filter(run => {
+              const runTime = new Date(run.created_at).getTime();
+              const now = new Date().getTime();
+              return (now - runTime) < 60000; // Within last minute
+            });
+            
+            if (recentRuns.length === 0) {
+              throw new Error('Could not find the triggered workflow run');
+            }
+            
+            const runId = recentRuns[0].id;
+            console.log(`Found workflow run ID: ${runId}`);
+            core.setOutput('run-id', runId);
+            return runId;
 
   # Wait for build to complete
   wait-for-build:
     name: Wait for Build
     needs: trigger-build
     runs-on: ubuntu-latest
+    outputs:
+      run-id: ${{ needs.trigger-build.outputs.workflow-run-id }}
     steps:
       - uses: actions/checkout@v4
       
@@ -67,6 +93,9 @@ jobs:
           script: |
             const runId = ${{ needs.trigger-build.outputs.workflow-run-id }};
             let status = 'in_progress';
+            let conclusion = null;
+            
+            console.log(`Waiting for workflow run ${runId} to complete...`);
             
             while (status === 'in_progress' || status === 'queued') {
               const run = await github.rest.actions.getWorkflowRun({
@@ -76,16 +105,19 @@ jobs:
               });
               
               status = run.data.status;
-              console.log(`Build status: ${status}`);
+              conclusion = run.data.conclusion;
+              console.log(`Build status: ${status}, conclusion: ${conclusion}`);
               
               if (status === 'in_progress' || status === 'queued') {
                 await new Promise(resolve => setTimeout(resolve, 30000)); // Wait 30s
               }
             }
             
-            if (status !== 'completed' || run.data.conclusion !== 'success') {
-              throw new Error('Build failed');
+            if (status !== 'completed' || conclusion !== 'success') {
+              throw new Error(`Build failed with status: ${status}, conclusion: ${conclusion}`);
             }
+            
+            console.log('Build completed successfully!');
 
   # Create release
   create-release:
@@ -107,11 +139,58 @@ jobs:
           fi
           echo "tag=dev-$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
       
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - name: Download artifacts from other workflow
+        uses: actions/github-script@v7
         with:
-          pattern: piper-*
-          path: artifacts/
+          script: |
+            const runId = ${{ needs.wait-for-build.outputs.run-id }};
+            const fs = require('fs');
+            const path = require('path');
+            
+            // Create artifacts directory
+            const artifactsDir = 'artifacts';
+            if (!fs.existsSync(artifactsDir)) {
+              fs.mkdirSync(artifactsDir, { recursive: true });
+            }
+            
+            // List artifacts for the workflow run
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId
+            });
+            
+            console.log(`Found ${artifacts.data.artifacts.length} artifacts`);
+            
+            // Download each artifact
+            for (const artifact of artifacts.data.artifacts) {
+              console.log(`Downloading artifact: ${artifact.name}`);
+              
+              // Download artifact
+              const download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+                archive_format: 'zip'
+              });
+              
+              // Save to file
+              const artifactPath = path.join(artifactsDir, `${artifact.name}.zip`);
+              fs.writeFileSync(artifactPath, Buffer.from(download.data));
+              
+              console.log(`Saved artifact to: ${artifactPath}`);
+            }
+      
+      - name: Extract artifacts
+        run: |
+          cd artifacts
+          for zip in *.zip; do
+            echo "Extracting $zip"
+            unzip -o "$zip"
+            rm "$zip"
+          done
+          echo "Extracted files:"
+          ls -la
       
       - name: Create release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## 概要
`create-dev-release.yml`ワークフローが失敗していた問題を修正しました。

## 問題点
1. `actions/download-artifact@v4`は同一ワークフロー内のアーティファクトのみダウンロード可能
2. 別のワークフローからアーティファクトを取得するにはGitHub APIを使用する必要がある
3. ワークフローランIDの取得が不正確だった

## 修正内容
- ✅ `actions:read`権限を追加
- ✅ workflow run IDの取得ロジックを改善（タイミング問題の修正）
- ✅ GitHub APIを使用して別ワークフローのアーティファクトをダウンロード
- ✅ エラーハンドリングとログ出力を改善

## テスト方法
1. このPRをマージ後、devブランチへのpushまたは手動でワークフローを実行
2. ビルドワークフローが正常に完了することを確認
3. アーティファクトが正しくダウンロードされ、リリースが作成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)