### PR TITLE
docs: Windowsクイックスタート手順の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,61 +107,28 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
-**2. モデルをダウンロード**
+**2. モデルをダウンロード & 音声を生成**
 
-つくよみちゃんモデルの例:
+```sh
+# つくよみちゃんモデルをダウンロード
+./bin/piper --download-model tsukuyomi
 
-**Windows (PowerShell):**
-
-```powershell
-mkdir models
-Invoke-WebRequest -Uri "https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/tsukuyomi-chan-6lang-fp16.onnx" -OutFile models/tsukuyomi.onnx
-Invoke-WebRequest -Uri "https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/config.json" -OutFile models/config.json
+# 音声を生成 (ダウンロード完了時に表示されるパスを --model に指定)
+./bin/piper --text "こんにちは、今日は良い天気ですね。" \
+  --model ~/.local/share/piper/models/tsukuyomi-chan-6lang-fp16.onnx \
+  --output_file output.wav
 ```
 
-**macOS / Linux:**
-
-```bash
-mkdir -p models
-curl -L -o models/tsukuyomi.onnx https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/tsukuyomi-chan-6lang-fp16.onnx
-curl -L -o models/config.json https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/config.json
-```
-
-**3. 音声を生成**
-
-**Windows (PowerShell):**
-
-```powershell
-.\bin\piper.exe --text "こんにちは、今日は良い天気ですね。" --model models\tsukuyomi.onnx --config models\config.json --output_file output.wav
-```
-
-**macOS / Linux:**
-
-```bash
-./bin/piper --text 'こんにちは、今日は良い天気ですね。' \
-  --model models/tsukuyomi.onnx --config models/config.json --output_file output.wav
-```
-
+> **Windows (PowerShell) での実行例:**
+>
+> ```powershell
+> .\bin\piper.exe --download-model tsukuyomi
+> .\bin\piper.exe --text "こんにちは、今日は良い天気ですね。" --model $env:APPDATA\piper\models\tsukuyomi-chan-6lang-fp16.onnx --output_file output.wav
+> ```
+>
+> **Windows cmd を使う場合:** cmd はデフォルトで Shift-JIS (CP932) のため、先に `chcp 65001` で UTF-8 に切り替えてください。
+>
 > **output.wav の出力先:** カレントディレクトリ（`cd piper` した場所）に生成されます。
->
-> **Windows cmd を使う場合:** cmd はデフォルトで Shift-JIS (CP932) のため、UTF-8 に切り替えてから実行してください:
->
-> ```cmd
-> chcp 65001
-> bin\piper.exe --text "こんにちは、今日は良い天気ですね。" --model models\tsukuyomi.onnx --config models\config.json --output_file output.wav
-> ```
-
-> **config.json の命名規則:** piper は `<モデル名>.onnx.json` を優先的に自動検出します。見つからない場合、モデルと同じディレクトリの `config.json` にフォールバックします。どちらも見つからない場合は `--config` で明示的に指定してください。
->
-> ```sh
-> # 自動検出 (--config 不要)
-> ./bin/piper --model models/tsukuyomi.onnx --output_file output.wav
-> # → 1. models/tsukuyomi.onnx.json を検索
-> # → 2. models/config.json にフォールバック
->
-> # 手動指定 (上記どちらも存在しない場合)
-> ./bin/piper --model models/tsukuyomi.onnx --config /path/to/config.json --output_file output.wav
-> ```
 
 ### Python推論
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ cd piper
 ./bin/piper --model tsukuyomi --text "こんにちは、今日は良い天気ですね。" --output_file output.wav
 ```
 
-> **Windows cmd を使う場合:** cmd はデフォルトで Shift-JIS (CP932) のため、先に `chcp 65001` で UTF-8 に切り替えてください。
+> **Windows cmd のコードページについて:** `--text` オプションは内部で `GetCommandLineW()` (UTF-16) を使用するため、コードページに依存せずそのまま動作します。パイプ入力（`echo ... | piper`）を使う場合のみ、事前に `chcp 65001` で UTF-8 に切り替えてください。
 >
 > **output.wav の出力先:** カレントディレクトリ（`cd piper` した場所）に生成されます。
 

--- a/README.md
+++ b/README.md
@@ -113,19 +113,10 @@ cd piper
 # つくよみちゃんモデルをダウンロード
 ./bin/piper --download-model tsukuyomi
 
