### PR TITLE
refactor: Phonemizer ABC + 言語レジストリ導入

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,28 @@ cat test.jsonl | CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.infer_onnx
 
 ## 実装済み機能
 
+### Phonemizer ABC + 言語レジストリ ✅ NEW (2026-02-01)
+
+`Phonemizer` 抽象基底クラスと言語レジストリにより、if/elif分岐を解消。新言語追加が容易に。
+
+**新言語追加手順:**
+1. `Phonemizer` を継承したクラスを作成 (`phonemize`, `phonemize_with_prosody`, `get_phoneme_id_map` を実装)
+2. 必要に応じて `post_process_ids` をオーバーライド (BOS/EOS等)
+3. `registry.py` の `_auto_register()` に登録
+
+**実装ファイル:**
+- `src/python/piper_train/phonemize/base.py` — `Phonemizer` ABC, 共通 `ProsodyInfo`
+- `src/python/piper_train/phonemize/registry.py` — 言語レジストリ
+- `src/python/piper_train/phonemize/japanese.py` — `JapanesePhonemizer`
+- `src/python/piper_train/phonemize/english.py` — `EnglishPhonemizer`
+- `test/test_phonemizer_registry.py` — レジストリ・ABCテスト
+
+**変更点:**
+- `ProsodyInfo` を `base.py` に統一 (日本語/英語共通)
+- `EnglishProsodyInfo` は `ProsodyInfo` のエイリアス (後方互換)
+- `infer_onnx.py` の言語分岐をレジストリ経由に変更
+- BOS/EOS/パディング処理を `EnglishPhonemizer.post_process_ids()` に移動
+
 ### GPL-free 英語G2P (g2p-en) ✅ NEW (2026-01-31)
 
 g2p-en (Apache-2.0) を使用したespeak-ng互換の英語音素化。espeak-ng/piper-phonemize (GPL) なしで英語推論が可能。
@@ -328,6 +350,8 @@ NCCL_IB_DISABLE=1
 |------|------|
 | 学習スクリプト | `src/python/piper_train/__main__.py` |
 | VITS実装 | `src/python/piper_train/vits/` |
+| Phonemizer ABC | `src/python/piper_train/phonemize/base.py` |
+| 言語レジストリ | `src/python/piper_train/phonemize/registry.py` |
 | 英語音素化 | `src/python/piper_train/phonemize/english.py` |
 | 日本語音素化 | `src/python/piper_train/phonemize/japanese.py` |
 | IDマップ | `src/python/piper_train/phonemize/jp_id_map.py` |

