### PR TITLE
feat: マルチスピーカーモデルから単一話者モデルへの変換スクリプトを追加

### DIFF
--- a/.github/workflows/build-piper.yml
+++ b/.github/workflows/build-piper.yml
@@ -106,7 +106,10 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install cmake ninja wget
+          # Unlink conflicting cmake if exists
+          brew unlink cmake || true
+          # Install or upgrade cmake from homebrew/core
+          brew install --overwrite cmake ninja wget || brew upgrade cmake ninja wget
           
           # Check if ONNX Runtime is already cached
           if [ ! -f "/usr/local/lib/libonnxruntime.dylib" ]; then

--- a/scripts/README_convert_multi_to_single.md
+++ b/scripts/README_convert_multi_to_single.md
@@ -12,25 +12,29 @@
 
 ## 使用方法
 
-### 1. スクリプトの実行
+### 1. 基本的な実行
 
 ```bash
+# デフォルトパスで実行
+python scripts/convert_multi_to_single_speaker.py
+
+# カスタムパスを指定
+python scripts/convert_multi_to_single_speaker.py \
+  --input-checkpoint /path/to/multi_speaker_model.ckpt \
+  --output-checkpoint /path/to/base_model.ckpt
+
+# 環境変数を使用
+export INPUT_CHECKPOINT=/path/to/multi_speaker_model.ckpt
+export OUTPUT_CHECKPOINT=/path/to/base_model.ckpt
 python scripts/convert_multi_to_single_speaker.py
 ```
 
-デフォルトでは以下のパスを使用します：
-- 入力: 既存のマルチスピーカーチェックポイント
-- 出力: `/data/piper/base_model/model.ckpt`
+### 2. コマンドライン引数
 
-### 2. カスタムパスの指定
+- `--input-checkpoint`: 入力マルチスピーカーモデルのパス
+- `--output-checkpoint`: 出力単一話者ベースモデルのパス
 
-スクリプト内の設定箇所を編集することで、異なるモデルを変換できます：
-
-```python
-# --- 設定箇所 ---
-original_checkpoint = "path/to/your/multi_speaker_model.ckpt"
-partial_checkpoint = "path/to/output/single_speaker_base.ckpt"
-```
+環境変数 `INPUT_CHECKPOINT` と `OUTPUT_CHECKPOINT` でデフォルト値を設定可能です。
 
 ### 3. config.jsonの作成
 

