### PR TITLE
fix: config.json フォールバック検索を全コンポーネントに統一

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -114,6 +114,59 @@ jobs:
           fi
           echo "English inference test passed"
 
+      - name: Config auto-detect test - {model}.onnx.json
+        run: |
+          # Test that --config can be omitted when {model}.onnx.json exists next to the model
+          docker run --rm \
+            -v ${{ github.workspace }}/test/models:/models \
+            -v /tmp/output:/output \
+            -e CUDA_VISIBLE_DEVICES="" \
+            piper-python-inference:test \
+            python inference.py \
+              --model /models/ja_JP-test-medium.onnx \
+              --output /output/test_autodetect.wav \
+              --text "自動検出テストです。" \
+              --language ja \
+              --speaker-id 0 \
+              --device cpu
+
+          FILE_SIZE=$(stat --format=%s /tmp/output/test_autodetect.wav)
+          echo "Output: test_autodetect.wav ($FILE_SIZE bytes)"
+          if [ "$FILE_SIZE" -lt 1000 ]; then
+            echo "ERROR: Output file too small ($FILE_SIZE bytes)"
+            exit 1
+          fi
+          echo "Config auto-detect ({model}.onnx.json) test passed"
+
+      - name: Config fallback test - config.json
+        run: |
+          # Test that --config can be omitted when only config.json exists in model directory
+          # Create a temp directory with model + config.json (no {model}.onnx.json)
+          mkdir -p /tmp/fallback-test
+          cp ${{ github.workspace }}/test/models/test_voice.onnx /tmp/fallback-test/test_voice.onnx
+          cp ${{ github.workspace }}/test/models/test_voice.onnx.json /tmp/fallback-test/config.json
+
+          docker run --rm \
+            -v /tmp/fallback-test:/models/fallback \
+            -v /tmp/output:/output \
+            -e CUDA_VISIBLE_DEVICES="" \
+            piper-python-inference:test \
+            python inference.py \
+              --model /models/fallback/test_voice.onnx \
+              --output /output/test_fallback.wav \
+              --text "Hello, this is a fallback config test." \
+              --language en \
+              --speaker-id 0 \
+              --device cpu
+
+          FILE_SIZE=$(stat --format=%s /tmp/output/test_fallback.wav)
+          echo "Output: test_fallback.wav ($FILE_SIZE bytes)"
+          if [ "$FILE_SIZE" -lt 1000 ]; then
+            echo "ERROR: Output file too small ($FILE_SIZE bytes)"
+            exit 1
+          fi
+          echo "Config fallback (config.json) test passed"
+
   test-cpp-inference:
     runs-on: ubuntu-latest
     steps:
@@ -177,6 +230,49 @@ jobs:
             exit 1
           fi
           echo "C++ Japanese inference test passed"
+
+      - name: Config auto-detect test - {model}.onnx.json
+        run: |
+          # Test that --config can be omitted when {model}.onnx.json exists next to the model
+          echo "Auto-detect config test." | docker run --rm -i \
+            -v ${{ github.workspace }}/test/models:/models \
+            -v /tmp/output:/output \
+            --entrypoint piper \
+            piper-cpp-inference:test \
+              --model /models/test_voice.onnx \
+              --output_file /output/test_cpp_autodetect.wav
+
+          FILE_SIZE=$(stat --format=%s /tmp/output/test_cpp_autodetect.wav)
+          echo "Output: test_cpp_autodetect.wav ($FILE_SIZE bytes)"
+          if [ "$FILE_SIZE" -lt 1000 ]; then
+            echo "ERROR: Output file too small ($FILE_SIZE bytes)"
+            exit 1
+          fi
+          echo "C++ config auto-detect ({model}.onnx.json) test passed"
+
+      - name: Config fallback test - config.json
+        run: |
+          # Test that --config can be omitted when only config.json exists in model directory
+          # Create a temp directory with model + config.json (no {model}.onnx.json)
+          mkdir -p /tmp/fallback-test-cpp
+          cp ${{ github.workspace }}/test/models/test_voice.onnx /tmp/fallback-test-cpp/test_voice.onnx
+          cp ${{ github.workspace }}/test/models/test_voice.onnx.json /tmp/fallback-test-cpp/config.json
+
+          echo "Fallback config test." | docker run --rm -i \
+            -v /tmp/fallback-test-cpp:/models/fallback \
+            -v /tmp/output:/output \
+            --entrypoint piper \
+            piper-cpp-inference:test \
+              --model /models/fallback/test_voice.onnx \
+              --output_file /output/test_cpp_fallback.wav
+
+          FILE_SIZE=$(stat --format=%s /tmp/output/test_cpp_fallback.wav)
+          echo "Output: test_cpp_fallback.wav ($FILE_SIZE bytes)"
+          if [ "$FILE_SIZE" -lt 1000 ]; then
+            echo "ERROR: Output file too small ($FILE_SIZE bytes)"
+            exit 1
+          fi
+          echo "C++ config fallback (config.json) test passed"
 
   test-python-train:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -167,6 +167,33 @@ jobs:
           fi
           echo "Config fallback (config.json) test passed"
 