--- a/src/python/piper_train/infer_onnx.py
+++ b/src/python/piper_train/infer_onnx.py
@@ -34,24 +34,19 @@ def text_to_phoneme_ids_and_prosody(
         - phoneme_ids: List of phoneme IDs
         - prosody_features: List of {"a1": int, "a2": int, "a3": int} or None
     """
-    if language == "en":
-        from .phonemize.english import phonemize_english_with_prosody  # noqa: PLC0415
+    from .phonemize.registry import get_phonemizer  # noqa: PLC0415
 
-        phonemes, prosody_info_list = phonemize_english_with_prosody(text)
-    else:
-        from .phonemize.japanese import phonemize_japanese_with_prosody  # noqa: PLC0415
-
-        phonemes, prosody_info_list = phonemize_japanese_with_prosody(text)
+    phonemizer = get_phonemizer(language)
+    phonemes, prosody_info_list = phonemizer.phonemize_with_prosody(text)
 
     # Convert phonemes to IDs
-    phoneme_ids = []
-    prosody_features = []
+    phoneme_ids: list[int] = []
+    prosody_features: list[dict | None] = []
 
     for phoneme, prosody_info in zip(phonemes, prosody_info_list, strict=True):
         if phoneme in phoneme_id_map:
             ids = phoneme_id_map[phoneme]
             phoneme_ids.extend(ids)
-            # Each phoneme ID gets the same prosody info
             for _ in ids:
                 if prosody_info is not None:
                     prosody_features.append(
@@ -66,34 +61,10 @@ def text_to_phoneme_ids_and_prosody(
         else:
             _LOGGER.warning("Unknown phoneme: %s", phoneme)
 
-    # Add BOS/EOS and inter-phoneme padding for English
-    # piper/espeak-ng models expect: BOS, pad, id1, pad, id2, pad, ..., idN, pad, EOS
-    if language == "en":
-        pad_ids = phoneme_id_map.get("_", [0])
-        bos_ids = phoneme_id_map.get("^")
-        eos_ids = phoneme_id_map.get("$")
-
-        # Insert pad between every phoneme ID
-        padded_ids = []
-        padded_prosody = []
-        for phoneme_id, prosody_feature in zip(
-            phoneme_ids, prosody_features, strict=True
-        ):
-            padded_ids.append(phoneme_id)
-            padded_prosody.append(prosody_feature)
-            padded_ids.extend(pad_ids)
-            padded_prosody.extend([None] * len(pad_ids))
-
-        phoneme_ids = padded_ids
-        prosody_features = padded_prosody
-
-        # Wrap with BOS/EOS
-        if bos_ids:
-            phoneme_ids = bos_ids + [pad_ids[0]] + phoneme_ids
-            prosody_features = [None] * (len(bos_ids) + 1) + prosody_features
-        if eos_ids:
-            phoneme_ids = phoneme_ids + eos_ids
-            prosody_features = prosody_features + [None] * len(eos_ids)
+    # Language-specific post-processing (BOS/EOS/padding)
+    phoneme_ids, prosody_features = phonemizer.post_process_ids(
+        phoneme_ids, prosody_features, phoneme_id_map
+    )
 
     return phoneme_ids, prosody_features
 
@@ -118,11 +89,13 @@ def main():
         help="Path to config.json with phoneme_id_map (required with --text). "
         "If not specified, looks for config.json next to the model.",
     )
+    from .phonemize.registry import available_languages  # noqa: PLC0415
+
     parser.add_argument(
         "--language",
-        choices=["ja", "en"],
+        choices=available_languages(),
         default="ja",
-        help="Language for --text mode: ja (Japanese, default) or en (English, uses g2p-en)",
+        help="Language for --text mode (default: ja)",
     )
     parser.add_argument(
         "--speaker-id",

--- a/src/python/piper_train/phonemize/__init__.py
+++ b/src/python/piper_train/phonemize/__init__.py
@@ -1,9 +1,15 @@
 # Mark submodule for phonemizers
 
+from .base import Phonemizer, ProsodyInfo  # noqa: F401
 from .custom_dict import (  # noqa: F401
     CustomDictionary,
     apply_custom_dictionary,
     create_default_dictionary,
+)
+from .registry import (  # noqa: F401
+    available_languages,
+    get_phonemizer,
+    register_language,
 )
 
 

--- a/src/python/piper_train/phonemize/base.py
+++ b/src/python/piper_train/phonemize/base.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 @dataclass
 class ProsodyInfo:
-    """共通prosody情報 (全言語共通).
+    """Common prosody information shared across all languages.
 
     Attributes
     ----------
@@ -30,21 +30,21 @@ class ProsodyInfo:
 
 
 class Phonemizer(ABC):
-    """言語phonemizerの抽象基底クラス."""
+    """Abstract base class for language phonemizers."""
 
     @abstractmethod
     def phonemize(self, text: str) -> list[str]:
-        """テキスト→音素リスト."""
+        """Convert text to a list of phoneme tokens."""
 
     @abstractmethod
     def phonemize_with_prosody(
         self, text: str
     ) -> tuple[list[str], list[ProsodyInfo | None]]:
-        """テキスト→(音素リスト, prosody情報リスト)."""
+        """Convert text to phoneme tokens with prosody information."""
 
     @abstractmethod
     def get_phoneme_id_map(self) -> dict[str, list[int]] | None:
-        """言語固有のphoneme_id_mapを返す。Noneならconfig由来のmapを使用."""
+        """Return language-specific phoneme_id_map, or None to use config-provided map."""
 
     def post_process_ids(
         self,
@@ -52,5 +52,5 @@ class Phonemizer(ABC):
         prosody_features: list[dict | None],
         phoneme_id_map: dict[str, list[int]],
     ) -> tuple[list[int], list[dict | None]]:
-        """BOS/EOS/パディング等の後処理。デフォルトはno-op."""
+        """Post-process phoneme IDs (e.g. BOS/EOS/padding). Default is no-op."""
         return phoneme_ids, prosody_features

--- a/src/python/piper_train/phonemize/base.py
+++ b/src/python/piper_train/phonemize/base.py
@@ -1,0 +1,56 @@
+"""Abstract base class and common types for language phonemizers."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class ProsodyInfo:
+    """共通prosody情報 (全言語共通).
+
+    Attributes
+    ----------
+    a1 : int
+        Language-dependent prosody dimension 1.
+        Japanese: relative position from accent nucleus.
+        English: fixed at 0.
+    a2 : int
+        Language-dependent prosody dimension 2.
+        Japanese: mora position in accent phrase (1-based).
+        English: stress level (0=none, 1=secondary, 2=primary).
+    a3 : int
+        Language-dependent prosody dimension 3.
+        Japanese: total morae in accent phrase.
+        English: number of phonemes in the word.
+    """
+
+    a1: int
+    a2: int
+    a3: int
+
+
+class Phonemizer(ABC):
+    """言語phonemizerの抽象基底クラス."""
+
+    @abstractmethod
+    def phonemize(self, text: str) -> list[str]:
+        """テキスト→音素リスト."""
+
+    @abstractmethod
+    def phonemize_with_prosody(
+        self, text: str
+    ) -> tuple[list[str], list[ProsodyInfo | None]]:
+        """テキスト→(音素リスト, prosody情報リスト)."""
+
+    @abstractmethod
+    def get_phoneme_id_map(self) -> dict[str, list[int]] | None:
+        """言語固有のphoneme_id_mapを返す。Noneならconfig由来のmapを使用."""
+
+    def post_process_ids(
+        self,
+        phoneme_ids: list[int],
+        prosody_features: list[dict | None],
+        phoneme_id_map: dict[str, list[int]],
+    ) -> tuple[list[int], list[dict | None]]:
+        """BOS/EOS/パディング等の後処理。デフォルトはno-op."""
+        return phoneme_ids, prosody_features

--- a/src/python/piper_train/phonemize/english.py
+++ b/src/python/piper_train/phonemize/english.py
@@ -6,12 +6,18 @@ requiring espeak-ng or piper-phonemize (GPL dependencies).
 
 import logging
 import re
-from dataclasses import dataclass
+
+from .base import Phonemizer, ProsodyInfo
 
 
 _LOGGER = logging.getLogger(__name__)
 
-__all__ = ["phonemize_english", "phonemize_english_with_prosody", "EnglishProsodyInfo"]
+__all__ = [
+    "phonemize_english",
+    "phonemize_english_with_prosody",
+    "EnglishProsodyInfo",
+    "EnglishPhonemizer",
+]
 
 # ARPAbet to espeak-compatible IPA mapping
 ARPABET_TO_IPA: dict[str, str] = {
@@ -169,13 +175,8 @@ _FUNCTION_WORDS = {
 }
 
 
-@dataclass
-class EnglishProsodyInfo:
-    """Prosody information for English phonemes."""
-
-    a1: int  # Fixed at 0 (no accent nucleus concept in English)
-    a2: int  # Stress level: 0=none, 1=secondary, 2=primary
-    a3: int  # Number of phonemes in the word
+# Backward-compatible alias
+EnglishProsodyInfo = ProsodyInfo
 
 
 def _g2p_en_to_arpabet_tokens(text: str) -> list[list[str]]:
@@ -379,3 +380,53 @@ def phonemize_english(text: str) -> list[str]:
     """Convert English text to phoneme list (without prosody)."""
     phonemes, _ = phonemize_english_with_prosody(text)
     return phonemes
+
+
+class EnglishPhonemizer(Phonemizer):
+    """English phonemizer using g2p-en."""
+
+    def phonemize(self, text: str) -> list[str]:
+        return phonemize_english(text)
+
+    def phonemize_with_prosody(
+        self, text: str
+    ) -> tuple[list[str], list[ProsodyInfo | None]]:
+        return phonemize_english_with_prosody(text)
+
+    def get_phoneme_id_map(self) -> dict[str, list[int]] | None:
+        return None
+
+    def post_process_ids(
+        self,
+        phoneme_ids: list[int],
+        prosody_features: list[dict | None],
+        phoneme_id_map: dict[str, list[int]],
+    ) -> tuple[list[int], list[dict | None]]:
+        """Add BOS/EOS and inter-phoneme padding for English (espeak-ng compat)."""
+        pad_ids = phoneme_id_map.get("_", [0])
+        bos_ids = phoneme_id_map.get("^")
+        eos_ids = phoneme_id_map.get("$")
+
+        # Insert pad between every phoneme ID
+        padded_ids: list[int] = []
+        padded_prosody: list[dict | None] = []
+        for phoneme_id, prosody_feature in zip(
+            phoneme_ids, prosody_features, strict=True
+        ):
+            padded_ids.append(phoneme_id)
+            padded_prosody.append(prosody_feature)
+            padded_ids.extend(pad_ids)
+            padded_prosody.extend([None] * len(pad_ids))
+
+        phoneme_ids = padded_ids
+        prosody_features = padded_prosody
+
+        # Wrap with BOS/EOS
+        if bos_ids:
+            phoneme_ids = bos_ids + [pad_ids[0]] + phoneme_ids
+            prosody_features = [None] * (len(bos_ids) + 1) + prosody_features
+        if eos_ids:
+            phoneme_ids = phoneme_ids + eos_ids
+            prosody_features = prosody_features + [None] * len(eos_ids)
+
+        return phoneme_ids, prosody_features

--- a/src/python/piper_train/phonemize/japanese.py
+++ b/src/python/piper_train/phonemize/japanese.py
@@ -1,5 +1,4 @@
 import re
-from dataclasses import dataclass
 
 
 # Try to import pyopenjtalk-plus first (Windows compatible), fall back to pyopenjtalk
@@ -13,33 +12,17 @@ except ImportError:
             "Neither pyopenjtalk nor pyopenjtalk-plus is installed"
         ) from None
 
+from .base import Phonemizer, ProsodyInfo
 from .custom_dict import CustomDictionary
 from .token_mapper import map_sequence
 
 
-__all__ = ["phonemize_japanese", "phonemize_japanese_with_prosody", "ProsodyInfo"]
-
-
-@dataclass
-class ProsodyInfo:
-    """Prosody information extracted from OpenJTalk labels.
-
-    Attributes
-    ----------
-    a1 : int
-        Relative position from accent nucleus. Can be negative (before nucleus),
-        zero (at nucleus), or positive (after nucleus). Example: -4, -3, ..., 0, 1, ...
-    a2 : int
-        Position of current mora in the accent phrase (1-based).
-        Resets to 1 at each accent phrase boundary.
-    a3 : int
-        Total number of morae in the current accent phrase.
-        Useful for phrase-level prosody control.
-    """
-
-    a1: int  # アクセント核からの相対位置 (負値=核より前, 0=核, 正値=核より後)
-    a2: int  # アクセント句内のモーラ位置 (1-based)
-    a3: int  # アクセント句内の総モーラ数
+__all__ = [
+    "phonemize_japanese",
+    "phonemize_japanese_with_prosody",
+    "ProsodyInfo",
+    "JapanesePhonemizer",
+]
 
 
 # Regular expressions reused many times
@@ -381,3 +364,18 @@ def phonemize_japanese_with_prosody(
     mapped_tokens = map_sequence(tokens)
 
     return mapped_tokens, prosody_info
+
+
+class JapanesePhonemizer(Phonemizer):
+    """Japanese phonemizer using OpenJTalk."""
+
+    def phonemize(self, text: str) -> list[str]:
+        return phonemize_japanese(text)
+
+    def phonemize_with_prosody(
+        self, text: str
+    ) -> tuple[list[str], list[ProsodyInfo | None]]:
+        return phonemize_japanese_with_prosody(text)
+
+    def get_phoneme_id_map(self) -> dict[str, list[int]] | None:
+        return None

--- a/src/python/piper_train/phonemize/registry.py
+++ b/src/python/piper_train/phonemize/registry.py
@@ -1,0 +1,44 @@
+"""Language phonemizer registry."""
+
+from .base import Phonemizer
+
+
+_REGISTRY: dict[str, Phonemizer] = {}
+
+
+def register_language(code: str, phonemizer: Phonemizer):
+    """Register a phonemizer for a language code."""
+    _REGISTRY[code] = phonemizer
+
+
+def get_phonemizer(language: str) -> Phonemizer:
+    """Get the phonemizer for a language code."""
+    if language not in _REGISTRY:
+        raise ValueError(
+            f"Unsupported language: {language}. Available: {list(_REGISTRY.keys())}"
+        )
+    return _REGISTRY[language]
+
+
+def available_languages() -> list[str]:
+    """Return list of registered language codes."""
+    return list(_REGISTRY.keys())
+
+
+def _auto_register():
+    """Register available language phonemizers at import time."""
+    try:
+        from .japanese import JapanesePhonemizer  # noqa: PLC0415
+
+        register_language("ja", JapanesePhonemizer())
+    except ImportError:
+        pass
+    try:
+        from .english import EnglishPhonemizer  # noqa: PLC0415
+
+        register_language("en", EnglishPhonemizer())
+    except ImportError:
+        pass
+
+
+_auto_register()

--- a/test/test_phonemizer_registry.py
+++ b/test/test_phonemizer_registry.py
@@ -1,0 +1,109 @@
+"""Tests for phonemizer ABC and language registry."""
+
+import pytest
+
+from piper_train.phonemize.base import Phonemizer, ProsodyInfo
+from piper_train.phonemize.english import EnglishPhonemizer, EnglishProsodyInfo
+from piper_train.phonemize.japanese import JapanesePhonemizer
+from piper_train.phonemize.registry import (
+    available_languages,
+    get_phonemizer,
+)
+
+
+class TestProsodyInfoUnification:
+    """ProsodyInfo is shared across languages."""
+
+    def test_english_alias(self):
+        assert EnglishProsodyInfo is ProsodyInfo
+
+    def test_japanese_reexport(self):
+        from piper_train.phonemize.japanese import ProsodyInfo as JaProsody
+
+        assert JaProsody is ProsodyInfo
+
+
+class TestRegistry:
+    def test_ja_registered(self):
+        assert "ja" in available_languages()
+
+    def test_en_registered(self):
+        assert "en" in available_languages()
+
+    def test_get_ja(self):
+        p = get_phonemizer("ja")
+        assert isinstance(p, JapanesePhonemizer)
+
+    def test_get_en(self):
+        p = get_phonemizer("en")
+        assert isinstance(p, EnglishPhonemizer)
+
+    def test_unknown_language_raises(self):
+        with pytest.raises(ValueError, match="Unsupported language"):
+            get_phonemizer("xx")
+
+    def test_available_languages_returns_list(self):
+        langs = available_languages()
+        assert isinstance(langs, list)
+        assert set(langs) >= {"ja", "en"}
+
+
+class TestABCInterface:
+    """Phonemizer ABC contract tests."""
+
+    def test_ja_phonemize(self):
+        p = get_phonemizer("ja")
+        result = p.phonemize("こんにちは")
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_ja_phonemize_with_prosody(self):
+        p = get_phonemizer("ja")
+        phonemes, prosody = p.phonemize_with_prosody("こんにちは")
+        assert len(phonemes) == len(prosody)
+
+    def test_en_phonemize(self):
+        p = get_phonemizer("en")
+        result = p.phonemize("hello")
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_en_phonemize_with_prosody(self):
+        p = get_phonemizer("en")
+        phonemes, prosody = p.phonemize_with_prosody("hello")
+        assert len(phonemes) == len(prosody)
+
+    def test_get_phoneme_id_map_returns_none(self):
+        for lang in available_languages():
+            p = get_phonemizer(lang)
+            assert p.get_phoneme_id_map() is None
+
+
+class TestDefaultPostProcessIds:
+    """Base class post_process_ids is a no-op."""
+
+    def test_ja_noop(self):
+        p = get_phonemizer("ja")
+        ids = [1, 2, 3]
+        prosody = [None, None, None]
+        result_ids, result_prosody = p.post_process_ids(ids, prosody, {})
+        assert result_ids == ids
+        assert result_prosody == prosody
+
+
+class TestEnglishPostProcessIds:
+    """English post_process_ids adds BOS/EOS/padding."""
+
+    def test_bos_eos(self):
+        p = get_phonemizer("en")
+        phoneme_id_map = {"_": [0], "^": [1], "$": [2]}
+        ids, prosody = p.post_process_ids([10, 20], [None, None], phoneme_id_map)
+        assert ids[0] == 1  # BOS
+        assert ids[-1] == 2  # EOS
+
+    def test_padding_inserted(self):
+        p = get_phonemizer("en")
+        phoneme_id_map = {"_": [0], "^": [1], "$": [2]}
+        ids, _ = p.post_process_ids([10, 20], [None, None], phoneme_id_map)
+        # BOS(1), pad(0), 10, pad(0), 20, pad(0), EOS(2)
+        assert ids == [1, 0, 10, 0, 20, 0, 2]


### PR DESCRIPTION
## 概要

`infer_onnx.py` の if/elif 言語分岐を解消し、新言語追加を容易にする抽象基底クラス（ABC）とレジストリパターンを導入。

- `Phonemizer` ABC と共通 `ProsodyInfo` を `base.py` に定義
- 言語コード → Phonemizer インスタンスのレジストリを `registry.py` に実装
- `JapanesePhonemizer` / `EnglishPhonemizer` クラスを既存モジュールに追加
- BOS/EOS/パディング処理を `EnglishPhonemizer.post_process_ids()` に移動
- `EnglishProsodyInfo` は `ProsodyInfo` のエイリアスとして後方互換維持

## 変更内容

| ファイル | 変更 |
|---------|------|
| `phonemize/base.py` | **新規** — `Phonemizer` ABC、`ProsodyInfo` |
| `phonemize/registry.py` | **新規** — 言語レジストリ（ja/en自動登録） |
| `phonemize/japanese.py` | `JapanesePhonemizer` 追加、`ProsodyInfo` を `base` から import |
| `phonemize/english.py` | `EnglishPhonemizer` 追加、`EnglishProsodyInfo` をエイリアス化 |
| `infer_onnx.py` | if/elif → レジストリ経由に変更 |
| `phonemize/__init__.py` | re-export 追加 |
| `test/test_phonemizer_registry.py` | **新規** — レジストリ・ABC テスト16件 |
| `CLAUDE.md` | ドキュメント更新 |

## 動作への影響

**なし（内部リファクタのみ）。** 生成される音素IDの列は変更前と完全に同一のため、推論結果に影響はありません。

## テスト計画

- [x] 既存英語テスト42件パス
- [x] 新規レジストリテスト16件パス（計58件）
- [x] ruff lint / format クリーン
- [x] `EnglishProsodyInfo` エイリアスの後方互換確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)