-# 音声を生成 (ダウンロード完了時に表示されるパスを --model に指定)
-./bin/piper --text "こんにちは、今日は良い天気ですね。" \
-  --model ~/.local/share/piper/models/tsukuyomi-chan-6lang-fp16.onnx \
-  --output_file output.wav
+# 音声を生成 (モデル名だけで OK — ダウンロード済みモデルを自動解決)
+./bin/piper --model tsukuyomi --text "こんにちは、今日は良い天気ですね。" --output_file output.wav
 ```
 
-> **Windows (PowerShell) での実行例:**
->
-> ```powershell
-> .\bin\piper.exe --download-model tsukuyomi
-> .\bin\piper.exe --text "こんにちは、今日は良い天気ですね。" --model $env:APPDATA\piper\models\tsukuyomi-chan-6lang-fp16.onnx --output_file output.wav
-> ```
->
 > **Windows cmd を使う場合:** cmd はデフォルトで Shift-JIS (CP932) のため、先に `chcp 65001` で UTF-8 に切り替えてください。
 >
 > **output.wav の出力先:** カレントディレクトリ（`cd piper` した場所）に生成されます。

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@
 
 ```powershell
 Invoke-WebRequest -Uri "https://github.com/ayutaz/piper-plus/releases/latest/download/piper-windows-x64.zip" -OutFile piper.zip
-Expand-Archive piper.zip -DestinationPath piper
+Expand-Archive piper.zip -DestinationPath .
 cd piper
 ```
 
@@ -129,29 +129,38 @@ curl -L -o models/config.json https://huggingface.co/ayousanz/piper-plus-tsukuyo
 
 **3. 音声を生成**
 
-**Windows (cmd):**
+**Windows (PowerShell):**
 
-```cmd
-echo こんにちは、今日は良い天気ですね。| piper.exe --model models\tsukuyomi.onnx --config models\config.json --output_file output.wav
+```powershell
+.\bin\piper.exe --text "こんにちは、今日は良い天気ですね。" --model models\tsukuyomi.onnx --config models\config.json --output_file output.wav
 ```
 
 **macOS / Linux:**
 
 ```bash
-echo 'こんにちは、今日は良い天気ですね。' | \
-  ./piper --model models/tsukuyomi.onnx --config models/config.json --output_file output.wav
+./bin/piper --text 'こんにちは、今日は良い天気ですね。' \
+  --model models/tsukuyomi.onnx --config models/config.json --output_file output.wav
 ```
+
+> **output.wav の出力先:** カレントディレクトリ（`cd piper` した場所）に生成されます。
+>
+> **Windows cmd を使う場合:** cmd はデフォルトで Shift-JIS (CP932) のため、UTF-8 に切り替えてから実行してください:
+>
+> ```cmd
+> chcp 65001
+> bin\piper.exe --text "こんにちは、今日は良い天気ですね。" --model models\tsukuyomi.onnx --config models\config.json --output_file output.wav
+> ```
 
 > **config.json の命名規則:** piper は `<モデル名>.onnx.json` を優先的に自動検出します。見つからない場合、モデルと同じディレクトリの `config.json` にフォールバックします。どちらも見つからない場合は `--config` で明示的に指定してください。
 >
 > ```sh
 > # 自動検出 (--config 不要)
-> ./piper --model models/tsukuyomi.onnx --output_file output.wav
+> ./bin/piper --model models/tsukuyomi.onnx --output_file output.wav
 > # → 1. models/tsukuyomi.onnx.json を検索
 > # → 2. models/config.json にフォールバック
 >
 > # 手動指定 (上記どちらも存在しない場合)
-> ./piper --model models/tsukuyomi.onnx --config /path/to/config.json --output_file output.wav
+> ./bin/piper --model models/tsukuyomi.onnx --config /path/to/config.json --output_file output.wav
 > ```
 
 ### Python推論