+      - name: Config not found error test
+        run: |
+          # Test that inference exits with error when no config file exists
+          mkdir -p /tmp/noconfig
+          cp ${{ github.workspace }}/test/models/test_voice.onnx /tmp/noconfig/test_voice.onnx
+
+          docker run --rm \
+            -v /tmp/noconfig:/models/noconfig \
+            -v /tmp/output:/output \
+            -e CUDA_VISIBLE_DEVICES="" \
+            piper-python-inference:test \
+            python inference.py \
+              --model /models/noconfig/test_voice.onnx \
+              --output /output/should_not_exist.wav \
+              --text "This should fail." \
+              --language en \
+              --speaker-id 0 \
+              --device cpu \
+            && { echo "ERROR: Expected non-zero exit code but got 0"; exit 1; } \
+            || echo "Config not found error test passed (non-zero exit as expected)"
+
+          if [ -f /tmp/output/should_not_exist.wav ]; then
+            echo "ERROR: Output file should not exist"
+            exit 1
+          fi
+          echo "Python config not found error test passed"
+
   test-cpp-inference:
     runs-on: ubuntu-latest
     steps:
@@ -273,6 +300,28 @@ jobs:
             exit 1
           fi
           echo "C++ config fallback (config.json) test passed"
+
+      - name: Config not found error test
+        run: |
+          # Test that piper exits with error when no config file exists
+          mkdir -p /tmp/noconfig-cpp
+          cp ${{ github.workspace }}/test/models/test_voice.onnx /tmp/noconfig-cpp/test_voice.onnx
+
+          echo "This should fail." | docker run --rm -i \
+            -v /tmp/noconfig-cpp:/models/noconfig \
+            -v /tmp/output:/output \
+            --entrypoint piper \
+            piper-cpp-inference:test \
+              --model /models/noconfig/test_voice.onnx \
+              --output_file /output/should_not_exist_cpp.wav \
+            && { echo "ERROR: Expected non-zero exit code but got 0"; exit 1; } \
+            || echo "Config not found error test passed (non-zero exit as expected)"
+
+          if [ -f /tmp/output/should_not_exist_cpp.wav ]; then
+            echo "ERROR: Output file should not exist"
+            exit 1
+          fi
+          echo "C++ config not found error test passed"
 
   test-python-train:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -137,15 +137,16 @@ echo 'こんにちは、今日は良い天気ですね。' | \
   ./piper --model models/tsukuyomi.onnx --config models/config.json --output_file output.wav
 ```
 
-> **config.json の命名規則:** piper は `<モデル名>.onnx.json` (例: `tsukuyomi.onnx.json`) を自動検出します。設定ファイルが別名の場合 (例: `config.json`) は `--config` で明示的に指定してください。
+> **config.json の命名規則:** piper は `<モデル名>.onnx.json` を優先的に自動検出します。見つからない場合、モデルと同じディレクトリの `config.json` にフォールバックします。どちらも見つからない場合は `--config` で明示的に指定してください。
 >
 > ```sh
-> # 自動検出される場合 (--config 不要)
+> # 自動検出 (--config 不要)
 > ./piper --model models/tsukuyomi.onnx --output_file output.wav
-> # → models/tsukuyomi.onnx.json を自動読み込み
+> # → 1. models/tsukuyomi.onnx.json を検索
+> # → 2. models/config.json にフォールバック
 >
