### PR TITLE
fix: GitHub PagesのWebデモで日本語モデルが読み込めない問題を修正

### DIFF
--- a/.github/workflows/deploy-webassembly-demo.yml
+++ b/.github/workflows/deploy-webassembly-demo.yml
@@ -38,6 +38,35 @@ jobs:
           mkdir -p deploy
           echo "Deploying WebAssembly demo with English model support"
           
+          # Function to copy model files from fallback location
+          copy_models_fallback() {
+            local source_dir="$1"
+            local dest_dir="$2"
+            
+            if [ -d "$source_dir" ]; then
+              echo "Attempting to copy models from $source_dir..."
+              
+              # Copy ONNX files with explicit error handling
+              if ls "$source_dir"/*.onnx 1>/dev/null 2>&1; then
+                cp "$source_dir"/*.onnx "$dest_dir/"
+                echo "ONNX model files copied from $source_dir"
+              else
+                echo "WARNING: No .onnx model files found in $source_dir"
+              fi
+              
+              # Copy JSON files with explicit error handling
+              if ls "$source_dir"/*.json 1>/dev/null 2>&1; then
+                cp "$source_dir"/*.json "$dest_dir/"
+                echo "JSON config files copied from $source_dir"
+              else
+                echo "WARNING: No .json config files found in $source_dir"
+              fi
+              
+              ls -la "$dest_dir/"
+            else
+              echo "WARNING: Fallback directory $source_dir does not exist"
+            fi
+          }
           
           # Copy WebAssembly artifacts
           if [ -d "src/wasm/openjtalk-web/dist" ]; then
@@ -54,6 +83,7 @@ jobs:
             mkdir -p deploy/assets
           fi
           
+          # Handle models directory
           if [ -d "src/wasm/openjtalk-web/models" ]; then
             echo "Copying models directory..."
             ls -la src/wasm/openjtalk-web/models/
@@ -74,25 +104,39 @@ jobs:
               fi
             fi
             
-            # Verify all required model files are present
-            REQUIRED_FILES="ja_JP-test-medium.onnx ja_JP-test-medium.onnx.json test_voice.onnx test_voice.onnx.json"
-            for file in $REQUIRED_FILES; do
-              if [ ! -f "deploy/models/$file" ]; then
-                echo "ERROR: Required model file $file is missing!"
+            # Dynamically verify all model files from source are present in deploy
+            echo "Verifying model files..."
+            if [ -d "src/wasm/openjtalk-web/models" ]; then
+              for model_file in src/wasm/openjtalk-web/models/*.onnx src/wasm/openjtalk-web/models/*.json; do
+                if [ -f "$model_file" ]; then
+                  filename=$(basename "$model_file")
+                  if [ ! -f "deploy/models/$filename" ]; then
+                    echo "ERROR: Model file $filename is missing in deploy/models!"
+                    exit 1
+                  fi
+                fi
+              done
+            fi
+            
+            # Additionally verify critical model files are present
+            CRITICAL_MODELS="ja_JP-test-medium.onnx test_voice.onnx"
+            for model in $CRITICAL_MODELS; do
+              if [ ! -f "deploy/models/$model" ]; then
+                echo "ERROR: Critical model file $model is missing!"
+                exit 1
+              fi
+              # Also check for corresponding JSON config
+              if [ ! -f "deploy/models/${model}.json" ]; then
+                echo "ERROR: Config file ${model}.json is missing!"
                 exit 1
               fi
             done
-            echo "All required model files verified"
+            echo "All model files verified successfully"
           else
             mkdir -p deploy/models
             echo "WARNING: models directory not found!"
-            # Try to copy from test/models as fallback
-            if [ -d "test/models" ]; then
-              echo "Copying models from test/models..."
-              cp test/models/*.onnx deploy/models/ 2>/dev/null || true
-              cp test/models/*.json deploy/models/ 2>/dev/null || true
-              ls -la deploy/models/
-            fi
+            # Use the fallback function to copy from test/models
+            copy_models_fallback "test/models" "deploy/models"
           fi
           
           # Copy multilingual demo as the main index page

--- a/.github/workflows/deploy-webassembly-demo.yml
+++ b/.github/workflows/deploy-webassembly-demo.yml
@@ -60,9 +60,39 @@ jobs:
             cp -r src/wasm/openjtalk-web/models deploy/
             echo "Models copied to deploy/models"
             ls -la deploy/models/
+            
+            # Ensure Japanese model is present, fallback to test/models if needed
+            if [ ! -f "deploy/models/ja_JP-test-medium.onnx" ]; then
+              echo "WARNING: ja_JP-test-medium.onnx not found in src/wasm/openjtalk-web/models"
+              if [ -f "test/models/ja_JP-test-medium.onnx" ]; then
+                echo "Copying ja_JP-test-medium.onnx from test/models..."
+                cp test/models/ja_JP-test-medium.onnx deploy/models/
+                echo "Japanese model copied from test/models"
+              else
+                echo "ERROR: ja_JP-test-medium.onnx not found in either location!"
+                exit 1
+              fi
+            fi
+            
+            # Verify all required model files are present
+            REQUIRED_FILES="ja_JP-test-medium.onnx ja_JP-test-medium.onnx.json test_voice.onnx test_voice.onnx.json"
+            for file in $REQUIRED_FILES; do
+              if [ ! -f "deploy/models/$file" ]; then
+                echo "ERROR: Required model file $file is missing!"
+                exit 1
+              fi
+            done
+            echo "All required model files verified"
           else
             mkdir -p deploy/models
             echo "WARNING: models directory not found!"
+            # Try to copy from test/models as fallback
+            if [ -d "test/models" ]; then
+              echo "Copying models from test/models..."
+              cp test/models/*.onnx deploy/models/ 2>/dev/null || true
+              cp test/models/*.json deploy/models/ 2>/dev/null || true
+              ls -la deploy/models/
+            fi
           fi
           
           # Copy multilingual demo as the main index page

--- a/src/wasm/openjtalk-web/.gitignore
+++ b/src/wasm/openjtalk-web/.gitignore
@@ -11,6 +11,7 @@ models/*.onnx
 !models/.gitkeep
 !models/test_voice.onnx
 !models/en_US-test-medium.onnx
+!models/ja_JP-test-medium.onnx
 
 # Node modules (if any get added)
 node_modules/


### PR DESCRIPTION
## 概要
GitHub PagesにデプロイされたWebデモで、日本語モデル(`ja_JP-test-medium.onnx`)が404エラーで読み込めない問題を修正しました。

## 問題の原因
- `src/wasm/openjtalk-web/models/`ディレクトリに日本語モデルのONNXファイル本体が存在していませんでした（JSONファイルのみ）
- GitHub Pagesへのデプロイ時に必要なモデルファイルが欠落していました

## 修正内容
### 1. モデルファイルの追加
- `test/models/ja_JP-test-medium.onnx`を`src/wasm/openjtalk-web/models/`にコピー
- `.gitignore`に日本語モデルの例外を追加して、Gitで管理できるように

### 2. デプロイワークフローの改善
- `deploy-webassembly-demo.yml`に以下の機能を追加：
  - 日本語モデルが存在しない場合の`test/models`からのフォールバック処理
  - 必要な全モデルファイル（ONNX本体とJSON設定）の存在確認
  - ファイルが見つからない場合の適切なエラー処理

## テスト方法
1. GitHub Actionsの`Deploy WebAssembly Demo to GitHub Pages`ワークフローを実行
2. デプロイされたページ（https://ayutaz.github.io/piper-plus/）にアクセス
3. 日本語テキストの音声合成が正常に動作することを確認

## 注意事項
- 日本語モデルファイル（60MB）がGitHubの推奨サイズ（50MB）を超えていますが、Git LFSは使用せずに直接管理しています
- 今後、大きなモデルファイルを追加する場合はGit LFSの使用を検討することを推奨します

🤖 Generated with [Claude Code](https://claude.ai/code)