### PR TITLE
feat: WebUI・HuggingFace・GitHub Pages の6言語マルチリンガルUI対応

### DIFF
--- a/.github/workflows/deploy-huggingface.yml
+++ b/.github/workflows/deploy-huggingface.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Validate Python imports before deployment
         working-directory: hf-space-deploy
         run: |
-          pip install numpy
+          pip install numpy onnxruntime
           echo "=== Pre-deployment import validation ==="
           python3 << 'PYEOF'
           import sys, importlib

--- a/.github/workflows/deploy-huggingface.yml
+++ b/.github/workflows/deploy-huggingface.yml
@@ -115,6 +115,47 @@ jobs:
           echo "Directory structure:"
           tree -h hf-space-deploy 2>/dev/null || ls -lah hf-space-deploy/ 2>/dev/null || echo "Directory not found"
 
+      - name: Validate Python imports before deployment
+        working-directory: hf-space-deploy
+        run: |
+          echo "=== Pre-deployment import validation ==="
+          python3 -c "
+import sys, importlib
+
+modules = [
+    ('piper_train.infer_onnx', 'text_to_phoneme_ids_and_prosody'),
+    ('piper_train.phonemize.registry', 'get_phonemizer'),
+    ('piper_train.phonemize.base', 'Phonemizer'),
+    ('piper_train.phonemize.multilingual', 'UnicodeLanguageDetector'),
+    ('piper_train.phonemize.token_mapper', None),
+    ('piper_train.phonemize.jp_id_map', None),
+    ('piper_train.phonemize.multilingual_id_map', None),
+    ('piper_train.vits.utils', 'audio_float_to_int16'),
+    ('piper_train.vits.wavfile', 'write'),
+]
+
+failed = []
+for mod_name, attr_name in modules:
+    try:
+        mod = importlib.import_module(mod_name)
+        if attr_name and not hasattr(mod, attr_name):
+            failed.append(f'{mod_name}.{attr_name} not found')
+            print(f'  ✗ {mod_name}.{attr_name} — attribute missing')
+        else:
+            print(f'  ✓ {mod_name}' + (f'.{attr_name}' if attr_name else ''))
+    except ImportError as e:
+        failed.append(f'{mod_name}: {e}')
+        print(f'  ✗ {mod_name} — {e}')
+
+if failed:
+    print(f'\n✗ {len(failed)} import(s) failed. Aborting deployment.')
+    for f in failed:
+        print(f'  - {f}')
+    sys.exit(1)
+else:
+    print(f'\n✓ All {len(modules)} imports validated. Safe to deploy.')
+"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/deploy-huggingface.yml
+++ b/.github/workflows/deploy-huggingface.yml
@@ -119,42 +119,43 @@ jobs:
         working-directory: hf-space-deploy
         run: |
           echo "=== Pre-deployment import validation ==="
-          python3 -c "
-import sys, importlib
+          python3 << 'PYEOF'
+          import sys, importlib
 
-modules = [
-    ('piper_train.infer_onnx', 'text_to_phoneme_ids_and_prosody'),
-    ('piper_train.phonemize.registry', 'get_phonemizer'),
-    ('piper_train.phonemize.base', 'Phonemizer'),
-    ('piper_train.phonemize.multilingual', 'UnicodeLanguageDetector'),
-    ('piper_train.phonemize.token_mapper', None),
-    ('piper_train.phonemize.jp_id_map', None),
-    ('piper_train.phonemize.multilingual_id_map', None),
-    ('piper_train.vits.utils', 'audio_float_to_int16'),
-    ('piper_train.vits.wavfile', 'write'),
-]
+          modules = [
+              ("piper_train.infer_onnx", "text_to_phoneme_ids_and_prosody"),
+              ("piper_train.phonemize.registry", "get_phonemizer"),
+              ("piper_train.phonemize.base", "Phonemizer"),
+              ("piper_train.phonemize.multilingual", "UnicodeLanguageDetector"),
+              ("piper_train.phonemize.token_mapper", None),
+              ("piper_train.phonemize.jp_id_map", None),
+              ("piper_train.phonemize.multilingual_id_map", None),
+              ("piper_train.vits.utils", "audio_float_to_int16"),
+              ("piper_train.vits.wavfile", "write"),
+          ]
 
-failed = []
-for mod_name, attr_name in modules:
-    try:
-        mod = importlib.import_module(mod_name)
-        if attr_name and not hasattr(mod, attr_name):
-            failed.append(f'{mod_name}.{attr_name} not found')
-            print(f'  ✗ {mod_name}.{attr_name} — attribute missing')
-        else:
-            print(f'  ✓ {mod_name}' + (f'.{attr_name}' if attr_name else ''))
-    except ImportError as e:
-        failed.append(f'{mod_name}: {e}')
-        print(f'  ✗ {mod_name} — {e}')
+          failed = []
+          for mod_name, attr_name in modules:
+              try:
+                  mod = importlib.import_module(mod_name)
+                  if attr_name and not hasattr(mod, attr_name):
+                      failed.append(f"{mod_name}.{attr_name} not found")
+                      print(f"  FAIL {mod_name}.{attr_name} -- attribute missing")
+                  else:
+                      label = f"{mod_name}.{attr_name}" if attr_name else mod_name
+                      print(f"  OK {label}")
+              except ImportError as e:
+                  failed.append(f"{mod_name} -- {e}")
+                  print(f"  FAIL {mod_name} -- {e}")
 
-if failed:
-    print(f'\n✗ {len(failed)} import(s) failed. Aborting deployment.')
-    for f in failed:
-        print(f'  - {f}')
-    sys.exit(1)
-else:
-    print(f'\n✓ All {len(modules)} imports validated. Safe to deploy.')
-"
+          if failed:
+              print(f"\nFAILED: {len(failed)} import(s) failed. Aborting deployment.")
+              for f in failed:
+                  print(f"  - {f}")
+              sys.exit(1)
+          else:
+              print(f"\nPASSED: All {len(modules)} imports validated. Safe to deploy.")
+          PYEOF
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy-huggingface.yml
+++ b/.github/workflows/deploy-huggingface.yml
@@ -102,7 +102,9 @@ jobs:
 
           # vits utilities (audio processing, no torch)
           touch hf-space-deploy/piper_train/vits/__init__.py
-          echo "✓ Created piper_train/vits/__init__.py"
+          cp src/python/piper_train/vits/utils.py hf-space-deploy/piper_train/vits/
+          cp src/python/piper_train/vits/wavfile.py hf-space-deploy/piper_train/vits/
+          echo "✓ Copied piper_train/vits/ (utils.py, wavfile.py)"
 
           echo "piper_train module ready: $(find hf-space-deploy/piper_train -name '*.py' | wc -l) total Python files"
 

--- a/.github/workflows/deploy-huggingface.yml
+++ b/.github/workflows/deploy-huggingface.yml
@@ -115,9 +115,15 @@ jobs:
           echo "Directory structure:"
           tree -h hf-space-deploy 2>/dev/null || ls -lah hf-space-deploy/ 2>/dev/null || echo "Directory not found"
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Validate Python imports before deployment
         working-directory: hf-space-deploy
         run: |
+          pip install numpy
           echo "=== Pre-deployment import validation ==="
           python3 << 'PYEOF'
           import sys, importlib
@@ -156,11 +162,6 @@ jobs:
           else:
               print(f"\nPASSED: All {len(modules)} imports validated. Safe to deploy.")
           PYEOF
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
 
       - name: Install and deploy to Hugging Face
         env:

--- a/.github/workflows/deploy-huggingface.yml
+++ b/.github/workflows/deploy-huggingface.yml
@@ -62,7 +62,50 @@ jobs:
           
           # Show total size of models
           echo "Total model size: $(du -sh hf-space-deploy/models | cut -f1)"
-          
+
+          # Copy piper_train phonemize module (inference-only, no torch dependency)
+          echo "Copying piper_train phonemize module..."
+          mkdir -p hf-space-deploy/piper_train/phonemize
+          mkdir -p hf-space-deploy/piper_train/vits
+
+          # piper_train package init (empty - avoids importing heavy dependencies)
+          touch hf-space-deploy/piper_train/__init__.py
+
+          # Phonemize module
+          cp src/python/piper_train/phonemize/__init__.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/base.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/registry.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/multilingual.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/bilingual.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/japanese.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/english.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/chinese.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/korean.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/spanish.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/portuguese.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/french.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/token_mapper.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/custom_dict.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/jp_id_map.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/multilingual_id_map.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/bilingual_id_map.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/zh_id_map.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/ko_id_map.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/es_id_map.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/pt_id_map.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/phonemize/fr_id_map.py hf-space-deploy/piper_train/phonemize/
+          echo "✓ Copied phonemize module ($(find hf-space-deploy/piper_train/phonemize -name '*.py' | wc -l) files)"
+
+          # Inference script (text_to_phoneme_ids_and_prosody)
+          cp src/python/piper_train/infer_onnx.py hf-space-deploy/piper_train/
+          echo "✓ Copied infer_onnx.py"
+
+          # vits utilities (audio processing, no torch)
+          touch hf-space-deploy/piper_train/vits/__init__.py
+          echo "✓ Created piper_train/vits/__init__.py"
+
+          echo "piper_train module ready: $(find hf-space-deploy/piper_train -name '*.py' | wc -l) total Python files"
+
           # List files to be deployed
           echo "Files to deploy:"
           find hf-space-deploy -type f \( -name "*.py" -o -name "*.txt" -o -name "*.md" -o -name "*.onnx" -o -name "*.json" \) | sort

--- a/.github/workflows/test-hf-space.yml
+++ b/.github/workflows/test-hf-space.yml
@@ -63,12 +63,11 @@ jobs:
           python3 -c "
           import sys, importlib
 
+          # Only modules that have NO external dependencies (no numpy, no pyopenjtalk, etc.)
           modules = [
-              ('piper_train.infer_onnx', 'text_to_phoneme_ids_and_prosody'),
               ('piper_train.phonemize.registry', 'get_phonemizer'),
               ('piper_train.phonemize.base', 'Phonemizer'),
               ('piper_train.phonemize.multilingual', 'UnicodeLanguageDetector'),
-              ('piper_train.phonemize.japanese', None),
               ('piper_train.phonemize.english', None),
               ('piper_train.phonemize.chinese', None),
               ('piper_train.phonemize.spanish', None),
@@ -77,8 +76,6 @@ jobs:
               ('piper_train.phonemize.token_mapper', None),
               ('piper_train.phonemize.jp_id_map', None),
               ('piper_train.phonemize.multilingual_id_map', None),
-              ('piper_train.vits.utils', 'audio_float_to_int16'),
-              ('piper_train.vits.wavfile', 'write'),
           ]
 
           failed = []
@@ -102,6 +99,39 @@ jobs:
 
       - name: "Layer 2: Install HF Space requirements"
         run: pip install -r hf-space-deploy/requirements.txt
+
+      - name: "Layer 2.5: Import validation (with external deps)"
+        working-directory: hf-space-deploy
+        run: |
+          python3 -c "
+          import sys, importlib
+
+          # Modules that require external deps (numpy, pyopenjtalk, etc.)
+          modules = [
+              ('piper_train.infer_onnx', 'text_to_phoneme_ids_and_prosody'),
+              ('piper_train.phonemize.japanese', None),
+              ('piper_train.vits.utils', 'audio_float_to_int16'),
+              ('piper_train.vits.wavfile', 'write'),
+          ]
+
+          failed = []
+          for mod_name, attr_name in modules:
+              try:
+                  mod = importlib.import_module(mod_name)
+                  if attr_name and not hasattr(mod, attr_name):
+                      failed.append(f'{mod_name}.{attr_name} not found')
+                  else:
+                      label = f'{mod_name}.{attr_name}' if attr_name else mod_name
+                      print(f'  OK {label}')
+              except ImportError as e:
+                  failed.append(f'{mod_name}: {e}')
+                  print(f'  FAIL {mod_name} -- {e}')
+
+          if failed:
+              print(f'\nFAIL: {len(failed)} import(s) failed')
+              sys.exit(1)
+          print(f'\nOK: All {len(modules)} imports with deps passed')
+          "
 
       - name: "Layer 3: Japanese phonemization test"
         working-directory: hf-space-deploy

--- a/.github/workflows/test-hf-space.yml
+++ b/.github/workflows/test-hf-space.yml
@@ -98,7 +98,9 @@ jobs:
           "
 
       - name: "Layer 2: Install HF Space requirements"
-        run: pip install -r hf-space-deploy/requirements.txt
+        run: |
+          pip install -r hf-space-deploy/requirements.txt
+          python3 -c "import nltk; nltk.download('averaged_perceptron_tagger_eng', quiet=True); nltk.download('cmudict', quiet=True)"
 
       - name: "Layer 2.5: Import validation (with external deps)"
         working-directory: hf-space-deploy