-> # 別名の場合 (--config 必須)
-> ./piper --model models/tsukuyomi.onnx --config models/config.json --output_file output.wav
+> # 手動指定 (上記どちらも存在しない場合)
+> ./piper --model models/tsukuyomi.onnx --config /path/to/config.json --output_file output.wav
 > ```
 
 ### Python推論

--- a/docker/python-inference/inference.py
+++ b/docker/python-inference/inference.py
@@ -239,8 +239,15 @@ def main():
     if not args.model:
         parser.error("--model is required for CLI and server modes")
 
-    # Resolve config path
-    config_path = args.config or str(Path(args.model).parent / "config.json")
+    # Resolve config path: {model}.json -> {dir}/config.json
+    if args.config:
+        config_path = args.config
+    else:
+        candidate = Path(f"{args.model}.json")
+        if candidate.exists():
+            config_path = str(candidate)
+        else:
+            config_path = str(Path(args.model).parent / "config.json")
 
     engine = PiperInferenceEngine(
         args.model, config_path, sample_rate=args.sample_rate, device=args.device

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -32,14 +32,21 @@ Error: Model file not found: model.onnx
 Model config doesn't exist
 ```
 
-**原因**: piper は `<モデル名>.onnx.json` を自動検出します（例: `model.onnx` → `model.onnx.json`）。設定ファイルが `config.json` など異なる名前の場合、自動検出に失敗します。
+**設定ファイルの検索順序**: piper は以下の順序で設定ファイルを自動検索します。
+1. `<モデル名>.onnx.json`（例: `model.onnx` → `model.onnx.json`）
+2. モデルと同じディレクトリ内の `config.json`（フォールバック）
+
+このフォールバックにより、多くの場合 `--config` の指定は不要です。
+
+**原因**: 上記のどちらも見つからない場合にこのエラーが発生します。
 
 **解決方法**:
-1. `--config` オプションで明示的に指定:
+1. モデルと同じディレクトリに `config.json` または `<モデル名>.onnx.json` を配置する
+2. `--config` オプションで明示的に指定:
    ```bash
-   piper --model models/model.onnx --config models/config.json --output_file out.wav
+   piper --model models/model.onnx --config /path/to/config.json --output_file out.wav
    ```
-2. または設定ファイルをリネーム:
+3. または設定ファイルをリネーム:
    ```bash
    mv config.json model.onnx.json
    ```

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -46,7 +46,7 @@ Model config doesn't exist
    ```bash
    piper --model models/model.onnx --config /path/to/config.json --output_file out.wav
    ```