@@ -319,41 +328,41 @@ cargo test -p piper-core
 
 ```sh
 # テキストから音声生成
-./piper --model model.onnx --text "Hello, how are you?" -f output.wav
+./bin/piper --model model.onnx --text "Hello, how are you?" -f output.wav
 
 # 日本語テキスト (Windowsでのエンコーディング問題を回避)
-piper.exe --model models\tsukuyomi.onnx --text "こんにちは、今日は良い天気ですね。" -f output.wav
+bin\piper.exe --model models\tsukuyomi.onnx --text "こんにちは、今日は良い天気ですね。" -f output.wav
 
 # 話者指定
-./piper --model model.onnx --text "Hello" --speaker 3 -f output.wav
+./bin/piper --model model.onnx --text "Hello" --speaker 3 -f output.wav
 ```
 
 #### パイプ入力
 
 ```sh
 # 基本
-echo "こんにちは" | ./piper --model ja_model.onnx --output_file output.wav
+echo "こんにちは" | ./bin/piper --model ja_model.onnx --output_file output.wav
 
 # ストリーミング (低レイテンシ)
-echo "長いテキスト..." | ./piper --model ja_model.onnx --output_file output.wav --streaming
+echo "長いテキスト..." | ./bin/piper --model ja_model.onnx --output_file output.wav --streaming
 
 # GPU推論
-echo "Hello" | ./piper --model en_model.onnx --use-cuda --output_file output.wav
+echo "Hello" | ./bin/piper --model en_model.onnx --use-cuda --output_file output.wav
 
 # 音素タイミング出力 (リップシンク・字幕同期用)
-echo "Hello world" | ./piper --model en_model.onnx -f speech.wav --output-timing timing.json
+echo "Hello world" | ./bin/piper --model en_model.onnx -f speech.wav --output-timing timing.json
 
 # カスタム辞書
-echo "DockerとGitHubを使います" | ./piper --model ja_model.onnx --custom-dict my_dict.json -f output.wav
+echo "DockerとGitHubを使います" | ./bin/piper --model ja_model.onnx --custom-dict my_dict.json -f output.wav
 
 # インライン音素入力
-echo 'Hello [[ h ə l oʊ ]] world' | ./piper --model en_model.onnx -f output.wav
+echo 'Hello [[ h ə l oʊ ]] world' | ./bin/piper --model en_model.onnx -f output.wav
 
 # 生の音素入力
-echo 'h ə l oʊ _ w ɜː l d' | ./piper --model en_model.onnx --raw-phonemes -f output.wav
+echo 'h ə l oʊ _ w ɜː l d' | ./bin/piper --model en_model.onnx --raw-phonemes -f output.wav
 
 # ストリーミング (raw audio 出力)
-echo 'Long text...' | ./piper --model en_model.onnx --output-raw | \
+echo 'Long text...' | ./bin/piper --model en_model.onnx --output-raw | \
   aplay -r 22050 -f S16_LE -t raw -
 ```
 
@@ -385,7 +394,7 @@ echo 'Long text...' | ./piper --model en_model.onnx --output-raw | \
 > **WavLMモデルの推奨設定:** WavLM Discriminatorで学習されたモデルは `--noise-scale 0.5` を推奨します (デフォルトは 0.667)。
 >
 > ```sh
-> echo "こんにちは" | ./piper --model tsukuyomi.onnx --config config.json --noise-scale 0.5 -f output.wav
+> echo "こんにちは" | ./bin/piper --model tsukuyomi.onnx --config config.json --noise-scale 0.5 -f output.wav
 > ```
 
 ### JSON入力
@@ -403,25 +412,25 @@ echo 'Long text...' | ./piper --model en_model.onnx --output-raw | \
 
 ```bash
 # 利用可能なモデル一覧を表示
-./piper --list-models
+./bin/piper --list-models
 
 # 言語でフィルタリング
-./piper --list-models ja
-./piper --list-models en
+./bin/piper --list-models ja
+./bin/piper --list-models en
 ```
 
 #### モデルのダウンロード
 
 ```bash
 # モデル名を指定してダウンロード
-./piper --download-model tsukuyomi
-./piper --download-model en_US-lessac-medium
+./bin/piper --download-model tsukuyomi
+./bin/piper --download-model en_US-lessac-medium
 
 # ダウンロード先ディレクトリを指定
-./piper --download-model tsukuyomi --model-dir /path/to/models
+./bin/piper --download-model tsukuyomi --model-dir /path/to/models
 
 # ダウンロード後、モデルを使用
-./piper --model ~/.local/share/piper/models/ja_JP-tsukuyomi-chan-medium/tsukuyomi-chan-6lang-fp16.onnx --text "こんにちは"
+./bin/piper --model ~/.local/share/piper/models/ja_JP-tsukuyomi-chan-medium/tsukuyomi-chan-6lang-fp16.onnx --text "こんにちは"
 ```
 
 ### 環境変数 (C++ CLI)

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ echo 'Long text...' | ./bin/piper --model en_model.onnx --output-raw | \
 
 | オプション | 説明 | デフォルト |
 |---|---|---|
