### PR TITLE
fix: マルチスピーカーモデル学習時のメモリ管理最適化

### DIFF
--- a/src/python/piper_train/__main__.py
+++ b/src/python/piper_train/__main__.py
@@ -272,7 +272,7 @@ def main():
 
             # モデルの重みだけをロードする (不一致は許容)
             checkpoint = torch.load(
-                args.resume_from_checkpoint, map_location="cpu", weights_only=True
+                args.resume_from_checkpoint, map_location="cpu", weights_only=False
             )
             model.load_state_dict(checkpoint["state_dict"], strict=False)
 

--- a/src/python/piper_train/__main__.py
+++ b/src/python/piper_train/__main__.py
@@ -271,6 +271,8 @@ def main():
             _LOGGER.info("Attempting to load weights only (strict=False)...")
 
             # モデルの重みだけをロードする (不一致は許容)
+            # NOTE: weights_only=False is required to handle PosixPath objects in checkpoints
+            # This poses a security risk - only load trusted checkpoints
             checkpoint = torch.load(
                 args.resume_from_checkpoint, map_location="cpu", weights_only=False
             )

--- a/src/python/piper_train/vits/lightning.py
+++ b/src/python/piper_train/vits/lightning.py
@@ -17,6 +17,9 @@ from .models import MultiPeriodDiscriminator, SynthesizerTrn
 
 _LOGGER = logging.getLogger("vits.lightning")
 
