### PR TITLE
🐛 num_workers自動調整機能の削除（マルチスピーカーモデル学習の安定化）

### DIFF
--- a/src/python/piper_train/__main__.py
+++ b/src/python/piper_train/__main__.py
@@ -24,12 +24,6 @@ def calculate_learning_rate(base_lr, effective_batch_size, base_batch_size=16):
     return base_lr * (effective_batch_size / base_batch_size)
 
 
-def get_optimal_num_workers(num_gpus=1):
-    """Get optimal number of DataLoader workers for multi-GPU training."""
-    # 4 workers per GPU is generally optimal
-    return min(4 * num_gpus, torch.get_num_threads())
-
-
 def main():
     logging.basicConfig(level=logging.DEBUG)
 
@@ -218,14 +212,10 @@ def main():
     if num_speakers > 1 and "gin_channels" not in dict_args:
         dict_args["gin_channels"] = 768
 
-    # Multi-GPU DataLoader optimization
-    if num_gpus > 1 and "num_workers" in dict_args:
-        optimal_workers = get_optimal_num_workers(num_gpus)
-        if dict_args["num_workers"] < optimal_workers:
-            _LOGGER.info(
-                f"Adjusting num_workers from {dict_args['num_workers']} to {optimal_workers} for multi-GPU training"
-            )
-            dict_args["num_workers"] = optimal_workers
+    # num_workers自動調整機能を削除
+    # ユーザー指定のnum_workersをそのまま使用する
+    # 大規模マルチスピーカーモデルでは共有メモリ制約のため、
+    # ユーザーが適切な値を設定する必要がある
 
     model = VitsModel(
         num_symbols=num_symbols,


### PR DESCRIPTION
## 概要
大規模マルチスピーカーモデル（473話者）の学習時に発生する共有メモリ不足問題を解決するため、num_workers自動調整機能を削除しました。

## 問題点
### 1. 誤った計算ロジック
- `get_optimal_num_workers()`が**総ワーカー数**を計算していた（`4 * num_gpus = 16`）
- しかしPyTorch Lightningでは`num_workers`は**GPU毎のワーカー数**を指定
- 結果: 4GPU時に意図した16ワーカーではなく、実際は64ワーカー（16×4GPU）が生成

### 2. 実際のエラー
```
RuntimeError: unable to write to file </torch_4808_251596166_14>: No space left on device (28)
DataLoader worker (pid 4807) is killed by signal: Bus error. 
It is possible that dataloader's workers are out of shared memory.
```

### 3. ユーザー指定の無視
- ユーザーがメモリ制約を考慮して`num_workers=4`を指定しても、自動的に16に増やされてしまう
- 大規模マルチスピーカーモデルでは致命的

## 変更内容
- `get_optimal_num_workers()`関数を削除
- マルチGPU時のnum_workers自動調整ロジックを削除
- ユーザー指定のnum_workersをそのまま使用するように変更

## 影響範囲
- `/src/python/piper_train/__main__.py`のみ
- 既存の学習には影響なし（ユーザーが明示的にnum_workersを指定すれば良い）

## 推奨設定
### マルチスピーカーモデル（100話者以上）
- `--num-workers 0`または`--num-workers 1`を推奨
- 共有メモリ制限に応じて調整

### シングルスピーカーモデル
- `--num-workers 4`程度が適切
- GPU数に応じて調整可能

## テスト結果
- 473話者のマルチスピーカーモデルで修正版での動作を確認
- 自動調整が削除され、ユーザー指定値が正しく使用されることを確認

## 関連Issue
- 大規模マルチスピーカーモデルの学習安定化

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>