+| `--model PATH\|NAME` | モデルファイルのパス、またはモデル名 (ダウンロード済みモデルを自動解決) | - |
 | `--text TEXT` | テキスト直接入力 (パイプ不要) | - |
 | `--streaming` | チャンクベースのストリーミングモード | off |
 | `--use-cuda` | CUDA GPU推論を有効化 | off |
@@ -380,15 +381,15 @@ echo 'Long text...' | ./bin/piper --model en_model.onnx --output-raw | \
 #### モデルのダウンロード
 
 ```bash
-# モデル名を指定してダウンロード
+# モデル名を指定してダウンロード (エイリアスも使用可能)
 ./bin/piper --download-model tsukuyomi
 ./bin/piper --download-model en_US-lessac-medium
 
 # ダウンロード先ディレクトリを指定
 ./bin/piper --download-model tsukuyomi --model-dir /path/to/models
 
-# ダウンロード後、モデルを使用
-./bin/piper --model ~/.local/share/piper/models/ja_JP-tsukuyomi-chan-medium/tsukuyomi-chan-6lang-fp16.onnx --text "こんにちは"
+# ダウンロード後、モデル名で推論 (フルパス不要)
+./bin/piper --model tsukuyomi --text "こんにちは"
 ```
 
 ### 環境変数 (C++ CLI)

--- a/README_EN.md
+++ b/README_EN.md
@@ -262,6 +262,7 @@ Key options:
 
 | Option | Description | Default |
 |---|---|---|
+| `--model PATH\|NAME` | Model file path, or model name (auto-resolves downloaded models) | - |
 | `--text TEXT` | Direct text input (no piping required) | - |
 | `--streaming` | Chunk-based streaming mode | off |
 | `--use-cuda` | Enable CUDA GPU inference | off |
@@ -308,15 +309,15 @@ Use `--json-input` flag for JSON input:
 #### Download Models
 
 ```bash
-# Download a model by name
+# Download a model by name (aliases also work)
 ./bin/piper --download-model tsukuyomi
 ./bin/piper --download-model en_US-lessac-medium
 
 # Specify download directory
 ./bin/piper --download-model tsukuyomi --model-dir /path/to/models
 
-# After download, use the model
-./bin/piper --model ~/.local/share/piper/models/ja_JP-tsukuyomi-chan-medium/tsukuyomi-chan-6lang-fp16.onnx --text "こんにちは"
+# After download, use by model name (no full path needed)
+./bin/piper --model tsukuyomi --text "こんにちは"
 ```
 
 ### Environment Variables (C++ CLI)