--- a/.github/workflows/test-hf-space.yml
+++ b/.github/workflows/test-hf-space.yml
@@ -1,0 +1,170 @@
+name: Test HF Space Build
+
+on:
+  push:
+    branches: [dev, feat/multilingual-ui-hf-demo]
+    paths:
+      - 'huggingface-space/**'
+      - 'src/python/piper_train/phonemize/**'
+      - 'src/python/piper_train/infer_onnx.py'
+      - 'src/python/piper_train/vits/utils.py'
+      - 'src/python/piper_train/vits/wavfile.py'
+      - '.github/workflows/test-hf-space.yml'
+      - '.github/workflows/deploy-huggingface.yml'
+  pull_request:
+    paths:
+      - 'huggingface-space/**'
+      - 'src/python/piper_train/phonemize/**'
+      - 'src/python/piper_train/infer_onnx.py'
+  workflow_dispatch:
+
+jobs:
+  test-hf-space:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Prepare HF Space deployment directory
+        run: |
+          mkdir -p hf-space-deploy/models
+
+          # Copy app files (same as deploy-huggingface.yml)
+          cp huggingface-space/app.py hf-space-deploy/
+          cp huggingface-space/app_imports.py hf-space-deploy/
+          cp huggingface-space/download_models.py hf-space-deploy/
+          cp huggingface-space/requirements.txt hf-space-deploy/
+
+          # Copy piper_train module (same as deploy-huggingface.yml)
+          mkdir -p hf-space-deploy/piper_train/phonemize
+          mkdir -p hf-space-deploy/piper_train/vits
+          touch hf-space-deploy/piper_train/__init__.py
+          cp src/python/piper_train/phonemize/*.py hf-space-deploy/piper_train/phonemize/
+          cp src/python/piper_train/infer_onnx.py hf-space-deploy/piper_train/
+          touch hf-space-deploy/piper_train/vits/__init__.py
+          cp src/python/piper_train/vits/utils.py hf-space-deploy/piper_train/vits/
+          cp src/python/piper_train/vits/wavfile.py hf-space-deploy/piper_train/vits/
+
+          # Copy model config for integration test (skip .onnx — 75MB)
+          if [ -f "test/models/multilingual-test-medium.onnx.json" ]; then
+            cp test/models/multilingual-test-medium.onnx.json hf-space-deploy/models/
+          fi
+
+          echo "Files prepared:"
+          find hf-space-deploy -name '*.py' | wc -l
+          echo "Python files"
+
+      - name: "Layer 1: Core import validation (no external deps)"
+        working-directory: hf-space-deploy
+        run: |
+          python3 -c "
+          import sys, importlib
+
+          modules = [
+              ('piper_train.infer_onnx', 'text_to_phoneme_ids_and_prosody'),
+              ('piper_train.phonemize.registry', 'get_phonemizer'),
+              ('piper_train.phonemize.base', 'Phonemizer'),
+              ('piper_train.phonemize.multilingual', 'UnicodeLanguageDetector'),
+              ('piper_train.phonemize.japanese', None),
+              ('piper_train.phonemize.english', None),
+              ('piper_train.phonemize.chinese', None),
+              ('piper_train.phonemize.spanish', None),
+              ('piper_train.phonemize.french', None),
+              ('piper_train.phonemize.portuguese', None),
+              ('piper_train.phonemize.token_mapper', None),
+              ('piper_train.phonemize.jp_id_map', None),
+              ('piper_train.phonemize.multilingual_id_map', None),
+              ('piper_train.vits.utils', 'audio_float_to_int16'),
+              ('piper_train.vits.wavfile', 'write'),
+          ]
+
+          failed = []
+          for mod_name, attr_name in modules:
+              try:
+                  mod = importlib.import_module(mod_name)
+                  if attr_name and not hasattr(mod, attr_name):
+                      failed.append(f'{mod_name}.{attr_name} not found')
+                  else:
+                      label = f'{mod_name}.{attr_name}' if attr_name else mod_name
+                      print(f'  OK {label}')
+              except ImportError as e:
+                  failed.append(f'{mod_name}: {e}')
+                  print(f'  FAIL {mod_name} -- {e}')
+
+          if failed:
+              print(f'\nFAIL: {len(failed)} import(s) failed')
+              sys.exit(1)
+          print(f'\nOK: All {len(modules)} core imports passed')
+          "
+
+      - name: "Layer 2: Install HF Space requirements"
+        run: pip install -r hf-space-deploy/requirements.txt
+
+      - name: "Layer 3: Japanese phonemization test"
+        working-directory: hf-space-deploy
+        run: |
+          python3 -c "
+          from piper_train.infer_onnx import text_to_phoneme_ids_and_prosody
+          import json
+
+          with open('models/multilingual-test-medium.onnx.json') as f:
+              config = json.load(f)
+
+          phoneme_id_map = config['phoneme_id_map']
+          language_id_map = config.get('language_id_map', {})
+
+          phoneme_ids, prosody = text_to_phoneme_ids_and_prosody(
+              'こんにちは、世界！', phoneme_id_map, language='ja', language_id_map=language_id_map
+          )
+          assert len(phoneme_ids) > 0, 'JA phonemization failed'
+          assert prosody is not None, 'JA prosody is None'
+          # JA should have real prosody data (not all zeros)
+          has_nonzero = any(p is not None and (p.get('a1', 0) != 0 or p.get('a2', 0) != 0 or p.get('a3', 0) != 0) for p in prosody if p is not None)
+          print(f'OK JA: {len(phoneme_ids)} phoneme IDs, prosody has_nonzero={has_nonzero}')
+          "
+
+      - name: "Layer 4: English phonemization test"
+        working-directory: hf-space-deploy
+        run: |
+          python3 -c "
+          from piper_train.infer_onnx import text_to_phoneme_ids_and_prosody
+          import json
+
+          with open('models/multilingual-test-medium.onnx.json') as f:
+              config = json.load(f)
+
+          phoneme_ids, prosody = text_to_phoneme_ids_and_prosody(
+              'Hello, how are you today?', config['phoneme_id_map'],
+              language='en', language_id_map=config.get('language_id_map', {})
+          )
+          assert len(phoneme_ids) > 0, 'EN phonemization failed'
+          print(f'OK EN: {len(phoneme_ids)} phoneme IDs')
+          "
+
+      - name: "Layer 5: App module import test"
+        working-directory: hf-space-deploy
+        run: |
+          python3 -c "
+          # Verify app.py can be imported without errors
+          # (download_models will run but models already exist or will be skipped)
+          import app
+          assert hasattr(app, 'create_interface'), 'Missing create_interface'
+          assert hasattr(app, 'synthesize_speech'), 'Missing synthesize_speech'
+          assert hasattr(app, 'MODELS'), 'Missing MODELS'
+          assert len(app.MODELS) == 6, f'Expected 6 models, got {len(app.MODELS)}'
+          print('OK app.py imports passed, 6 language models configured')
+          "
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## HF Space Build Test" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "All layers passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Test failed -- do NOT deploy to HF Spaces" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -18,8 +18,8 @@ COPY pyproject.toml /app/pyproject.toml
 COPY src/python /app/src/python
 COPY src/python_run/requirements_webui.txt /app/requirements_webui.txt
 
-# Install piper_train with inference extras + gradio
-RUN uv pip install --system "/app/src/python[inference]" && \
+# Install piper_train with inference extras + gradio + multilingual
+RUN uv pip install --system "/app/src/python[inference,multilingual]" && \
     uv pip install --system -r /app/requirements_webui.txt
 
 # Copy WebUI application

--- a/docker/webui/app.py
+++ b/docker/webui/app.py
@@ -97,14 +97,17 @@ def synthesize(
 
     sample_rate = config.get("audio", {}).get("sample_rate", 22050)
 
+    language_id_map = config.get("language_id_map", {})
+
     phoneme_ids, prosody_features_data = text_to_phoneme_ids_and_prosody(
-        text, phoneme_id_map, language=language
+        text, phoneme_id_map, language=language, language_id_map=language_id_map
     )
 
     session = _get_session(model_path)
     input_names = [inp.name for inp in session.get_inputs()]
     has_prosody = "prosody_features" in input_names
     has_sid = "sid" in input_names
+    has_lid = "lid" in input_names
 
     text_array = np.expand_dims(np.array(phoneme_ids, dtype=np.int64), 0)
     text_lengths = np.array([text_array.shape[1]], dtype=np.int64)
@@ -118,6 +121,10 @@ def synthesize(
 
     if has_sid:
         inputs["sid"] = np.array([int(speaker_id)], dtype=np.int64)
+
+    if has_lid:
+        language_id = language_id_map.get(language, 0)
+        inputs["lid"] = np.array([language_id], dtype=np.int64)
 
     if has_prosody and prosody_features_data:
         prosody_array = []
@@ -158,7 +165,7 @@ def create_ui(model_dir: str, output_dir: str):
                     value=model_choices[0] if models else None,
                 )
                 language = gr.Radio(
-                    choices=["ja", "en"],
+                    choices=["ja", "en", "zh", "es", "fr", "pt"],
                     label="Language",
                     value="ja",
                 )

--- a/docker/webui/app.py
+++ b/docker/webui/app.py
@@ -13,6 +13,21 @@ import onnxruntime
 from piper_train.infer_onnx import text_to_phoneme_ids_and_prosody
 
 
+SAMPLE_TEXTS = {
+    "ja": "こんにちは、今日はとても良い天気ですね。散歩に出かけましょう。",
+    "en": "Hello, how are you today? The weather is beautiful, let's go for a walk.",
+    "zh": "你好，今天天气非常好。我们一起去散步吧。",
+    "es": "Hola, ¿cómo estás hoy? El clima es hermoso, vamos a dar un paseo.",
+    "fr": "Bonjour, comment allez-vous aujourd'hui? Il fait beau, allons nous promener.",
+    "pt": "Olá, como você está hoje? O tempo está lindo, vamos dar um passeio.",
+}
+
+
+def on_language_change(language: str) -> str:
+    """Return sample text for the selected language."""
+    return SAMPLE_TEXTS.get(language, "")
+
+
 _session_cache: dict[str, onnxruntime.InferenceSession] = {}
 _config_cache: dict[str, dict] = {}
 _cache_lock = threading.Lock()
@@ -158,6 +173,7 @@ def create_ui(model_dir: str, output_dir: str):
                     label="Text",
                     placeholder="Enter text to synthesize...",
                     lines=3,
+                    value=SAMPLE_TEXTS["ja"],
                 )
                 model_dropdown = gr.Dropdown(
                     choices=model_choices,
@@ -182,6 +198,12 @@ def create_ui(model_dir: str, output_dir: str):
 
             with gr.Column():
                 audio_output = gr.Audio(label="Output", type="numpy")
+
+        language.change(
+            fn=on_language_change,
+            inputs=[language],
+            outputs=[text_input],
+        )
 
         btn.click(
             fn=synthesize,

--- a/huggingface-space/README.md
+++ b/huggingface-space/README.md
@@ -12,35 +12,74 @@ license: mit
 
 # piper-plus Demo
 
-A web-based demo for [piper-plus](https://github.com/ayutaz/piper-plus), featuring high-quality text-to-speech synthesis for Japanese and English.
+A web-based demo for [piper-plus](https://github.com/ayutaz/piper-plus), featuring high-quality text-to-speech synthesis supporting 6 languages: Japanese, English, Chinese, Spanish, French, and Portuguese.
 
 ## Features
 
 - 🇯🇵 **Japanese TTS**: High-quality Japanese speech synthesis using OpenJTalk phonemization
 - 🇺🇸 **English TTS**: Natural English speech synthesis
+- 🇨🇳 **Chinese TTS**: Mandarin Chinese speech synthesis using pypinyin
+- 🇪🇸 **Spanish TTS**: Spanish speech synthesis with rule-based phonemization
+- 🇫🇷 **French TTS**: French speech synthesis with rule-based phonemization
+- 🇵🇹 **Portuguese TTS**: Portuguese speech synthesis with rule-based phonemization
 - 🚀 **Fast Inference**: ONNX Runtime for efficient CPU-based inference
 - 🎛️ **Adjustable Parameters**: Control speech speed, expressiveness, and phoneme duration
 - 🌐 **Web Interface**: Easy-to-use Gradio interface
 
+## Supported Languages
+
+| Code | Language | Script | Phonemizer |
+|------|----------|--------|------------|
+| `ja` | Japanese | Hiragana/Katakana/Kanji | pyopenjtalk |
+| `en` | English | Latin | g2p-en |
+| `zh` | Chinese (Mandarin) | Simplified Chinese | pypinyin |
+| `es` | Spanish | Latin | Rule-based |
+| `fr` | French | Latin | Rule-based |
+| `pt` | Portuguese | Latin | Rule-based |
+
 ## Models
 
-This demo uses a single multilingual model that supports both Japanese and English:
-- **Multilingual (Medium)**: Handles Japanese (OpenJTalk) and English phonemization with a unified model
+This demo uses a multilingual model trained on 6 languages with 571 speakers and 508,187 utterances:
+- **Multilingual 6-lang (Medium)**: Supports Japanese, English, Chinese, Spanish, French, and Portuguese with a unified 173-symbol model
 
 ## Usage
 
 1. Select a model from the dropdown
-2. Enter your text in the input field
-3. Adjust advanced settings if needed
-4. Click "Generate Speech" to synthesize
+2. Select the language of your input text
+3. Enter your text in the input field (see sample texts below)
+4. Adjust advanced settings if needed
+5. Click "Generate Speech" to synthesize
+
+### Sample Texts by Language
+
+| Language | Sample Text |
+|----------|-------------|
+| Japanese (`ja`) | こんにちは、今日は良い天気ですね。 |
+| English (`en`) | Hello, how are you today? |
+| Chinese (`zh`) | 你好，今天天气很好。 |
+| Spanish (`es`) | Hola, como estas hoy? |
+| French (`fr`) | Bonjour, comment allez-vous? |
+| Portuguese (`pt`) | Ola, como voce esta hoje? |
+
+### Code-Switching (Mixed Language)
+
+The multilingual model supports code-switching within a single utterance. The language detector automatically identifies language segments:
+
+```
+今日はgood morningですね  →  JA + EN mixed
+```
 
 ## Technical Details
 
 - **Framework**: ONNX Runtime (CPU inference)
-- **Phonemization**: 
-  - Japanese: pyopenjtalk
-  - English: Character-based fallback
+- **Phonemization**:
+  - Japanese: pyopenjtalk (OpenJTalk-based)
+  - English: g2p-en (Apache-2.0, espeak-ng compatible)
+  - Chinese: pypinyin (MIT)
+  - Spanish / French / Portuguese: Rule-based (no external dependency)
+- **Language Detection**: Unicode range-based automatic detection
 - **Audio**: 16-bit PCM WAV output
+- **Model Architecture**: VITS with language embedding (`emb_lang`), 173 phoneme symbols, 6 language IDs
 
 ## Local Development
 
@@ -59,11 +98,13 @@ python app.py
 ## Credits
 
 - Piper TTS by [Rhasspy](https://github.com/rhasspy/piper)
-- Japanese enhancements by [ayutaz](https://github.com/ayutaz/piper-plus)
+- Multilingual (6-language) enhancements by [ayutaz](https://github.com/ayutaz/piper-plus)
+- Chinese phonemization: [pypinyin](https://github.com/mozillazg/python-pinyin) (MIT)
+- English G2P: [g2p-en](https://github.com/Kyubyong/g2p) (Apache-2.0)
 
 ## License
 
 This project is licensed under the MIT License. See the original [Piper repository](https://github.com/rhasspy/piper) for more details.
 
 ---
-_Last updated: 2026-03-09 - Using Gradio 6.9.0_
+_Last updated: 2026-03-18 - 6-language multilingual support (ja/en/zh/es/fr/pt)_

--- a/huggingface-space/app.py
+++ b/huggingface-space/app.py
@@ -11,21 +11,15 @@ import threading
 import gradio as gr
 import numpy as np
 import onnxruntime
-from app_imports import ESPEAK_AVAILABLE, PYOPENJTALK_AVAILABLE
 
 # Download models if not present
 from download_models import download_models
 
+from piper_train.infer_onnx import text_to_phoneme_ids_and_prosody
+
 
 # Ensure models are downloaded
 download_models()
-
-
-# Import optional dependencies
-if PYOPENJTALK_AVAILABLE:
-    import pyopenjtalk
-if ESPEAK_AVAILABLE:
-    from espeak_phonemizer import Phonemizer
 
 
 # Configure logging
@@ -78,90 +72,6 @@ SAMPLE_TEXTS = {
     "pt": "Olá, como você está hoje? O tempo está lindo, vamos dar um passeio.",
 }
 
-# Basic English word to IPA mapping for common words
-# This is a simplified fallback when espeak-ng is not available
-ENGLISH_IPA_MAP = {
-    "hello": "hɛloʊ",
-    "world": "wɜrld",
-    "this": "ðɪs",
-    "is": "ɪz",
-    "a": "ə",
-    "test": "tɛst",
-    "text": "tɛkst",
-    "to": "tu",
-    "speech": "spitʃ",
-    "demo": "dɛmoʊ",
-    "welcome": "wɛlkəm",
-    "piper": "paɪpər",
-    "tts": "titiɛs",
-    "enjoy": "ɛndʒɔɪ",
-    "high": "haɪ",
-    "quality": "kwɑləti",
-    "synthesis": "sɪnθəsɪs",
-    "the": "ðə",
-    "and": "ænd",
-    "for": "fɔr",
-    "with": "wɪð",
-    "you": "ju",
-    "can": "kæn",
-    "it": "ɪt",
-    "that": "ðæt",
-    "have": "hæv",
-    "from": "frʌm",
-    "or": "ɔr",
-    "which": "wɪtʃ",
-    "one": "wʌn",
-    "would": "wʊd",
-    "all": "ɔl",
-    "will": "wɪl",
-    "there": "ðɛr",
-    "say": "seɪ",
-    "who": "hu",
-    "make": "meɪk",
-    "when": "wɛn",
-    "time": "taɪm",
-    "if": "ɪf",
-    "no": "noʊ",
-    "way": "weɪ",
-    "has": "hæz",
-    "yes": "jɛs",
-    "good": "gʊd",
-    "very": "vɛri",
-}
-
-# Japanese multi-character phoneme to Unicode PUA mapping
-# This mapping must match the C++ implementation and training data
-PHONEME_TO_PUA = {
-    # Long vowels
-    "a:": "\ue000",
-    "i:": "\ue001",
-    "u:": "\ue002",
-    "e:": "\ue003",
-    "o:": "\ue004",
-    # Special consonants
-    "cl": "\ue005",  # Geminate/glottal stop
-    # Palatalized consonants
-    "ky": "\ue006",
-    "kw": "\ue007",
-    "gy": "\ue008",
-    "gw": "\ue009",
-    "ty": "\ue00a",
-    "dy": "\ue00b",
-    "py": "\ue00c",
-    "by": "\ue00d",
-    # Affricates and special sounds
-    "ch": "\ue00e",
-    "ts": "\ue00f",
-    "sh": "\ue010",
-    "zy": "\ue011",
-    "hy": "\ue012",
-    # Palatalized nasals/liquids
-    "ny": "\ue013",
-    "my": "\ue014",
-    "ry": "\ue015",
-}
-
-
 _session_cache: dict[str, onnxruntime.InferenceSession] = {}
 _session_lock = threading.Lock()
 
@@ -187,165 +97,6 @@ def load_model_config(config_path: str) -> dict:
         return json.load(f)
 
 
-def map_phonemes(phonemes: list[str]) -> list[str]:
-    """Map multi-character phonemes to Unicode PUA characters"""
-    result = []
-    for phoneme in phonemes:
-        if phoneme in PHONEME_TO_PUA:
-            result.append(PHONEME_TO_PUA[phoneme])
-        else:
-            result.append(phoneme)
-    return result
-
-
-def text_to_phonemes(text: str, language: str) -> list[str]:
-    """Convert text to phoneme strings based on language"""
-
-    if language == "ja":
-        if PYOPENJTALK_AVAILABLE:
-            # Get phonemes from OpenJTalk
-            labels = pyopenjtalk.extract_fullcontext(text)
-            phonemes = []
-
-            for label in labels:
-                # Extract phoneme from label
-                if "-" in label and "+" in label:
-                    phoneme = label.split("-")[1].split("+")[0]
-                    if phoneme not in ["sil", "pau"]:
-                        phonemes.append(phoneme)
-
-            # Add sentence markers
-            phonemes = ["^"] + phonemes + ["$"]
-
-            # Convert multi-character phonemes to Unicode PUA
-            phonemes = map_phonemes(phonemes)
-        else:
-            logger.warning("pyopenjtalk not available, using fallback")
-            # Simple fallback - just use dummy phonemes
-            phonemes = ["^"] + list("aiueo") * 5 + ["$"]
-
-    elif language == "en":
-        if ESPEAK_AVAILABLE:
-            phonemizer = Phonemizer("en-us")
-            phoneme_str = phonemizer.phonemize(text)
-            # Convert phoneme string to list
-            phonemes = ["^"] + list(phoneme_str.replace(" ", "")) + ["$"]
-        else:
-            logger.warning("espeak_phonemizer not available, using IPA fallback")
-            # IPA-based fallback for better English pronunciation
-            words = text.lower().split()
-            phonemes = ["^"]
-
-            for i, word in enumerate(words):
-                # Add space between words
-                if i > 0:
-                    phonemes.append(" ")
-
-                # Remove punctuation from word
-                clean_word = "".join(c for c in word if c.isalpha())
-
-                if clean_word in ENGLISH_IPA_MAP:
-                    # Use IPA mapping if available
-                    ipa = ENGLISH_IPA_MAP[clean_word]
-                    phonemes.extend(list(ipa))
-                else:
-                    # Fall back to character-by-character for unknown words
-                    phonemes.extend(list(clean_word))
-
-            phonemes.append("$")
-
-    else:
-        # zh / es / fr / pt: try MultilingualPhonemizer first
-        try:
-            from piper_train.phonemize.multilingual import (
-                MultilingualPhonemizer,  # noqa: PLC0415
-            )
-
-            mp = MultilingualPhonemizer(languages=["ja", "en", "zh", "es", "fr", "pt"])
-            phonemes = mp.phonemize(text)
-        except Exception:
-            logger.warning(
-                "MultilingualPhonemizer unavailable for language '%s', "
-                "trying individual phonemizer",
-                language,
-            )
-            phonemes = None
-            try:
-                if language == "zh":
-                    from piper_train.phonemize.chinese import (
-                        ChinesePhonemizer,  # noqa: PLC0415
-                    )
-
-                    phonemes = ChinesePhonemizer().phonemize(text)
-                elif language == "es":
-                    from piper_train.phonemize.spanish import (
-                        SpanishPhonemizer,  # noqa: PLC0415
-                    )
-
-                    phonemes = SpanishPhonemizer().phonemize(text)
-                elif language == "fr":
-                    from piper_train.phonemize.french import (
-                        FrenchPhonemizer,  # noqa: PLC0415
-                    )
-
-                    phonemes = FrenchPhonemizer().phonemize(text)
-                elif language == "pt":
-                    from piper_train.phonemize.portuguese import (
-                        PortuguesePhonemizer,  # noqa: PLC0415
-                    )
-
-                    phonemes = PortuguesePhonemizer().phonemize(text)
-            except Exception:
-                logger.warning(
-                    "Individual phonemizer unavailable for language '%s'",
-                    language,
-                )
-
-            if phonemes is None:
-                if ESPEAK_AVAILABLE:
-                    # Map language code to espeak locale
-                    espeak_lang_map = {
-                        "zh": "zh",
-                        "es": "es",
-                        "fr": "fr",
-                        "pt": "pt",
-                    }
-                    espeak_lang = espeak_lang_map.get(language, language)
-                    try:
-                        phonemizer = Phonemizer(espeak_lang)
-                        phoneme_str = phonemizer.phonemize(text)
-                        phonemes = ["^"] + list(phoneme_str.replace(" ", "")) + ["$"]
-                    except Exception:
-                        logger.warning(
-                            "espeak fallback failed for language '%s', using characters",
-                            language,
-                        )
-                        phonemes = list(text)
-                else:
-                    logger.warning(
-                        "No phonemizer available for language '%s', using characters",
-                        language,
-                    )
-                    phonemes = list(text)
-
-    return phonemes
-
-
-def phonemes_to_ids(phonemes: list[str], config: dict) -> list[int]:
-    """Convert phonemes to model input IDs"""
-    phoneme_id_map = config.get("phoneme_id_map", {})
-
-    ids = []
-    for phoneme in phonemes:
-        if phoneme in phoneme_id_map:
-            ids.extend(phoneme_id_map[phoneme])
-        else:
-            # Use pad token for unknown phonemes
-            ids.append(0)
-
-    return ids
-
-
 def synthesize_speech(
     text: str,
     model_name: str,
@@ -366,9 +117,12 @@ def synthesize_speech(
     language = model_info["language"]
     config = load_model_config(model_info["config"])
 
-    # Convert text to phoneme IDs
-    phonemes = text_to_phonemes(text, language)
-    phoneme_ids = phonemes_to_ids(phonemes, config)
+    # Convert text to phoneme IDs and prosody features
+    phoneme_id_map = config.get("phoneme_id_map", {})
+    language_id_map = config.get("language_id_map", {})
+    phoneme_ids, prosody_features_data = text_to_phoneme_ids_and_prosody(
+        text, phoneme_id_map, language=language, language_id_map=language_id_map
+    )
 
     if not phoneme_ids:
         raise gr.Error("Failed to convert text to phonemes")
@@ -404,19 +158,27 @@ def synthesize_speech(
         # Add language ID (lid) if the model supports multilingual conditioning
         input_names_set = {inp.name for inp in model.get_inputs()}
         if "lid" in input_names_set:
-            language_id_map = config.get(
-                "language_id_map",
-                {"ja": 0, "en": 1, "zh": 2, "es": 3, "fr": 4, "pt": 5},
-            )
             lid_value = language_id_map.get(language, 0)
             inputs["lid"] = np.array([lid_value], dtype=np.int64)
 
-        # Add prosody_features if the model requires them (zeros as default)
+        # Add prosody_features if the model requires them
         if "prosody_features" in input_names_set:
-            num_phonemes = text_array.shape[1]
-            inputs["prosody_features"] = np.zeros(
-                (1, num_phonemes, 3), dtype=np.int64
-            )
+            if prosody_features_data:
+                prosody_array = []
+                for pf in prosody_features_data:
+                    if pf is None:
+                        prosody_array.append([0, 0, 0])
+                    else:
+                        prosody_array.append([pf["a1"], pf["a2"], pf["a3"]])
+                inputs["prosody_features"] = np.expand_dims(
+                    np.array(prosody_array, dtype=np.int64), 0
+                )
+            else:
+                # Fallback: zero-filled prosody
+                num_phonemes = text_array.shape[1]
+                inputs["prosody_features"] = np.zeros(
+                    (1, num_phonemes, 3), dtype=np.int64
+                )
 
         audio = model.run(None, inputs)[0]
 
@@ -540,7 +302,10 @@ def create_interface():
                 ],
                 ["你好，世界！今天天气很好。", "Multilingual (Chinese)"],
                 ["¡Hola, mundo! Bienvenido a piper-plus.", "Multilingual (Spanish)"],
-                ["Bonjour le monde! Bienvenue sur piper-plus.", "Multilingual (French)"],
+                [
+                    "Bonjour le monde! Bienvenue sur piper-plus.",
+                    "Multilingual (French)",
+                ],
                 ["Olá, mundo! Bem-vindo ao piper-plus.", "Multilingual (Portuguese)"],
             ],
             inputs=[text_input, model_dropdown],

--- a/huggingface-space/app.py
+++ b/huggingface-space/app.py
@@ -68,6 +68,16 @@ MODELS = {
     },
 }
 
+# Sample texts shown when the user switches language/model
+SAMPLE_TEXTS = {
+    "ja": "こんにちは、今日はとても良い天気ですね。散歩に出かけましょう。",
+    "en": "Hello, how are you today? The weather is beautiful, let's go for a walk.",
+    "zh": "你好，今天天气非常好。我们一起去散步吧。",
+    "es": "Hola, ¿cómo estás hoy? El clima es hermoso, vamos a dar un paseo.",
+    "fr": "Bonjour, comment allez-vous aujourd'hui? Il fait beau, allons nous promener.",
+    "pt": "Olá, como você está hoje? O tempo está lindo, vamos dar um passeio.",
+}
+
 # Basic English word to IPA mapping for common words
 # This is a simplified fallback when espeak-ng is not available
 ENGLISH_IPA_MAP = {
@@ -418,6 +428,13 @@ def synthesize_speech(
         raise gr.Error(f"Failed to generate speech: {str(e)}") from e
 
 
+def on_model_change(model_name: str) -> str:
+    """Return sample text for the selected model's language."""
+    model_info = MODELS.get(model_name, {})
+    language = model_info.get("language", "ja")
+    return SAMPLE_TEXTS.get(language, "")
+
+
 def create_interface():
     """Create Gradio interface"""
     with gr.Blocks(title="piper-plus Demo") as interface:
@@ -441,6 +458,7 @@ def create_interface():
                 text_input = gr.Textbox(
                     label="Text to synthesize",
                     placeholder="Enter text here...",
+                    value=SAMPLE_TEXTS["ja"],
                     lines=3,
                 )
 
@@ -522,6 +540,12 @@ def create_interface():
         )
 
         # Event handlers
+        model_dropdown.change(
+            fn=on_model_change,
+            inputs=[model_dropdown],
+            outputs=[text_input],
+        )
+
         synthesize_btn.click(
             fn=synthesize_speech,
             inputs=[

--- a/huggingface-space/app.py
+++ b/huggingface-space/app.py
@@ -9,19 +9,20 @@ import logging
 import threading
 
 import gradio as gr
+import nltk
 import numpy as np
 import onnxruntime
 
-# Download NLTK data required by g2p-en (English phonemizer)
-import nltk
 
+# Download NLTK data required by g2p-en (English phonemizer).
+# This must run before importing modules that transitively load g2p-en.
 nltk.download("averaged_perceptron_tagger_eng", quiet=True)
 nltk.download("cmudict", quiet=True)
 
 # Download models if not present
-from download_models import download_models
+from download_models import download_models  # noqa: E402
 
-from piper_train.infer_onnx import text_to_phoneme_ids_and_prosody
+from piper_train.infer_onnx import text_to_phoneme_ids_and_prosody  # noqa: E402
 
 
 # Ensure models are downloaded

--- a/huggingface-space/app.py
+++ b/huggingface-space/app.py
@@ -12,6 +12,12 @@ import gradio as gr
 import numpy as np
 import onnxruntime
 
+# Download NLTK data required by g2p-en (English phonemizer)
+import nltk
+
+nltk.download("averaged_perceptron_tagger_eng", quiet=True)
+nltk.download("cmudict", quiet=True)
+
 # Download models if not present
 from download_models import download_models
 

--- a/huggingface-space/app.py
+++ b/huggingface-space/app.py
@@ -411,6 +411,13 @@ def synthesize_speech(
             lid_value = language_id_map.get(language, 0)
             inputs["lid"] = np.array([lid_value], dtype=np.int64)
 
+        # Add prosody_features if the model requires them (zeros as default)
+        if "prosody_features" in input_names_set:
+            num_phonemes = text_array.shape[1]
+            inputs["prosody_features"] = np.zeros(
+                (1, num_phonemes, 3), dtype=np.int64
+            )
+
         audio = model.run(None, inputs)[0]
 
         # Remove batch and channel dimensions

--- a/huggingface-space/app.py
+++ b/huggingface-space/app.py
@@ -46,6 +46,26 @@ MODELS = {
         "config": "models/multilingual-test-medium.onnx.json",
         "language": "en",
     },
+    "Multilingual (Chinese)": {
+        "path": "models/multilingual-test-medium.onnx",
+        "config": "models/multilingual-test-medium.onnx.json",
+        "language": "zh",
+    },
+    "Multilingual (Spanish)": {
+        "path": "models/multilingual-test-medium.onnx",
+        "config": "models/multilingual-test-medium.onnx.json",
+        "language": "es",
+    },
+    "Multilingual (French)": {
+        "path": "models/multilingual-test-medium.onnx",
+        "config": "models/multilingual-test-medium.onnx.json",
+        "language": "fr",
+    },
+    "Multilingual (Portuguese)": {
+        "path": "models/multilingual-test-medium.onnx",
+        "config": "models/multilingual-test-medium.onnx.json",
+        "language": "pt",
+    },
 }
 
 # Basic English word to IPA mapping for common words
@@ -194,34 +214,109 @@ def text_to_phonemes(text: str, language: str) -> list[str]:
             # Simple fallback - just use dummy phonemes
             phonemes = ["^"] + list("aiueo") * 5 + ["$"]
 
-    elif ESPEAK_AVAILABLE:  # English
-        phonemizer = Phonemizer("en-us")
-        phoneme_str = phonemizer.phonemize(text)
-        # Convert phoneme string to list
-        phonemes = ["^"] + list(phoneme_str.replace(" ", "")) + ["$"]
+    elif language == "en":
+        if ESPEAK_AVAILABLE:
+            phonemizer = Phonemizer("en-us")
+            phoneme_str = phonemizer.phonemize(text)
+            # Convert phoneme string to list
+            phonemes = ["^"] + list(phoneme_str.replace(" ", "")) + ["$"]
+        else:
+            logger.warning("espeak_phonemizer not available, using IPA fallback")
+            # IPA-based fallback for better English pronunciation
+            words = text.lower().split()
+            phonemes = ["^"]
+
+            for i, word in enumerate(words):
+                # Add space between words
+                if i > 0:
+                    phonemes.append(" ")
+
+                # Remove punctuation from word
+                clean_word = "".join(c for c in word if c.isalpha())
+
+                if clean_word in ENGLISH_IPA_MAP:
+                    # Use IPA mapping if available
+                    ipa = ENGLISH_IPA_MAP[clean_word]
+                    phonemes.extend(list(ipa))
+                else:
+                    # Fall back to character-by-character for unknown words
+                    phonemes.extend(list(clean_word))
+
+            phonemes.append("$")
+
     else:
-        logger.warning("espeak_phonemizer not available, using IPA fallback")
-        # IPA-based fallback for better English pronunciation
-        words = text.lower().split()
-        phonemes = ["^"]
+        # zh / es / fr / pt: try MultilingualPhonemizer first
+        try:
+            from piper_train.phonemize.multilingual import (
+                MultilingualPhonemizer,  # noqa: PLC0415
+            )
 
-        for i, word in enumerate(words):
-            # Add space between words
-            if i > 0:
-                phonemes.append(" ")
+            mp = MultilingualPhonemizer(languages=["ja", "en", "zh", "es", "fr", "pt"])
+            phonemes = mp.phonemize(text)
+        except Exception:
+            logger.warning(
+                "MultilingualPhonemizer unavailable for language '%s', "
+                "trying individual phonemizer",
+                language,
+            )
+            phonemes = None
+            try:
+                if language == "zh":
+                    from piper_train.phonemize.chinese import (
+                        ChinesePhonemizer,  # noqa: PLC0415
+                    )
 
-            # Remove punctuation from word
-            clean_word = "".join(c for c in word if c.isalpha())
+                    phonemes = ChinesePhonemizer().phonemize(text)
+                elif language == "es":
+                    from piper_train.phonemize.spanish import (
+                        SpanishPhonemizer,  # noqa: PLC0415
+                    )
 
-            if clean_word in ENGLISH_IPA_MAP:
-                # Use IPA mapping if available
-                ipa = ENGLISH_IPA_MAP[clean_word]
-                phonemes.extend(list(ipa))
-            else:
-                # Fall back to character-by-character for unknown words
-                phonemes.extend(list(clean_word))
+                    phonemes = SpanishPhonemizer().phonemize(text)
+                elif language == "fr":
+                    from piper_train.phonemize.french import (
+                        FrenchPhonemizer,  # noqa: PLC0415
+                    )
 
-        phonemes.append("$")
+                    phonemes = FrenchPhonemizer().phonemize(text)
+                elif language == "pt":
+                    from piper_train.phonemize.portuguese import (
+                        PortuguesePhonemizer,  # noqa: PLC0415
+                    )
+
+                    phonemes = PortuguesePhonemizer().phonemize(text)
+            except Exception:
+                logger.warning(
+                    "Individual phonemizer unavailable for language '%s'",
+                    language,
+                )
+
+            if phonemes is None:
+                if ESPEAK_AVAILABLE:
+                    # Map language code to espeak locale
+                    espeak_lang_map = {
+                        "zh": "zh",
+                        "es": "es",
+                        "fr": "fr",
+                        "pt": "pt",
+                    }
+                    espeak_lang = espeak_lang_map.get(language, language)
+                    try:
+                        phonemizer = Phonemizer(espeak_lang)
+                        phoneme_str = phonemizer.phonemize(text)
+                        phonemes = ["^"] + list(phoneme_str.replace(" ", "")) + ["$"]
+                    except Exception:
+                        logger.warning(
+                            "espeak fallback failed for language '%s', using characters",
+                            language,
+                        )
+                        phonemes = list(text)
+                else:
+                    logger.warning(
+                        "No phonemizer available for language '%s', using characters",
+                        language,
+                    )
+                    phonemes = list(text)
 
     return phonemes
 
@@ -258,10 +353,11 @@ def synthesize_speech(
         raise gr.Error("Invalid model selected")
 
     model_info = MODELS[model_name]
+    language = model_info["language"]
     config = load_model_config(model_info["config"])
 
     # Convert text to phoneme IDs
-    phonemes = text_to_phonemes(text, model_info["language"])
+    phonemes = text_to_phonemes(text, language)
     phoneme_ids = phonemes_to_ids(phonemes, config)
 
     if not phoneme_ids:
@@ -295,6 +391,16 @@ def synthesize_speech(
         if sid is not None:
             inputs["sid"] = sid
 
+        # Add language ID (lid) if the model supports multilingual conditioning
+        input_names_set = {inp.name for inp in model.get_inputs()}
+        if "lid" in input_names_set:
+            language_id_map = config.get(
+                "language_id_map",
+                {"ja": 0, "en": 1, "zh": 2, "es": 3, "fr": 4, "pt": 5},
+            )
+            lid_value = language_id_map.get(language, 0)
+            inputs["lid"] = np.array([lid_value], dtype=np.int64)
+
         audio = model.run(None, inputs)[0]
 
         # Remove batch and channel dimensions
@@ -318,7 +424,8 @@ def create_interface():
         gr.Markdown("""
             # piper-plus Demo
 
-            High-quality multilingual text-to-speech synthesis supporting Japanese and English.
+            High-quality multilingual text-to-speech synthesis supporting Japanese, English,
+            Chinese, Spanish, French, and Portuguese.
 
             This demo uses a single multilingual ONNX model for fast CPU inference.
             """)
@@ -383,11 +490,11 @@ def create_interface():
 
             gr.Markdown("""
                 ### Tips:
-                - Select Japanese mode for hiragana/kanji text
-                - Select English mode for standard English text
-                - Both modes use the same multilingual model
+                - Select the language matching your input text
+                - All modes use the same multilingual ONNX model
                 - Adjust speed for faster/slower speech
                 - Higher expressiveness = more natural variation
+                - Chinese, Spanish, French, Portuguese require piper_train installed
                 """)
 
         # Examples
@@ -406,6 +513,10 @@ def create_interface():
                     "Welcome to piper-plus. Enjoy high quality speech synthesis.",
                     "Multilingual (English)",
                 ],
+                ["你好，世界！今天天气很好。", "Multilingual (Chinese)"],
+                ["¡Hola, mundo! Bienvenido a piper-plus.", "Multilingual (Spanish)"],
+                ["Bonjour le monde! Bienvenue sur piper-plus.", "Multilingual (French)"],
+                ["Olá, mundo! Bem-vindo ao piper-plus.", "Multilingual (Portuguese)"],
             ],
             inputs=[text_input, model_dropdown],
         )

--- a/huggingface-space/app_imports.py
+++ b/huggingface-space/app_imports.py
@@ -30,8 +30,8 @@ except ImportError:
     HAS_PYPINYIN = False
 
 try:
-    import g2pk  # noqa: F401
+    import g2pk2  # noqa: F401
 
-    HAS_G2PK = True
+    HAS_G2PK2 = True
 except ImportError:
-    HAS_G2PK = False
+    HAS_G2PK2 = False

--- a/huggingface-space/app_imports.py
+++ b/huggingface-space/app_imports.py
@@ -21,3 +21,17 @@ try:
         ESPEAK_AVAILABLE = False
 except ImportError:
     ESPEAK_AVAILABLE = False
+
+try:
+    import pypinyin  # noqa: F401
+
+    HAS_PYPINYIN = True
+except ImportError:
+    HAS_PYPINYIN = False
+
+try:
+    import g2pk  # noqa: F401
+
+    HAS_G2PK = True
+except ImportError:
+    HAS_G2PK = False

--- a/huggingface-space/download_models.py
+++ b/huggingface-space/download_models.py
@@ -78,6 +78,15 @@ def create_dummy_config(output_path: Path, language: str = "multilingual"):
         "num_symbols": 10,
         "num_speakers": 1,
         "speaker_id_map": {},
+        "language_id_map": {
+            "ja": 0,
+            "en": 1,
+            "zh": 2,
+            "es": 3,
+            "fr": 4,
+            "pt": 5,
+        },
+        "num_languages": 6,
     }
 
     with open(output_path, "w", encoding="utf-8") as f:

--- a/huggingface-space/requirements.txt
+++ b/huggingface-space/requirements.txt
@@ -2,9 +2,10 @@
 gradio==6.9.0
 numpy>=1.24.0,<2.3
 onnxruntime>=1.16.0
-pyopenjtalk>=0.3.0
+pyopenjtalk-plus>=0.4  # Japanese Phonemizer (JapanesePhonemizer), Apache-2.0
 onnx>=1.14.0
 # Note: espeak-phonemizer requires system espeak-ng library
 # For simplified deployment, using IPA-based fallback for English
 pypinyin>=0.50
+g2p-en>=2.1.0  # English Phonemizer (EnglishPhonemizer)
 # g2pk2>=0.0.3  # Optional: Korean phonemization (KoreanPhonemizer)

--- a/huggingface-space/requirements.txt
+++ b/huggingface-space/requirements.txt
@@ -6,3 +6,5 @@ pyopenjtalk>=0.3.0
 onnx>=1.14.0
 # Note: espeak-phonemizer requires system espeak-ng library
 # For simplified deployment, using IPA-based fallback for English
+pypinyin>=0.50
+# g2pk2>=0.0.3  # Optional: Korean phonemization (KoreanPhonemizer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,8 @@ inline-quotes = "double"
 "src/python_run/*" = ["PLC0415"]
 # Docker test scripts: テスト関数内での条件付きインポートを許可
 "docker/**/test.py" = ["PLC0415"]
