### PR TITLE
Apply utf-8 to piper_phonemize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,12 @@ if(NOT DEFINED PIPER_PHONEMIZE_DIR)
     CMAKE_ARGS -DESPEAK_NG_BUILD_SHARED:BOOL=${PIPER_PHONEMIZE_SHARED_LIBS}
     CMAKE_ARGS -DCMAKE_MSVC_RUNTIME_LIBRARY:STRING=${CMAKE_MSVC_RUNTIME_LIBRARY}
     CMAKE_ARGS ${EXTERNAL_CMAKE_ARGS}
+    # Patch piper-phonemize sources to force UTF-8 on MSVC for all subprojects
+    PATCH_COMMAND
+      ${CMAKE_COMMAND} -D SOURCE_DIR=<SOURCE_DIR> -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/apply_piper_phonemize_patch.cmake
+    # Ensure nested builds (e.g., espeak-ng) receive MSVC UTF-8 option even if flags are overridden
+    BUILD_COMMAND ${CMAKE_COMMAND} -E env CL=/utf-8 ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG>
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E env CL=/utf-8 ${CMAKE_COMMAND} --build <BINARY_DIR> --target install --config $<CONFIG>
   )
   add_dependencies(piper piper_phonemize_external)
   add_dependencies(test_piper piper_phonemize_external)

--- a/cmake/apply_piper_phonemize_patch.cmake
+++ b/cmake/apply_piper_phonemize_patch.cmake
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.15)
+
+# Inputs:
+#  - SOURCE_DIR: path to the downloaded piper-phonemize source directory
+
+if(NOT DEFINED SOURCE_DIR)
+  message(FATAL_ERROR "apply_piper_phonemize_patch.cmake: SOURCE_DIR is not defined")
+endif()
+
+set(src "${SOURCE_DIR}/CMakeLists.txt")
+if(NOT EXISTS "${src}")
+  message(FATAL_ERROR "apply_piper_phonemize_patch.cmake: CMakeLists.txt not found under ${SOURCE_DIR}")
+endif()
+
+# Read file to check if already patched
+file(READ "${src}" contents)
+string(FIND "${contents}" "/utf-8" already)
+if(NOT already EQUAL -1)
+  message(STATUS "piper-phonemize already contains /utf-8 settings; skipping patch")
+  return()
+endif()
+
+message(STATUS "Patching piper-phonemize CMakeLists.txt to force MSVC UTF-8")
+
+set(patch "\n# Injected by piper-plus build: force UTF-8 on MSVC for all subprojects\nif(MSVC)\n  add_compile_options(\"$<$<COMPILE_LANGUAGE:C>:/utf-8>\" \"$<$<COMPILE_LANGUAGE:CXX>:/utf-8>\")\nendif()\n")
+
+file(APPEND "${src}" "${patch}")
+
+message(STATUS "Applied UTF-8 compile options to ${src}")
+


### PR DESCRIPTION
The piper-phonemize source code contains UTF-8 characters, but in Japanese environments, files are not treated as UTF-8 by default, causing errors. Therefore, UTF-8 encoding must be explicitly configured.