--- a/README_EN.md
+++ b/README_EN.md
@@ -123,8 +123,8 @@ python -m piper.webui --data-dir /path/to/models
 Download from [GitHub Releases](https://github.com/ayutaz/piper-plus/releases) (amd64 / arm64).
 
 ```sh
-echo 'Welcome to the world of speech synthesis!' | \
-  ./piper --model en_US-lessac-medium.onnx --output_file welcome.wav
+./bin/piper --text 'Welcome to the world of speech synthesis!' \
+  --model en_US-lessac-medium.onnx --output_file welcome.wav
 ```
 
 ### Docker
@@ -220,41 +220,41 @@ The `--text` option allows direct text input without piping:
 
 ```sh
 # Simple text-to-speech
-./piper --model model.onnx --text "Hello, how are you?" -f output.wav
+./bin/piper --model model.onnx --text "Hello, how are you?" -f output.wav
 
 # Japanese text (no encoding issues on Windows)
-piper.exe --model models\tsukuyomi.onnx --text "こんにちは、今日は良い天気ですね。" -f output.wav
+bin\piper.exe --model models\tsukuyomi.onnx --text "こんにちは、今日は良い天気ですね。" -f output.wav
 
 # With speaker selection
-./piper --model model.onnx --text "Hello" --speaker 3 -f output.wav
+./bin/piper --model model.onnx --text "Hello" --speaker 3 -f output.wav
 ```
 
 #### Pipe Input
 
 ```sh
 # Basic usage
-echo "Hello world" | ./piper --model en_model.onnx --output_file output.wav
+echo "Hello world" | ./bin/piper --model en_model.onnx --output_file output.wav
 
 # Streaming (low latency)
-echo "Long text..." | ./piper --model en_model.onnx --output_file output.wav --streaming
+echo "Long text..." | ./bin/piper --model en_model.onnx --output_file output.wav --streaming
 
 # GPU inference
-echo "Hello" | ./piper --model en_model.onnx --use-cuda --output_file output.wav
+echo "Hello" | ./bin/piper --model en_model.onnx --use-cuda --output_file output.wav
 
 # Phoneme timing output (for lip-sync, subtitles)
-echo "Hello world" | ./piper --model en_model.onnx -f speech.wav --output-timing timing.json
+echo "Hello world" | ./bin/piper --model en_model.onnx -f speech.wav --output-timing timing.json
 
 # Custom dictionary
-echo "DockerとGitHubを使います" | ./piper --model ja_model.onnx --custom-dict my_dict.json -f output.wav
+echo "DockerとGitHubを使います" | ./bin/piper --model ja_model.onnx --custom-dict my_dict.json -f output.wav
 
 # Inline phoneme input
-echo 'Hello [[ h ə l oʊ ]] world' | ./piper --model en_model.onnx -f output.wav
+echo 'Hello [[ h ə l oʊ ]] world' | ./bin/piper --model en_model.onnx -f output.wav
 
 # Raw phoneme input
-echo 'h ə l oʊ _ w ɜː l d' | ./piper --model en_model.onnx --raw-phonemes -f output.wav
+echo 'h ə l oʊ _ w ɜː l d' | ./bin/piper --model en_model.onnx --raw-phonemes -f output.wav
 
 # Streaming raw audio output
-echo 'Long text...' | ./piper --model en_model.onnx --output-raw | \
+echo 'Long text...' | ./bin/piper --model en_model.onnx --output-raw | \
   aplay -r 22050 -f S16_LE -t raw -
 ```
 
@@ -298,25 +298,25 @@ Use `--json-input` flag for JSON input:
 
 ```bash
 # List all available models
-./piper --list-models
+./bin/piper --list-models
 
 # Filter by language
-./piper --list-models ja
-./piper --list-models en
+./bin/piper --list-models ja
+./bin/piper --list-models en
 ```
 
 #### Download Models
 
 ```bash
 # Download a model by name
-./piper --download-model tsukuyomi
-./piper --download-model en_US-lessac-medium
+./bin/piper --download-model tsukuyomi
+./bin/piper --download-model en_US-lessac-medium
 
 # Specify download directory
-./piper --download-model tsukuyomi --model-dir /path/to/models
+./bin/piper --download-model tsukuyomi --model-dir /path/to/models
 
 # After download, use the model
-./piper --model ~/.local/share/piper/models/ja_JP-tsukuyomi-chan-medium/tsukuyomi-chan-6lang-fp16.onnx --text "こんにちは"
+./bin/piper --model ~/.local/share/piper/models/ja_JP-tsukuyomi-chan-medium/tsukuyomi-chan-6lang-fp16.onnx --text "こんにちは"
 ```
 
 ### Environment Variables (C++ CLI)

--- a/README_FR.md
+++ b/README_FR.md
@@ -109,7 +109,7 @@ Telecharger depuis [GitHub Releases](https://github.com/ayutaz/piper-plus/releas
 
 ```sh
 echo 'Welcome to the world of speech synthesis!' | \
-  ./piper --model en_US-lessac-medium.onnx --output_file welcome.wav
+  ./bin/piper --model en_US-lessac-medium.onnx --output_file welcome.wav
 ```
 
 ### Docker
@@ -201,25 +201,25 @@ Prerequis : compilateur C++17, CMake 3.13+
 
 ```sh
 # Utilisation de base
-echo "こんにちは" | ./piper --model ja_model.onnx --output_file output.wav
+echo "こんにちは" | ./bin/piper --model ja_model.onnx --output_file output.wav
 
 # Streaming (faible latence)
-echo "Texte long..." | ./piper --model ja_model.onnx --output_file output.wav --streaming
+echo "Texte long..." | ./bin/piper --model ja_model.onnx --output_file output.wav --streaming
 
 # Inference GPU
-echo "Hello" | ./piper --model en_model.onnx --use-cuda --output_file output.wav
+echo "Hello" | ./bin/piper --model en_model.onnx --use-cuda --output_file output.wav
 
 # Sortie de timing phonemique (pour lip-sync, sous-titres)
-echo "Hello world" | ./piper --model en_model.onnx -f speech.wav --output-timing timing.json
+echo "Hello world" | ./bin/piper --model en_model.onnx -f speech.wav --output-timing timing.json
 
 # Dictionnaire personnalise
-echo "DockerとGitHubを使います" | ./piper --model ja_model.onnx --custom-dict my_dict.json -f output.wav
+echo "DockerとGitHubを使います" | ./bin/piper --model ja_model.onnx --custom-dict my_dict.json -f output.wav
 
 # Saisie phonemique en ligne
-echo 'Hello [[ h ə l oʊ ]] world' | ./piper --model en_model.onnx -f output.wav
+echo 'Hello [[ h ə l oʊ ]] world' | ./bin/piper --model en_model.onnx -f output.wav
 
 # Saisie de phonemes bruts
-echo 'h ə l oʊ _ w ɜː l d' | ./piper --model en_model.onnx --raw-phonemes -f output.wav
+echo 'h ə l oʊ _ w ɜː l d' | ./bin/piper --model en_model.onnx --raw-phonemes -f output.wav
 ```
 
 Options principales :

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -109,7 +109,7 @@ python -m piper.webui --data-dir /path/to/models
 
 ```sh
 echo 'Welcome to the world of speech synthesis!' | \
-  ./piper --model en_US-lessac-medium.onnx --output_file welcome.wav
+  ./bin/piper --model en_US-lessac-medium.onnx --output_file welcome.wav
 ```
 
 ### Docker
@@ -201,25 +201,25 @@ cmake --build . --config Release
 
 ```sh
 # 基本用法
-echo "こんにちは" | ./piper --model ja_model.onnx --output_file output.wav
+echo "こんにちは" | ./bin/piper --model ja_model.onnx --output_file output.wav
 
 # 流式处理（低延迟）
-echo "长文本..." | ./piper --model ja_model.onnx --output_file output.wav --streaming
+echo "长文本..." | ./bin/piper --model ja_model.onnx --output_file output.wav --streaming
 
 # GPU 推理
-echo "Hello" | ./piper --model en_model.onnx --use-cuda --output_file output.wav
+echo "Hello" | ./bin/piper --model en_model.onnx --use-cuda --output_file output.wav
 
 # 音素时间输出（用于口型同步、字幕同步）
-echo "Hello world" | ./piper --model en_model.onnx -f speech.wav --output-timing timing.json
+echo "Hello world" | ./bin/piper --model en_model.onnx -f speech.wav --output-timing timing.json
 
 # 自定义词典
-echo "DockerとGitHubを使います" | ./piper --model ja_model.onnx --custom-dict my_dict.json -f output.wav
+echo "DockerとGitHubを使います" | ./bin/piper --model ja_model.onnx --custom-dict my_dict.json -f output.wav
 
 # 内联音素输入
-echo 'Hello [[ h ə l oʊ ]] world' | ./piper --model en_model.onnx -f output.wav
+echo 'Hello [[ h ə l oʊ ]] world' | ./bin/piper --model en_model.onnx -f output.wav
 
 # 原始音素输入
-echo 'h ə l oʊ _ w ɜː l d' | ./piper --model en_model.onnx --raw-phonemes -f output.wav
+echo 'h ə l oʊ _ w ɜː l d' | ./bin/piper --model en_model.onnx --raw-phonemes -f output.wav
 ```
 
 主要选项：

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -925,6 +925,47 @@ void parseArgs(int argc, char *argv[], RunConfig &runConfig) {
     } else if (arg == "-h" || arg == "--help") {
       printUsage(argv);
       exit(0);
+    } else if (arg.rfind("--", 0) == 0) {
+      // Unknown flag starting with "--": suggest closest match
+      static const vector<string> knownFlags = {
+        "--model", "--config", "--output_file", "--output-file",
+        "--output_dir", "--output-dir", "--output_raw", "--output-raw",
+        "--speaker", "--language", "--noise-scale", "--noise_scale",
+        "--length-scale", "--length_scale", "--noise-w", "--noise_w",
+        "--sentence-silence", "--sentence_silence",
+        "--phoneme-silence", "--phoneme_silence",
+        "--json-input", "--json_input", "--use-cuda", "--use_cuda",
+        "--gpu-device-id", "--gpu_device_id",
+        "--raw-phonemes", "--raw_phonemes", "--streaming",
+        "--output-timing", "--output_timing",
+        "--timing-format", "--timing_format",
+        "--custom-dict", "--custom_dict", "--text",
+        "--list-models", "--download-model", "--model-dir", "--model_dir",
+        "--version", "--test-mode", "--debug", "--quiet", "--help",
+        "--no-stochastic",
+      };
+      // Find best match by edit distance (simple Levenshtein)
+      string bestMatch;
+      size_t bestDist = string::npos;
+      for (const auto& flag : knownFlags) {
+        // Simple distance: count differing chars after common prefix
+        size_t maxLen = max(arg.size(), flag.size());
+        size_t minLen = min(arg.size(), flag.size());
+        size_t dist = maxLen - minLen;
+        for (size_t j = 0; j < minLen; ++j) {
+          if (arg[j] != flag[j]) ++dist;
+        }
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestMatch = flag;
+        }
+      }
+      cerr << "Unknown option: " << arg << endl;
+      if (bestDist <= 3 && !bestMatch.empty()) {
+        cerr << "Did you mean: " << bestMatch << " ?" << endl;
+      }
+      cerr << "Use --help for usage information." << endl;
+      exit(1);
     }
   }
 
