### PR TITLE
feat: raw phonemesモードでのストリーミング対応を実装

### DIFF
--- a/docs/features/streaming-mode.md
+++ b/docs/features/streaming-mode.md
@@ -7,14 +7,24 @@ Piper now supports a streaming synthesis mode that reduces latency by processing
 Add the `--streaming` flag when using raw audio output:
 
 ```bash
+# Text input
 echo "Your text here" | piper --model model.onnx --output-raw --streaming
+
+# Raw phonemes input (also supported)
+echo "h ə l oʊ w ɜː l d" | piper --model model.onnx --output-raw --streaming --raw-phonemes
 ```
 
 ## How It Works
 
+### Text Mode
 1. **Text Chunking**: Input text is split into smaller chunks at natural boundaries (punctuation, conjunctions)
 2. **Progressive Synthesis**: Each chunk is phonemized and synthesized independently
 3. **Immediate Output**: Audio is output as soon as each chunk is ready
+
+### Raw Phonemes Mode
+1. **Phoneme Chunking**: Input phonemes are split into configurable chunks (default: 10 phonemes)
+2. **Progressive Synthesis**: Each chunk is synthesized with proper BOS/EOS token handling
+3. **Immediate Output**: Audio chunks are output progressively
 
 ## Performance
 
@@ -32,7 +42,6 @@ Streaming mode provides the most benefit for longer texts:
 ## Limitations
 
 - Currently only works with `--output-raw` mode
-- Not yet supported with `--raw-phonemes` input
 - Audio quality at chunk boundaries may vary slightly
 
 ## API Usage