+# HuggingFace Spaces app: オプショナルな多言語依存の条件付きインポート
+"huggingface-space/*.py" = ["PLC0415"]
 # __main__.py: torch.serialization.add_safe_globals() がimport前に必要
 "src/python/piper_train/__main__.py" = ["E402"]
 # export_onnx.py: 同上

--- a/src/python_run/piper/config.py
+++ b/src/python_run/piper/config.py
@@ -40,6 +40,12 @@ class PiperConfig:
     phoneme_type: PhonemeType
     """espeak or text"""
 
+    num_languages: int = 1
+    """Number of languages"""
+
+    language_id_map: Mapping[str, int] | None = None
+    """Language code -> language id (e.g. {"ja": 0, "en": 1})"""
+
     @staticmethod
     def from_dict(config: dict[str, Any]) -> "PiperConfig":
         inference = config.get("inference", {})
@@ -54,4 +60,6 @@ class PiperConfig:
             espeak_voice=config.get("espeak", {}).get("voice", ""),
             phoneme_id_map=config["phoneme_id_map"],
             phoneme_type=PhonemeType(config.get("phoneme_type", PhonemeType.ESPEAK)),
+            num_languages=config.get("num_languages", 1),
+            language_id_map=config.get("language_id_map"),
         )

--- a/src/python_run/piper/http_server.py
+++ b/src/python_run/piper/http_server.py
@@ -125,7 +125,9 @@ def main() -> None:
         _LOGGER.debug("Synthesizing text: %s (language_id=%s)", text, language_id)
         with io.BytesIO() as wav_io:
             with wave.open(wav_io, "wb") as wav_file:
-                voice.synthesize(text, wav_file, **synthesize_args, language_id=language_id)
+                voice.synthesize(
+                    text, wav_file, **synthesize_args, language_id=language_id
+                )
 
             return wav_io.getvalue()
 

--- a/src/python_run/piper/http_server.py
+++ b/src/python_run/piper/http_server.py
@@ -107,10 +107,25 @@ def main() -> None:
         if not text:
             raise ValueError("No text provided")
 
-        _LOGGER.debug("Synthesizing text: %s", text)
+        # Resolve language_id from query parameters
+        language_id: int | None = None
+        language_id_raw = request.args.get("language_id", None)
+        language = request.args.get("language", None)
+
+        if language_id_raw is not None:
+            try:
+                language_id = int(language_id_raw)
+            except (ValueError, TypeError):
+                language_id = None
+        elif language is not None:
+            language_id_map = voice.config.language_id_map
+            if language_id_map:
+                language_id = language_id_map.get(language)
+
+        _LOGGER.debug("Synthesizing text: %s (language_id=%s)", text, language_id)
         with io.BytesIO() as wav_io:
             with wave.open(wav_io, "wb") as wav_file:
-                voice.synthesize(text, wav_file, **synthesize_args)
+                voice.synthesize(text, wav_file, **synthesize_args, language_id=language_id)
 
             return wav_io.getvalue()
 