@@ -949,7 +990,25 @@ void parseArgs(int argc, char *argv[], RunConfig &runConfig) {
       modelFile.open(runConfig.modelPath.c_str(), ios::binary);
     }
     if (!modelFile.good()) {
-      throw runtime_error("Model file doesn't exist: " + runConfig.modelPath.string());
+      // Check if it looks like a model name (no path separators or extension)
+      auto pathStr = runConfig.modelPath.string();
+      bool looksLikeName = pathStr.find('/') == string::npos &&
+                           pathStr.find('\\') == string::npos &&
+                           pathStr.find('.') == string::npos;
+      if (looksLikeName) {
+        auto voice = piper::findVoice(pathStr);
+        if (voice) {
+          cerr << "Model '" << pathStr << "' was found in the catalog but is not downloaded yet." << endl;
+          cerr << "Run:  --download-model " << pathStr << endl;
+        } else {
+          cerr << "Model '" << pathStr << "' not found." << endl;
+          cerr << "Use --list-models to see available models, "
+               << "or specify a file path with --model /path/to/model.onnx" << endl;
+        }
+      } else {
+        cerr << "Model file not found: " << pathStr << endl;
+      }
+      exit(1);
     }
   }
 

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -938,10 +938,19 @@ void parseArgs(int argc, char *argv[], RunConfig &runConfig) {
     return;
   }
 
