### PR TITLE
fix: Always output durations in ONNX export (#209)

### DIFF
--- a/docs/features/phoneme-timing.md
+++ b/docs/features/phoneme-timing.md
@@ -4,13 +4,13 @@ Piper can output timing information for each phoneme during text-to-speech synth
 
 ## Overview
 
-When enabled, Piper extracts phoneme duration information from the synthesis process and outputs start/end times for each phoneme. This feature requires models exported with the `--with-durations` flag.
+Piper extracts phoneme duration information from the synthesis process and outputs start/end times for each phoneme. Duration information is automatically included in all ONNX model exports.
 
 ## Requirements
 
-1. **Model Support**: The ONNX model must be exported with duration information:
+1. **Model Support**: All ONNX models exported with piper_train include duration information by default:
    ```bash
-   python -m piper_train.export_onnx checkpoint.ckpt model.onnx --with-durations
+   python -m piper_train.export_onnx checkpoint.ckpt model.onnx
    ```
 
 2. **Piper Version**: Requires Piper built from this branch or later
@@ -131,13 +131,12 @@ for word in words:
 - No impact on audio quality
 
 ### Limitations
-1. **Model Dependency**: Only works with models exported with `--with-durations`
-2. **Frame Granularity**: Timing precision limited by hop size
-3. **No Sub-phoneme Information**: Cannot provide timing for phoneme parts
+1. **Frame Granularity**: Timing precision limited by hop size
+2. **No Sub-phoneme Information**: Cannot provide timing for phoneme parts
 
-## Fallback for Older Models
+## Compatibility with Older Models
 
-For models without duration support, timing is not available. The synthesis will complete normally but no timing file will be generated.
+Models exported before this change (without duration output) will still work for audio synthesis, but timing information will not be available. Re-export such models to enable timing support.
 
 ## Integration Example
 

--- a/src/python/piper_train/export_onnx.py
+++ b/src/python/piper_train/export_onnx.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import torch
 
+from .vits import commons
 from .vits.lightning import VitsModel
 
 
@@ -132,15 +133,12 @@ def main() -> None:
     # Check if model uses prosody features
     has_prosody = getattr(model_g, "prosody_dim", 0) > 0
 
-    # Import commons for sequence_mask and generate_path
-    from .vits import commons
-
     def infer_forward(text, text_lengths, scales, sid=None, prosody_features=None):
         """
         Efficient forward function that returns both audio and duration information.
         Duration predictor is called only once (not twice as in the previous implementation).
         """
-        noise_scale = scales[0]
+        # noise_scale = scales[0]  # unused in ONNX export (deterministic mode)
         length_scale = scales[1]
         noise_scale_w = scales[2]
 

--- a/src/python/piper_train/export_onnx.py
+++ b/src/python/piper_train/export_onnx.py
@@ -136,7 +136,7 @@ def main() -> None:
     def infer_forward(text, text_lengths, scales, sid=None, prosody_features=None):
         """
         Efficient forward function that returns both audio and duration information.
-        Duration predictor is called only once (not twice as in the previous implementation).
+        The duration predictor is called once to compute both durations and audio output.
         """
         # noise_scale = scales[0]  # unused in ONNX export (deterministic mode)
         length_scale = scales[1]
@@ -175,8 +175,8 @@ def main() -> None:
         m_p = torch.matmul(attn.squeeze(1), m_p.transpose(1, 2)).transpose(1, 2)
         logs_p = torch.matmul(attn.squeeze(1), logs_p.transpose(1, 2)).transpose(1, 2)
 
-        # 5. Sample z_p (deterministic in ONNX export mode)
-        z_p = m_p  # onnx_export_mode uses mean only
+        # 5. Sample z_p (deterministic: use mean instead of stochastic sampling)
+        z_p = m_p  # use mean only (no sampling)
 
         # 6. Flow + Decoder
         z = model_g.flow(z_p, y_mask, g=g, reverse=True)

--- a/src/python/piper_train/export_onnx.py
+++ b/src/python/piper_train/export_onnx.py
@@ -87,11 +87,6 @@ def main() -> None:
     parser.add_argument(
         "--simplify-only", help="Only simplify existing ONNX model (path to .onnx file)"
     )
-    parser.add_argument(
-        "--with-durations",
-        action="store_true",
-        help="Include duration information in ONNX output for phoneme timing",
-    )
     args = parser.parse_args()
 
     if args.debug:
@@ -122,8 +117,11 @@ def main() -> None:
     num_symbols = model_g.n_vocab
     num_speakers = model_g.n_speakers
 
-    # Enable ONNX export mode
+    # Enable ONNX export mode for deterministic output
     model_g.onnx_export_mode = True
+    # Propagate to Duration Predictor (StochasticDurationPredictor)
+    if hasattr(model_g, "dp"):
+        model_g.dp.onnx_export_mode = True
 
     # Inference only
     model_g.eval()
@@ -131,79 +129,65 @@ def main() -> None:
     with torch.no_grad():
         model_g.dec.remove_weight_norm()
 
-    # old_forward = model_g.infer
-
     # Check if model uses prosody features
     has_prosody = getattr(model_g, "prosody_dim", 0) > 0
 
-    if args.with_durations:
+    # Import commons for sequence_mask and generate_path
+    from .vits import commons
 
-        def infer_forward_with_durations(
-            text, text_lengths, scales, sid=None, prosody_features=None
-        ):
-            """Forward function that returns both audio and duration information"""
-            noise_scale = scales[0]
-            length_scale = scales[1]
-            noise_scale_w = scales[2]
+    def infer_forward(text, text_lengths, scales, sid=None, prosody_features=None):
+        """
+        Efficient forward function that returns both audio and duration information.
+        Duration predictor is called only once (not twice as in the previous implementation).
+        """
+        noise_scale = scales[0]
+        length_scale = scales[1]
+        noise_scale_w = scales[2]
 
-            # Get encoder output
-            x, m_p, logs_p, x_mask = model_g.enc_p(text, text_lengths)
+        # 1. Encoder
+        x, m_p, logs_p, x_mask = model_g.enc_p(text, text_lengths)
 
-            if model_g.n_speakers > 1 and sid is not None:
-                g = model_g.emb_g(sid).unsqueeze(-1)
-            else:
-                g = None
+        if model_g.n_speakers > 1 and sid is not None:
+            g = model_g.emb_g(sid).unsqueeze(-1)
+        else:
+            g = None
 
-            # Prepare prosody input for duration predictor
-            x_dp = model_g._prepare_prosody_input(x, x_mask, prosody_features)
+        # 2. Duration Predictor (called only once)
+        x_dp = model_g._prepare_prosody_input(x, x_mask, prosody_features)
+        if model_g.use_sdp:
+            logw = model_g.dp(
+                x_dp, x_mask, g=g, reverse=True, noise_scale=noise_scale_w
+            )
+        else:
+            logw = model_g.dp(x_dp, x_mask, g=g)
 
-            # Get duration predictions
-            if model_g.use_sdp:
-                logw = model_g.dp(
-                    x_dp, x_mask, g=g, reverse=True, noise_scale=noise_scale_w
-                )
-            else:
-                logw = model_g.dp(x_dp, x_mask, g=g)
+        w = torch.exp(logw) * x_mask * length_scale
+        durations = w.squeeze(1)  # [batch, phoneme_length]
 
-            w = torch.exp(logw) * x_mask * length_scale
+        # 3. Attention/Alignment
+        w_ceil = torch.ceil(w)
+        y_lengths = torch.clamp_min(torch.sum(w_ceil, [1, 2]), 1).long()
+        y_mask = torch.unsqueeze(
+            commons.sequence_mask(y_lengths, y_lengths.max()), 1
+        ).type_as(x_mask)
+        attn_mask = torch.unsqueeze(x_mask, 2) * torch.unsqueeze(y_mask, -1)
+        attn = commons.generate_path(w_ceil, attn_mask)
 
-            # Get audio using regular inference
-            audio = model_g.infer(
-                text,
-                text_lengths,
-                noise_scale=noise_scale,
-                length_scale=length_scale,
-                noise_scale_w=noise_scale_w,
-                sid=sid,
-                prosody_features=prosody_features,
-            )[0].unsqueeze(1)
+        # 4. Expand prior
+        m_p = torch.matmul(attn.squeeze(1), m_p.transpose(1, 2)).transpose(1, 2)
+        logs_p = torch.matmul(attn.squeeze(1), logs_p.transpose(1, 2)).transpose(1, 2)
 
-            # Return both audio and durations
-            # Squeeze durations to remove channel dimension [batch, 1, phoneme_length] -> [batch, phoneme_length]
-            durations = w.squeeze(1)
+        # 5. Sample z_p (deterministic in ONNX export mode)
+        z_p = m_p  # onnx_export_mode uses mean only
 
-            return audio, durations
+        # 6. Flow + Decoder
+        z = model_g.flow(z_p, y_mask, g=g, reverse=True)
+        o = model_g.dec((z * y_mask), g=g)
+        audio = o.unsqueeze(1)
 
-        model_g.forward = infer_forward_with_durations
-    else:
+        return audio, durations
 
-        def infer_forward(text, text_lengths, scales, sid=None, prosody_features=None):
-            noise_scale = scales[0]
-            length_scale = scales[1]
-            noise_scale_w = scales[2]
-            audio = model_g.infer(
-                text,
-                text_lengths,
-                noise_scale=noise_scale,
-                length_scale=length_scale,
-                noise_scale_w=noise_scale_w,
-                sid=sid,
-                prosody_features=prosody_features,
-            )[0].unsqueeze(1)
-
-            return audio
-
-        model_g.forward = infer_forward
+    model_g.forward = infer_forward
 
     dummy_input_length = 50
     sequences = torch.randint(
@@ -234,28 +218,19 @@ def main() -> None:
     else:
         dummy_input = (sequences, sequence_lengths, scales)
 
-    # Export
-    if args.with_durations:
-        output_names = ["output", "durations"]
-        dynamic_axes = {
-            "input": {0: "batch_size", 1: "phonemes"},
-            "input_lengths": {0: "batch_size"},
-            "output": {0: "batch_size", 1: "time"},
-            "durations": {0: "batch_size", 1: "phonemes"},
-        }
-    else:
-        output_names = ["output"]
-        dynamic_axes = {
-            "input": {0: "batch_size", 1: "phonemes"},
-            "input_lengths": {0: "batch_size"},
-            "output": {0: "batch_size", 1: "time"},
-        }
+    # Export - always include durations output
+    output_names = ["output", "durations"]
+    dynamic_axes = {
+        "input": {0: "batch_size", 1: "phonemes"},
+        "input_lengths": {0: "batch_size"},
+        "output": {0: "batch_size", 1: "time"},
+        "durations": {0: "batch_size", 1: "phonemes"},
+    }
 
     # Configure input names based on model type
     if num_speakers > 1:
         input_names = ["input", "input_lengths", "scales", "sid"]
-        if args.with_durations:
-            dynamic_axes["sid"] = {0: "batch_size"}
+        dynamic_axes["sid"] = {0: "batch_size"}
     else:
         input_names = ["input", "input_lengths", "scales"]
 

--- a/src/python/piper_train/infer_onnx.py
+++ b/src/python/piper_train/infer_onnx.py
@@ -109,7 +109,10 @@ def main():
             inputs["prosody_features"] = prosody_features
 
         start_time = time.perf_counter()
-        audio = model.run(None, inputs)[0].squeeze((0, 1))
+        outputs = model.run(None, inputs)
+        audio = outputs[0].squeeze((0, 1))
+        # durations output is available for phoneme timing (e.g., lip-sync, karaoke)
+        durations = outputs[1] if len(outputs) > 1 else None
         # audio = denoise(audio, bias_spec, 10)
         audio = audio_float_to_int16(audio.squeeze())
         end_time = time.perf_counter()
@@ -127,6 +130,10 @@ def main():
             infer_sec,
             audio_duration_sec,
         )
+
+        # Log phoneme durations if available (useful for debugging/timing)
+        if durations is not None:
+            _LOGGER.debug("Phoneme durations shape: %s", durations.shape)
 
         output_path = args.output_dir / f"{utt_id}.wav"
         write_wav(str(output_path), args.sample_rate, audio)

--- a/src/python/piper_train/vits/models.py
+++ b/src/python/piper_train/vits/models.py
@@ -106,7 +106,11 @@ class StochasticDurationPredictor(nn.Module):
         else:
             flows = list(reversed(self.flows))
             flows = flows[:-2] + [flows[-1]]  # remove a useless vflow
-            z = torch.randn(x.size(0), 2, x.size(2)).type_as(x) * noise_scale
+            # Use zeros for deterministic ONNX export
+            if getattr(self, "onnx_export_mode", False):
+                z = torch.zeros(x.size(0), 2, x.size(2)).type_as(x)
+            else:
+                z = torch.randn(x.size(0), 2, x.size(2)).type_as(x) * noise_scale
 
             for flow in flows:
                 z = flow(z, x_mask, g=x, reverse=reverse)
@@ -775,7 +779,11 @@ class SynthesizerTrn(nn.Module):
             1, 2
         )  # [b, t', t], [b, t, d] -> [b, d, t']
 
