### PR TITLE
fix: performance-monitor.ymlでGH_TOKEN環境変数を追加

### DIFF
--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Get workflow run details
         id: metrics
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Get workflow run details
           WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
@@ -60,6 +62,8 @@ jobs:
           echo "duration_min=$DURATION_MIN" >> $GITHUB_OUTPUT
 
       - name: Update performance tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Find or create performance tracking issue
           ISSUE_NUMBER=$(gh issue list \
@@ -84,6 +88,8 @@ jobs:
           echo "Metrics posted to issue #$ISSUE_NUMBER"
 
       - name: Check performance trends
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Get historical data from issue comments
           ISSUE_NUMBER=$(gh issue list \
@@ -143,6 +149,8 @@ jobs:
       - uses: actions/checkout@v4.2.2
 
       - name: Generate performance report
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Find performance tracking issue
           ISSUE_NUMBER=$(gh issue list \


### PR DESCRIPTION
## Summary
- performance-monitor.ymlワークフローでgh CLIコマンド実行時のエラーを修正
- 全てのgh CLIコマンドを使用するステップにGH_TOKEN環境変数を追加

## 問題の詳細
GitHub Actionsでgh CLIを使用する際、以下のエラーが発生していました：
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
Error: Process completed with exit code 4.
```

## 修正内容
以下の4つのステップにGH_TOKEN環境変数を追加：
1. Get workflow run details
2. Update performance tracking issue
3. Check performance trends
4. Generate performance report

## Test plan
- [ ] GitHub Actionsでワークフローが正常に実行されることを確認
- [ ] gh CLIコマンドがエラーなく実行されることを確認
- [ ] performance-trackingラベル付きのIssueが正常に作成/更新されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)