--- a/src/python_run/piper/sample_texts.py
+++ b/src/python_run/piper/sample_texts.py
@@ -84,6 +84,74 @@ SAMPLE_TEXTS = {
             "健康的な生活習慣を身につけることが大切です。",
         ],
     },
+    "zh": {
+        "greeting": [
+            "你好，很高兴认识你。",
+        ],
+        "news": [
+            "今天天气非常好，适合外出活动。",
+        ],
+        "story": [
+            "从前有一个小女孩，她住在美丽的森林里。",
+        ],
+        "question": [
+            "你今天感觉怎么样？",
+        ],
+        "farewell": [
+            "再见，下次见。",
+        ],
+    },
+    "es": {
+        "greeting": [
+            "Hola, mucho gusto en conocerte.",
+        ],
+        "news": [
+            "Hoy hace muy buen tiempo, ideal para salir.",
+        ],
+        "story": [
+            "Érase una vez una niña que vivía en un hermoso bosque.",
+        ],
+        "question": [
+            "¿Cómo te sientes hoy?",
+        ],
+        "farewell": [
+            "Adiós, hasta la próxima.",
+        ],
+    },
+    "fr": {
+        "greeting": [
+            "Bonjour, enchanté de vous rencontrer.",
+        ],
+        "news": [
+            "Il fait très beau aujourd'hui, parfait pour sortir.",
+        ],
+        "story": [
+            "Il était une fois une petite fille qui vivait dans une belle forêt.",
+        ],
+        "question": [
+            "Comment vous sentez-vous aujourd'hui?",
+        ],
+        "farewell": [
+            "Au revoir, à bientôt.",
+        ],
+    },
+    "pt": {
+        "greeting": [
+            "Olá, prazer em conhecê-lo.",
+        ],
+        "news": [
+            "Hoje está muito bom tempo, ideal para sair.",
+        ],
+        "story": [
+            "Era uma vez uma menina que vivia numa bela floresta.",
+        ],
+        "question": [
+            "Como você está se sentindo hoje?",
+        ],
+        "farewell": [
+            "Tchau, até a próxima.",
+        ],
+    },
 }
 
 # Voice-over and narration samples

--- a/src/python_run/piper/webui.py
+++ b/src/python_run/piper/webui.py
@@ -272,6 +272,7 @@ def synthesize_speech(
     length_scale: float,
     noise_scale: float,
     noise_w: float,
+    language_code: str = "auto",
 ) -> tuple[int, np.ndarray]:
     """Generate speech from text"""
     if not text.strip():
@@ -298,6 +299,18 @@ def synthesize_speech(
 
         voice = _get_voice(model_path)
 
+        # Resolve language_code -> numeric language_id
+        language_id: int | None = None
+        if language_code and language_code != "auto":
+            if voice.config.language_id_map:
+                language_id = voice.config.language_id_map.get(language_code)
+                if language_id is None:
+                    logger.warning(
+                        "Language '%s' not found in model's language_id_map; "
+                        "falling back to model default",
+                        language_code,
+                    )
+
         # Create in-memory WAV file
         wav_buffer = io.BytesIO()
 
@@ -314,6 +327,7 @@ def synthesize_speech(
                 length_scale=length_scale,
                 noise_scale=noise_scale,
                 noise_w=noise_w,
+                language_id=language_id,
             )
 
         # Read audio data from buffer
@@ -550,6 +564,21 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                                 maximum=99,
                             )
 
+                            language_selector = gr.Dropdown(
+                                choices=[
+                                    ("Auto (model default)", "auto"),
+                                    ("Japanese (ja)", "ja"),
+                                    ("English (en)", "en"),
+                                    ("Chinese (zh)", "zh"),
+                                    ("Spanish (es)", "es"),
+                                    ("French (fr)", "fr"),
+                                    ("Portuguese (pt)", "pt"),
+                                ],
+                                label="Language",
+                                value="auto",
+                                info="Select output language for multilingual models",
+                            )
+
                             length_scale = gr.Slider(
                                 label="Speed (Length Scale)",
                                 minimum=0.5,
@@ -618,6 +647,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                             1.0,
                             0.667,
                             0.8,
+                            "en",
                         ],
                         [
                             "The quick brown fox jumps over the lazy dog.",
@@ -626,6 +656,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                             0.8,
                             0.5,
                             0.8,
+                            "en",
                         ],
                         [
                             "Good morning! Today's weather is perfect for a walk in the park.",
@@ -634,6 +665,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                             1.0,
                             0.667,
                             0.8,
+                            "en",
                         ],
                         [
                             "Artificial intelligence is transforming how we interact with technology.",
@@ -642,6 +674,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                             0.9,
                             0.7,
                             0.8,
+                            "en",
                         ],
                         [
                             "Testing speech synthesis with numbers: 1, 2, 3, 4, 5.",
@@ -650,6 +683,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                             1.0,
                             0.667,
                             0.8,
+                            "en",
                         ],
                         # Japanese examples with Japanese model
                         [
@@ -659,6 +693,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                             1.0,
                             0.667,
                             0.8,
+                            "ja",
                         ],
                         [
                             "人工知能による音声合成のデモンストレーションです。",
@@ -667,6 +702,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                             1.0,
                             0.667,
                             0.8,
+                            "ja",
                         ],
                         [
                             "明日の会議は午後3時から始まります。よろしくお願いします。",
@@ -675,6 +711,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                             0.9,
                             0.667,
                             0.8,
+                            "ja",
                         ],
                         [
                             "春の桜は本当に美しいです。日本の四季は素晴らしいですね。",
@@ -683,6 +720,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                             1.1,
                             0.7,
                             0.8,
+                            "ja",
                         ],
                         [
                             "2024年の技術トレンドについて説明します。",
@@ -691,6 +729,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                             1.0,
                             0.667,
                             0.8,
+                            "ja",
                         ],
                     ],
                     inputs=[
@@ -700,6 +739,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                         length_scale,
                         noise_scale,
                         noise_w,
+                        language_selector,
                     ],
                     label="Example Texts (English & Japanese)",
                 )