-3. または設定ファイルをリネーム:
+3. 同一ディレクトリに複数モデルがあり `config.json` では区別できない場合、モデルごとにリネーム:
    ```bash
    mv config.json model.onnx.json
    ```

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -634,7 +634,7 @@ void printUsage(char *argv[]) {
   cerr << "   -h        --help              show this message and exit" << endl;
   cerr << "   -m  FILE  --model       FILE  path to onnx model file" << endl;
   cerr << "   -c  FILE  --config      FILE  path to model config file "
-          "(default: model path + .json)"
+          "(default: model path + .json, fallback: config.json in model dir)"
        << endl;
   cerr << "   -f  FILE  --output_file FILE  path to output WAV file ('-' for "
           "stdout)"
@@ -832,6 +832,12 @@ void parseArgs(int argc, char *argv[], RunConfig &runConfig) {
   if (!modelConfigPath) {
     runConfig.modelConfigPath =
         filesystem::path(runConfig.modelPath.string() + ".json");
+    if (!filesystem::exists(runConfig.modelConfigPath)) {
+      auto fallback = runConfig.modelPath.parent_path() / "config.json";
+      if (filesystem::exists(fallback)) {
+        runConfig.modelConfigPath = fallback;
+      }
+    }
   } else {
     runConfig.modelConfigPath = modelConfigPath.value();
   }

--- a/src/python/piper_train/infer_onnx.py
+++ b/src/python/piper_train/infer_onnx.py
@@ -143,9 +143,13 @@ def main():
         if args.config:
             config_path = Path(args.config)
         else:
-            # Look for config.json next to the model
+            # Fallback: {model}.json first (C++ CLI convention), then {model_dir}/config.json
             model_path = Path(args.model)
-            config_path = model_path.parent / "config.json"
+            onnx_json = model_path.with_suffix(model_path.suffix + ".json")
+            if onnx_json.exists():
+                config_path = onnx_json
+            else:
+                config_path = model_path.parent / "config.json"
 
         if not config_path.exists():
             _LOGGER.error(

--- a/src/python/tests/test_infer_onnx_config.py
+++ b/src/python/tests/test_infer_onnx_config.py
@@ -1,0 +1,94 @@
+"""Tests for infer_onnx config path resolution logic.
+
+The config fallback logic in main() (lines 143-152) resolves the config path as:
+  1. If --config is explicitly given, use that path directly.
+  2. Otherwise, try {model}.onnx.json first (C++ CLI convention).
+  3. Fall back to {model_dir}/config.json.
+
+These tests exercise the same Path logic without loading an ONNX model.
+"""
+
+import json
+from pathlib import Path
+
+
+def resolve_config_path(
+    model: str, config: str | None
+) -> Path:
+    """Reproduce the config resolution logic from infer_onnx.main().
+
+    This is a pure-function extraction of lines 143-152 so it can be
+    unit-tested without argparse or onnxruntime.
+    """
+    if config:
+        return Path(config)
+
+    model_path = Path(model)
+    onnx_json = model_path.with_suffix(model_path.suffix + ".json")
+    if onnx_json.exists():
+        return onnx_json
+    return model_path.parent / "config.json"
+
+
+class TestConfigPathResolution:
+    """Config パス解決ロジックのユニットテスト."""
+
+    def test_onnx_json_preferred(self, tmp_path: Path):
+        """model.onnx.json が存在する場合、config.json より優先される."""
+        model = tmp_path / "model.onnx"
+        model.touch()
+
+        onnx_json = tmp_path / "model.onnx.json"
+        onnx_json.write_text(json.dumps({}), encoding="utf-8")
+
+        config_json = tmp_path / "config.json"
+        config_json.write_text(json.dumps({}), encoding="utf-8")
+
+        result = resolve_config_path(str(model), config=None)
+
+        assert result == onnx_json
+        assert result.exists()
+
+    def test_fallback_to_config_json(self, tmp_path: Path):
+        """model.onnx.json が存在しない場合、config.json にフォールバック."""
+        model = tmp_path / "model.onnx"
+        model.touch()
+
+        config_json = tmp_path / "config.json"
+        config_json.write_text(json.dumps({}), encoding="utf-8")
+
+        result = resolve_config_path(str(model), config=None)
+
+        assert result == config_json
+        assert result.exists()
+
+    def test_neither_exists(self, tmp_path: Path):
+        """どちらの config も存在しない場合、返却パスは存在しない."""
+        model = tmp_path / "model.onnx"
+        model.touch()
+
+        result = resolve_config_path(str(model), config=None)
+
+        # ロジックは config.json パスを返すが、ファイルは存在しない
+        assert result == tmp_path / "config.json"
+        assert not result.exists()
+
+    def test_explicit_config_overrides(self, tmp_path: Path):
+        """--config を明示指定すると、フォールバックせずそのパスを使う."""
+        model = tmp_path / "model.onnx"
+        model.touch()
+
+        # フォールバック先も配置しておく
+        onnx_json = tmp_path / "model.onnx.json"
+        onnx_json.write_text(json.dumps({}), encoding="utf-8")
+
+        explicit = tmp_path / "custom" / "my_config.json"
+        explicit.parent.mkdir(parents=True, exist_ok=True)
+        explicit.write_text(json.dumps({}), encoding="utf-8")
+
+        result = resolve_config_path(str(model), config=str(explicit))
+
+        assert result == explicit
+        assert result.exists()
+        # model.onnx.json が存在しても選ばれないことを確認
+        assert result != onnx_json

--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -97,7 +97,11 @@ class PiperVoice:
     ) -> "PiperVoice":
         """Load an ONNX model and config."""
         if config_path is None:
-            config_path = f"{model_path}.json"
+            candidate = Path(f"{model_path}.json")
+            if candidate.exists():
+                config_path = candidate
+            else:
+                config_path = Path(model_path).parent / "config.json"
 
         with open(config_path, encoding="utf-8") as config_file:
             config_dict = json.load(config_file)

--- a/src/python_run/tests/test_config_fallback.py
+++ b/src/python_run/tests/test_config_fallback.py
@@ -1,0 +1,81 @@
+"""
+Tests for PiperVoice.load() config path fallback logic.
+
+Verifies the three-tier resolution:
+  1. {model}.onnx.json  (auto-detected)
+  2. config.json         (fallback in same directory)
+  3. FileNotFoundError   (neither exists)
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+# Guard: skip entire module when onnxruntime is unavailable
+ort = pytest.importorskip("onnxruntime", reason="onnxruntime is required")
+
+from piper.voice import PiperVoice  # noqa: E402
+
+
+# Absolute path to the real test model shipped with the repo
+_REPO_ROOT = Path(__file__).resolve().parents[3]  # src/python_run/tests -> repo root
+_TEST_MODEL = _REPO_ROOT / "test" / "models" / "test_voice.onnx"
+_TEST_CONFIG = _REPO_ROOT / "test" / "models" / "test_voice.onnx.json"
+
+
+@pytest.fixture()
+def config_dict():
+    """Return the reference config dict from the test model."""
+    with open(_TEST_CONFIG, encoding="utf-8") as f:
+        return json.load(f)
+
+
+# ------------------------------------------------------------------
+# Helper: copy the real .onnx into tmp_path so each test is isolated
+# ------------------------------------------------------------------
+def _copy_model(tmp_path: Path) -> Path:
+    """Copy the real ONNX model into *tmp_path* and return its path."""
+    dest = tmp_path / "model.onnx"
+    shutil.copy2(_TEST_MODEL, dest)
+    return dest
+
+
+class TestConfigFallback:
+    """PiperVoice.load() config resolution."""
+
+    @pytest.mark.unit
+    def test_onnx_json_auto_detected(self, tmp_path, config_dict):
+        """{model}.onnx.json is picked up when config_path is None."""
+        model_path = _copy_model(tmp_path)
+        config_path = tmp_path / "model.onnx.json"
+        config_path.write_text(json.dumps(config_dict), encoding="utf-8")
+
+        voice = PiperVoice.load(model_path)
+
+        assert voice.config.sample_rate == config_dict["audio"]["sample_rate"]
+        assert len(voice.config.phoneme_id_map) > 0
+
+    @pytest.mark.unit
+    def test_config_json_fallback(self, tmp_path, config_dict):
+        """config.json in the same directory is used when .onnx.json is absent."""
+        model_path = _copy_model(tmp_path)
+        # Do NOT create model.onnx.json; place config.json instead
+        fallback_path = tmp_path / "config.json"
+        fallback_path.write_text(json.dumps(config_dict), encoding="utf-8")
+
+        voice = PiperVoice.load(model_path)
+
+        assert voice.config.sample_rate == config_dict["audio"]["sample_rate"]
+        assert len(voice.config.phoneme_id_map) > 0
+
+    @pytest.mark.unit
+    def test_no_config_raises(self, tmp_path):
+        """FileNotFoundError is raised when no config file exists at all."""
+        model_path = _copy_model(tmp_path)
+        # No config files in tmp_path
+
+        with pytest.raises(FileNotFoundError):
+            PiperVoice.load(model_path)


### PR DESCRIPTION
## Summary
- HuggingFace 上のモデルが `config.json` で公開されているのに対し、piper は `<model>.onnx.json` のみを自動検出していた問題を修正
- 全コンポーネントで統一されたフォールバック検索を導入: `{model}.onnx.json` → `{dir}/config.json`
- これにより HuggingFace モデルのリネームが不要になり、`--config` の手動指定も不要に

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `src/cpp/main.cpp` | `parseArgs()` にフォールバック追加 + `--help` テキスト更新 |
| `src/python_run/piper/voice.py` | `PiperVoice.load()` にフォールバック追加 |
| `src/python/piper_train/infer_onnx.py` | `--text` モードのフォールバック追加 |
| `docker/python-inference/inference.py` | フォールバック順序を統一（`config.json` のみ → 2段階検索に修正） |
| `README.md` | フォールバック動作の記述に更新 |
| `docs/getting-started/troubleshooting.md` | 検索順序とフォールバック動作を明記 |

## Before / After
```bash
# Before: --config 必須
echo "テスト" | piper --model models/tsukuyomi.onnx --config models/config.json --output_file out.wav

# After: config.json が同ディレクトリにあれば自動検出
echo "テスト" | piper --model models/tsukuyomi.onnx --output_file out.wav
```

## Test plan
- [x] 既存テスト (229 pass in core, 47 pass in runtime) にリグレッションなし
- [x] ruff lint 通過
- [x] C++ フォールバックロジックのコードレビュー完了
- [x] Python 3ファイルのフォールバックロジックのコードレビュー完了
- [x] C++ ビルドの CI 通過確認
- [x] HuggingFace モデル (`config.json` 形式) での動作確認