--- a/scripts/README_convert_multi_to_single.md
+++ b/scripts/README_convert_multi_to_single.md
@@ -1,0 +1,110 @@
+# マルチスピーカーモデルから単一話者モデルへの変換
+
+このスクリプトは、マルチスピーカーモデルから単一話者用の追加学習（ファインチューニング）用モデルを作成します。
+
+## 概要
+
+事前学習されたマルチスピーカーモデルを特定の単一話者データセットでファインチューニングする場合、以下の処理が必要です：
+
+1. **話者埋め込み層の削除** - マルチスピーカーモデルの話者関連レイヤーを削除
+2. **オプティマイザ状態の初期化** - 新しい学習のためオプティマイザをリセット
+3. **設定の更新** - `num_speakers`を0に変更
+
+## 使用方法
+
+### 1. スクリプトの実行
+
+```bash
+python scripts/convert_multi_to_single_speaker.py
+```
+
+デフォルトでは以下のパスを使用します：
+- 入力: 既存のマルチスピーカーチェックポイント
+- 出力: `/data/piper/base_model/model.ckpt`
+
+### 2. カスタムパスの指定
+
+スクリプト内の設定箇所を編集することで、異なるモデルを変換できます：
+
+```python
+# --- 設定箇所 ---
+original_checkpoint = "path/to/your/multi_speaker_model.ckpt"
+partial_checkpoint = "path/to/output/single_speaker_base.ckpt"
+```
+
+### 3. config.jsonの作成
+
+変換後は、対応するconfig.jsonも作成する必要があります：
+
+```python
+import json
+
+# 元のconfig.jsonを読み込み
+with open('original_config.json', 'r') as f:
+    config = json.load(f)
+
+# 単一話者用に修正
+config['num_speakers'] = 0
+if 'speaker_id_map' in config:
+    del config['speaker_id_map']
+
+# 保存
+with open('base_model_config.json', 'w') as f:
+    json.dump(config, f, ensure_ascii=False, indent=2)
+```
+
+## 削除されるレイヤー
+
+以下のレイヤーが自動的に削除されます：
+
+- `model_g.emb_g.weight` - 話者埋め込み層
+- `model_g.dec.cond.*` - デコーダーの条件付けレイヤー
+- `model_g.enc_q.enc.cond_layer.*` - エンコーダーの条件付けレイヤー
+- `model_g.dp.cond.*` - Duration Predictorの条件付けレイヤー
+- `model_g.flow.flows.*.enc.cond_layer.*` - フローの条件付けレイヤー
+
+## ファインチューニング例
+
+### 単一話者データセットの準備
+
+```bash
+# LJSpeech形式のデータセットを前処理
+python -m piper_train.preprocess \
+  --language ja \
+  --input-dir /path/to/wav/files \
+  --output-dir /path/to/dataset \
+  --dataset-format ljspeech \
+  --single-speaker \
+  --sample-rate 22050
+```
+
+### ファインチューニングの実行
+
+```bash
+python -m piper_train \
+  --dataset-dir /path/to/dataset \
+  --resume_from_checkpoint /path/to/base_model.ckpt \
+  --accelerator gpu \
+  --devices 1 \
+  --batch-size 32 \
+  --learning-rate 1e-4 \
+  --max_epochs 500 \
+  --checkpoint-epochs 50 \
+  --default_root_dir /path/to/output
+```
+
+## 注意事項
+
+- 変換前のモデルと同じサンプルレート、言語設定を使用してください
+- ファインチューニング時の学習率は、事前学習時より低めに設定することを推奨します（例：1e-4）
+- 十分なVRAMがある場合は、バッチサイズを大きくすることで学習を高速化できます
+
+## トラブルシューティング
+
+### Unexpected keysエラー
+
+ファインチューニング時に「Unexpected keys」のエラーが発生した場合、話者関連のレイヤーが正しく削除されていない可能性があります。スクリプトを再実行するか、手動で該当キーを削除してください。
+
+### サイズ不一致エラー
+
+モデルアーキテクチャが異なる場合（例：品質設定が異なる）、レイヤーサイズが一致しないことがあります。同じ品質設定（medium/high）のモデルを使用してください。

--- a/scripts/convert_multi_to_single_speaker.py
+++ b/scripts/convert_multi_to_single_speaker.py
@@ -5,10 +5,12 @@
 """
 
 import argparse
-import torch
-import sys
 import os
+import sys
 from pathlib import Path
+
+import torch
+
 
 def create_partial_checkpoint_for_finetuning(original_ckpt_path, new_ckpt_path):
     """