@@ -868,6 +908,7 @@ def create_interface(data_dir: Path) -> gr.Blocks:
                 length_scale,
                 noise_scale,
                 noise_w,
+                language_selector,
             ],
             outputs=audio_output,
         )

--- a/src/wasm/openjtalk-web/src/simple_unified_api.js
+++ b/src/wasm/openjtalk-web/src/simple_unified_api.js
@@ -1,6 +1,7 @@
 /**
  * Simple Unified Phonemizer API
- * Uses OpenJTalk for Japanese and a simple phonemizer for English
+ * Uses OpenJTalk for Japanese, a simple phonemizer for English,
+ * and character-based fallbacks for zh/es/fr/pt.
  */
 
 import { SimpleEnglishPhonemizer, createEnglishPhonemeMap } from './simple_english_phonemizer.js';
@@ -12,6 +13,8 @@ export class SimpleUnifiedPhonemizer {
         this.englishPhonemizer = new SimpleEnglishPhonemizer();
         this.englishPhonemeMap = createEnglishPhonemeMap();
         this.initialized = false;
+        // phoneme_id_map from model config (set via setPhonemeIdMap or initialize)
+        this.phonemeIdMap = options.phonemeIdMap || null;
         // GitHub Pages deployment configuration
         this.deploymentConfig = options.deploymentConfig || {
             isGitHubPages: false,
@@ -179,9 +182,15 @@ export class SimpleUnifiedPhonemizer {
         if (language === 'ja') {
             // Use OpenJTalk for Japanese
             return this.textToPhonemesJapanese(text);
-        } else {
+        } else if (language === 'en') {
             // Use simple phonemizer for English
             return this.textToPhonemesEnglish(text);
+        } else if (language === 'zh') {
+            // Chinese: character-based phoneme_id_map fallback
+            return this.phonemizeChinese(text);
+        } else {
+            // es/fr/pt: Latin-script character-based fallback
+            return this.phonemizeLatinFallback(text);
         }
     }
 
@@ -213,13 +222,77 @@ export class SimpleUnifiedPhonemizer {
     }
 
     /**
+     * Chinese text to phoneme IDs using character-based phoneme_id_map fallback.
+     * Since proper pinyin conversion requires a large dictionary, this maps
+     * each character directly through the model's phoneme_id_map.
+     * Returns an array of phoneme IDs (integers).
+     */
+    phonemizeChinese(text) {
+        const phonemeIdMap = this.phonemeIdMap;
+        if (!phonemeIdMap) {
+            throw new Error('phonemeIdMap is required for Chinese phonemization. Call setPhonemeIdMap() first.');
+        }
+        const phonemeIds = [1]; // BOS
+        for (const char of text) {
+            if (phonemeIdMap[char]) {
+                phonemeIds.push(...phonemeIdMap[char]);
+                phonemeIds.push(0); // PAD
+            }
+        }
+        phonemeIds.push(2); // EOS
+        return phonemeIds;
+    }
+
+    /**
+     * Latin-script language (es/fr/pt) text to phoneme IDs using character-based
+     * phoneme_id_map fallback. Lowercases the text and maps each character
+     * through the model's phoneme_id_map.
+     * Returns an array of phoneme IDs (integers).
+     */
+    phonemizeLatinFallback(text) {
+        const phonemeIdMap = this.phonemeIdMap;
+        if (!phonemeIdMap) {
+            throw new Error('phonemeIdMap is required for Latin fallback phonemization. Call setPhonemeIdMap() first.');
+        }
+        const phonemeIds = [1]; // BOS
+        for (const char of text.toLowerCase()) {
+            if (phonemeIdMap[char]) {
+                phonemeIds.push(...phonemeIdMap[char]);
+                phonemeIds.push(0); // PAD
+            } else if (char === ' ') {
+                // Use space mapping if available
+                if (phonemeIdMap[' ']) {
+                    phonemeIds.push(...phonemeIdMap[' ']);
+                    phonemeIds.push(0); // PAD
+                }
+            }
+            // Unknown characters are skipped
+        }
+        phonemeIds.push(2); // EOS
+        return phonemeIds;
+    }
+
+    /**
+     * Set the phoneme_id_map from model config.
+     * Required for zh/es/fr/pt fallback phonemization.
+     * @param {Object} phonemeIdMap - mapping from character/phoneme string to array of IDs
+     */
+    setPhonemeIdMap(phonemeIdMap) {
+        this.phonemeIdMap = phonemeIdMap;
+    }
+
+    /**
      * Extract phonemes from OpenJTalk labels
      */
     extractPhonemes(labels, language = 'ja') {
         if (language === 'ja') {
             return this.extractPhonemesFromLabels(labels);
-        } else {
+        } else if (language === 'en') {
             return this.extractPhonemesFromIPA(labels);
+        } else {
+            // zh/es/fr/pt: textToPhonemes already returns phoneme ID arrays,
+            // so pass through directly
+            return labels;
         }
     }
 
@@ -283,23 +356,43 @@ export class SimpleUnifiedPhonemizer {
         if (language === 'en') {
             return this.englishPhonemeMap;
         }
+        if (language === 'zh' || language === 'es' || language === 'fr' || language === 'pt') {
+            // zh/es/fr/pt use the model's phoneme_id_map directly
+            return this.phonemeIdMap;
+        }
         // For Japanese, the map should come from the model config
         return null;
     }
 
     /**
-     * Detect language from text
+     * Detect language from text.
+     * Priority: JA (Hiragana/Katakana) > ZH (CJK without Kana) > EN (default).
+     * Note: es/fr/pt cannot be reliably distinguished from EN by characters alone,
+     * so they must be specified explicitly via the language parameter.
      */
     detectLanguage(text) {
         // Simple detection based on character ranges
+        let hasKana = false;
+        let hasCJK = false;
         for (const char of text) {
             const code = char.charCodeAt(0);
-            // Check for Japanese characters
+            // Check for Japanese Kana (definitive JA indicator)
             if ((code >= 0x3040 && code <= 0x309F) || // Hiragana
-                (code >= 0x30A0 && code <= 0x30FF) || // Katakana
-                (code >= 0x4E00 && code <= 0x9FAF)) { // Kanji
-                return 'ja';
+                (code >= 0x30A0 && code <= 0x30FF)) { // Katakana
+                hasKana = true;
+                break; // Kana is definitive for JA
             }
+            // Check for CJK Unified Ideographs (shared by JA and ZH)
+            if (code >= 0x4E00 && code <= 0x9FFF) {
+                hasCJK = true;
+            }
+        }
+        if (hasKana) {
+            return 'ja';
+        }
+        if (hasCJK) {
+            // CJK characters without Kana → Chinese
+            return 'zh';
         }
         return 'en';
     }

--- a/src/wasm/openjtalk-web/test/multilingual-demo/index.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/index.html
@@ -34,6 +34,7 @@
         }
         .language-buttons {
             display: flex;
+            flex-wrap: wrap;
             gap: 10px;
             margin-top: 10px;
         }
@@ -235,7 +236,7 @@
 <body>
     <div class="container">
         <h1>🎤 piper-plus</h1>
-        <p class="subtitle">WebAssemblyとONNX Runtimeを使用した日本語・英語のニューラル音声合成</p>
+        <p class="subtitle">WebAssemblyとONNX Runtimeを使用した6言語マルチリンガルニューラル音声合成</p>
         
         <div id="status" class="status info">
             初期化中...
@@ -246,6 +247,10 @@
             <ul>
                 <li>🇯🇵 日本語音声合成（OpenJTalk + Piperニューラルモデル）</li>
                 <li>🇺🇸 英語音声合成（eSpeak-ng + Piperニューラルモデル）</li>
+                <li>🇨🇳 中国語音声合成（eSpeak-ng + Piperニューラルモデル）</li>
+                <li>🇪🇸 スペイン語音声合成（eSpeak-ng + Piperニューラルモデル）</li>
+                <li>🇫🇷 フランス語音声合成（eSpeak-ng + Piperニューラルモデル）</li>
+                <li>🇧🇷 ポルトガル語音声合成（eSpeak-ng + Piperニューラルモデル）</li>
                 <li>🎯 完全ブラウザ実装（サーバー不要）</li>
                 <li>⚡ WebAssembly + ONNX Runtime Webによる高速処理</li>
             </ul>
@@ -254,12 +259,12 @@
         <div class="language-selector">
             <label>言語選択 / Language Selection</label>
             <div class="language-buttons">
-                <button class="lang-button active" data-lang="ja">
-                    🇯🇵 日本語
-                </button>
-                <button class="lang-button" data-lang="en">
-                    🇺🇸 English
-                </button>
+                <button class="lang-button active" data-lang="ja">🇯🇵 日本語</button>
+                <button class="lang-button" data-lang="en">🇺🇸 English</button>
+                <button class="lang-button" data-lang="zh">🇨🇳 中文</button>
+                <button class="lang-button" data-lang="es">🇪🇸 Español</button>
+                <button class="lang-button" data-lang="fr">🇫🇷 Français</button>
+                <button class="lang-button" data-lang="pt">🇧🇷 Português</button>
             </div>
         </div>
 
@@ -326,6 +331,7 @@
                 name: '英語 (eSpeak-ng)',
                 model: 'multilingual-test-medium.onnx',
                 phonemizer: 'espeak-ng',
+                espeakLang: 'en-us',
                 testText: 'Hello world! This is a test of the Piper text to speech system.',
                 templates: [
                     'Hello world!',
@@ -333,6 +339,62 @@
                     'How are you today?',
                     'Welcome to the Piper speech synthesis demo.',
                     'The quick brown fox jumps over the lazy dog.'
+                ]
+            },
+            'zh': {
+                name: '中国語',
+                model: 'multilingual-test-medium.onnx',
+                phonemizer: 'espeak-ng',
+                espeakLang: 'cmn',
+                testText: '你好，今天天气非常好。我们一起去散步吧。',
+                templates: [
+                    '你好，今天天气非常好。',
+                    '我们一起去散步吧。',
+                    '欢迎来到语音合成演示。',
+                    '中文语音合成听起来很自然。',
+                    '春天的花开得很美丽。'
+                ]
+            },
+            'es': {
+                name: 'スペイン語',
+                model: 'multilingual-test-medium.onnx',
+                phonemizer: 'espeak-ng',
+                espeakLang: 'es',
+                testText: 'Hola, ¿cómo estás hoy? El clima es hermoso, vamos a dar un paseo.',
+                templates: [
+                    '¡Hola, mundo!',
+                    'Hola, ¿cómo estás hoy? El clima es hermoso, vamos a dar un paseo.',
+                    'Bienvenido a la demostración de síntesis de voz.',
+                    'La síntesis de voz en español suena muy natural.',
+                    'Las flores de primavera son muy hermosas.'
+                ]
+            },
+            'fr': {
+                name: 'フランス語',
+                model: 'multilingual-test-medium.onnx',
+                phonemizer: 'espeak-ng',
+                espeakLang: 'fr',
+                testText: 'Bonjour, comment allez-vous aujourd\'hui? Il fait beau, allons nous promener.',
+                templates: [
+                    'Bonjour, le monde!',
+                    'Bonjour, comment allez-vous aujourd\'hui?',
+                    'Bienvenue à la démonstration de synthèse vocale.',
+                    'La synthèse vocale en français sonne très naturelle.',
+                    'Les fleurs du printemps sont très belles.'
+                ]
+            },
+            'pt': {
+                name: 'ポルトガル語',
+                model: 'multilingual-test-medium.onnx',
+                phonemizer: 'espeak-ng',
+                espeakLang: 'pt-br',
+                testText: 'Olá, como você está hoje? O tempo está lindo, vamos dar um passeio.',
+                templates: [
+                    'Olá, mundo!',
+                    'Olá, como você está hoje? O tempo está lindo, vamos dar um passeio.',
+                    'Bem-vindo à demonstração de síntese de voz.',
+                    'A síntese de voz em português soa muito natural.',
+                    'As flores da primavera são muito bonitas.'
                 ]
             }
         };
