### PR TITLE
feat: GitHubスポンサーボタンを追加

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,13 @@
+# These are supported funding model platforms
+
+github: [ayutaz]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
## 概要
GitHubスポンサーボタンをリポジトリに追加します。

## 変更内容
- `.github/FUNDING.yml`ファイルを作成
- GitHubスポンサー（@ayutaz）を設定

## 動作確認
- [ ] PRをマージ後、リポジトリのトップページにスポンサーボタンが表示されることを確認
- [ ] スポンサーボタンをクリックすると、GitHubスポンサーページに遷移することを確認

## スクリーンショット
マージ後、以下の場所にスポンサーボタンが表示されます：
- リポジトリのトップページ右側の「Sponsor」ボタン
- READMEの上部（GitHubが自動的に追加）

## 今後の拡張
必要に応じて、以下のプラットフォームも追加可能です：
- Patreon
- Ko-fi
- カスタムスポンサーリンク

🤖 Generated with [Claude Code](https://claude.ai/code)