@@ -16,11 +18,13 @@ def create_partial_checkpoint_for_finetuning(original_ckpt_path, new_ckpt_path):
     オプティマイザの状態を削除した新しいチェックポイントを作成します。
     """
     print(f"Loading original checkpoint from: {original_ckpt_path}")
-    
+
     if not Path(original_ckpt_path).exists():
-        print(f"ERROR: Checkpoint file not found at {original_ckpt_path}", file=sys.stderr)
+        print(
+            f"ERROR: Checkpoint file not found at {original_ckpt_path}", file=sys.stderr
+        )
         return False
-    
+
     try:
         # CPUにロードしてGPUメモリを節約
         checkpoint = torch.load(original_ckpt_path, map_location="cpu")
@@ -31,21 +35,21 @@ def create_partial_checkpoint_for_finetuning(original_ckpt_path, new_ckpt_path):
     # チェックポイントの内容を確認
     print("\n--- Original Checkpoint Info ---")
     print(f"Keys in checkpoint: {list(checkpoint.keys())}")
-    
+
     # ハイパーパラメータの確認と更新
     if "hyper_parameters" in checkpoint:
         hp = checkpoint["hyper_parameters"]
         print(f"Original num_speakers: {hp.get('num_speakers', 'N/A')}")
         print(f"Original batch_size: {hp.get('batch_size', 'N/A')}")
         print(f"Original learning_rate: {hp.get('learning_rate', 'N/A')}")
-        
+
         # 単一話者用に更新（0: 話者埋め込みなし）
-        hp['num_speakers'] = 0
-        hp['speaker_id'] = None
+        hp["num_speakers"] = 0
+        hp["speaker_id"] = None
         print(f"Updated num_speakers to: {hp['num_speakers']}")
 
     original_state_dict = checkpoint["state_dict"]
-    
+
     # 削除するキーのリスト
     # これらは主に、話者数が変わったことで不要になったレイヤーです
     keys_to_remove = [
@@ -59,79 +63,88 @@ def create_partial_checkpoint_for_finetuning(original_ckpt_path, new_ckpt_path):
         "model_g.dp.cond.weight",
         "model_g.dp.cond.bias",
     ]
-    
+
     # フローの条件付けレイヤーも動的にリストに追加
     for i in [0, 2, 4, 6]:
         for suffix in ["bias", "weight_g", "weight_v"]:
             keys_to_remove.append(f"model_g.flow.flows.{i}.enc.cond_layer.{suffix}")
-    
+
     # discriminatorの話者関連レイヤーも削除（存在する場合）
     discriminator_keys_to_check = [
         "model_d.emb",
         "model_d.cond",
     ]
-    
+
     # 実際に存在するキーのみを削除対象に追加
     keys_to_remove_set = set()
     for key in keys_to_remove:
         if key in original_state_dict:
             keys_to_remove_set.add(key)
-    
+
     # discriminator関連のキーも確認（set comprehensionで最適化）
-    keys_to_remove_set.update({
-        key for key in original_state_dict.keys()
-        for pattern in discriminator_keys_to_check
-        if pattern in key
-    })
+    keys_to_remove_set.update(
+        {
+            key
+            for key in original_state_dict.keys()
+            for pattern in discriminator_keys_to_check
+            if pattern in key
+        }
+    )
 
     # 新しいstate_dictから、削除対象のキーを除外して作成
-    new_state_dict = {key: value for key, value in original_state_dict.items() 
-                      if key not in keys_to_remove_set}
+    new_state_dict = {
+        key: value
+        for key, value in original_state_dict.items()
+        if key not in keys_to_remove_set
+    }
 
     # チェックポイントのstate_dictを新しいものに更新
     checkpoint["state_dict"] = new_state_dict
-    
+
     # オプティマイザの状態を削除（新しい学習のため）
     if "optimizer_states" in checkpoint:
         del checkpoint["optimizer_states"]
         print("Removed optimizer states from the checkpoint.")
-    
+
     # LRスケジューラの状態も削除
     if "lr_schedulers" in checkpoint:
         del checkpoint["lr_schedulers"]
         print("Removed lr_schedulers from the checkpoint.")
-    
+
     # EMA状態も確認して削除（必要に応じて）
     ema_keys_removed = []
     # パターンを事前に計算して効率化
-    cleaned_patterns = {pattern.replace("model_g.", "").replace("model_d.", "") 
-                       for pattern in keys_to_remove_set}
-    
+    cleaned_patterns = {
+        pattern.replace("model_g.", "").replace("model_d.", "")
+        for pattern in keys_to_remove_set
+    }
+
     for key in ["ema_generator_state", "ema_discriminator_state"]:
         if key in checkpoint:
             # EMA状態内の話者関連キーを削除
             if isinstance(checkpoint[key], dict) and "module" in checkpoint[key]:
                 ema_state = checkpoint[key]["module"]
                 ema_keys_to_remove = {
-                    ema_key for ema_key in ema_state.keys()
+                    ema_key
+                    for ema_key in ema_state.keys()
                     if any(pattern in ema_key for pattern in cleaned_patterns)
                 }
-                
+
                 for ema_key in ema_keys_to_remove:
                     del ema_state[ema_key]
                     ema_keys_removed.append(ema_key)
-    
+
     if ema_keys_removed:
         print(f"Removed {len(ema_keys_removed)} keys from EMA states")
-    
+
     # エポック数とステップ数をリセット（オプション）
     # checkpoint["epoch"] = 0
     # checkpoint["global_step"] = 0
-    
+
     # 新しいチェックポイントディレクトリの作成
     output_path = Path(new_ckpt_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    
+
     # 新しい部分的なチェックポイントを保存
     torch.save(checkpoint, new_ckpt_path)
 
@@ -143,8 +156,10 @@ def create_partial_checkpoint_for_finetuning(original_ckpt_path, new_ckpt_path):
     print(f"New state_dict has {len(new_state_dict)} keys.")
     print("---------------------------------------")
     print(f"\nPartial checkpoint for fine-tuning saved to: {new_ckpt_path}")
-    print("\nNow, use this new partial checkpoint path for the --resume_from_checkpoint argument.")
-    
+    print(
+        "\nNow, use this new partial checkpoint path for the --resume_from_checkpoint argument."
+    )
+
     return True
 
 
@@ -157,31 +172,29 @@ if __name__ == "__main__":
         type=str,
         default=os.environ.get(
             "INPUT_CHECKPOINT",
-            "/data/piper/output-moe-speech-50speakers-v1/lightning_logs/version_4/checkpoints/epoch=139-step=2027480.ckpt"
+            "/data/piper/output-moe-speech-50speakers-v1/lightning_logs/version_4/checkpoints/epoch=139-step=2027480.ckpt",
         ),
-        help="入力マルチスピーカーチェックポイントのパス（環境変数: INPUT_CHECKPOINT）"
+        help="入力マルチスピーカーチェックポイントのパス（環境変数: INPUT_CHECKPOINT）",
     )
     parser.add_argument(
         "--output-checkpoint",
         type=str,
         default=os.environ.get(
-            "OUTPUT_CHECKPOINT",
-            "/data/piper/base_model/model.ckpt"
+            "OUTPUT_CHECKPOINT", "/data/piper/base_model/model.ckpt"
         ),
-        help="出力単一話者チェックポイントのパス（環境変数: OUTPUT_CHECKPOINT）"
+        help="出力単一話者チェックポイントのパス（環境変数: OUTPUT_CHECKPOINT）",
     )
-    
+
     args = parser.parse_args()
-    
+
     success = create_partial_checkpoint_for_finetuning(
-        args.input_checkpoint,
-        args.output_checkpoint
+        args.input_checkpoint, args.output_checkpoint
     )
-    
+
     if success:
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("✓ 変換成功！")
-        print("="*60)
+        print("=" * 60)
         print("\n次のステップ:")
         print("1. データセットの前処理:")
         print("   python -m piper_train.preprocess \\")

--- a/scripts/convert_multi_to_single_speaker.py
+++ b/scripts/convert_multi_to_single_speaker.py
@@ -4,6 +4,7 @@
 事前学習モデルから話者埋め込み層を削除し、オプティマイザ状態を初期化します
 """
 