@@ -56,4 +65,4 @@ piper::textToAudioStreaming(config, voice, text, audioBuffer,
 - Fine-grained chunking at word/syllable level
 - Progressive phonemization for even lower latency
 - Support for WAV output mode
-- Configurable chunk size
+- Configurable chunk size for raw phonemes mode via command-line flag

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -481,20 +481,12 @@ int main(int argc, char *argv[]) {
         };
         
         if (runConfig.rawPhonemes) {
-          spdlog::warn("Streaming mode not yet supported with raw phonemes");
-          // Fall back to regular mode for now
+          // Use streaming synthesis for raw phonemes
           auto phonemeType = static_cast<piper::PhonemeTypeInt>(voice.phonemizeConfig.phonemeType);
           auto phonemes = piper::parsePhonemeString(line, phonemeType);
-          piper::phonemesToAudio(piperConfig, voice, phonemes, audioBuffer, result);
-          // Send all audio at once
-          {
-            unique_lock lockAudio(mutAudio);
-            copy(audioBuffer.begin(), audioBuffer.end(), back_inserter(sharedAudioBuffer));
-            audioReady = true;
-            cvAudio.notify_one();
-          }
+          piper::phonemesToAudioStreaming(piperConfig, voice, phonemes, audioBuffer, result, chunkCallback);
         } else {
-          // Use streaming synthesis
+          // Use streaming synthesis for text
           piper::textToAudioStreaming(piperConfig, voice, line, audioBuffer, result, chunkCallback);
         }
       } else {

--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -1280,6 +1280,119 @@ void textToAudioStreaming(PiperConfig &config, Voice &voice, std::string text,
   
 } /* textToAudioStreaming */
 
+// Streaming phonemes-to-audio synthesis with reduced latency
+void phonemesToAudioStreaming(PiperConfig &config, Voice &voice,
+                              const std::vector<Phoneme> &phonemes,
+                              std::vector<int16_t> &audioBuffer,
+                              SynthesisResult &result,
+                              const std::function<void(const std::vector<int16_t>&)> &chunkCallback,
+                              size_t phonemesPerChunk) {
+  spdlog::debug("phonemesToAudioStreaming: {} phonemes, chunk size={}",
+                phonemes.size(), phonemesPerChunk);
+  
+  // Clear result
+  result.inferSeconds = 0;
+  result.audioSeconds = 0;
+  result.realTimeFactor = 0;
+  
+  // Clear output buffer
+  audioBuffer.clear();
+  
+  if (phonemes.empty()) {
+    return;
+  }
+  
+  // Setup phoneme ID configuration
+  PhonemeIdConfig idConfig;
+  idConfig.phonemeIdMap = 
+      std::make_shared<PhonemeIdMap>(voice.phonemizeConfig.phonemeIdMap);
+  idConfig.interspersePad = voice.phonemizeConfig.interspersePad;
+  idConfig.addBos = true;
+  idConfig.addEos = false;  // We'll add EOS only to the last chunk
+  
+  std::vector<PhonemeId> phonemeIds;
+  std::map<Phoneme, std::size_t> missingPhonemes;
+  std::vector<int16_t> chunkAudioBuffer;
+  
+  // Process phonemes in chunks
+  size_t processedPhonemes = 0;
+  while (processedPhonemes < phonemes.size()) {
+    // Determine chunk boundaries
+    size_t chunkStart = processedPhonemes;
+    size_t chunkEnd = std::min(processedPhonemes + phonemesPerChunk, phonemes.size());
+    bool isLastChunk = (chunkEnd == phonemes.size());
+    
+    // Extract chunk phonemes
+    std::vector<Phoneme> chunkPhonemes(phonemes.begin() + chunkStart,
+                                        phonemes.begin() + chunkEnd);
+    
+    // Add EOS only to the last chunk
+    idConfig.addEos = isLastChunk;
+    
+    // Convert chunk phonemes to IDs
+    phonemeIds.clear();
+    phonemes_to_ids(chunkPhonemes, idConfig, phonemeIds, missingPhonemes);
+    
+    // Log phoneme IDs for debugging
+    if (spdlog::should_log(spdlog::level::debug)) {
+      std::stringstream phonemeIdsStr;
+      for (auto phonemeId : phonemeIds) {
+        phonemeIdsStr << phonemeId << ", ";
+      }
+      spdlog::debug("Chunk {}: {} phonemes -> {} IDs: {}", 
+                    (processedPhonemes / phonemesPerChunk) + 1,
+                    chunkPhonemes.size(), phonemeIds.size(), phonemeIdsStr.str());
+    }
+    
+    // Synthesize chunk
+    chunkAudioBuffer.clear();
+    SynthesisResult chunkResult;
+    synthesize(phonemeIds, voice.synthesisConfig, voice.session, 
+               chunkAudioBuffer, chunkResult, &voice);
+    
+    // Accumulate results
+    result.audioSeconds += chunkResult.audioSeconds;
+    result.inferSeconds += chunkResult.inferSeconds;
+    
+    // Append to main buffer
+    audioBuffer.insert(audioBuffer.end(), 
+                       chunkAudioBuffer.begin(), 
+                       chunkAudioBuffer.end());
+    
+    // Call chunk callback
+    if (chunkCallback && !chunkAudioBuffer.empty()) {
+      chunkCallback(chunkAudioBuffer);
+    }
+    
+    // Move to next chunk
+    processedPhonemes = chunkEnd;
+    
+    // For subsequent chunks, don't add BOS
+    idConfig.addBos = false;
+  }
+  
+  // Report missing phonemes
+  if (!missingPhonemes.empty()) {
+    spdlog::warn("Missing {} phoneme(s) from phoneme/id map!", missingPhonemes.size());
+    for (auto& [phoneme, count] : missingPhonemes) {
+      std::string phonemeStr;
+      utf8::append(phoneme, std::back_inserter(phonemeStr));
+      spdlog::warn("Missing \"{}\" (\\u{:04X}): {} time(s)", phonemeStr,
+                   (uint32_t)phoneme, count);
+    }
+  }
+  
+  // Calculate final real-time factor
+  if (result.audioSeconds > 0) {
+    result.realTimeFactor = result.inferSeconds / result.audioSeconds;
+  }
+  
+  spdlog::debug("Streaming phoneme synthesis complete: {} chunks, {:.2f}s audio, RTF={:.2f}",
+                (phonemes.size() + phonemesPerChunk - 1) / phonemesPerChunk,
+                result.audioSeconds, result.realTimeFactor);
+  
+} /* phonemesToAudioStreaming */
+
 // Output phoneme timing information as JSON
 void outputTimingsAsJSON(const std::vector<PhonemeInfo> &timings,
                          std::ostream &output,

--- a/src/cpp/piper.hpp
+++ b/src/cpp/piper.hpp
@@ -161,6 +161,14 @@ void textToAudioStreaming(PiperConfig &config, Voice &voice, std::string text,
                           const std::function<void(const std::vector<int16_t>&)> &chunkCallback,
                           size_t chunkSize = 4096);
 
+// Streaming phonemes-to-audio synthesis with reduced latency
+void phonemesToAudioStreaming(PiperConfig &config, Voice &voice,
+                              const std::vector<Phoneme> &phonemes,
+                              std::vector<int16_t> &audioBuffer,
+                              SynthesisResult &result,
+                              const std::function<void(const std::vector<int16_t>&)> &chunkCallback,
+                              size_t phonemesPerChunk = 10);
+
 // Output phoneme timing information as JSON
 void outputTimingsAsJSON(const std::vector<PhonemeInfo> &timings,
                          std::ostream &output,

--- a/src/cpp/tests/CMakeLists.txt
+++ b/src/cpp/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_SOURCES
     test_gpu_device_id.cpp
     test_phoneme_parser.cpp
     test_streaming_simple.cpp
+    test_streaming_raw_phonemes.cpp
 )
 
 # Add dictionary manager test for Unix platforms
@@ -124,6 +125,71 @@ foreach(test_source ${TEST_SOURCES})
 
     # Link additional dependencies for streaming test - using same approach as test_piper
     if(${test_name} STREQUAL "test_streaming_simple")
+        target_sources(${test_name} PRIVATE
+            ../piper.cpp
+            ../phoneme_parser.cpp
+            ../openjtalk_phonemize.cpp
+            ../openjtalk_wrapper.c
+            ../openjtalk_dictionary_manager.c
+            ../openjtalk_error.c
+            ../openjtalk_security.c
+            ../openjtalk_optimized.c
+        )
+        
+        # Include directories
+        target_include_directories(${test_name} PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/..
+            ${CMAKE_BINARY_DIR}/fi/include
+            ${CMAKE_BINARY_DIR}/si/include
+            ${CMAKE_BINARY_DIR}/pi/include
+        )
+        
+        # Add library directories
+        target_link_directories(${test_name} PRIVATE
+            ${CMAKE_BINARY_DIR}/fi/lib
+            ${CMAKE_BINARY_DIR}/si/lib
+            ${CMAKE_BINARY_DIR}/pi/lib
+        )
+        
+        # Platform-specific library linking (same as main piper)
+        if(WIN32)
+            # Windows: Link libraries directly
+            target_link_libraries(${test_name}
+                optimized ${CMAKE_BINARY_DIR}/fi/lib/fmt.lib
+                debug ${CMAKE_BINARY_DIR}/fi/lib/fmtd.lib
+                optimized ${CMAKE_BINARY_DIR}/si/lib/spdlog.lib
+                debug ${CMAKE_BINARY_DIR}/si/lib/spdlogd.lib
+                ${CMAKE_BINARY_DIR}/pi/lib/piper_phonemize.lib
+                ${CMAKE_BINARY_DIR}/pi/lib/espeak-ng.lib
+                ${CMAKE_BINARY_DIR}/pi/lib/onnxruntime.lib
+            )
+        else()
+            # Unix: Use library names and let CMake find them in link directories
+            target_link_libraries(${test_name}
+                fmt
+                spdlog
+                piper_phonemize
+                espeak-ng
+                onnxruntime
+            )
+        endif()
+        
+        # Platform-specific linking
+        if(UNIX)
+            find_package(Threads REQUIRED)
+            target_link_libraries(${test_name} Threads::Threads)
+        endif()
+        
+        # Add dependencies to ensure build order
+        add_dependencies(${test_name} 
+            piper_phonemize_external 
+            fmt_external 
+            spdlog_external
+        )
+    endif()
+    
+    # Link additional dependencies for streaming raw phonemes test
+    if(${test_name} STREQUAL "test_streaming_raw_phonemes")
         target_sources(${test_name} PRIVATE
             ../piper.cpp
             ../phoneme_parser.cpp

--- a/src/cpp/tests/test_streaming_raw_phonemes.cpp
+++ b/src/cpp/tests/test_streaming_raw_phonemes.cpp
@@ -1,0 +1,180 @@
+#include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+#include <vector>
+#include <string>
+#include <chrono>
+
+#include "piper.hpp"
+#include "phoneme_parser.hpp"
+
+namespace piper {
+
+class StreamingRawPhonemesTest : public ::testing::Test {
+protected:
+  PiperConfig config;
+  Voice voice;
+  std::string modelPath;
+  
+  void SetUp() override {
+    // Use the test model if available
+    modelPath = "test/models/text_voice.onnx";
+    
+    // Initialize minimal voice configuration
+    voice.phonemizeConfig.phonemeType = PHONEME_TYPE_ESPEAK;
+    voice.phonemizeConfig.interspersePad = true;
+    
+    // Create basic phoneme map
+    voice.phonemizeConfig.phonemeIdMap[PHONEME_PAD] = 0;
+    voice.phonemizeConfig.phonemeIdMap[PHONEME_BOS] = 1;
+    voice.phonemizeConfig.phonemeIdMap[PHONEME_EOS] = 2;
+    
+    // Add some basic phonemes for testing
+    PhonemeId id = 3;
+    for (char c = 'a'; c <= 'z'; c++) {
+      voice.phonemizeConfig.phonemeIdMap[c] = id++;
+    }
+    
+    // Set synthesis config
+    voice.synthesisConfig.sampleRate = 22050;
+    voice.synthesisConfig.sampleWidth = 2;
+    voice.synthesisConfig.channels = 1;
+  }
+};
+
+TEST_F(StreamingRawPhonemesTest, BasicStreamingTest) {
+  // Skip if no model is loaded
+  if (!std::filesystem::exists(modelPath)) {
+    GTEST_SKIP() << "Skipping streaming test - no model at " << modelPath;
+  }
+  
+  // Test phoneme string
+  std::string phonemeString = "h ə l oʊ w ɜː l d";
+  auto phonemes = parsePhonemeString(phonemeString, PHONEME_TYPE_ESPEAK);
+  
+  std::vector<int16_t> audioBuffer;
+  SynthesisResult result;
+  
+  // Track chunks received
+  size_t chunksReceived = 0;
+  std::vector<size_t> chunkSizes;
+  
+  auto chunkCallback = [&](const std::vector<int16_t>& chunk) {
+    chunksReceived++;
+    chunkSizes.push_back(chunk.size());
+  };
+  
+  // Test streaming synthesis
+  phonemesToAudioStreaming(config, voice, phonemes, audioBuffer, result, 
+                           chunkCallback, 5); // 5 phonemes per chunk
+  
+  // Verify we received chunks
+  EXPECT_GT(chunksReceived, 0) << "Should receive at least one chunk";
+  
+  // Verify audio was generated
+  EXPECT_GT(audioBuffer.size(), 0) << "Should generate audio";
+  
+  // Verify chunks match expected count (8 phonemes / 5 per chunk = 2 chunks)
+  size_t expectedChunks = (phonemes.size() + 4) / 5;
+  EXPECT_EQ(chunksReceived, expectedChunks) << "Should receive expected number of chunks";
+}
+
+TEST_F(StreamingRawPhonemesTest, CompareStreamingVsRegular) {
+  // Skip if no model is loaded
+  if (!std::filesystem::exists(modelPath)) {
+    GTEST_SKIP() << "Skipping streaming test - no model at " << modelPath;
+  }
+  
+  std::string phonemeString = "t ɛ s t ɪ ŋ s t r iː m ɪ ŋ";
+  auto phonemes = parsePhonemeString(phonemeString, PHONEME_TYPE_ESPEAK);
+  
+  // Regular synthesis
+  std::vector<int16_t> regularBuffer;
+  SynthesisResult regularResult;
+  phonemesToAudio(config, voice, phonemes, regularBuffer, regularResult);
+  
+  // Streaming synthesis
+  std::vector<int16_t> streamingBuffer;
+  SynthesisResult streamingResult;
+  size_t chunks = 0;
+  
+  phonemesToAudioStreaming(config, voice, phonemes, streamingBuffer, 
+                           streamingResult, 
+                           [&](const std::vector<int16_t>&) { chunks++; },
+                           4); // Small chunks for testing
+  
+  // Audio sizes should be similar (streaming might have slight variations)
+  EXPECT_NEAR(regularBuffer.size(), streamingBuffer.size(), 
+              regularBuffer.size() * 0.1) // Allow 10% variation
+      << "Streaming and regular audio should have similar sizes";
+  
+  // Verify we got multiple chunks
+  EXPECT_GT(chunks, 1) << "Should receive multiple chunks for streaming";
+}
+
+TEST_F(StreamingRawPhonemesTest, EmptyPhonemesTest) {
+  std::vector<Phoneme> phonemes; // Empty
+  std::vector<int16_t> audioBuffer;
+  SynthesisResult result;
+  
+  size_t chunksReceived = 0;
+  auto chunkCallback = [&](const std::vector<int16_t>&) {
+    chunksReceived++;
+  };
+  
+  // Should handle empty phonemes gracefully
+  phonemesToAudioStreaming(config, voice, phonemes, audioBuffer, result, 
+                           chunkCallback);
+  
+  EXPECT_EQ(audioBuffer.size(), 0) << "Empty phonemes should produce no audio";
+  EXPECT_EQ(chunksReceived, 0) << "Empty phonemes should produce no chunks";
+}
+
+TEST_F(StreamingRawPhonemesTest, PerformanceTest) {
+  // Skip if no model is loaded
+  if (!std::filesystem::exists(modelPath)) {
+    GTEST_SKIP() << "Skipping performance test - no model at " << modelPath;
+  }
+  
+  // Create a longer phoneme sequence
+  std::string longPhonemeString = "p ɜː f ɔː m ə n s t ɛ s t ";
+  for (int i = 0; i < 5; i++) {
+    longPhonemeString += longPhonemeString;
+  }
+  
+  auto phonemes = parsePhonemeString(longPhonemeString, PHONEME_TYPE_ESPEAK);
+  
+  std::vector<int16_t> audioBuffer;
+  SynthesisResult result;
+  
+  // Measure time to first chunk
+  std::chrono::steady_clock::time_point firstChunkTime;
+  bool firstChunk = true;
+  
+  auto start = std::chrono::steady_clock::now();
+  
+  phonemesToAudioStreaming(config, voice, phonemes, audioBuffer, result,
+                           [&](const std::vector<int16_t>&) {
+                             if (firstChunk) {
+                               firstChunkTime = std::chrono::steady_clock::now();
+                               firstChunk = false;
+                             }
+                           },
+                           10);
+  
+  auto end = std::chrono::steady_clock::now();
+  
+  // Calculate latencies
+  auto timeToFirstChunk = std::chrono::duration_cast<std::chrono::milliseconds>(
+      firstChunkTime - start).count();
+  auto totalTime = std::chrono::duration_cast<std::chrono::milliseconds>(
+      end - start).count();
+  
+  spdlog::info("Streaming performance: {} phonemes, {}ms to first chunk, {}ms total",
+               phonemes.size(), timeToFirstChunk, totalTime);
+  
+  // Verify streaming provides lower latency to first audio
+  EXPECT_LT(timeToFirstChunk, totalTime / 2) 
+      << "First chunk should arrive before half the total processing time";
+}
+
+} // namespace piper


### PR DESCRIPTION
## 概要

Issue #130で報告されていた、raw phonemesモードでのストリーミング未対応の問題を修正しました。

## 変更内容

### 実装
- phonemesToAudioStreaming関数を新規追加
  - 音素列をチャンク単位で処理（デフォルト: 10音素/チャンク）
  - BOS/EOSトークンの適切な管理
  - チャンクごとにコールバックを呼び出し

- main.cppの修正
  - raw phonemesモードでもストリーミング処理を有効化
  - 警告メッセージを削除

### テスト
- test_streaming_raw_phonemes.cppを追加
  - 基本的なストリーミング動作のテスト
  - 通常モードとストリーミングモードの比較
  - パフォーマンステスト

### ドキュメント
- streaming-mode.mdを更新
  - raw phonemesモードでの使用例を追加
  - 動作原理の説明を追加

Fixes #130