-        z_p = m_p + torch.randn_like(m_p) * torch.exp(logs_p) * noise_scale
+        # Use mean only for deterministic ONNX export
+        if getattr(self, "onnx_export_mode", False):
+            z_p = m_p
+        else:
+            z_p = m_p + torch.randn_like(m_p) * torch.exp(logs_p) * noise_scale
         z = self.flow(z_p, y_mask, g=g, reverse=True)
         o = self.dec((z * y_mask)[:, :, :max_len], g=g)
 

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -154,8 +154,8 @@ def temp_onnx_model(mock_vits_model, tmp_path_factory):
         m_p = torch.matmul(attn.squeeze(1), m_p.transpose(1, 2)).transpose(1, 2)
         logs_p = torch.matmul(attn.squeeze(1), logs_p.transpose(1, 2)).transpose(1, 2)
 
-        # 5. Sample z_p (deterministic in ONNX export mode)
-        z_p = m_p  # onnx_export_mode uses mean only
+        # 5. Sample z_p: in this test we always use the mean to mimic ONNX export mode
+        z_p = m_p  # deterministic behavior matching when onnx_export_mode is enabled
 
         # 6. Flow + Decoder
         z = mock_vits_model.flow(z_p, y_mask, g=g, reverse=True)

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -91,8 +91,10 @@ def mock_vits_model():
 
 @pytest.fixture(scope="module")
 def temp_onnx_model(mock_vits_model, tmp_path_factory):