+import argparse
 import torch
 import sys
 import os
@@ -38,8 +39,8 @@ def create_partial_checkpoint_for_finetuning(original_ckpt_path, new_ckpt_path):
         print(f"Original batch_size: {hp.get('batch_size', 'N/A')}")
         print(f"Original learning_rate: {hp.get('learning_rate', 'N/A')}")
         
-        # 単一話者用に更新
-        hp['num_speakers'] = 0  # または1
+        # 単一話者用に更新（0: 話者埋め込みなし）
+        hp['num_speakers'] = 0
         hp['speaker_id'] = None
         print(f"Updated num_speakers to: {hp['num_speakers']}")
 
@@ -76,11 +77,12 @@ def create_partial_checkpoint_for_finetuning(original_ckpt_path, new_ckpt_path):
         if key in original_state_dict:
             keys_to_remove_set.add(key)
     
-    # discriminator関連のキーも確認
-    for key in original_state_dict.keys():
-        for pattern in discriminator_keys_to_check:
-            if pattern in key:
-                keys_to_remove_set.add(key)
+    # discriminator関連のキーも確認（set comprehensionで最適化）
+    keys_to_remove_set.update({
+        key for key in original_state_dict.keys()
+        for pattern in discriminator_keys_to_check
+        if pattern in key
+    })
 
     # 新しいstate_dictから、削除対象のキーを除外して作成
     new_state_dict = {key: value for key, value in original_state_dict.items() 
@@ -101,21 +103,23 @@ def create_partial_checkpoint_for_finetuning(original_ckpt_path, new_ckpt_path):
     
     # EMA状態も確認して削除（必要に応じて）
     ema_keys_removed = []
+    # パターンを事前に計算して効率化
+    cleaned_patterns = {pattern.replace("model_g.", "").replace("model_d.", "") 
+                       for pattern in keys_to_remove_set}
+    
     for key in ["ema_generator_state", "ema_discriminator_state"]:
         if key in checkpoint:
             # EMA状態内の話者関連キーを削除
             if isinstance(checkpoint[key], dict) and "module" in checkpoint[key]:
                 ema_state = checkpoint[key]["module"]
-                ema_keys_to_remove = []
-                for ema_key in ema_state.keys():
-                    for pattern in keys_to_remove_set:
-                        if pattern.replace("model_g.", "") in ema_key or pattern.replace("model_d.", "") in ema_key:
-                            ema_keys_to_remove.append(ema_key)
+                ema_keys_to_remove = {
+                    ema_key for ema_key in ema_state.keys()
+                    if any(pattern in ema_key for pattern in cleaned_patterns)
+                }
                 
                 for ema_key in ema_keys_to_remove:
-                    if ema_key in ema_state:
-                        del ema_state[ema_key]
-                        ema_keys_removed.append(ema_key)
+                    del ema_state[ema_key]
+                    ema_keys_removed.append(ema_key)
     
     if ema_keys_removed:
         print(f"Removed {len(ema_keys_removed)} keys from EMA states")
@@ -145,33 +149,52 @@ def create_partial_checkpoint_for_finetuning(original_ckpt_path, new_ckpt_path):
 
 
 if __name__ == "__main__":
-    # --- 設定箇所 ---
-    # エポック139のマルチスピーカーモデルのチェックポイントパス
-    original_checkpoint = "/data/piper/output-moe-speech-50speakers-v1/lightning_logs/version_4/checkpoints/epoch=139-step=2027480.ckpt"
+    parser = argparse.ArgumentParser(
+        description="マルチスピーカーモデルから単一話者モデルへの変換"
+    )
+    parser.add_argument(
+        "--input-checkpoint",
+        type=str,
+        default=os.environ.get(
+            "INPUT_CHECKPOINT",
+            "/data/piper/output-moe-speech-50speakers-v1/lightning_logs/version_4/checkpoints/epoch=139-step=2027480.ckpt"
+        ),
+        help="入力マルチスピーカーチェックポイントのパス（環境変数: INPUT_CHECKPOINT）"
+    )
+    parser.add_argument(
+        "--output-checkpoint",
+        type=str,
+        default=os.environ.get(
+            "OUTPUT_CHECKPOINT",
+            "/data/piper/base_model/model.ckpt"
+        ),
+        help="出力単一話者チェックポイントのパス（環境変数: OUTPUT_CHECKPOINT）"
+    )
     
-    # 保存する新しい「部分的チェックポイント」のパスとファイル名
-    partial_checkpoint = "/data/piper/base_model/model.ckpt"
-    # --- 設定ここまで ---
+    args = parser.parse_args()
     
-    success = create_partial_checkpoint_for_finetuning(original_checkpoint, partial_checkpoint)
+    success = create_partial_checkpoint_for_finetuning(
+        args.input_checkpoint,
+        args.output_checkpoint
+    )
     
     if success:
         print("\n" + "="*60)
         print("✓ 変換成功！")
         print("="*60)
         print("\n次のステップ:")
-        print("1. tsukuyomi-chanデータセットの前処理:")
+        print("1. データセットの前処理:")
         print("   python -m piper_train.preprocess \\")
         print("     --language ja \\")
-        print("     --input-dir /data/tsukuyomi-chan-ljspeech/wavs \\")
-        print("     --output-dir /data/piper/dataset-tsukuyomi-single \\")
+        print("     --input-dir /path/to/wavs \\")
+        print("     --output-dir /path/to/dataset \\")
         print("     --dataset-format ljspeech \\")
         print("     --single-speaker \\")
         print("     --sample-rate 22050")
         print("\n2. 追加学習の実行:")
         print("   python -m piper_train \\")
-        print("     --dataset-dir /data/piper/dataset-tsukuyomi-single \\")
-        print(f"     --resume_from_checkpoint {partial_checkpoint} \\")
+        print("     --dataset-dir /path/to/dataset \\")
+        print(f"     --resume_from_checkpoint {args.output_checkpoint} \\")
         print("     --accelerator gpu \\")
         print("     --devices 1 \\")
         print("     --batch-size 32 \\")

--- a/scripts/convert_multi_to_single_speaker.py
+++ b/scripts/convert_multi_to_single_speaker.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+マルチスピーカーモデルから単一話者用の追加学習モデルを作成するスクリプト
+事前学習モデルから話者埋め込み層を削除し、オプティマイザ状態を初期化します
+"""
+
+import torch
+import sys
+import os
+from pathlib import Path
+
+def create_partial_checkpoint_for_finetuning(original_ckpt_path, new_ckpt_path):
+    """
+    ファインチューニングのために、不整合なレイヤー（話者関連の層）と
+    オプティマイザの状態を削除した新しいチェックポイントを作成します。
+    """
+    print(f"Loading original checkpoint from: {original_ckpt_path}")
+    
+    if not Path(original_ckpt_path).exists():
+        print(f"ERROR: Checkpoint file not found at {original_ckpt_path}", file=sys.stderr)
+        return False
+    
+    try:
+        # CPUにロードしてGPUメモリを節約
+        checkpoint = torch.load(original_ckpt_path, map_location="cpu")
+    except Exception as e:
+        print(f"ERROR: Failed to load checkpoint: {e}", file=sys.stderr)
+        return False
+
+    # チェックポイントの内容を確認
+    print("\n--- Original Checkpoint Info ---")
+    print(f"Keys in checkpoint: {list(checkpoint.keys())}")
+    
+    # ハイパーパラメータの確認と更新
+    if "hyper_parameters" in checkpoint:
+        hp = checkpoint["hyper_parameters"]
+        print(f"Original num_speakers: {hp.get('num_speakers', 'N/A')}")
+        print(f"Original batch_size: {hp.get('batch_size', 'N/A')}")
+        print(f"Original learning_rate: {hp.get('learning_rate', 'N/A')}")
+        
+        # 単一話者用に更新
+        hp['num_speakers'] = 0  # または1
+        hp['speaker_id'] = None
+        print(f"Updated num_speakers to: {hp['num_speakers']}")
+
+    original_state_dict = checkpoint["state_dict"]
+    
+    # 削除するキーのリスト
+    # これらは主に、話者数が変わったことで不要になったレイヤーです
+    keys_to_remove = [
+        # 話者埋め込み層と関連する条件付けレイヤー
+        "model_g.emb_g.weight",
+        "model_g.dec.cond.weight",
+        "model_g.dec.cond.bias",
+        "model_g.enc_q.enc.cond_layer.bias",
+        "model_g.enc_q.enc.cond_layer.weight_g",
+        "model_g.enc_q.enc.cond_layer.weight_v",
+        "model_g.dp.cond.weight",
+        "model_g.dp.cond.bias",
+    ]
+    
+    # フローの条件付けレイヤーも動的にリストに追加
+    for i in [0, 2, 4, 6]:
+        for suffix in ["bias", "weight_g", "weight_v"]:
+            keys_to_remove.append(f"model_g.flow.flows.{i}.enc.cond_layer.{suffix}")
+    
+    # discriminatorの話者関連レイヤーも削除（存在する場合）
+    discriminator_keys_to_check = [
+        "model_d.emb",
+        "model_d.cond",
+    ]
+    
+    # 実際に存在するキーのみを削除対象に追加
+    keys_to_remove_set = set()
+    for key in keys_to_remove:
+        if key in original_state_dict:
+            keys_to_remove_set.add(key)
+    
+    # discriminator関連のキーも確認
+    for key in original_state_dict.keys():
+        for pattern in discriminator_keys_to_check:
+            if pattern in key:
+                keys_to_remove_set.add(key)
+
+    # 新しいstate_dictから、削除対象のキーを除外して作成
+    new_state_dict = {key: value for key, value in original_state_dict.items() 
+                      if key not in keys_to_remove_set}
+
+    # チェックポイントのstate_dictを新しいものに更新
+    checkpoint["state_dict"] = new_state_dict
+    
+    # オプティマイザの状態を削除（新しい学習のため）
+    if "optimizer_states" in checkpoint:
+        del checkpoint["optimizer_states"]
+        print("Removed optimizer states from the checkpoint.")
+    
+    # LRスケジューラの状態も削除
+    if "lr_schedulers" in checkpoint:
+        del checkpoint["lr_schedulers"]
+        print("Removed lr_schedulers from the checkpoint.")
+    
+    # EMA状態も確認して削除（必要に応じて）
+    ema_keys_removed = []
+    for key in ["ema_generator_state", "ema_discriminator_state"]:
+        if key in checkpoint:
+            # EMA状態内の話者関連キーを削除
+            if isinstance(checkpoint[key], dict) and "module" in checkpoint[key]:
+                ema_state = checkpoint[key]["module"]
+                ema_keys_to_remove = []
+                for ema_key in ema_state.keys():
+                    for pattern in keys_to_remove_set:
+                        if pattern.replace("model_g.", "") in ema_key or pattern.replace("model_d.", "") in ema_key:
+                            ema_keys_to_remove.append(ema_key)
+                
+                for ema_key in ema_keys_to_remove:
+                    if ema_key in ema_state:
+                        del ema_state[ema_key]
+                        ema_keys_removed.append(ema_key)
+    
+    if ema_keys_removed:
+        print(f"Removed {len(ema_keys_removed)} keys from EMA states")
+    
+    # エポック数とステップ数をリセット（オプション）
+    # checkpoint["epoch"] = 0
+    # checkpoint["global_step"] = 0
+    
+    # 新しいチェックポイントディレクトリの作成
+    output_path = Path(new_ckpt_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    # 新しい部分的なチェックポイントを保存
+    torch.save(checkpoint, new_ckpt_path)
+
+    print("\n--- Checkpoint Modification Summary ---")
+    print(f"Original state_dict had {len(original_state_dict)} keys.")
+    print(f"Removed {len(keys_to_remove_set)} keys:")
+    for key in sorted(keys_to_remove_set):
+        print(f"  - {key}")
+    print(f"New state_dict has {len(new_state_dict)} keys.")
+    print("---------------------------------------")
+    print(f"\nPartial checkpoint for fine-tuning saved to: {new_ckpt_path}")
+    print("\nNow, use this new partial checkpoint path for the --resume_from_checkpoint argument.")
+    
+    return True
+
+
+if __name__ == "__main__":
+    # --- 設定箇所 ---
+    # エポック139のマルチスピーカーモデルのチェックポイントパス
+    original_checkpoint = "/data/piper/output-moe-speech-50speakers-v1/lightning_logs/version_4/checkpoints/epoch=139-step=2027480.ckpt"
+    
+    # 保存する新しい「部分的チェックポイント」のパスとファイル名
+    partial_checkpoint = "/data/piper/base_model/model.ckpt"
+    # --- 設定ここまで ---
+    
+    success = create_partial_checkpoint_for_finetuning(original_checkpoint, partial_checkpoint)
+    
+    if success:
+        print("\n" + "="*60)
+        print("✓ 変換成功！")
+        print("="*60)
+        print("\n次のステップ:")
+        print("1. tsukuyomi-chanデータセットの前処理:")
+        print("   python -m piper_train.preprocess \\")
+        print("     --language ja \\")
+        print("     --input-dir /data/tsukuyomi-chan-ljspeech/wavs \\")
+        print("     --output-dir /data/piper/dataset-tsukuyomi-single \\")
+        print("     --dataset-format ljspeech \\")
+        print("     --single-speaker \\")
+        print("     --sample-rate 22050")
+        print("\n2. 追加学習の実行:")
+        print("   python -m piper_train \\")
+        print("     --dataset-dir /data/piper/dataset-tsukuyomi-single \\")
+        print(f"     --resume_from_checkpoint {partial_checkpoint} \\")
+        print("     --accelerator gpu \\")
+        print("     --devices 1 \\")
+        print("     --batch-size 32 \\")
+        print("     --max_epochs 500 \\")
+        print("     --checkpoint-epochs 50")
+    else:
+        print("\n✗ 変換失敗", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## 概要
マルチスピーカーモデルから単一話者用のファインチューニングベースモデルを作成するスクリプトを追加しました。

## 背景
事前学習されたマルチスピーカーモデルを特定の話者でファインチューニングする際、話者埋め込み層の不整合によりエラーが発生します。このスクリプトは、その問題を解決するためのツールです。

## 主な機能
- 話者埋め込み層（emb_g）と条件付けレイヤー（cond）の自動削除
- オプティマイザ状態の初期化（新しい学習のため）
- ハイパーパラメータの更新（num_speakers: 50 → 0）
- 変換前後の詳細なレポート出力

## テスト結果
エポック139のマルチスピーカーモデル（50話者）から変換：
- 元のstate_dict: 804キー
- 削除: 20キー
- 変換後: 784キー
- ファイルサイズ: 888.4MB → 276MB

## ドキュメント
詳細な使用方法は scripts/README_convert_multi_to_single.md を参照してください。