+# Memory cleanup frequency (iterations)
+MEMORY_CLEANUP_FREQUENCY = 100
+
 
 class VitsModel(pl.LightningModule):
     def __init__(
@@ -214,11 +217,15 @@ class VitsModel(pl.LightningModule):
         self.manual_backward(loss_d)
         opt_d.step()
 
-        # Periodic memory cleanup to prevent fragmentation (every 100 iterations)
-        if batch_idx % 100 == 0:
+        # Periodic memory cleanup to prevent fragmentation
+        if batch_idx % MEMORY_CLEANUP_FREQUENCY == 0:
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
-                _LOGGER.debug(f"Memory cache cleared at iteration {batch_idx}")
+                # Use info level only for first cleanup, then debug
+                if batch_idx == 0:
+                    _LOGGER.info(f"Memory cache clearing enabled every {MEMORY_CLEANUP_FREQUENCY} iterations")
+                else:
+                    _LOGGER.debug(f"Memory cache cleared at iteration {batch_idx}")
 
     def _log_with_batch_info(
         self, key: str, value, batch: Batch = None, batch_size: int = None

--- a/src/python/piper_train/vits/lightning.py
+++ b/src/python/piper_train/vits/lightning.py
@@ -213,6 +213,12 @@ class VitsModel(pl.LightningModule):
         loss_d = self.training_step_d(batch)
         self.manual_backward(loss_d)
         opt_d.step()
+        
+        # Periodic memory cleanup to prevent fragmentation (every 100 iterations)
+        if batch_idx % 100 == 0:
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+                _LOGGER.debug(f"Memory cache cleared at iteration {batch_idx}")
 
     def _log_with_batch_info(
         self, key: str, value, batch: Batch = None, batch_size: int = None
@@ -246,7 +252,7 @@ class VitsModel(pl.LightningModule):
             z_mask,
             (_z, z_p, m_p, logs_p, _m_q, logs_q),
         ) = self.model_g(x, x_lengths, spec, spec_lengths, speaker_ids)
-        self._y_hat = y_hat
+        self._y_hat = y_hat.contiguous()
 
         mel = spec_to_mel_torch(
             spec,
@@ -276,6 +282,10 @@ class VitsModel(pl.LightningModule):
             ids_slice * self.hparams.hop_length,
             self.hparams.segment_size,
         )  # slice
+        
+        # Ensure contiguous memory layout to prevent fragmentation
+        y = y.contiguous()
+        y_hat = y_hat.contiguous()
 
         # Save for training_step_d
         self._y = y
@@ -301,7 +311,9 @@ class VitsModel(pl.LightningModule):
         # From training_step_g
         y = self._y
         y_hat = self._y_hat
-        y_d_hat_r, y_d_hat_g, _, _ = self.model_d(y, y_hat.detach())
+        # Ensure detached tensors are contiguous
+        y_hat_detached = y_hat.detach().contiguous()
+        y_d_hat_r, y_d_hat_g, _, _ = self.model_d(y, y_hat_detached)
 
         with autocast(self.device.type, enabled=False):
             # Discriminator

--- a/src/python/piper_train/vits/lightning.py
+++ b/src/python/piper_train/vits/lightning.py
@@ -223,7 +223,9 @@ class VitsModel(pl.LightningModule):
                 torch.cuda.empty_cache()
                 # Use info level only for first cleanup, then debug
                 if batch_idx == 0:
-                    _LOGGER.info(f"Memory cache clearing enabled every {MEMORY_CLEANUP_FREQUENCY} iterations")
+                    _LOGGER.info(
+                        f"Memory cache clearing enabled every {MEMORY_CLEANUP_FREQUENCY} iterations"
+                    )
                 else:
                     _LOGGER.debug(f"Memory cache cleared at iteration {batch_idx}")
 

--- a/src/python/piper_train/vits/lightning.py
+++ b/src/python/piper_train/vits/lightning.py
@@ -213,7 +213,7 @@ class VitsModel(pl.LightningModule):
         loss_d = self.training_step_d(batch)
         self.manual_backward(loss_d)
         opt_d.step()
-        
+
         # Periodic memory cleanup to prevent fragmentation (every 100 iterations)
         if batch_idx % 100 == 0:
             if torch.cuda.is_available():
@@ -282,7 +282,7 @@ class VitsModel(pl.LightningModule):
             ids_slice * self.hparams.hop_length,
             self.hparams.segment_size,
         )  # slice
-        
+
         # Ensure contiguous memory layout to prevent fragmentation
         y = y.contiguous()
         y_hat = y_hat.contiguous()


### PR DESCRIPTION
## 概要
473話者のマルチスピーカーモデル学習時に発生するOOM（Out of Memory）エラーを解決するため、メモリ管理を最適化しました。

## 背景・問題
大規模マルチスピーカーモデル（473話者、1.5Mサンプル）の学習で以下の問題が発生：
- バッチサイズ60: 40イテレーションでOOM
- バッチサイズ48: 147イテレーションでOOM  
- バッチサイズ32: 220イテレーションでOOM
- メモリ使用量が累積的に増加（10イテレーションごとに約100-500MB）

## 根本原因
1. DDP（Distributed Data Parallel）でのgrad stridesミスマッチによるメモリ断片化
2. テンソルのメモリレイアウトが非連続になることによる効率低下
3. PyTorchの内部キャッシュが解放されない

## 変更内容

### 1. チェックポイント読み込みの修正
- `weights_only=True` → `weights_only=False`
- PosixPathオブジェクトを含むチェックポイントの読み込みエラーを修正

### 2. 定期的なメモリクリア（100イテレーションごと）
```python
if batch_idx % 100 == 0:
    if torch.cuda.is_available():
        torch.cuda.empty_cache()
```

### 3. テンソルのメモリレイアウト最適化
- `contiguous()`呼び出しを追加してメモリ断片化を防止
- Generator/Discriminator間で受け渡すテンソルを連続メモリ配置に

## 期待される効果
- **メモリ使用量の安定化**: 累積的な増加を防止
- **学習の継続性**: OOMエラーなしで長時間学習可能
- **パフォーマンス**: メモリアクセスパターンの改善

## テスト計画
- [x] コード実装完了
- [ ] 473話者モデルでの20エポック学習
- [ ] メモリ使用量のモニタリング
- [ ] チェックポイント保存・読み込みの動作確認

## 関連PR
- #164: num_workers自動調整機能の削除
- #165: 勾配累積サポート（VITSとの非互換性により使用不可）

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>