-    """モックモデルをONNXにエクスポート"""
+    """モックモデルをONNXにエクスポート（durations出力付き）"""
     import torch
+
+    from piper_train.vits import commons
 
     tmp_dir = tmp_path_factory.mktemp("models")
     onnx_path = tmp_dir / "mock_model.onnx"
@@ -104,7 +106,13 @@ def temp_onnx_model(mock_vits_model, tmp_path_factory):
     scales = torch.FloatTensor([0.667, 1.0, 0.8])
     prosody_features = torch.zeros(1, dummy_input_length, 3, dtype=torch.long)
 
+    # Enable ONNX export mode for deterministic output
+    mock_vits_model.onnx_export_mode = True
+    if hasattr(mock_vits_model, "dp"):
+        mock_vits_model.dp.onnx_export_mode = True
+
     # Define infer_forward for export (single-speaker, no sid)
+    # Returns both audio and durations
     def infer_forward(
         input_tensor,
         input_lengths,
@@ -115,33 +123,63 @@ def temp_onnx_model(mock_vits_model, tmp_path_factory):
         length_scale = scales_tensor[1]
         noise_scale_w = scales_tensor[2]
 
-        audio = mock_vits_model.infer(
-            input_tensor,
-            input_lengths,
-            noise_scale=noise_scale,
-            length_scale=length_scale,
-            noise_scale_w=noise_scale_w,
-            sid=None,  # Single speaker model
-            prosody_features=prosody_features_tensor,
-        )[0].unsqueeze(1)
+        # 1. Encoder
+        x, m_p, logs_p, x_mask = mock_vits_model.enc_p(input_tensor, input_lengths)
+        g = None  # Single speaker model
 
-        return audio
+        # 2. Duration Predictor (called only once)
+        x_dp = mock_vits_model._prepare_prosody_input(
+            x, x_mask, prosody_features_tensor
+        )
+        if mock_vits_model.use_sdp:
+            logw = mock_vits_model.dp(
+                x_dp, x_mask, g=g, reverse=True, noise_scale=noise_scale_w
+            )
+        else:
+            logw = mock_vits_model.dp(x_dp, x_mask, g=g)
+
+        w = torch.exp(logw) * x_mask * length_scale
+        durations = w.squeeze(1)  # [batch, phoneme_length]
+
+        # 3. Attention/Alignment
+        w_ceil = torch.ceil(w)
+        y_lengths = torch.clamp_min(torch.sum(w_ceil, [1, 2]), 1).long()
+        y_mask = torch.unsqueeze(
+            commons.sequence_mask(y_lengths, y_lengths.max()), 1
+        ).type_as(x_mask)
+        attn_mask = torch.unsqueeze(x_mask, 2) * torch.unsqueeze(y_mask, -1)
+        attn = commons.generate_path(w_ceil, attn_mask)
+
+        # 4. Expand prior
+        m_p = torch.matmul(attn.squeeze(1), m_p.transpose(1, 2)).transpose(1, 2)
+        logs_p = torch.matmul(attn.squeeze(1), logs_p.transpose(1, 2)).transpose(1, 2)
+
+        # 5. Sample z_p (deterministic in ONNX export mode)
+        z_p = m_p  # onnx_export_mode uses mean only
+
+        # 6. Flow + Decoder
+        z = mock_vits_model.flow(z_p, y_mask, g=g, reverse=True)
+        o = mock_vits_model.dec((z * y_mask), g=g)
+        audio = o.unsqueeze(1)
+
+        return audio, durations
 
     mock_vits_model.forward = infer_forward
 
-    # ONNX export (single-speaker, no sid input)
+    # ONNX export (single-speaker, no sid input) with durations output
     torch.onnx.export(
         mock_vits_model,
         (sequences, sequence_lengths, scales, prosody_features),
         str(onnx_path),
         opset_version=15,
         input_names=["input", "input_lengths", "scales", "prosody_features"],
-        output_names=["output"],
+        output_names=["output", "durations"],
         dynamic_axes={
             "input": {0: "batch_size", 1: "phonemes"},
             "input_lengths": {0: "batch_size"},
             "prosody_features": {0: "batch_size", 1: "phonemes"},
             "output": {0: "batch_size", 1: "time"},
+            "durations": {0: "batch_size", 1: "phonemes"},
         },
         verbose=False,
     )

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -119,7 +119,7 @@ def temp_onnx_model(mock_vits_model, tmp_path_factory):
         scales_tensor,
         prosody_features_tensor,
     ):