@@ -379,7 +441,7 @@
                     }
                 });
                 
-                // Initialize eSpeak-ng for English
+                // Initialize eSpeak-ng for non-Japanese languages (en/zh/es/fr/pt)
                 updateStatus('eSpeak-ngを初期化しています...');
                 espeakExtractor = new ESpeakPhonemeExtractor();
                 await espeakExtractor.initialize();
@@ -487,17 +549,37 @@
         
         // Update language info
         function updateLanguageInfo(lang) {
-            if (lang === 'ja') {
-                languageInfo.innerHTML = `
-                    <h3>日本語：OpenJTalkによる音素化</h3>
-                    <p>MeCab形態素解析とHTS音声合成エンジンを使用した高精度な日本語音素化</p>
-                `;
-            } else if (lang === 'en') {
-                languageInfo.innerHTML = `
-                    <h3>英語：eSpeak-ng + Piperによる音声合成</h3>
-                    <p>Python版と同等のeSpeak-ng音素化とPiperニューラル音声合成</p>
-                `;
-            }
+            const langInfoMap = {
+                'ja': {
+                    title: '日本語：OpenJTalkによる音素化',
+                    desc: 'MeCab形態素解析とHTS音声合成エンジンを使用した高精度な日本語音素化'
+                },
+                'en': {
+                    title: '英語：eSpeak-ng + Piperによる音声合成',
+                    desc: 'Python版と同等のeSpeak-ng音素化とPiperニューラル音声合成'
+                },
+                'zh': {
+                    title: '中国語：eSpeak-ng + Piperによる音声合成',
+                    desc: 'eSpeak-ng (cmn) による中国語音素化とPiperニューラル音声合成'
+                },
+                'es': {
+                    title: 'スペイン語：eSpeak-ng + Piperによる音声合成',
+                    desc: 'eSpeak-ng (es) によるスペイン語音素化とPiperニューラル音声合成'
+                },
+                'fr': {
+                    title: 'フランス語：eSpeak-ng + Piperによる音声合成',
+                    desc: 'eSpeak-ng (fr) によるフランス語音素化とPiperニューラル音声合成'
+                },
+                'pt': {
+                    title: 'ポルトガル語：eSpeak-ng + Piperによる音声合成',
+                    desc: 'eSpeak-ng (pt-br) によるポルトガル語音素化とPiperニューラル音声合成'
+                }
+            };
+            const info = langInfoMap[lang] || langInfoMap['ja'];
+            languageInfo.innerHTML = `
+                <h3>${info.title}</h3>
+                <p>${info.desc}</p>
+            `;
         }
         
         // Load ONNX model
@@ -528,15 +610,17 @@
                     if (customDict && customDict.initialized) {
                         processedText = customDict.processText(text);
                     }
-                    
+
                     // Use OpenJTalk for Japanese
                     unifiedPhonemizer.textToPhonemes(processedText, 'ja').then(labels => {
                         const phonemes = unifiedPhonemizer.extractPhonemes(labels, 'ja');
                         resolve({ phonemes, labels });
                     }).catch(reject);
-                } else if (lang === 'en') {
-                    // Use eSpeak-ng phoneme extractor for Python-compatible phonemization
-                    espeakExtractor.phonemize(text, 'en-us').then(phonemes => {
+                } else {
+                    // Use eSpeak-ng for all non-Japanese languages
+                    const config = languageConfigs[lang];
+                    const espeakLang = config.espeakLang || 'en-us';
+                    espeakExtractor.phonemize(text, espeakLang).then(phonemes => {
                         resolve({ phonemes, labels: null });
                     }).catch(reject);
                 }
@@ -652,7 +736,7 @@
                     if (currentLanguage === 'ja') {
                         ids.push(...(phonemeIdMap['_'] || [0]));
                     } else {
-                        // Use space as fallback for English
+                        // Use space as fallback for non-Japanese languages
                         ids.push(...(phonemeIdMap[' '] || [3]));
                     }
                 }
@@ -687,6 +771,11 @@
                 'input_lengths': lengthTensor,
                 'scales': scalesTensor
             };
+
+            // Add language ID (lid) tensor for multilingual models
+            const langIdMap = { 'ja': 0, 'en': 1, 'zh': 2, 'es': 3, 'fr': 4, 'pt': 5 };
+            const langId = langIdMap[currentLanguage] || 0;
+            feeds['lid'] = new ort.Tensor('int64', new BigInt64Array([BigInt(langId)]), [1]);
 
             // Add prosody features if model supports it
             if (prosodyFeatures && currentModelConfig.prosody_id_map) {

--- a/src/wasm/openjtalk-web/test/multilingual-demo/index.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/index.html
@@ -777,7 +777,7 @@
             const langId = langIdMap[currentLanguage] || 0;
             feeds['lid'] = new ort.Tensor('int64', new BigInt64Array([BigInt(langId)]), [1]);
 
-            // Add prosody features if model supports it
+            // Add prosody features (required input for this model)
             if (prosodyFeatures && currentModelConfig.prosody_id_map) {
                 const flatProsody = [];
                 for (const [a1, a2, a3] of prosodyFeatures) {
@@ -785,6 +785,13 @@
                 }
                 feeds['prosody_features'] = new ort.Tensor('int64',
                     new BigInt64Array(flatProsody),
+                    [1, phonemeIds.length, 3]
+                );
+            } else {
+                // Zero-filled prosody for non-JA languages or when prosody data unavailable
+                const zeroProsody = new BigInt64Array(phonemeIds.length * 3);
+                feeds['prosody_features'] = new ort.Tensor('int64',
+                    zeroProsody,
                     [1, phonemeIds.length, 3]
                 );
             }

--- a/src/wasm/openjtalk-web/test/multilingual-demo/index.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/index.html
@@ -712,36 +712,31 @@
 
         // Convert phonemes to IDs
         function phonemesToIds(phonemes) {
-            // Apply padding for short Japanese text to improve synthesis quality
-            let processedPhonemes = phonemes;
-            if (currentLanguage === 'ja' && phonemes.length < 20) {
-                // Add silence tokens for short text
-                processedPhonemes = [
-                    phonemes[0],  // Keep BOS (^)
-                    '_', '_',     // Add silence padding
-                    ...phonemes.slice(1, -1),  // Original phonemes without BOS/EOS
-                    '_', '_',     // Add silence padding
-                    phonemes[phonemes.length - 1]  // Keep EOS ($)
-                ];
-            }
-            
-            const ids = [];
             const phonemeIdMap = currentModelConfig.phoneme_id_map;
-            
-            for (const phoneme of processedPhonemes) {
+            const padIds = phonemeIdMap['_'] || [0];
+            const bosIds = phonemeIdMap['^'] || [1];
+            const eosIds = phonemeIdMap['$'] || [2];
+
+            // Build IDs with BOS/EOS and PAD intersperse between every phoneme
+            // Format: [BOS, PAD, phoneme1, PAD, phoneme2, PAD, ..., EOS]
+            const ids = [];
+            ids.push(...bosIds);
+            ids.push(...padIds);
+
+            for (const phoneme of phonemes) {
+                // Skip BOS/EOS markers from phoneme list (we add them ourselves)
+                if (phoneme === '^' || phoneme === '$') continue;
+
                 if (phonemeIdMap[phoneme]) {
                     ids.push(...phonemeIdMap[phoneme]);
                 } else {
-                    // Use padding token as fallback for Japanese
-                    if (currentLanguage === 'ja') {
-                        ids.push(...(phonemeIdMap['_'] || [0]));
-                    } else {
-                        // Use space as fallback for non-Japanese languages
-                        ids.push(...(phonemeIdMap[' '] || [3]));
-                    }
+                    // Unknown phoneme: skip
+                    continue;
                 }
+                ids.push(...padIds);  // PAD after each phoneme
             }
-            
+
+            ids.push(...eosIds);
             return ids;
         }
         

--- a/src/wasm/openjtalk-web/test/multilingual-demo/multilingual.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/multilingual.html
@@ -535,18 +535,28 @@
         
         // Convert phonemes to IDs
         function phonemesToIds(phonemes) {
-            const ids = [];
             const phonemeIdMap = modelConfig.phoneme_id_map;
-            
+            const padIds = phonemeIdMap['_'] || [0];
+            const bosIds = phonemeIdMap['^'] || [1];
+            const eosIds = phonemeIdMap['$'] || [2];
+
+            // BOS/EOS + PAD intersperse: [BOS, PAD, ph1, PAD, ph2, PAD, ..., EOS]
+            const ids = [];
+            ids.push(...bosIds);
+            ids.push(...padIds);
+
             for (const phoneme of phonemes) {
+                if (phoneme === '^' || phoneme === '$') continue;
                 if (phonemeIdMap[phoneme]) {
                     ids.push(...phonemeIdMap[phoneme]);
                 } else {
                     console.warn(`Unknown phoneme: ${phoneme}`);
-                    ids.push(0); // Use padding ID
+                    continue;
                 }
+                ids.push(...padIds);
             }
-            
+
+            ids.push(...eosIds);
             return ids;
         }
         

--- a/src/wasm/openjtalk-web/test/multilingual-demo/multilingual.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/multilingual.html
@@ -34,6 +34,7 @@
         }
         .language-buttons {
             display: flex;
+            flex-wrap: wrap;
             gap: 10px;
             margin-top: 10px;
         }
@@ -209,7 +210,7 @@
 <body>
     <div class="container">
         <h1>Multilingual TTS WebAssembly Demo</h1>
-        <p class="subtitle">多言語対応音声合成エンジン - 日本語（OpenJTalk）・英語（eSpeak-ng）</p>
+        <p class="subtitle">多言語対応音声合成エンジン - 6言語対応（JA/EN/ZH/ES/FR/PT）</p>
         
         <div id="status" class="status info">
             初期化中... <span class="loading-spinner"></span>
@@ -224,9 +225,21 @@
                 <button class="lang-button" data-lang="en" data-model="multilingual-test-medium">
                     🇺🇸 English
                 </button>
+                <button class="lang-button" data-lang="zh" data-model="multilingual-test-medium">
+                    🇨🇳 中文
+                </button>
+                <button class="lang-button" data-lang="es" data-model="multilingual-test-medium">
+                    🇪🇸 Español
+                </button>
+                <button class="lang-button" data-lang="fr" data-model="multilingual-test-medium">
+                    🇫🇷 Français
+                </button>
+                <button class="lang-button" data-lang="pt" data-model="multilingual-test-medium">
+                    🇧🇷 Português
+                </button>
             </div>
             <div class="model-info" id="modelInfo">
-                モデル: multilingual-test-medium.onnx (OpenJTalk)
+                モデル: multilingual-test-medium.onnx (JA - OpenJTalk)
             </div>
         </div>
 
@@ -283,9 +296,46 @@
                 { text: 'Artificial intelligence text-to-speech technology', label: 'Technical' },
                 { text: 'The quick brown fox jumps over the lazy dog.', label: 'Pangram' },
                 { text: 'To be or not to be, that is the question.', label: 'Literature' }
+            ],
+            'zh': [
+                { text: '你好，世界！', label: '问候' },
+                { text: '人工智能语音合成技术', label: '技术' },
+                { text: '今天天气很好，适合出去散步。', label: '日常' },
+                { text: '千里之行，始于足下。', label: '成语' }
+            ],
+            'es': [
+                { text: '¡Hola, mundo!', label: 'Saludo' },
+                { text: 'La inteligencia artificial y la sintesis de voz', label: 'Tecnico' },
+                { text: 'El cielo esta muy azul hoy.', label: 'Cotidiano' },
+                { text: 'En un lugar de la Mancha, de cuyo nombre no quiero acordarme.', label: 'Literatura' }
+            ],
+            'fr': [
+                { text: 'Bonjour, le monde!', label: 'Salutation' },
+                { text: "L'intelligence artificielle et la synthese vocale", label: 'Technique' },
+                { text: 'Il fait tres beau temps aujourd\'hui.', label: 'Quotidien' },
+                { text: 'Etre ou ne pas etre, telle est la question.', label: 'Litterature' }
+            ],
+            'pt': [
+                { text: 'Ola, mundo!', label: 'Saudacao' },
+                { text: 'Inteligencia artificial e sintese de voz', label: 'Tecnico' },
+                { text: 'Hoje o tempo esta muito bom para passear.', label: 'Cotidiano' },
+                { text: 'A vida e a arte do encontro, embora haja tanto desencontro pela vida.', label: 'Literatura' }
             ]
         };
         