-  // Verify model file exists
+  // Verify model file exists; if not, try resolving as a model name/alias
   ifstream modelFile(runConfig.modelPath.c_str(), ios::binary);
   if (!modelFile.good()) {
-    throw runtime_error("Model file doesn't exist");
+    auto modelDir = runConfig.modelDir.value_or(piper::getDefaultModelDir());
+    auto resolved = piper::resolveModelPath(runConfig.modelPath.string(), modelDir);
+    if (resolved) {
+      spdlog::info("Resolved model name '{}' to {}", runConfig.modelPath.string(), resolved->string());
+      runConfig.modelPath = resolved.value();
+      modelFile.open(runConfig.modelPath.c_str(), ios::binary);
+    }
+    if (!modelFile.good()) {
+      throw runtime_error("Model file doesn't exist: " + runConfig.modelPath.string());
+    }
   }
 
   if (!modelConfigPath) {

--- a/src/cpp/model_manager.cpp
+++ b/src/cpp/model_manager.cpp
@@ -464,7 +464,7 @@ void listModels(const std::string& languageFilter) {
             std::cerr << " [" << voice.languageCode << "]:" << std::endl;
         }
 
-        // Format: key  [source]  N speaker(s)  quality
+        // Format: key  [source]  N speaker(s)  quality  (aliases)
         std::cerr << "    " << voice.key;
 
         // Pad to 40 chars for alignment
@@ -478,7 +478,17 @@ void listModels(const std::string& languageFilter) {
         std::cerr << "[" << voice.source << "]  ";
         std::cerr << voice.numSpeakers << " speaker"
                   << (voice.numSpeakers != 1 ? "s" : "") << "   ";
-        std::cerr << voice.quality << std::endl;
+        std::cerr << voice.quality;
+
+        if (!voice.aliases.empty()) {
+            std::cerr << "   (";
+            for (size_t i = 0; i < voice.aliases.size(); ++i) {
+                if (i > 0) std::cerr << ", ";
+                std::cerr << voice.aliases[i];
+            }
+            std::cerr << ")";
+        }
+        std::cerr << std::endl;
     }
 
     std::cerr << std::endl;

--- a/src/cpp/model_manager.cpp
+++ b/src/cpp/model_manager.cpp
@@ -585,4 +585,28 @@ bool downloadModel(const std::string& modelName,
     return allOk;
 }
 
+std::optional<fs::path> resolveModelPath(
+    const std::string& nameOrAlias,
+    const fs::path& modelDir) {
+    auto maybeVoice = findVoice(nameOrAlias);
+    if (!maybeVoice) {
+        return std::nullopt;
+    }
+
+    const VoiceInfo& voice = maybeVoice.value();
+
+    // Find the .onnx file in the voice's file list
+    for (const auto& file : voice.files) {
+        fs::path fn = fs::path(file.relativePath).filename();
+        if (fn.extension() == ".onnx") {
+            fs::path candidate = modelDir / fn;
+            if (fs::exists(candidate)) {
+                return candidate;
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
 } // namespace piper

--- a/src/cpp/model_manager.hpp
+++ b/src/cpp/model_manager.hpp
@@ -52,6 +52,12 @@ bool downloadModel(const std::string& modelName,
 // Find a voice by key or alias
 std::optional<VoiceInfo> findVoice(const std::string& nameOrAlias);
 
+// Resolve a model name or alias to the downloaded .onnx file path.
+// Returns nullopt if the voice is not found in the catalog or not downloaded.
+std::optional<std::filesystem::path> resolveModelPath(
+    const std::string& nameOrAlias,
+    const std::filesystem::path& modelDir);
+
 } // namespace piper
 
 #endif // MODEL_MANAGER_H_


### PR DESCRIPTION
## Summary

v1.7.0リリースに対するユーザーフィードバックに基づき、Windowsクイックスタート手順の修正とCLI UX改善。

### ドキュメント修正
- **Expand-Archive の二重ネスト問題を修正**: `-DestinationPath piper` → `-DestinationPath .` に変更し、`piper/piper/` の入れ子構造を回避
- **ステップ3をPowerShellに統一**: cmd → PowerShell に変更し、手順全体がPowerShellで完結するように改善
- **クイックスタートを `--download-model` + `--model NAME` に簡略化**: 手動の `mkdir` + `Invoke-WebRequest`/`curl` を削除し、2コマンドで完結
- **`piper.exe` のパスを `bin\piper.exe` に修正**: 配布パッケージのディレクトリ構造 (`piper/bin/piper.exe`) と一致
- **全READMEの `./piper` → `./bin/piper` に統一**: JA/EN/ZH/FR の4ファイル
- **`chcp 65001` の注意書きを修正**: `--text` は `GetCommandLineW()` (UTF-16) を使用するためコードページに依存しない旨を明記
- **オプション表に `--model PATH|NAME` を追記**: モデル名でもフルパスでも指定可能

### CLI機能追加
- **`--model` にモデル名/エイリアスを指定可能に**: ファイルパスが存在しない場合、ダウンロード済みモデルを自動解決 (`--model tsukuyomi` で動作)
- **`--list-models` にエイリアス表示を追加**: ダウンロード時に使えるエイリアス名を括弧付きで表示
- **不明フラグのtypoサジェスト**: `--list-model` → `Did you mean: --list-models ?` のように近い候補を提案
- **モデル名エラーメッセージ改善**: カタログにあるが未DLの場合は `--download-model` を案内、存在しない名前は `--list-models` を案内

## Test plan

- [x] READMEのクイックスタート手順に従い、Windows PowerShellで一連の操作（DL→展開→モデルDL→音声生成）が完了することを確認
- [x] `Expand-Archive piper.zip -DestinationPath .` で `piper/bin/piper.exe` に正しくアクセスできることを確認
- [x] `.\bin\piper.exe --download-model tsukuyomi` でモデルがダウンロードされることを確認
- [x] `.\bin\piper.exe --model tsukuyomi --text "テスト" --output_file output.wav` で output.wav が生成されることを確認
- [x] `.\bin\piper.exe --model ja_JP-css10-6lang-medium` でフルキー名でもダウンロード・推論できることを確認
- [x] `.\bin\piper.exe --list-models` でエイリアスが括弧付きで表示されることを確認
- [x] `.\bin\piper.exe --list-model` でtypoサジェストが表示されることを確認
- [x] `.\bin\piper.exe --model hogehoge` で適切なエラーメッセージが表示されることを確認
- [x] 既存テスト (test_text_input: 21, test_model_manager: 35) が全てPASSすることを確認