-        noise_scale = scales_tensor[0]
+        # noise_scale = scales_tensor[0]  # unused in ONNX export (deterministic mode)
         length_scale = scales_tensor[1]
         noise_scale_w = scales_tensor[2]
 

--- a/src/python/tests/test_pytorch_onnx_parity.py
+++ b/src/python/tests/test_pytorch_onnx_parity.py
@@ -158,9 +158,12 @@ def onnx_inference(
             prosody_array = np.zeros((1, text.shape[1], 3), dtype=np.int64)
         inputs["prosody_features"] = prosody_array
 
-    audio = session.run(None, inputs)[0]
+    outputs = session.run(None, inputs)
+    audio = outputs[0]
+    # durations is the second output (if available)
+    durations = outputs[1] if len(outputs) > 1 else None
     # Remove batch and channel dimensions: (1, 1, time) -> (time,)
-    return audio.squeeze()
+    return audio.squeeze(), durations
 
 
 # ============================================================================
@@ -193,7 +196,7 @@ class TestPyTorchONNXParity:
             **inference_params,
         )
 
-        onnx_audio = onnx_inference(
+        onnx_audio, onnx_durations = onnx_inference(
             temp_onnx_model,
             sample_phoneme_ids,
             prosody_features=sample_prosody_features,
@@ -211,6 +214,9 @@ class TestPyTorchONNXParity:
         # 音声の値が妥当な範囲にあることを確認
         assert np.abs(pt_audio).max() < 1.0, "PyTorch音声の振幅が異常"
         assert np.abs(onnx_audio).max() < 1.0, "ONNX音声の振幅が異常"
+
+        # durations出力が存在することを確認
+        assert onnx_durations is not None, "ONNX durations出力が見つかりません"
 
     def test_audio_output_without_prosody(
         self,
@@ -231,7 +237,7 @@ class TestPyTorchONNXParity:
             **inference_params,
         )
 
-        onnx_audio = onnx_inference(
+        onnx_audio, onnx_durations = onnx_inference(
             temp_onnx_model,
             sample_phoneme_ids,
             prosody_features=None,
@@ -250,6 +256,9 @@ class TestPyTorchONNXParity:
         assert np.abs(pt_audio).max() < 1.0, "PyTorch音声の振幅が異常"
         assert np.abs(onnx_audio).max() < 1.0, "ONNX音声の振幅が異常"
 
+        # durations出力が存在することを確認
+        assert onnx_durations is not None, "ONNX durations出力が見つかりません"
+
     def test_prosody_data_type_consistency(self, temp_onnx_model):
         """ONNXモデルのprosody_features入力がint64であることを確認"""
         import onnxruntime
@@ -267,6 +276,58 @@ class TestPyTorchONNXParity:
         assert prosody_input.type == "tensor(int64)", (
             f"prosody_featuresの型がint64ではありません: {prosody_input.type}"
         )
+
+    def test_onnx_outputs_include_durations(self, temp_onnx_model):
+        """ONNXモデルの出力にdurationsが含まれることを確認"""
+        import onnxruntime
+
+        session = onnxruntime.InferenceSession(str(temp_onnx_model))
+        output_names = [out.name for out in session.get_outputs()]
+
+        assert "output" in output_names, "ONNX出力に'output'が見つかりません"
+        assert "durations" in output_names, "ONNX出力に'durations'が見つかりません"
+        assert len(output_names) == 2, f"ONNX出力数が2ではありません: {output_names}"
+
+    def test_durations_shape_matches_input(
+        self,
+        temp_onnx_model,
+        sample_phoneme_ids,
+        sample_prosody_features,
+        inference_params,
+    ):
+        """durationsの形状が入力音素数と一致することを確認"""
+        _, onnx_durations = onnx_inference(
+            temp_onnx_model,
+            sample_phoneme_ids,
+            prosody_features=sample_prosody_features,
+            **inference_params,
+        )
+
+        assert onnx_durations is not None, "durations出力がNone"
+        # durations shape should be (batch, phonemes) = (1, num_phoneme_ids)
+        expected_phonemes = len(sample_phoneme_ids)
+        assert onnx_durations.shape[-1] == expected_phonemes, (
+            f"durations長({onnx_durations.shape[-1]})が音素数({expected_phonemes})と不一致"
+        )
+
+    def test_durations_are_positive(
+        self,
+        temp_onnx_model,
+        sample_phoneme_ids,
+        sample_prosody_features,
+        inference_params,
+    ):
+        """durationsの値が非負であることを確認"""
+        _, onnx_durations = onnx_inference(
+            temp_onnx_model,
+            sample_phoneme_ids,
+            prosody_features=sample_prosody_features,
+            **inference_params,
+        )
+
+        assert onnx_durations is not None, "durations出力がNone"
+        # durations should be non-negative (they represent time durations)
+        assert np.all(onnx_durations >= 0), "durationsに負の値が含まれています"
 
     @pytest.mark.parametrize(
         "noise_scale,length_scale,noise_scale_w",
@@ -305,7 +366,7 @@ class TestPyTorchONNXParity:
             **params,
         )
 
-        onnx_audio = onnx_inference(
+        onnx_audio, onnx_durations = onnx_inference(
             temp_onnx_model,
             sample_phoneme_ids,
             prosody_features=sample_prosody_features,
@@ -323,3 +384,6 @@ class TestPyTorchONNXParity:
         # 音声の値が妥当な範囲にあることを確認
         assert np.abs(pt_audio).max() < 1.0, "PyTorch音声の振幅が異常"
         assert np.abs(onnx_audio).max() < 1.0, "ONNX音声の振幅が異常"
+
+        # durations出力が存在することを確認
+        assert onnx_durations is not None, "ONNX durations出力が見つかりません"


### PR DESCRIPTION
## Summary

`--with-durations` オプション使用時にONNXエクスポートがクラッシュする問題を修正し、常にdurationsを出力するようにしました。

## 変更内容

### バグ修正
- `StochasticDurationPredictor.forward()` 内の `torch.randn()` がONNXトレーシングと非互換だった問題を修正
- `onnx_export_mode` フラグを追加し、エクスポート時は決定論的な出力を使用

### 効率化
- `--with-durations` オプションを削除（常にdurationsを出力）
- Duration Predictor (`dp()`) の呼び出しを2回→1回に最適化

### テスト追加
- `test_onnx_outputs_include_durations`: ONNX出力にdurationsが含まれることを確認
- `test_durations_shape_matches_input`: durationsの形状が入力音素数と一致することを確認
- `test_durations_are_positive`: durationsの値が非負であることを確認

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `src/python/piper_train/vits/models.py` | `onnx_export_mode` チェック追加（2箇所）|
| `src/python/piper_train/export_onnx.py` | オプション削除、forward関数統一 |
| `src/python/piper_train/infer_onnx.py` | 新出力形式（audio, durations）対応 |
| `src/python/tests/conftest.py` | テストフィクスチャ更新 |
| `src/python/tests/test_pytorch_onnx_parity.py` | テスト追加 |

## Test plan

- [x] 既存テスト通過（10/10テスト）
- [x] CI通過確認
- [x] 実モデルでのONNXエクスポート動作確認

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)