+        // Language configurations
+        const languageConfigs = {
+            'ja': { name: '日本語', phonemizer: 'OpenJTalk', flag: '🇯🇵' },
+            'en': { name: 'English', phonemizer: 'eSpeak-ng', flag: '🇺🇸' },
+            'zh': { name: '中文', phonemizer: 'eSpeak-ng', flag: '🇨🇳' },
+            'es': { name: 'Espanol', phonemizer: 'eSpeak-ng', flag: '🇪🇸' },
+            'fr': { name: 'Francais', phonemizer: 'eSpeak-ng', flag: '🇫🇷' },
+            'pt': { name: 'Portugues', phonemizer: 'eSpeak-ng', flag: '🇧🇷' }
+        };
+
+        // Language ID map for ONNX lid tensor
+        const langIdMap = { 'ja': 0, 'en': 1, 'zh': 2, 'es': 3, 'fr': 4, 'pt': 5 };
+
         let phonemizer = null;
         let currentLanguage = 'ja';
         let onnxSession = null;
@@ -374,8 +424,8 @@
             });
             
             // Update model info
-            const phonemizerType = lang === 'ja' ? 'OpenJTalk' : 'eSpeak-ng';
-            modelInfo.textContent = `モデル: ${model}.onnx (${phonemizerType})`;
+            const config = languageConfigs[lang] || languageConfigs['ja'];
+            modelInfo.textContent = `モデル: ${model}.onnx (${lang.toUpperCase()} - ${config.phonemizer})`;
             
             // Load new model
             updateStatus('モデルを切り替えています...', 'loading');
@@ -422,9 +472,19 @@
                 updateStatus('音素変換中...', 'loading');
                 generateBtn.disabled = true;
                 
+                // Map language code to eSpeak voice name for non-JA languages
+                const espeakLangMap = {
+                    'en': 'en',
+                    'zh': 'cmn',
+                    'es': 'es',
+                    'fr': 'fr',
+                    'pt': 'pt'
+                };
+
                 // Get phonemes
-                const phonemeData = await phonemizer.textToPhonemes(text, currentLanguage);
-                
+                const phonemeLang = espeakLangMap[currentLanguage] || currentLanguage;
+                const phonemeData = await phonemizer.textToPhonemes(text, phonemeLang);
+
                 let phonemes;
                 if (currentLanguage === 'ja') {
                     // Extract phonemes from OpenJTalk labels
@@ -451,9 +511,12 @@
                 audioPlayer.src = audioUrl;
                 
                 // Show details
+                const langConfig = languageConfigs[currentLanguage] || languageConfigs['ja'];
                 detailsOutput.textContent = JSON.stringify({
                     language: currentLanguage,
-                    phonemizer: currentLanguage === 'ja' ? 'OpenJTalk' : 'eSpeak-ng',
+                    languageName: langConfig.name,
+                    phonemizer: langConfig.phonemizer,
+                    languageId: langIdMap[currentLanguage] || 0,
                     phonemes: phonemes.join(' '),
                     phonemeCount: phonemes.length,
                     sampleRate: modelConfig.audio.sample_rate
@@ -513,7 +576,11 @@
                 'input_lengths': lengthTensor,
                 'scales': scalesTensor
             };
-            
+
+            // Add language ID tensor for multilingual models
+            const lidValue = langIdMap[currentLanguage] || 0;
+            feeds['lid'] = new ort.Tensor('int64', new BigInt64Array([BigInt(lidValue)]), [1]);
+
             const results = await onnxSession.run(feeds);
             const audioTensor = results['output'] || results[Object.keys(results)[0]];
             

--- a/src/wasm/openjtalk-web/test/multilingual-demo/multilingual.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/multilingual.html
@@ -581,6 +581,10 @@
             const lidValue = langIdMap[currentLanguage] || 0;
             feeds['lid'] = new ort.Tensor('int64', new BigInt64Array([BigInt(lidValue)]), [1]);
 
+            // Add zero-filled prosody_features (required input)
+            const zeroProsody = new BigInt64Array(phonemeIds.length * 3);
+            feeds['prosody_features'] = new ort.Tensor('int64', zeroProsody, [1, phonemeIds.length, 3]);
+
             const results = await onnxSession.run(feeds);
             const audioTensor = results['output'] || results[Object.keys(results)[0]];
             

--- a/src/wasm/openjtalk-web/test/multilingual-demo/simple-multilingual.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/simple-multilingual.html
@@ -34,6 +34,7 @@
         }
         .language-buttons {
             display: flex;
+            flex-wrap: wrap;
             gap: 10px;
             margin-top: 10px;
         }
@@ -157,7 +158,7 @@
 <body>
     <div class="container">
         <h1>Simple Multilingual TTS Demo</h1>
-        <p class="subtitle">簡易多言語音声合成デモ - 日本語（OpenJTalk）・英語（Simple Phonemizer）</p>
+        <p class="subtitle">簡易多言語音声合成デモ - 日本語・英語・中国語・スペイン語・フランス語・ポルトガル語</p>
         
         <div id="status" class="status info">
             初期化中...
@@ -172,12 +173,24 @@
                 <button class="lang-button" data-lang="en">
                     🇺🇸 English
                 </button>
+                <button class="lang-button" data-lang="zh">
+                    🇨🇳 中文
+                </button>
+                <button class="lang-button" data-lang="es">
+                    🇪🇸 Español
+                </button>
+                <button class="lang-button" data-lang="fr">
+                    🇫🇷 Français
+                </button>
+                <button class="lang-button" data-lang="pt">
+                    🇧🇷 Português
+                </button>
             </div>
         </div>
 
         <div class="input-group">
             <label for="inputText">テキスト入力 / Text Input</label>
-            <textarea id="inputText" placeholder="ここにテキストを入力してください / Enter text here">今日は良い天気です。</textarea>
+            <textarea id="inputText" placeholder="ここにテキストを入力してください / Enter text here">こんにちは、今日はとても良い天気ですね。散歩に出かけましょう。</textarea>
         </div>
 
         <div class="button-group">
@@ -296,11 +309,15 @@
             });
             
             // Update example text
-            if (lang === 'ja') {
-                inputText.value = '今日は良い天気です。';
-            } else {
-                inputText.value = 'Hello world! This is a test.';
-            }
+            const sampleTexts = {
+                'ja': 'こんにちは、今日はとても良い天気ですね。散歩に出かけましょう。',
+                'en': 'Hello, how are you today? The weather is beautiful, let\'s go for a walk.',
+                'zh': '你好，今天天气非常好。我们一起去散步吧。',
+                'es': 'Hola, \u00bfc\u00f3mo est\u00e1s hoy? El clima es hermoso, vamos a dar un paseo.',
+                'fr': "Bonjour, comment allez-vous aujourd'hui? Il fait beau, allons nous promener.",
+                'pt': 'Ol\u00e1, como voc\u00ea est\u00e1 hoje? O tempo est\u00e1 lindo, vamos dar um passeio.'
+            };
+            inputText.value = sampleTexts[lang] || sampleTexts['en'];
             
             // Load new model
             updateStatus('モデルを切り替えています...');
@@ -430,10 +447,17 @@
             
             console.log('Using length_scale:', lengthScale);
             
+            const langIdMap = { 'ja': 0, 'en': 1, 'zh': 2, 'es': 3, 'fr': 4, 'pt': 5 };
+            const lidTensor = new ort.Tensor('int64',
+                new BigInt64Array([BigInt(langIdMap[currentLanguage] || 0)]),
+                [1]
+            );
+
             const feeds = {
                 'input': inputTensor,
                 'input_lengths': lengthTensor,
-                'scales': scalesTensor
+                'scales': scalesTensor,
+                'lid': lidTensor
             };
             
             console.log('Running ONNX inference...');

--- a/src/wasm/openjtalk-web/test/multilingual-demo/simple-multilingual.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/simple-multilingual.html
@@ -398,23 +398,29 @@
         
         // Convert phonemes to IDs
         function phonemesToIds(phonemes) {
-            const ids = [];
-            // Always use model's phoneme_id_map for consistency
             const phonemeIdMap = modelConfig.phoneme_id_map;
-            
-            console.log('Input phonemes:', phonemes);
-            
+            const padIds = phonemeIdMap['_'] || [0];
+            const bosIds = phonemeIdMap['^'] || [1];
+            const eosIds = phonemeIdMap['$'] || [2];
+
+            // BOS/EOS + PAD intersperse: [BOS, PAD, ph1, PAD, ph2, PAD, ..., EOS]
+            const ids = [];
+            ids.push(...bosIds);
+            ids.push(...padIds);
+
             for (const phoneme of phonemes) {
+                if (phoneme === '^' || phoneme === '$') continue;
                 if (phonemeIdMap[phoneme]) {
                     ids.push(...phonemeIdMap[phoneme]);
                 } else {
                     console.warn(`Unknown phoneme: ${phoneme}`);
-                    // Use space/silence for unknown
-                    ids.push(...(phonemeIdMap[' '] || [3]));
+                    continue;
                 }
+                ids.push(...padIds);
             }
-            
-            console.log('Output IDs:', ids);
+
+            ids.push(...eosIds);
+            console.log('Output IDs length:', ids.length);
             return ids;
         }
         

--- a/src/wasm/openjtalk-web/test/multilingual-demo/simple-multilingual.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/simple-multilingual.html
@@ -453,13 +453,18 @@
                 [1]
             );
 
+            // Add zero-filled prosody_features (required input)
+            const zeroProsody = new BigInt64Array(phonemeIds.length * 3);
+            const prosodyTensor = new ort.Tensor('int64', zeroProsody, [1, phonemeIds.length, 3]);
+
             const feeds = {
                 'input': inputTensor,
                 'input_lengths': lengthTensor,
                 'scales': scalesTensor,
-                'lid': lidTensor
+                'lid': lidTensor,
+                'prosody_features': prosodyTensor
             };
-            
+
             console.log('Running ONNX inference...');
             const results = await onnxSession.run(feeds);
             const audioTensor = results['output'] || results[Object.keys(results)[0]];


### PR DESCRIPTION
## 概要

- 全デモUI（Docker WebUI、HuggingFace Spaces、GitHub Pages WebAssemblyデモ）に6言語（ja/en/zh/es/fr/pt）対応を追加
- HuggingFaceデモに `piper_train.infer_onnx.text_to_phoneme_ids_and_prosody()` を統合し、日本語の韻律情報（A1/A2/A3）を正しく生成
- デプロイ前のimportバリデーションCIを追加し、HuggingFaceデプロイ障害を防止
- WebAssemblyデモの `phonemesToIds()` にBOS/EOS/PADインタースパースを追加し、正しいVITS推論を実現

## 変更内容

### WebUI (docker/webui)
- 言語選択ラジオを6言語に拡張
- ONNX推論に `lid` テンソルを送信
- 言語切り替え時にサンプルテキストを自動入力

### HuggingFace Spaces
- MODELS辞書を6言語に拡張、サンプルテキスト付き
- 独自のphonemizeパイプラインを共通の `text_to_phoneme_ids_and_prosody()` に置き換え
- 日本語のprosody_features（pyopenjtalk A1/A2/A3）を正しく計算、他言語はゼロ埋め
- デプロイワークフローで `piper_train/phonemize/` + `infer_onnx.py` をSpaceにコピー
- 英語g2p用にNLTK `averaged_perceptron_tagger_eng` を起動時ダウンロード

### GitHub Pages（WebAssemblyデモ）
- 3つのHTMLファイル全てで言語ボタンを6言語に拡張
- ONNX推論に `lid` テンソルと `prosody_features` テンソルを追加
- **`phonemesToIds()` にBOS/EOS/PADインタースパースを追加** — 音声が崩壊していた根本原因
- `simple_unified_api.js`: 中国語・ラテン系言語のフォールバックPhonemizerを追加

### CI
- `deploy-huggingface.yml`: デプロイ前importバリデーション（9モジュール検証、失敗時デプロイ中止）
- `test-hf-space.yml`: 5層CIワークフロー新設（import → requirements → JA/EN音素化 → appインポート）

### その他
- `src/python_run/piper/config.py`: `num_languages` / `language_id_map` フィールド追加
- `src/python_run/piper/http_server.py`: `language` / `language_id` クエリパラメータ対応
- `src/python_run/piper/sample_texts.py`: zh/es/fr/pt サンプルテキスト追加

## テスト計画

- [x] Docker WebUI: 6言語選択・lid入力付き推論を確認
- [x] HuggingFace Spaces: JA/EN推論確認、prosody_featuresが正しく設定
- [x] GitHub Pages: BOS/EOS/PADインタースパース修正後、音声品質が復元
- [x] デプロイ前CI: importバリデーションが不正デプロイをブロック
- [ ] 全6言語で各プラットフォームの音声品質を確認