### PR TITLE
feat: C# CLIをC++と同等の機能に拡充

### DIFF
--- a/src/csharp/PiperPlus.Cli/Program.cs
+++ b/src/csharp/PiperPlus.Cli/Program.cs
@@ -80,8 +80,8 @@ internal static class Program
     private static RootCommand BuildRootCommand()
     {
         // --model / -m
-        var modelOption = new Option<FileInfo?>("--model", "-m")
-        { Description = "Path to .onnx model file" };
+        var modelOption = new Option<string?>("--model", "-m")
+        { Description = "Path to .onnx model file, or model name/alias for auto-download" };
 
         // --config / -c
         var configOption = new Option<FileInfo?>("--config", "-c")
@@ -298,15 +298,23 @@ internal static class Program
                 string? downloadModelName = parseResult.GetValue(downloadModelOption);
                 if (!string.IsNullOrEmpty(downloadModelName))
                 {
+                    // Resolve alias to canonical key for better UX
+                    var resolvedVoice = ModelManager.FindVoice(downloadModelName);
+                    string resolvedName = resolvedVoice?.Key ?? downloadModelName;
+                    if (resolvedVoice is not null && resolvedName != downloadModelName)
+                    {
+                        LogInfo(quiet, $"Resolved '{downloadModelName}' -> '{resolvedName}'");
+                    }
+
                     var dlModelDir = parseResult.GetValue(modelDirOption);
                     string targetDir = dlModelDir?.FullName
                         ?? Environment.GetEnvironmentVariable("PIPER_MODEL_DIR")
                         ?? ModelManager.GetDefaultModelDir();
 
-                    LogInfo(quiet, $"Downloading model '{downloadModelName}' to {targetDir}...");
+                    LogInfo(quiet, $"Downloading model '{resolvedName}' to {targetDir}...");
 
                     bool success = ModelManager.DownloadModelAsync(
-                        downloadModelName, targetDir, CancellationToken.None).GetAwaiter().GetResult();
+                        resolvedName, targetDir, CancellationToken.None).GetAwaiter().GetResult();
 
                     if (!success)
                     {
@@ -368,8 +376,8 @@ internal static class Program
                 }
 
                 // Resolve model path: CLI > env > error
-                var modelFileInfo = parseResult.GetValue(modelOption);
-                string? modelPath = modelFileInfo?.FullName;
+                // --model now accepts file paths, model names, or aliases
+                string? modelPath = parseResult.GetValue(modelOption);
 
                 if (string.IsNullOrEmpty(modelPath))
                 {
@@ -388,11 +396,32 @@ internal static class Program
                     return;
                 }
 
-                if (!testMode && !string.IsNullOrEmpty(modelPath) && !File.Exists(modelPath))
+                // Resolve model name/alias to a file path (with auto-download)
+                string? modelDirStr = modelDirInfo?.FullName;
+                if (!testMode && !string.IsNullOrEmpty(modelPath))
                 {
-                    LogError($"Model file not found: {modelPath}");
-                    Environment.ExitCode = 1;
-                    return;
+                    try
+                    {
+                        string resolvedModelPath = ModelManager.ResolveModelPathAsync(
+                            modelPath, modelDirStr, CancellationToken.None).GetAwaiter().GetResult();
+                        if (resolvedModelPath != modelPath)
+                        {
+                            LogInfo(quiet, $"Resolved model: {resolvedModelPath}");
+                        }
+                        modelPath = resolvedModelPath;
+                    }
+                    catch (FileNotFoundException ex)
+                    {
+                        LogError(ex.Message);
+                        Environment.ExitCode = 1;
+                        return;
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        LogError(ex.Message);
+                        Environment.ExitCode = 1;
+                        return;
+                    }
                 }
 
                 // Resolve config path
@@ -449,17 +478,32 @@ internal static class Program
                 }
 
                 // ============================================================
-                // Load --custom-dict
+                // Load --custom-dict + default dictionaries
                 // ============================================================
                 CustomDictionary? customDict = null;
                 if (!string.IsNullOrEmpty(customDictPaths))
                 {
+                    // Explicit --custom-dict: load defaults first (lower priority),
+                    // then user-specified files (higher priority wins via priority system).
                     customDict = new CustomDictionary();
+                    customDict.LoadDefaults();
                     var paths = customDictPaths.Split(',',
                         StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                     customDict.LoadDictionaries(paths);
                     LogDebug(debug, quiet,
-                        $"Custom dictionary: {customDict.Count} entries from {paths.Length} file(s)");
+                        $"Custom dictionary: {customDict.Count} entries from defaults + {paths.Length} file(s)");
+                }
+                else
+                {
+                    // No explicit --custom-dict: try loading default dictionaries
+                    var defaultDict = new CustomDictionary();
+                    defaultDict.LoadDefaults();
+                    if (defaultDict.Count > 0)
+                    {
+                        customDict = defaultDict;
+                        LogDebug(debug, quiet,
+                            $"Loaded {defaultDict.Count} default dictionary entries");
+                    }
                 }
 
                 // Gather synthesis parameters
@@ -514,8 +558,34 @@ internal static class Program
                     var phonemeIdMap = phonemizer.GetPhonemeIdMap()
                                       ?? config?.PhonemeIdMap
                                       ?? new Dictionary<string, int[]>();
-                    var (phonemeIdsLong, _) = PhonemeEncoder.EncodeDirect(
-                        phonemizer, textInput, phonemeIdMap);
+
+                    long[] phonemeIdsLong;
+
+                    // Check for [[ phoneme ]] inline notation
+                    var testSegments = InlinePhonemeParser.Parse(textInput);
+                    if (testSegments.Any(s => s.IsPhonemes))
+                    {
+                        var allIds = new List<long>();
+                        foreach (var seg in testSegments)
+                        {
+                            if (seg.IsPhonemes)
+                            {
+                                allIds.AddRange(RawPhonemeParser.Parse(seg.Text, phonemeIdMap));
+                            }
+                            else
+                            {
+                                var (ids, _) = PhonemeEncoder.EncodeDirect(
+                                    phonemizer, seg.Text, phonemeIdMap);
+                                allIds.AddRange(ids);
+                            }
+                        }
+                        phonemeIdsLong = allIds.ToArray();
+                    }
+                    else
+                    {
+                        (phonemeIdsLong, _) = PhonemeEncoder.EncodeDirect(
+                            phonemizer, textInput, phonemeIdMap);
+                    }
 
                     Console.Error.WriteLine(
                         $"[test-mode] phoneme_ids({phonemeIdsLong.Length}): " +
@@ -721,9 +791,68 @@ internal static class Program
                     // Use the phonemizer's own ID map if available, else fall back to config
                     var phonemeIdMap = phonemizer.GetPhonemeIdMap() ?? config.PhonemeIdMap;
 
-                    // Phonemize + encode in one step via PhonemeEncoder
-                    var (phonemeIdsLong, prosodyFlat) = PhonemeEncoder.EncodeDirect(
-                        phonemizer, textInput, phonemeIdMap);
+                    long[] phonemeIdsLong;
+                    long[]? prosodyFlat;
+
+                    // Check for [[ phoneme ]] inline notation
+                    var inlineSegments = InlinePhonemeParser.Parse(textInput);
+                    if (inlineSegments.Any(s => s.IsPhonemes))
+                    {
+                        // Mixed mode: process each segment separately
+                        var allIds = new List<long>();
+                        var allProsody = new List<long>();
+                        bool hasAnyProsody = false;
+
+                        foreach (var seg in inlineSegments)
+                        {
+                            if (seg.IsPhonemes)
+                            {
+                                // Direct phoneme input — parse like --raw-phonemes
+                                var ids = RawPhonemeParser.Parse(seg.Text, phonemeIdMap);
+                                allIds.AddRange(ids);
+                                // No prosody for inline phonemes — fill with zeros
+                                for (int pi = 0; pi < ids.Length; pi++)
+                                {
+                                    allProsody.Add(0);
+                                    allProsody.Add(0);
+                                    allProsody.Add(0);
+                                }
+                            }
+                            else
+                            {
+                                // Normal text — phonemize
+                                var (ids, prosody) = PhonemeEncoder.EncodeDirect(
+                                    phonemizer, seg.Text, phonemeIdMap);
+                                allIds.AddRange(ids);
+                                if (prosody != null)
+                                {
+                                    hasAnyProsody = true;
+                                    allProsody.AddRange(prosody);
+                                }
+                                else
+                                {
+                                    for (int pi = 0; pi < ids.Length; pi++)
+                                    {
+                                        allProsody.Add(0);
+                                        allProsody.Add(0);
+                                        allProsody.Add(0);
+                                    }
+                                }
+                            }
+                        }
+
+                        phonemeIdsLong = allIds.ToArray();
+                        prosodyFlat = hasAnyProsody ? allProsody.ToArray() : null;
+
+                        LogDebug(debug, quiet,
+                            $"Inline phoneme mode: {inlineSegments.Count} segments");
+                    }
+                    else
+                    {
+                        // Normal mode — no inline notation
+                        (phonemeIdsLong, prosodyFlat) = PhonemeEncoder.EncodeDirect(
+                            phonemizer, textInput, phonemeIdMap);
+                    }
 
                     LogDebug(debug, quiet,
                         $"Encoded: {phonemeIdsLong.Length} phoneme IDs" +

--- a/src/csharp/PiperPlus.Cli/Program.cs
+++ b/src/csharp/PiperPlus.Cli/Program.cs
@@ -566,17 +566,32 @@ internal static class Program
                     if (testSegments.Any(s => s.IsPhonemes))
                     {
                         var allIds = new List<long>();
-                        foreach (var seg in testSegments)
+                        for (int segIndex = 0; segIndex < testSegments.Count; segIndex++)
                         {
+                            var seg = testSegments[segIndex];
+                            bool isFirst = segIndex == 0;
+                            bool isLast = segIndex == testSegments.Count - 1;
+
+                            long[] segIds;
                             if (seg.IsPhonemes)
                             {
-                                allIds.AddRange(RawPhonemeParser.Parse(seg.Text, phonemeIdMap));
+                                segIds = RawPhonemeParser.Parse(seg.Text, phonemeIdMap);
                             }
                             else
                             {
                                 var (ids, _) = PhonemeEncoder.EncodeDirect(
                                     phonemizer, seg.Text, phonemeIdMap);
-                                allIds.AddRange(ids);
+                                segIds = ids;
+                            }
+
+                            // Trim BOS from non-first segments, EOS from non-last segments
+                            // to avoid duplicated BOS/EOS at concatenation boundaries.
+                            int start = (!isFirst && segIds.Length > 0) ? 1 : 0;
+                            int end = (!isLast && segIds.Length > 0) ? segIds.Length - 1 : segIds.Length;
+
+                            for (int i = start; i < end; i++)
+                            {
+                                allIds.Add(segIds[i]);
                             }
                         }
                         phonemeIdsLong = allIds.ToArray();
@@ -803,40 +818,50 @@ internal static class Program
                         var allProsody = new List<long>();
                         bool hasAnyProsody = false;
 
-                        foreach (var seg in inlineSegments)
+                        for (int segIndex = 0; segIndex < inlineSegments.Count; segIndex++)
                         {
+                            var seg = inlineSegments[segIndex];
+                            bool isFirst = segIndex == 0;
+                            bool isLast = segIndex == inlineSegments.Count - 1;
+
+                            long[] segIds;
+                            long[]? segProsody = null;
+
                             if (seg.IsPhonemes)
                             {
                                 // Direct phoneme input — parse like --raw-phonemes
-                                var ids = RawPhonemeParser.Parse(seg.Text, phonemeIdMap);
-                                allIds.AddRange(ids);
-                                // No prosody for inline phonemes — fill with zeros
-                                for (int pi = 0; pi < ids.Length; pi++)
-                                {
-                                    allProsody.Add(0);
-                                    allProsody.Add(0);
-                                    allProsody.Add(0);
-                                }
+                                segIds = RawPhonemeParser.Parse(seg.Text, phonemeIdMap);
                             }
                             else
                             {
                                 // Normal text — phonemize
                                 var (ids, prosody) = PhonemeEncoder.EncodeDirect(
                                     phonemizer, seg.Text, phonemeIdMap);
-                                allIds.AddRange(ids);
+                                segIds = ids;
+                                segProsody = prosody;
                                 if (prosody != null)
-                                {
                                     hasAnyProsody = true;
-                                    allProsody.AddRange(prosody);
+                            }
+
+                            // Trim BOS from non-first segments, EOS from non-last segments
+                            // to avoid duplicated BOS/EOS at concatenation boundaries.
+                            int start = (!isFirst && segIds.Length > 0) ? 1 : 0;
+                            int end = (!isLast && segIds.Length > 0) ? segIds.Length - 1 : segIds.Length;
+
+                            for (int i = start; i < end; i++)
+                            {
+                                allIds.Add(segIds[i]);
+                                if (segProsody != null && i * 3 + 2 < segProsody.Length)
+                                {
+                                    allProsody.Add(segProsody[i * 3]);
+                                    allProsody.Add(segProsody[i * 3 + 1]);
+                                    allProsody.Add(segProsody[i * 3 + 2]);
                                 }
                                 else
                                 {
-                                    for (int pi = 0; pi < ids.Length; pi++)
-                                    {
-                                        allProsody.Add(0);
-                                        allProsody.Add(0);
-                                        allProsody.Add(0);
-                                    }
+                                    allProsody.Add(0);
+                                    allProsody.Add(0);
+                                    allProsody.Add(0);
                                 }
                             }
                         }

--- a/src/csharp/PiperPlus.Core.Tests/CliIntegrationTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/CliIntegrationTests.cs
@@ -380,4 +380,125 @@ public sealed class CliIntegrationTests
             $"Expected successful test-mode run with default output. " +
             $"ExitCode={exitCode}, Output: {combined}");
     }
+
+    // ================================================================
+    // --model with model name/alias (auto-resolve)
+    // ================================================================
+
+    [Fact]
+    [Trait("Category", "CLI")]
+    public async Task Model_NonexistentNameOrFile_ShowsError()
+    {
+        // --model with a string that is neither a file nor a known model name
+        // should display an error message.
+        var (exitCode, _, stderr) = await RunCliAsync(
+            "--model", "totally-fake-nonexistent-model-xyz",
+            "--text", "test");
+        SkipIfBuildFailed(exitCode, stderr);
+
+        Assert.True(
+            exitCode != 0 || stderr.Contains("not found", StringComparison.OrdinalIgnoreCase),
+            $"Expected error for unknown model name. ExitCode={exitCode}, stderr: {stderr}");
+    }
+
+    // ================================================================
+    // --download-model with alias
+    // ================================================================
+
+    [Fact]
+    [Trait("Category", "CLI")]
+    public async Task DownloadModel_InvalidName_ShowsError()
+    {
+        // --download-model with a name that doesn't exist in the catalog
+        var (exitCode, _, stderr) = await RunCliAsync(
+            "--download-model", "totally-nonexistent-model-xyz");
+        SkipIfBuildFailed(exitCode, stderr);
+
+        Assert.True(
+            exitCode != 0
+            || stderr.Contains("not found", StringComparison.OrdinalIgnoreCase)
+            || stderr.Contains("Error", StringComparison.OrdinalIgnoreCase),
+            $"Expected error for unknown model name. ExitCode={exitCode}, stderr: {stderr}");
+    }
+
+    // ================================================================
+    // --test-mode with [[ inline phonemes ]] notation
+    // ================================================================
+
+    [Fact]
+    [Trait("Category", "CLI")]
+    public async Task TestMode_InlinePhonemes_JapaneseWithNotation()
+    {
+        // The [[ ... ]] inline phoneme notation should be recognized in test-mode.
+        // Mix plain text with inline phonemes: "hello [[ k o N n i ch i w a ]]"
+        var (exitCode, stdout, stderr) = await RunCliAsync(
+            "--test-mode", "--text", "hello [[ k o N n i ch i w a ]]",
+            "--language", "ja-en");
+        SkipIfBuildFailed(exitCode, stderr);
+
+        string combined = stdout + stderr;
+
+        // Either phonemizer succeeds and outputs phoneme_ids (which would include
+        // IDs from both the phonemized "hello" and the raw phoneme tokens),
+        // or the G2P engine is not available.
+        Assert.True(
+            combined.Contains("phoneme_ids", StringComparison.Ordinal)
+            || combined.Contains("not yet available", StringComparison.OrdinalIgnoreCase)
+            || combined.Contains("DotNetG2P", StringComparison.Ordinal),
+            $"Expected phoneme_ids or G2P unavailable. ExitCode={exitCode}, Output: {combined}");
+    }
+
+    [Fact]
+    [Trait("Category", "CLI")]
+    public async Task TestMode_InlinePhonemes_OnlyBrackets()
+    {
+        // Input with only [[ ... ]] notation (no plain text part)
+        var (exitCode, stdout, stderr) = await RunCliAsync(
+            "--test-mode", "--text", "[[ a i u e o ]]",
+            "--language", "ja");
+        SkipIfBuildFailed(exitCode, stderr);
+
+        string combined = stdout + stderr;
+
+        Assert.True(
+            combined.Contains("phoneme_ids", StringComparison.Ordinal)
+            || combined.Contains("not yet available", StringComparison.OrdinalIgnoreCase)
+            || combined.Contains("DotNetG2P", StringComparison.Ordinal),
+            $"Expected phoneme_ids output. ExitCode={exitCode}, Output: {combined}");
+    }
+
+    // ================================================================
+    // --model accepts string (not just FileInfo)
+    // ================================================================
+
+    [Fact]
+    [Trait("Category", "CLI")]
+    public async Task Model_AcceptsModelNameString_NotJustFilePath()
+    {
+        // Verify that --model accepts arbitrary strings (not just file paths).
+        // With --test-mode, a known model name should be recognized
+        // (though it may fail at download since we're in test mode).
+        // An unknown name should produce an appropriate error.
+        var (exitCode, stdout, stderr) = await RunCliAsync(
+            "--model", "tsukuyomi", "--text", "テスト");
+        SkipIfBuildFailed(exitCode, stderr);
+
+        string combined = stdout + stderr;
+
+        // The CLI should either:
+        //   - Resolve the model and fail at inference (no actual model file)
+        //   - Attempt auto-download and fail
+        //   - Show "not found locally. Downloading..." message
+        // The key test is that it does NOT fail with "Invalid option" or
+        // "unrecognized command" — the string is accepted as a valid option value.
+        Assert.True(
+            combined.Contains("Resolved model", StringComparison.OrdinalIgnoreCase)
+            || combined.Contains("not found locally", StringComparison.OrdinalIgnoreCase)
+            || combined.Contains("Downloading", StringComparison.OrdinalIgnoreCase)
+            || combined.Contains("download", StringComparison.OrdinalIgnoreCase)
+            || combined.Contains("failed", StringComparison.OrdinalIgnoreCase)
+            || combined.Contains("Error", StringComparison.OrdinalIgnoreCase)
+            || exitCode != 0,
+            $"Expected model resolution attempt. ExitCode={exitCode}, Output: {combined}");
+    }
 }

--- a/src/csharp/PiperPlus.Core.Tests/CustomDictionaryTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/CustomDictionaryTests.cs
@@ -200,15 +200,16 @@ public sealed class CustomDictionaryTests : IDisposable
     [Fact]
     public void ApplyToText_LongestMatchFirst()
     {
-        // "abc" should match before "ab" and "a"
-        string content = "a\t1\nab\t2\nabc\t3\n";
+        // Non-ASCII keys use substring replacement (no word boundary), so we
+        // can test longest-match-first ordering with Japanese characters.
+        string content = "あ\t1\nあい\t2\nあいう\t3\n";
         string path = CreateTempFile(content);
 
         var dict = new CustomDictionary();
         dict.LoadDictionary(path);
 
-        // "abc" is replaced first (longest), leaving "d" untouched
-        Assert.Equal("3d", dict.ApplyToText("abcd"));
+        // "あいう" is replaced first (longest), leaving "え" untouched
+        Assert.Equal("3え", dict.ApplyToText("あいうえ"));
     }
 
     [Fact]
@@ -531,5 +532,591 @@ public sealed class CustomDictionaryTests : IDisposable
         // Only "API" should be loaded; version/description/metadata are skipped
         Assert.Equal(1, dict.Count);
         Assert.Equal("エーピーアイ", dict.ApplyToText("API"));
+    }
+
+    // ================================================================
+    // Word boundary matching (ASCII keys)
+    // ================================================================
+
+    [Fact]
+    public void ApplyToText_WordBoundary_API_NotInsideRapid()
+    {
+        // "API" should not match inside "rapid"
+        string content = "API\tエーピーアイ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("rapid development", dict.ApplyToText("rapid development"));
+    }
+
+    [Fact]
+    public void ApplyToText_WordBoundary_AI_StandaloneButNotInAIDS()
+    {
+        // "AI" should match standalone but not inside "AIDS"
+        string content = "AI\tエーアイ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("エーアイ and AIDS", dict.ApplyToText("AI and AIDS"));
+    }
+
+    [Fact]
+    public void ApplyToText_WordBoundary_StandaloneMatch()
+    {
+        // "API" should match as a standalone word
+        string content = "API\tエーピーアイ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("the エーピーアイ works", dict.ApplyToText("the API works"));
+    }
+
+    // ================================================================
+    // Case-insensitive matching (all-upper / all-lower keys)
+    // ================================================================
+
+    [Fact]
+    public void ApplyToText_CaseInsensitive_AllLowerMatchesAnyCase()
+    {
+        // "python" (all lowercase) should match "Python" and "PYTHON"
+        string content = "python\tパイソン\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("パイソン is great", dict.ApplyToText("Python is great"));
+        Assert.Equal("パイソン is great", dict.ApplyToText("PYTHON is great"));
+        Assert.Equal("パイソン is great", dict.ApplyToText("python is great"));
+    }
+
+    [Fact]
+    public void ApplyToText_CaseInsensitive_AllUpperMatchesAnyCase()
+    {
+        // "API" (all uppercase) should match "api" and "Api"
+        string content = "API\tエーピーアイ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("the エーピーアイ", dict.ApplyToText("the api"));
+        Assert.Equal("the エーピーアイ", dict.ApplyToText("the Api"));
+        Assert.Equal("the エーピーアイ", dict.ApplyToText("the API"));
+    }
+
+    // ================================================================
+    // Case-sensitive matching (mixed-case keys)
+    // ================================================================
+
+    [Fact]
+    public void ApplyToText_CaseSensitive_MixedCaseExactOnly()
+    {
+        // "PyTorch" (mixed case) should only match "PyTorch", not "pytorch" or "PYTORCH"
+        string content = "PyTorch\tパイトーチ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("パイトーチ is great", dict.ApplyToText("PyTorch is great"));
+        Assert.Equal("pytorch is great", dict.ApplyToText("pytorch is great"));
+        Assert.Equal("PYTORCH is great", dict.ApplyToText("PYTORCH is great"));
+    }
+
+    [Fact]
+    public void ApplyToText_CaseSensitive_iPhone()
+    {
+        // "iPhone" is mixed case — must match exactly
+        string content = "iPhone\tアイフォン\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("アイフォン 16", dict.ApplyToText("iPhone 16"));
+        Assert.Equal("iphone 16", dict.ApplyToText("iphone 16"));
+    }
+
+    // ================================================================
+    // Non-ASCII (Japanese/Chinese) — substring replacement, no boundary
+    // ================================================================
+
+    [Fact]
+    public void ApplyToText_NonAscii_JapaneseSubstringReplacement()
+    {
+        // Japanese word replaces as substring without word boundary
+        string content = "東京\tトウキョウ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("トウキョウタワー", dict.ApplyToText("東京タワー"));
+        Assert.Equal("トウキョウ駅", dict.ApplyToText("東京駅"));
+    }
+
+    [Fact]
+    public void ApplyToText_NonAscii_ChineseSubstringReplacement()
+    {
+        // Chinese word — substring, no boundary
+        string content = "机器\tジーチー\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("ジーチー学习", dict.ApplyToText("机器学习"));
+    }
+
+    // ================================================================
+    // Combined: word boundary + case sensitivity
+    // ================================================================
+
+    [Fact]
+    public void ApplyToText_WordBoundaryAndCaseInsensitive_Combined()
+    {
+        // "gpu" (all lowercase) should match "GPU" at word boundary
+        // but not inside "gpuXyz" (which should still be blocked by boundary)
+        string json = """
+            {
+                "version": "1.0",
+                "entries": {
+                    "gpu": "ジーピーユー"
+                }
+            }
+            """;
+        string path = CreateTempJsonFile(json);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("ジーピーユー acceleration", dict.ApplyToText("GPU acceleration"));
+        Assert.Equal("ジーピーユー acceleration", dict.ApplyToText("gpu acceleration"));
+    }
+
+    [Fact]
+    public void ApplyToText_MixedCaseWithBoundary()
+    {
+        // "TensorFlow" (mixed case) should use word boundary AND case sensitivity
+        string content = "TensorFlow\tテンソルフロー\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("テンソルフロー v2", dict.ApplyToText("TensorFlow v2"));
+        Assert.Equal("tensorflow v2", dict.ApplyToText("tensorflow v2"));
+        // Should not match inside a larger word
+        Assert.Equal("TensorFlowLite", dict.ApplyToText("TensorFlowLite"));
+    }
+
+    // ================================================================
+    // LoadDefaults
+    // ================================================================
+
+    [Fact]
+    public void LoadDefaults_NoDictionaryDirectory_DoesNotThrow()
+    {
+        // When no data/dictionaries/ directory exists in any search path,
+        // LoadDefaults should simply return without error.
+        var dict = new CustomDictionary();
+        dict.LoadDefaults(); // Must not throw
+        // Count may be 0 or > 0 depending on the working directory;
+        // just verify it does not crash.
+    }
+
+    [Fact]
+    public void LoadDefaults_WithTempDirectory_LoadsJsonFiles()
+    {
+        // Create a temporary directory structure: <tmpDir>/data/dictionaries/
+        var baseDir = Path.Combine(Path.GetTempPath(), $"piper_defaults_{Guid.NewGuid():N}");
+        var dictDir = Path.Combine(baseDir, "data", "dictionaries");
+        Directory.CreateDirectory(dictDir);
+
+        try
+        {
+            // Create two JSON dictionary files
+            string json1 = """
+                {
+                    "version": "1.0",
+                    "entries": { "alpha": "ALPHA_REPLACED" }
+                }
+                """;
+            string json2 = """
+                {
+                    "version": "1.0",
+                    "entries": { "beta": "BETA_REPLACED" }
+                }
+                """;
+            File.WriteAllText(Path.Combine(dictDir, "a_first.json"), json1, Encoding.UTF8);
+            File.WriteAllText(Path.Combine(dictDir, "b_second.json"), json2, Encoding.UTF8);
+
+            // Also create a non-JSON file that should be ignored
+            File.WriteAllText(Path.Combine(dictDir, "ignored.txt"), "gamma\tGAMMA", Encoding.UTF8);
+
+            // Save and change working directory so that data/dictionaries/ is found
+            var originalDir = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(baseDir);
+            try
+            {
+                var dict = new CustomDictionary();
+                dict.LoadDefaults();
+
+                // Should have loaded entries from both JSON files
+                Assert.Equal(2, dict.Count);
+                Assert.Equal("ALPHA_REPLACED", dict.ApplyToText("alpha"));
+                Assert.Equal("BETA_REPLACED", dict.ApplyToText("beta"));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalDir);
+            }
+        }
+        finally
+        {
+            Directory.Delete(baseDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadDefaults_MalformedFile_SkippedSilently()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), $"piper_defaults_{Guid.NewGuid():N}");
+        var dictDir = Path.Combine(baseDir, "data", "dictionaries");
+        Directory.CreateDirectory(dictDir);
+
+        try
+        {
+            // One valid, one malformed JSON
+            string validJson = """
+                {
+                    "version": "1.0",
+                    "entries": { "good": "GOOD_ENTRY" }
+                }
+                """;
+            string badJson = "{ this is not valid JSON }}}";
+
+            File.WriteAllText(Path.Combine(dictDir, "a_valid.json"), validJson, Encoding.UTF8);
+            File.WriteAllText(Path.Combine(dictDir, "b_broken.json"), badJson, Encoding.UTF8);
+
+            var originalDir = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(baseDir);
+            try
+            {
+                var dict = new CustomDictionary();
+                dict.LoadDefaults(); // Must not throw
+
+                // The valid file's entry should have been loaded
+                Assert.True(dict.Count >= 1);
+                Assert.Equal("GOOD_ENTRY", dict.ApplyToText("good"));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalDir);
+            }
+        }
+        finally
+        {
+            Directory.Delete(baseDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadDefaults_SortedOrder_FilesLoadedAlphabetically()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), $"piper_defaults_{Guid.NewGuid():N}");
+        var dictDir = Path.Combine(baseDir, "data", "dictionaries");
+        Directory.CreateDirectory(dictDir);
+
+        try
+        {
+            // Two files with same key but different values.
+            // "a_first.json" loads first with priority 5,
+            // "b_second.json" loads second with priority 5 => does not override (equal priority keeps first).
+            string json1 = """
+                {
+                    "version": "2.0",
+                    "entries": { "KEY": { "pronunciation": "FROM_FIRST", "priority": 5 } }
+                }
+                """;
+            string json2 = """
+                {
+                    "version": "2.0",
+                    "entries": { "KEY": { "pronunciation": "FROM_SECOND", "priority": 5 } }
+                }
+                """;
+            File.WriteAllText(Path.Combine(dictDir, "a_first.json"), json1, Encoding.UTF8);
+            File.WriteAllText(Path.Combine(dictDir, "b_second.json"), json2, Encoding.UTF8);
+
+            var originalDir = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(baseDir);
+            try
+            {
+                var dict = new CustomDictionary();
+                dict.LoadDefaults();
+
+                // Equal priority: first loaded wins => "FROM_FIRST"
+                Assert.Equal("FROM_FIRST", dict.ApplyToText("KEY"));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalDir);
+            }
+        }
+        finally
+        {
+            Directory.Delete(baseDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadDefaults_OnlyLoadsFromFirstFoundDirectory()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), $"piper_defaults_{Guid.NewGuid():N}");
+        var dictDir = Path.Combine(baseDir, "data", "dictionaries");
+        Directory.CreateDirectory(dictDir);
+
+        // Create a second candidate directory one level up (would be searched later)
+        var parentDictDir = Path.Combine(baseDir, "..", "data", "dictionaries");
+
+        try
+        {
+            string json1 = """
+                {
+                    "version": "1.0",
+                    "entries": { "first_dir": "FOUND" }
+                }
+                """;
+            File.WriteAllText(Path.Combine(dictDir, "test.json"), json1, Encoding.UTF8);
+
+            // We only verify the working-directory path is used
+            var originalDir = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(baseDir);
+            try
+            {
+                var dict = new CustomDictionary();
+                dict.LoadDefaults();
+
+                Assert.True(dict.Count >= 1);
+                Assert.Equal("FOUND", dict.ApplyToText("first_dir"));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalDir);
+            }
+        }
+        finally
+        {
+            Directory.Delete(baseDir, true);
+        }
+    }
+
+    // ================================================================
+    // Case-insensitive deduplication
+    // ================================================================
+
+    [Fact]
+    public void AddEntry_CaseInsensitiveDedup_AllUpperAndAllLower()
+    {
+        // Loading "API" and then "api" (both case-insensitive) should deduplicate.
+        // The first loaded entry (priority 5) should be kept.
+        string content1 = "API\tエーピーアイ\n";
+        string content2 = "api\tshould-not-override\n";
+        string path1 = CreateTempFile(content1);
+        string path2 = CreateTempFile(content2);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path1);
+        dict.LoadDictionary(path2);
+
+        // "api" and "API" are both all-upper/all-lower and deduplicated.
+        Assert.Equal(1, dict.Count);
+        Assert.Equal("エーピーアイ", dict.ApplyToText("API"));
+    }
+
+    [Fact]
+    public void AddEntry_MixedCaseAndCaseInsensitive_AreSeparate()
+    {
+        // "PyTorch" (mixed case, case-sensitive) and "pytorch" (all lower, case-insensitive)
+        // should be stored as separate entries.
+        string content = "PyTorch\tミックス\npytorch\tインセンシティブ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal(2, dict.Count);
+        // "PyTorch" matches the case-sensitive entry
+        Assert.Equal("ミックス is here", dict.ApplyToText("PyTorch is here"));
+        // "PYTORCH" matches the case-insensitive entry (all-lower "pytorch")
+        Assert.Equal("インセンシティブ is here", dict.ApplyToText("PYTORCH is here"));
+    }
+
+    // ================================================================
+    // Word boundary: multiple occurrences
+    // ================================================================
+
+    [Fact]
+    public void ApplyToText_WordBoundary_MultipleOccurrences()
+    {
+        // "AI" should replace all standalone occurrences but skip embedded ones
+        string content = "AI\tエーアイ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("エーアイ is エーアイ but AIDS is not",
+            dict.ApplyToText("AI is AI but AIDS is not"));
+    }
+
+    [Fact]
+    public void ApplyToText_WordBoundary_WithPunctuation()
+    {
+        // Word boundaries should work correctly with adjacent punctuation
+        string content = "AI\tエーアイ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("エーアイ, エーアイ. エーアイ!",
+            dict.ApplyToText("AI, AI. AI!"));
+    }
+
+    [Fact]
+    public void ApplyToText_WordBoundary_HyphenatedWord()
+    {
+        // Hyphens count as word boundaries for \b
+        string content = "AI\tエーアイ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("エーアイ-powered", dict.ApplyToText("AI-powered"));
+    }
+
+    // ================================================================
+    // Regex special characters in keys
+    // ================================================================
+
+    [Fact]
+    public void ApplyToText_SpecialRegexChars_EscapedProperly()
+    {
+        // Keys containing regex special characters should be escaped properly
+        // by Regex.Escape() before being used in the pattern.
+        // Note: \b word-boundary only fires between word (\w) and non-word (\W)
+        // characters. "C++" has '+' which is non-word, so "\bC\+\+\b" won't
+        // match "C++ is" because there's no \b between '+' and ' '.
+        // Only keys that consist entirely of word characters get full boundary
+        // matching. This is the expected behavior matching C++ implementation.
+        string content = "C++\tシープラスプラス\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        // "C++" boundary: \b fires before C (word char after start/space),
+        // but not after ++ (both non-word). So the replacement does NOT fire.
+        // This is consistent with the word-boundary design.
+        Assert.Equal("C++ is great", dict.ApplyToText("C++ is great"));
+    }
+
+    [Fact]
+    public void ApplyToText_DotInKey_EscapedProperly()
+    {
+        // "." is a regex metacharacter
+        string content = "v2.0\tバージョンニ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Contains("バージョンニ", dict.ApplyToText("upgrade to v2.0"));
+    }
+
+    // ================================================================
+    // Non-ASCII case insensitivity
+    // ================================================================
+
+    [Fact]
+    public void ApplyToText_NonAscii_CaseInsensitive_JapaneseUnchanged()
+    {
+        // Japanese characters don't have case, so IsMixedCase returns false
+        // and matching uses OrdinalIgnoreCase (which is effectively Ordinal for CJK).
+        string content = "東京\tトウキョウ\n";
+        string path = CreateTempFile(content);
+
+        var dict = new CustomDictionary();
+        dict.LoadDictionary(path);
+
+        Assert.Equal("トウキョウは首都です", dict.ApplyToText("東京は首都です"));
+    }
+
+    // ================================================================
+    // LoadDefaults with explicit --custom-dict integration
+    // ================================================================
+
+    [Fact]
+    public void LoadDefaults_ThenUserFile_UserOverridesDefaults()
+    {
+        // Simulates the CLI behavior: LoadDefaults (lower priority), then
+        // load user-specified files. User files with higher priority should win.
+        var baseDir = Path.Combine(Path.GetTempPath(), $"piper_defaults_{Guid.NewGuid():N}");
+        var dictDir = Path.Combine(baseDir, "data", "dictionaries");
+        Directory.CreateDirectory(dictDir);
+
+        try
+        {
+            // Default dictionary with priority 5
+            string defaultJson = """
+                {
+                    "version": "2.0",
+                    "entries": {
+                        "API": { "pronunciation": "default-pron", "priority": 5 }
+                    }
+                }
+                """;
+            File.WriteAllText(Path.Combine(dictDir, "defaults.json"), defaultJson, Encoding.UTF8);
+
+            // User dictionary with priority 8
+            string userJson = """
+                {
+                    "version": "2.0",
+                    "entries": {
+                        "API": { "pronunciation": "user-pron", "priority": 8 }
+                    }
+                }
+                """;
+            string userFile = CreateTempJsonFile(userJson);
+
+            var originalDir = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(baseDir);
+            try
+            {
+                var dict = new CustomDictionary();
+                dict.LoadDefaults();        // defaults first (priority 5)
+                dict.LoadDictionary(userFile);  // user override (priority 8)
+
+                // User entry should win
+                Assert.Equal("user-pron", dict.ApplyToText("API"));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalDir);
+            }
+        }
+        finally
+        {
+            Directory.Delete(baseDir, true);
+        }
     }
 }

--- a/src/csharp/PiperPlus.Core.Tests/InlinePhonemeParserTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/InlinePhonemeParserTests.cs
@@ -133,29 +133,45 @@ public sealed class InlinePhonemeParserTests
     }
 
     // ================================================================
-    // 9. Empty brackets — no phoneme segment added
+    // 9. Empty brackets — empty phoneme segment kept (matches C++)
     // ================================================================
 
     [Fact]
-    public void Parse_EmptyBrackets_NoPhonemeSegment()
+    public void Parse_EmptyBrackets_EmptyPhonemeSegmentKept()
     {
         var result = InlinePhonemeParser.Parse("hello [[]] world");
 
-        // Empty brackets produce no phoneme segment, but the surrounding text
-        // may be split into segments.
-        Assert.DoesNotContain(result, s => s.IsPhonemes);
+        Assert.Equal(3, result.Count);
+
+        Assert.False(result[0].IsPhonemes);
+        Assert.Equal("hello ", result[0].Text);
+
+        Assert.True(result[1].IsPhonemes);
+        Assert.Equal("", result[1].Text);
+
+        Assert.False(result[2].IsPhonemes);
+        Assert.Equal(" world", result[2].Text);
     }
 
     // ================================================================
-    // 10. Whitespace-only brackets — no phoneme segment added
+    // 10. Whitespace-only brackets — empty phoneme segment kept (matches C++)
     // ================================================================
 
     [Fact]
-    public void Parse_WhitespaceOnlyBrackets_NoPhonemeSegment()
+    public void Parse_WhitespaceOnlyBrackets_EmptyPhonemeSegmentKept()
     {
         var result = InlinePhonemeParser.Parse("hello [[   ]] world");
 
-        Assert.DoesNotContain(result, s => s.IsPhonemes);
+        Assert.Equal(3, result.Count);
+
+        Assert.False(result[0].IsPhonemes);
+        Assert.Equal("hello ", result[0].Text);
+
+        Assert.True(result[1].IsPhonemes);
+        Assert.Equal("", result[1].Text);
+
+        Assert.False(result[2].IsPhonemes);
+        Assert.Equal(" world", result[2].Text);
     }
 
     // ================================================================
@@ -227,17 +243,24 @@ public sealed class InlinePhonemeParserTests
     }
 
     // ================================================================
-    // 15. Whitespace-only text between blocks is skipped
+    // 15. Whitespace-only text between blocks is kept (matches C++)
     // ================================================================
 
     [Fact]
-    public void Parse_WhitespaceOnlyTextBetweenBlocks_Skipped()
+    public void Parse_WhitespaceOnlyTextBetweenBlocks_Kept()
     {
-        // Whitespace-only text segments between phoneme blocks are omitted
+        // Whitespace-only text segments between phoneme blocks are preserved
         var result = InlinePhonemeParser.Parse("[[ a ]]   [[ b ]]");
 
-        Assert.Equal(2, result.Count);
+        Assert.Equal(3, result.Count);
+
         Assert.True(result[0].IsPhonemes);
-        Assert.True(result[1].IsPhonemes);
+        Assert.Equal("a", result[0].Text);
+
+        Assert.False(result[1].IsPhonemes);
+        Assert.Equal("   ", result[1].Text);
+
+        Assert.True(result[2].IsPhonemes);
+        Assert.Equal("b", result[2].Text);
     }
 }

--- a/src/csharp/PiperPlus.Core.Tests/InlinePhonemeParserTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/InlinePhonemeParserTests.cs
@@ -1,0 +1,243 @@
+using PiperPlus.Core.Phonemize;
+
+namespace PiperPlus.Core.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="InlinePhonemeParser"/>.
+/// Covers parsing of <c>[[ phoneme ]]</c> inline notation into
+/// <see cref="TextOrPhonemes"/> segments.
+/// </summary>
+public sealed class InlinePhonemeParserTests
+{
+    // ================================================================
+    // 1. No notation — single text segment
+    // ================================================================
+
+    [Fact]
+    public void Parse_NoNotation_ReturnsSingleTextSegment()
+    {
+        var result = InlinePhonemeParser.Parse("Hello world");
+
+        Assert.Single(result);
+        Assert.False(result[0].IsPhonemes);
+        Assert.Equal("Hello world", result[0].Text);
+    }
+
+    // ================================================================
+    // 2. Only phonemes — single phoneme segment
+    // ================================================================
+
+    [Fact]
+    public void Parse_OnlyPhonemes_ReturnsSinglePhonemeSegment()
+    {
+        var result = InlinePhonemeParser.Parse("[[ h @ l oU ]]");
+
+        Assert.Single(result);
+        Assert.True(result[0].IsPhonemes);
+        Assert.Equal("h @ l oU", result[0].Text);
+    }
+
+    // ================================================================
+    // 3. Mixed: text + phonemes + text
+    // ================================================================
+
+    [Fact]
+    public void Parse_Mixed_ReturnsThreeSegments()
+    {
+        var result = InlinePhonemeParser.Parse("Hello [[ h @ l oU ]] world");
+
+        Assert.Equal(3, result.Count);
+
+        Assert.False(result[0].IsPhonemes);
+        Assert.Equal("Hello ", result[0].Text);
+
+        Assert.True(result[1].IsPhonemes);
+        Assert.Equal("h @ l oU", result[1].Text);
+
+        Assert.False(result[2].IsPhonemes);
+        Assert.Equal(" world", result[2].Text);
+    }
+
+    // ================================================================
+    // 4. Multiple inline phoneme blocks
+    // ================================================================
+
+    [Fact]
+    public void Parse_MultipleBlocks_ReturnsAlternatingSegments()
+    {
+        var result = InlinePhonemeParser.Parse("[[ a ]] and [[ b ]]");
+
+        Assert.Equal(3, result.Count);
+
+        Assert.True(result[0].IsPhonemes);
+        Assert.Equal("a", result[0].Text);
+
+        Assert.False(result[1].IsPhonemes);
+        Assert.Equal(" and ", result[1].Text);
+
+        Assert.True(result[2].IsPhonemes);
+        Assert.Equal("b", result[2].Text);
+    }
+
+    // ================================================================
+    // 5. Empty input — empty list
+    // ================================================================
+
+    [Fact]
+    public void Parse_EmptyInput_ReturnsEmptyList()
+    {
+        Assert.Empty(InlinePhonemeParser.Parse(""));
+    }
+
+    // ================================================================
+    // 6. Null input — empty list
+    // ================================================================
+
+    [Fact]
+    public void Parse_NullInput_ReturnsEmptyList()
+    {
+        Assert.Empty(InlinePhonemeParser.Parse(null));
+    }
+
+    // ================================================================
+    // 7. Nested brackets (invalid) — treated as text
+    // ================================================================
+
+    [Fact]
+    public void Parse_NestedBrackets_TreatedAsText()
+    {
+        // "[[ [[ a ]] ]]" — the regex will match the first valid [[ ... ]]
+        // The outer brackets and trailing ]] become text.
+        var result = InlinePhonemeParser.Parse("[[ [[ a ]] ]]");
+
+        // The regex matches "[[ [[ a ]]" as the first match (greedy inner)
+        // Then " ]]" is trailing text.
+        // Actual match: [[ ... ]] where inner is "[[ a"
+        Assert.True(result.Count >= 1);
+        // At least one phoneme segment should be found
+        Assert.Contains(result, s => s.IsPhonemes);
+    }
+
+    // ================================================================
+    // 8. Whitespace inside brackets is trimmed
+    // ================================================================
+
+    [Fact]
+    public void Parse_WhitespaceInsideBrackets_IsTrimmed()
+    {
+        var result = InlinePhonemeParser.Parse("[[   h @ l oU   ]]");
+
+        Assert.Single(result);
+        Assert.True(result[0].IsPhonemes);
+        Assert.Equal("h @ l oU", result[0].Text);
+    }
+
+    // ================================================================
+    // 9. Empty brackets — no phoneme segment added
+    // ================================================================
+
+    [Fact]
+    public void Parse_EmptyBrackets_NoPhonemeSegment()
+    {
+        var result = InlinePhonemeParser.Parse("hello [[]] world");
+
+        // Empty brackets produce no phoneme segment, but the surrounding text
+        // may be split into segments.
+        Assert.DoesNotContain(result, s => s.IsPhonemes);
+    }
+
+    // ================================================================
+    // 10. Whitespace-only brackets — no phoneme segment added
+    // ================================================================
+
+    [Fact]
+    public void Parse_WhitespaceOnlyBrackets_NoPhonemeSegment()
+    {
+        var result = InlinePhonemeParser.Parse("hello [[   ]] world");
+
+        Assert.DoesNotContain(result, s => s.IsPhonemes);
+    }
+
+    // ================================================================
+    // 11. Single bracket pairs are not matched
+    // ================================================================
+
+    [Fact]
+    public void Parse_SingleBrackets_NotMatched()
+    {
+        var result = InlinePhonemeParser.Parse("hello [ not phonemes ] world");
+
+        Assert.Single(result);
+        Assert.False(result[0].IsPhonemes);
+        Assert.Equal("hello [ not phonemes ] world", result[0].Text);
+    }
+
+    // ================================================================
+    // 12. Adjacent phoneme blocks with no text between
+    // ================================================================
+
+    [Fact]
+    public void Parse_AdjacentBlocks_NoTextBetween()
+    {
+        var result = InlinePhonemeParser.Parse("[[ a ]][[ b ]]");
+
+        Assert.Equal(2, result.Count);
+
+        Assert.True(result[0].IsPhonemes);
+        Assert.Equal("a", result[0].Text);
+
+        Assert.True(result[1].IsPhonemes);
+        Assert.Equal("b", result[1].Text);
+    }
+
+    // ================================================================
+    // 13. Phoneme block at start of string
+    // ================================================================
+
+    [Fact]
+    public void Parse_PhonemeBlockAtStart()
+    {
+        var result = InlinePhonemeParser.Parse("[[ a b ]] followed by text");
+
+        Assert.Equal(2, result.Count);
+
+        Assert.True(result[0].IsPhonemes);
+        Assert.Equal("a b", result[0].Text);
+
+        Assert.False(result[1].IsPhonemes);
+        Assert.Equal(" followed by text", result[1].Text);
+    }
+
+    // ================================================================
+    // 14. Phoneme block at end of string
+    // ================================================================
+
+    [Fact]
+    public void Parse_PhonemeBlockAtEnd()
+    {
+        var result = InlinePhonemeParser.Parse("text before [[ a b ]]");
+
+        Assert.Equal(2, result.Count);
+
+        Assert.False(result[0].IsPhonemes);
+        Assert.Equal("text before ", result[0].Text);
+
+        Assert.True(result[1].IsPhonemes);
+        Assert.Equal("a b", result[1].Text);
+    }
+
+    // ================================================================
+    // 15. Whitespace-only text between blocks is skipped
+    // ================================================================
+
+    [Fact]
+    public void Parse_WhitespaceOnlyTextBetweenBlocks_Skipped()
+    {
+        // Whitespace-only text segments between phoneme blocks are omitted
+        var result = InlinePhonemeParser.Parse("[[ a ]]   [[ b ]]");
+
+        Assert.Equal(2, result.Count);
+        Assert.True(result[0].IsPhonemes);
+        Assert.True(result[1].IsPhonemes);
+    }
+}

--- a/src/csharp/PiperPlus.Core.Tests/ModelManagerTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/ModelManagerTests.cs
@@ -383,25 +383,27 @@ public sealed class ModelManagerTests : IDisposable
     public async Task ResolveModelPathAsync_KnownVoiceName_ChecksCacheDir()
     {
         // Resolve with a known voice name but no cached file.
-        // This should either:
-        //   (a) find a cached file and return it, or
-        //   (b) attempt download (which may fail in CI),
-        //       throwing InvalidOperationException.
-        // We use a temp directory as modelDir so there's definitely no cache.
+        // Outcome depends on network availability:
+        //   (a) Download succeeds → returns path to downloaded .onnx file
+        //   (b) Download fails → throws InvalidOperationException or FileNotFoundException
+        // Both outcomes are valid in CI.
         var tempDir = Path.Combine(Path.GetTempPath(), $"resolve_test_{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempDir);
         try
         {
-            // Use a known voice name from the catalog
-            var ex = await Assert.ThrowsAnyAsync<Exception>(
-                () => ModelManager.ResolveModelPathAsync(
-                    "tsukuyomi", tempDir, TestContext.Current.CancellationToken));
+            try
+            {
+                string result = await ModelManager.ResolveModelPathAsync(
+                    "tsukuyomi", tempDir, TestContext.Current.CancellationToken);
 
-            // Should be InvalidOperationException (download failed) or
-            // FileNotFoundException (ONNX file not found after download)
-            Assert.True(
-                ex is InvalidOperationException || ex is FileNotFoundException,
-                $"Expected InvalidOperationException or FileNotFoundException, got {ex.GetType().Name}: {ex.Message}");
+                // Download succeeded: result should be a valid .onnx path
+                Assert.True(result.EndsWith(".onnx", StringComparison.OrdinalIgnoreCase),
+                    $"Expected .onnx path, got: {result}");
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or FileNotFoundException)
+            {
+                // Download failed: expected in offline/restricted environments
+            }
         }
         finally
         {

--- a/src/csharp/PiperPlus.Core.Tests/ModelManagerTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/ModelManagerTests.cs
@@ -382,32 +382,30 @@ public sealed class ModelManagerTests : IDisposable
     [Fact]
     public async Task ResolveModelPathAsync_KnownVoiceName_ChecksCacheDir()
     {
-        // Resolve with a known voice name but no cached file.
-        // Outcome depends on network availability:
-        //   (a) Download succeeds → returns path to downloaded .onnx file
-        //   (b) Download fails → throws InvalidOperationException or FileNotFoundException
-        // Both outcomes are valid in CI.
+        // Use a known voice and simulate cache hit
+        var voice = ModelManager.FindVoice("tsukuyomi");
+        Assert.NotNull(voice);
+
+        var onnxFile = voice!.Files
+            .FirstOrDefault(f => f.RelativePath.EndsWith(".onnx", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(onnxFile);
+
         var tempDir = Path.Combine(Path.GetTempPath(), $"resolve_test_{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempDir);
         try
         {
-            try
-            {
-                string result = await ModelManager.ResolveModelPathAsync(
-                    "tsukuyomi", tempDir, TestContext.Current.CancellationToken);
+            var cachedPath = Path.Combine(tempDir, Path.GetFileName(onnxFile!.RelativePath));
+            await File.WriteAllBytesAsync(cachedPath, new byte[] { 0 },
+                TestContext.Current.CancellationToken);
 
-                // Download succeeded: result should be a valid .onnx path
-                Assert.True(result.EndsWith(".onnx", StringComparison.OrdinalIgnoreCase),
-                    $"Expected .onnx path, got: {result}");
-            }
-            catch (Exception ex) when (ex is InvalidOperationException or FileNotFoundException)
-            {
-                // Download failed: expected in offline/restricted environments
-            }
+            string result = await ModelManager.ResolveModelPathAsync(
+                "tsukuyomi", tempDir, TestContext.Current.CancellationToken);
+
+            Assert.Equal(cachedPath, result);
         }
         finally
         {
-            try { Directory.Delete(tempDir, true); } catch { /* best-effort */ }
+            try { Directory.Delete(tempDir, true); } catch { }
         }
     }
 
@@ -475,15 +473,34 @@ public sealed class ModelManagerTests : IDisposable
     [Fact]
     public async Task ResolveModelPathAsync_NullModelDir_UsesDefault()
     {
-        // When modelDir is null, ResolveModelPathAsync should fall back to
-        // GetDefaultModelDir(). We can't easily test the download path,
-        // but we can verify it doesn't throw NullReferenceException.
-        // Use a nonexistent model name to trigger FileNotFoundException.
-        await Assert.ThrowsAsync<FileNotFoundException>(
-            () => ModelManager.ResolveModelPathAsync(
-                "nonexistent-model-xyz",
-                null,
-                TestContext.Current.CancellationToken));
+        var voice = ModelManager.FindVoice("css10");
+        Assert.NotNull(voice);
+
+        var onnxFile = voice!.Files
+            .FirstOrDefault(f => f.RelativePath.EndsWith(".onnx", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(onnxFile);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"resolve_default_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        var originalEnv = Environment.GetEnvironmentVariable("PIPER_MODEL_DIR");
+        Environment.SetEnvironmentVariable("PIPER_MODEL_DIR", tempDir);
+        try
+        {
+            var cachedPath = Path.Combine(tempDir, Path.GetFileName(onnxFile!.RelativePath));
+            await File.WriteAllBytesAsync(cachedPath, new byte[] { 0 },
+                TestContext.Current.CancellationToken);
+
+            string result = await ModelManager.ResolveModelPathAsync(
+                "css10", null, TestContext.Current.CancellationToken);
+
+            Assert.Equal(cachedPath, result);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PIPER_MODEL_DIR", originalEnv);
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
     }
 
     [Fact]

--- a/src/csharp/PiperPlus.Core.Tests/ModelManagerTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/ModelManagerTests.cs
@@ -330,4 +330,182 @@ public sealed class ModelManagerTests : IDisposable
             }
         }
     }
+
+    // ================================================================
+    // ResolveModelPathAsync — file path resolution
+    // ================================================================
+
+    [Fact]
+    public async Task ResolveModelPathAsync_ExistingFile_ReturnsFullPath()
+    {
+        // Create a temporary .onnx file to simulate a local model.
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_model_{Guid.NewGuid():N}.onnx");
+        try
+        {
+            await File.WriteAllBytesAsync(tempFile, new byte[] { 0 },
+                TestContext.Current.CancellationToken);
+
+            string result = await ModelManager.ResolveModelPathAsync(
+                tempFile, null, TestContext.Current.CancellationToken);
+
+            Assert.Equal(Path.GetFullPath(tempFile), result);
+        }
+        finally
+        {
+            try { File.Delete(tempFile); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ResolveModelPathAsync_NonexistentFileNorModelName_ThrowsFileNotFound()
+    {
+        // A string that is neither an existing file nor a known model name
+        // should throw FileNotFoundException.
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => ModelManager.ResolveModelPathAsync(
+                "totally-nonexistent-model-xyz-12345",
+                null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ResolveModelPathAsync_EmptyString_ThrowsFileNotFound()
+    {
+        // Empty string is not a file and not a model name.
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => ModelManager.ResolveModelPathAsync(
+                "",
+                null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ResolveModelPathAsync_KnownVoiceName_ChecksCacheDir()
+    {
+        // Resolve with a known voice name but no cached file.
+        // This should either:
+        //   (a) find a cached file and return it, or
+        //   (b) attempt download (which may fail in CI),
+        //       throwing InvalidOperationException.
+        // We use a temp directory as modelDir so there's definitely no cache.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"resolve_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Use a known voice name from the catalog
+            var ex = await Assert.ThrowsAnyAsync<Exception>(
+                () => ModelManager.ResolveModelPathAsync(
+                    "tsukuyomi", tempDir, TestContext.Current.CancellationToken));
+
+            // Should be InvalidOperationException (download failed) or
+            // FileNotFoundException (ONNX file not found after download)
+            Assert.True(
+                ex is InvalidOperationException || ex is FileNotFoundException,
+                $"Expected InvalidOperationException or FileNotFoundException, got {ex.GetType().Name}: {ex.Message}");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ResolveModelPathAsync_KnownVoiceWithCachedOnnx_ReturnsCachedPath()
+    {
+        // Simulate a cached ONNX file for a known voice.
+        var voice = ModelManager.FindVoice("tsukuyomi");
+        Assert.NotNull(voice);
+
+        var onnxFile = voice!.Files
+            .FirstOrDefault(f => f.RelativePath.EndsWith(".onnx", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(onnxFile);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"resolve_cache_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Create a fake cached ONNX file with the expected name
+            var cachedPath = Path.Combine(tempDir, Path.GetFileName(onnxFile!.RelativePath));
+            await File.WriteAllBytesAsync(cachedPath, new byte[] { 0 },
+                TestContext.Current.CancellationToken);
+
+            string result = await ModelManager.ResolveModelPathAsync(
+                "tsukuyomi", tempDir, TestContext.Current.CancellationToken);
+
+            Assert.Equal(cachedPath, result);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ResolveModelPathAsync_AliasResolvesToCachedFile()
+    {
+        // Resolve using an alias (e.g., "css10") with a cached ONNX file.
+        var voice = ModelManager.FindVoice("css10");
+        Assert.NotNull(voice);
+
+        var onnxFile = voice!.Files
+            .FirstOrDefault(f => f.RelativePath.EndsWith(".onnx", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(onnxFile);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"resolve_alias_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var cachedPath = Path.Combine(tempDir, Path.GetFileName(onnxFile!.RelativePath));
+            await File.WriteAllBytesAsync(cachedPath, new byte[] { 0 },
+                TestContext.Current.CancellationToken);
+
+            string result = await ModelManager.ResolveModelPathAsync(
+                "css10", tempDir, TestContext.Current.CancellationToken);
+
+            Assert.Equal(cachedPath, result);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ResolveModelPathAsync_NullModelDir_UsesDefault()
+    {
+        // When modelDir is null, ResolveModelPathAsync should fall back to
+        // GetDefaultModelDir(). We can't easily test the download path,
+        // but we can verify it doesn't throw NullReferenceException.
+        // Use a nonexistent model name to trigger FileNotFoundException.
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => ModelManager.ResolveModelPathAsync(
+                "nonexistent-model-xyz",
+                null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ResolveModelPathAsync_FilePathPrioritizedOverModelName()
+    {
+        // If a file exists on disk AND matches a model name, the file path
+        // should be returned (file check happens first).
+        var tempDir = Path.Combine(Path.GetTempPath(), $"resolve_priority_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var tempFile = Path.Combine(tempDir, "tsukuyomi");  // matches alias name
+        try
+        {
+            await File.WriteAllBytesAsync(tempFile, new byte[] { 0 },
+                TestContext.Current.CancellationToken);
+
+            string result = await ModelManager.ResolveModelPathAsync(
+                tempFile, null, TestContext.Current.CancellationToken);
+
+            // Should return the file path, not resolve as a model name
+            Assert.Equal(Path.GetFullPath(tempFile), result);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { /* best-effort */ }
+        }
+    }
 }

--- a/src/csharp/PiperPlus.Core/Config/ModelManager.cs
+++ b/src/csharp/PiperPlus.Core/Config/ModelManager.cs
@@ -357,6 +357,81 @@ public static class ModelManager
     }
 
     // ------------------------------------------------------------------
+    // ResolveModelPathAsync
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Resolves a model path from a file path, model name, or alias.
+    /// <list type="number">
+    ///   <item><description>If <paramref name="modelStr"/> exists as a file, returns it directly.</description></item>
+    ///   <item><description>If it matches a model name/alias, checks for a locally cached ONNX file.</description></item>
+    ///   <item><description>If not cached, auto-downloads the model and returns the ONNX path.</description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="modelStr">File path, model name, or alias.</param>
+    /// <param name="modelDir">
+    /// Directory for cached models. Falls back to <see cref="GetDefaultModelDir"/>.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Absolute path to the resolved <c>.onnx</c> model file.</returns>
+    /// <exception cref="FileNotFoundException">
+    /// Thrown when <paramref name="modelStr"/> is not a file and not a known model name,
+    /// or when the downloaded model does not contain an ONNX file.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the download fails.
+    /// </exception>
+    public static async Task<string> ResolveModelPathAsync(
+        string modelStr, string? modelDir = null, CancellationToken ct = default)
+    {
+        // 1. Direct file path
+        if (File.Exists(modelStr))
+            return Path.GetFullPath(modelStr);
+
+        // 2. Try as model name/alias
+        var voice = FindVoice(modelStr);
+        if (voice is null)
+        {
+            throw new FileNotFoundException(
+                $"Model '{modelStr}' not found as file or model name. " +
+                "Use --list-models to see available models.");
+        }
+
+        var dir = modelDir ?? GetDefaultModelDir();
+
+        // Find the .onnx file entry in the voice catalog
+        var onnxFile = voice.Files
+            .FirstOrDefault(f => f.RelativePath.EndsWith(".onnx", StringComparison.OrdinalIgnoreCase));
+
+        // Check if already cached locally
+        if (onnxFile is not null)
+        {
+            var cachedPath = Path.Combine(dir, Path.GetFileName(onnxFile.RelativePath));
+            if (File.Exists(cachedPath))
+                return cachedPath;
+        }
+
+        // 3. Auto-download
+        Console.Error.WriteLine($"Model '{voice.Key}' not found locally. Downloading...");
+        bool success = await DownloadModelAsync(voice.Key, dir, ct).ConfigureAwait(false);
+        if (!success)
+        {
+            throw new InvalidOperationException(
+                $"Failed to download model '{voice.Key}'.");
+        }
+
+        if (onnxFile is not null)
+        {
+            var downloadedPath = Path.Combine(dir, Path.GetFileName(onnxFile.RelativePath));
+            if (File.Exists(downloadedPath))
+                return downloadedPath;
+        }
+
+        throw new FileNotFoundException(
+            $"Model '{voice.Key}' downloaded but ONNX file not found in {dir}.");
+    }
+
+    // ------------------------------------------------------------------
     // Private: file download via HttpClient
     // ------------------------------------------------------------------
 

--- a/src/csharp/PiperPlus.Core/Phonemize/CustomDictionary.cs
+++ b/src/csharp/PiperPlus.Core/Phonemize/CustomDictionary.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -60,10 +61,18 @@ public sealed class CustomDictionary
     }
 
     /// <summary>
-    /// A single dictionary entry with key, value (replacement text) and priority.
+    /// A single dictionary entry with key, value (replacement text), priority,
+    /// and case-sensitivity flag.
     /// Higher priority wins when the same key is loaded from multiple files.
     /// </summary>
-    private record DictionaryEntry(string Key, string Value, int Priority = 5);
+    /// <param name="Key">The original dictionary key (before any normalization).</param>
+    /// <param name="Value">The replacement text (pronunciation).</param>
+    /// <param name="Priority">Priority for conflict resolution (higher wins).</param>
+    /// <param name="IsCaseSensitive">
+    /// <c>true</c> for mixed-case keys (e.g. "PyTorch") that must match exactly;
+    /// <c>false</c> for all-upper or all-lower keys that match case-insensitively.
+    /// </param>
+    private record DictionaryEntry(string Key, string Value, int Priority = 5, bool IsCaseSensitive = false);
 
     // Entries stored with priority support.
     // Kept in a list so we can sort by key length for longest-match-first application.
@@ -215,20 +224,82 @@ public sealed class CustomDictionary
 
     private void AddEntry(string key, string value, int priority)
     {
-        var existing = _entries.FindIndex(e => e.Key == key);
+        bool caseSensitive = IsMixedCase(key);
+
+        // For case-insensitive entries, match by lowered key to deduplicate
+        // (e.g. "API" and "api" should be treated as the same entry).
+        var existing = _entries.FindIndex(e =>
+            caseSensitive
+                ? (e.IsCaseSensitive && e.Key == key)
+                : (!e.IsCaseSensitive && string.Equals(e.Key, key, StringComparison.OrdinalIgnoreCase)));
+
         if (existing >= 0)
         {
             if (priority <= _entries[existing].Priority)
                 return; // Existing has higher or equal priority — keep it.
 
-            _entries[existing] = new DictionaryEntry(key, value, priority);
+            _entries[existing] = new DictionaryEntry(key, value, priority, caseSensitive);
         }
         else
         {
-            _entries.Add(new DictionaryEntry(key, value, priority));
+            _entries.Add(new DictionaryEntry(key, value, priority, caseSensitive));
         }
 
         _dirty = true;
+    }
+
+    /// <summary>
+    /// Load default dictionaries from standard locations.
+    /// <para>
+    /// Searches for a <c>data/dictionaries/</c> directory relative to the
+    /// application base directory, its parent directories, and the current
+    /// working directory.  All <c>*.json</c> files in the first directory
+    /// found are loaded in ordinal-sorted order (matching C++ behaviour).
+    /// Files that fail to parse are silently skipped with a log warning.
+    /// </para>
+    /// </summary>
+    public void LoadDefaults()
+    {
+        var searchPaths = new List<string>();
+
+        // Exe-relative paths (matches C++ findDictDir candidates)
+        var exeDir = AppContext.BaseDirectory.TrimEnd(
+            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        searchPaths.Add(Path.Combine(exeDir, "data", "dictionaries"));
+        searchPaths.Add(Path.Combine(exeDir, "..", "data", "dictionaries"));
+        searchPaths.Add(Path.Combine(exeDir, "..", "..", "data", "dictionaries"));
+
+        // Working directory
+        searchPaths.Add(Path.Combine(
+            Directory.GetCurrentDirectory(), "data", "dictionaries"));
+
+        foreach (var searchPath in searchPaths)
+        {
+            if (!Directory.Exists(searchPath))
+                continue;
+
+            // Load in sorted order (matching C++ behaviour)
+            var files = Directory.GetFiles(searchPath, "*.json")
+                .OrderBy(f => f, StringComparer.Ordinal)
+                .ToArray();
+
+            foreach (var file in files)
+            {
+                try
+                {
+                    LoadDictionary(file);
+                }
+                catch (Exception ex)
+                {
+                    s_logger.LogWarning(
+                        "Failed to load default dictionary {File}: {Message}",
+                        file, ex.Message);
+                }
+            }
+
+            // Only load from first found directory
+            return;
+        }
     }
 
     /// <summary>
@@ -262,7 +333,11 @@ public sealed class CustomDictionary
     /// Apply all dictionary entries to <paramref name="text"/>.
     /// <para>
     /// Entries are applied in longest-key-first order (longest match wins).
-    /// Replacement is case-sensitive.
+    /// Mixed-case keys (e.g. "PyTorch") match case-sensitively; all-upper
+    /// or all-lower keys (e.g. "AI", "python") match case-insensitively.
+    /// ASCII-only keys use word-boundary matching (<c>\b</c>) to prevent
+    /// partial matches (e.g. "AI" does not match inside "AIDS").
+    /// Non-ASCII keys (Japanese, Chinese, etc.) use simple substring replacement.
     /// </para>
     /// </summary>
     /// <param name="text">Input text.</param>
@@ -290,12 +365,60 @@ public sealed class CustomDictionary
 
         foreach (var entry in _sorted)
         {
-            if (text.Contains(entry.Key, StringComparison.Ordinal))
+            if (IsAsciiOnly(entry.Key))
             {
-                text = text.Replace(entry.Key, entry.Value, StringComparison.Ordinal);
+                // ASCII words: use \b word boundary to prevent partial matches.
+                var pattern = @"\b" + Regex.Escape(entry.Key) + @"\b";
+                var options = entry.IsCaseSensitive
+                    ? RegexOptions.None
+                    : RegexOptions.IgnoreCase;
+                text = Regex.Replace(text, pattern, entry.Value, options);
+            }
+            else
+            {
+                // Non-ASCII (Japanese, Chinese, etc.): simple substring replacement.
+                var comparison = entry.IsCaseSensitive
+                    ? StringComparison.Ordinal
+                    : StringComparison.OrdinalIgnoreCase;
+                text = text.Replace(entry.Key, entry.Value, comparison);
             }
         }
 
         return text;
+    }
+
+    // ----------------------------------------------------------------
+    // Helper methods for case sensitivity and word boundary detection
+    // ----------------------------------------------------------------
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="word"/> contains both
+    /// upper-case and lower-case characters (e.g. "PyTorch", "iPhone").
+    /// Such words are stored in the case-sensitive bucket and require
+    /// exact-case matching.
+    /// </summary>
+    private static bool IsMixedCase(string word)
+    {
+        bool hasUpper = false, hasLower = false;
+        foreach (char c in word)
+        {
+            if (char.IsUpper(c)) hasUpper = true;
+            if (char.IsLower(c)) hasLower = true;
+            if (hasUpper && hasLower) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when every character in <paramref name="word"/>
+    /// is in the ASCII range (0-127). Non-ASCII words (Japanese, Chinese,
+    /// etc.) skip <c>\b</c> word-boundary matching because regex word
+    /// boundaries do not work reliably with multi-byte characters.
+    /// </summary>
+    private static bool IsAsciiOnly(string word)
+    {
+        foreach (char c in word)
+            if (c > 127) return false;
+        return true;
     }
 }

--- a/src/csharp/PiperPlus.Core/Phonemize/CustomDictionary.cs
+++ b/src/csharp/PiperPlus.Core/Phonemize/CustomDictionary.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -51,6 +52,8 @@ public sealed class CustomDictionary
 {
     private static ILogger s_logger = NullLogger.Instance;
 
+    private static readonly ConcurrentDictionary<string, Regex> _regexCache = new();
+
     /// <summary>
     /// Replace the default (no-op) logger used for dictionary load warnings.
     /// Call once at application startup; not required for correct operation.
@@ -58,6 +61,18 @@ public sealed class CustomDictionary
     public static void SetLogger(ILogger logger)
     {
         s_logger = logger ?? NullLogger.Instance;
+    }
+
+    private static Regex GetOrCreateRegex(string key, bool caseSensitive)
+    {
+        string cacheKey = key + (caseSensitive ? "_cs" : "_ci");
+        return _regexCache.GetOrAdd(cacheKey, _ =>
+        {
+            var pattern = @"\b" + Regex.Escape(key) + @"\b";
+            var options = RegexOptions.Compiled | RegexOptions.CultureInvariant;
+            if (!caseSensitive) options |= RegexOptions.IgnoreCase;
+            return new Regex(pattern, options);
+        });
     }
 
     /// <summary>
@@ -365,14 +380,15 @@ public sealed class CustomDictionary
 
         foreach (var entry in _sorted)
         {
-            if (IsAsciiOnly(entry.Key))
+            if (StartsWithAscii(entry.Key))
             {
+                // Fast pre-check: skip regex if the key doesn't appear at all.
+                if (text.IndexOf(entry.Key, entry.IsCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
                 // ASCII words: use \b word boundary to prevent partial matches.
-                var pattern = @"\b" + Regex.Escape(entry.Key) + @"\b";
-                var options = entry.IsCaseSensitive
-                    ? RegexOptions.None
-                    : RegexOptions.IgnoreCase;
-                text = Regex.Replace(text, pattern, entry.Value, options);
+                var regex = GetOrCreateRegex(entry.Key, entry.IsCaseSensitive);
+                text = regex.Replace(text, entry.Value);
             }
             else
             {
@@ -410,15 +426,14 @@ public sealed class CustomDictionary
     }
 
     /// <summary>
-    /// Returns <c>true</c> when every character in <paramref name="word"/>
-    /// is in the ASCII range (0-127). Non-ASCII words (Japanese, Chinese,
-    /// etc.) skip <c>\b</c> word-boundary matching because regex word
-    /// boundaries do not work reliably with multi-byte characters.
+    /// Returns <c>true</c> when the first character of <paramref name="word"/>
+    /// is in the ASCII range (0-127), matching the C++ implementation.
+    /// Words starting with non-ASCII characters (Japanese, Chinese, etc.)
+    /// skip <c>\b</c> word-boundary matching because regex word boundaries
+    /// do not work reliably with multi-byte characters.
     /// </summary>
-    private static bool IsAsciiOnly(string word)
+    private static bool StartsWithAscii(string word)
     {
-        foreach (char c in word)
-            if (c > 127) return false;
-        return true;
+        return word.Length > 0 && word[0] <= 127;
     }
 }

--- a/src/csharp/PiperPlus.Core/Phonemize/InlinePhonemeParser.cs
+++ b/src/csharp/PiperPlus.Core/Phonemize/InlinePhonemeParser.cs
@@ -1,0 +1,81 @@
+using System.Text.RegularExpressions;
+
+namespace PiperPlus.Core.Phonemize;
+
+/// <summary>
+/// Segment of text that is either normal text or inline phonemes.
+/// When <see cref="IsPhonemes"/> is <c>true</c>, <see cref="Text"/> contains
+/// space-separated phoneme tokens (same format as <c>--raw-phonemes</c>).
+/// </summary>
+/// <param name="IsPhonemes">
+/// <c>true</c> when this segment was enclosed in <c>[[ ... ]]</c> notation.
+/// </param>
+/// <param name="Text">The segment content (plain text or phoneme string).</param>
+public record TextOrPhonemes(bool IsPhonemes, string Text);
+
+/// <summary>
+/// Parses <c>[[ phoneme ]]</c> inline notation in text, splitting input into
+/// alternating text and phoneme segments.
+/// <para>
+/// Mirrors the C++ <c>parsePhonemeString()</c> inline-notation support in
+/// <c>phoneme_parser.hpp</c>. The notation allows users to mix normal text
+/// (processed by the phonemizer) with pre-specified phoneme sequences:
+/// <code>
+///   "Hello [[ h ə l oʊ ]] world"
+///   → [TextOrPhonemes(false, "Hello "), TextOrPhonemes(true, "h ə l oʊ"), TextOrPhonemes(false, " world")]
+/// </code>
+/// </para>
+/// </summary>
+public static partial class InlinePhonemeParser
+{
+    // Match [[ ... ]] with optional internal whitespace.
+    // Group 1 captures the content between the brackets.
+    [GeneratedRegex(@"\[\[\s*([^\]]*?)\s*\]\]")]
+    private static partial Regex PhonemeNotationRegex();
+
+    /// <summary>
+    /// Parse text containing <c>[[ phoneme ]]</c> notation into segments.
+    /// Normal text is returned as-is; phoneme segments are marked with
+    /// <see cref="TextOrPhonemes.IsPhonemes"/> set to <c>true</c>.
+    /// </summary>
+    /// <param name="input">Input text, possibly containing <c>[[ ... ]]</c> notation.</param>
+    /// <returns>
+    /// Ordered list of segments. Returns an empty list for <c>null</c> or empty input.
+    /// </returns>
+    public static List<TextOrPhonemes> Parse(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return [];
+
+        var result = new List<TextOrPhonemes>();
+        int lastPos = 0;
+
+        foreach (Match match in PhonemeNotationRegex().Matches(input))
+        {
+            // Add preceding text segment
+            if (match.Index > lastPos)
+            {
+                var text = input[lastPos..match.Index];
+                if (!string.IsNullOrWhiteSpace(text))
+                    result.Add(new TextOrPhonemes(false, text));
+            }
+
+            // Add phoneme segment
+            var phonemes = match.Groups[1].Value.Trim();
+            if (phonemes.Length > 0)
+                result.Add(new TextOrPhonemes(true, phonemes));
+
+            lastPos = match.Index + match.Length;
+        }
+
+        // Add trailing text segment
+        if (lastPos < input.Length)
+        {
+            var text = input[lastPos..];
+            if (!string.IsNullOrWhiteSpace(text))
+                result.Add(new TextOrPhonemes(false, text));
+        }
+
+        return result;
+    }
+}

--- a/src/csharp/PiperPlus.Core/Phonemize/InlinePhonemeParser.cs
+++ b/src/csharp/PiperPlus.Core/Phonemize/InlinePhonemeParser.cs
@@ -56,14 +56,12 @@ public static partial class InlinePhonemeParser
             if (match.Index > lastPos)
             {
                 var text = input[lastPos..match.Index];
-                if (!string.IsNullOrWhiteSpace(text))
-                    result.Add(new TextOrPhonemes(false, text));
+                result.Add(new TextOrPhonemes(false, text));
             }
 
-            // Add phoneme segment
+            // Add phoneme segment (even if empty — matches C++ behavior)
             var phonemes = match.Groups[1].Value.Trim();
-            if (phonemes.Length > 0)
-                result.Add(new TextOrPhonemes(true, phonemes));
+            result.Add(new TextOrPhonemes(true, phonemes));
 
             lastPos = match.Index + match.Length;
         }
@@ -72,8 +70,7 @@ public static partial class InlinePhonemeParser
         if (lastPos < input.Length)
         {
             var text = input[lastPos..];
-            if (!string.IsNullOrWhiteSpace(text))
-                result.Add(new TextOrPhonemes(false, text));
+            result.Add(new TextOrPhonemes(false, text));
         }
 
         return result;


### PR DESCRIPTION
## Summary

C# CLI に C++ CLI と同等の機能を追加し、機能パリティを達成。

### 1. モデル名自動解決 + 自動ダウンロード (高優先)

```bash
# Before: 2ステップ必要
piper-plus --download-model tsukuyomi
piper-plus --model C:\Users\...\tsukuyomi-chan-6lang-fp16.onnx --text "こんにちは"

# After: 1ステップで完結
piper-plus --model tsukuyomi --text "こんにちは"
```

- `ResolveModelPathAsync()`: ファイルパス → キャッシュ検索 → 自動 DL
- `FindVoice()` によるエイリアス解決 (tsukuyomi, css10 等)
- 8テスト追加

### 2. [[ phoneme ]] インライン記法 (中優先)

```bash
piper-plus --model model.onnx --text "Hello [[ h ə l oʊ ]] world" --language en
```

- `InlinePhonemeParser`: `[[ ... ]]` 内を直接音素として処理
- テキスト部分は通常のG2P、音素部分は RawPhonemeParser で処理
- --text モードと --test-mode の両方で対応
- 15テスト追加

### 3. カスタム辞書の改善 (中優先)

**大小文字分離:**
- Mixed case (PyTorch) → case-sensitive (完全一致のみ)
- Uniform case (API, python) → case-insensitive

**単語境界マッチング:**
- ASCII 語: `\b` regex 境界で部分一致を防止 ("AI" が "AIDS" に一致しない)
- 非 ASCII 語: 従来通り substring 置換 (日本語等)

**デフォルト辞書自動読み込み:**
- `data/dictionaries/` から JSON ファイルを自動読み込み (C++ と同じ)
- 明示的な `--custom-dict` が優先

- 16テスト追加

### C++ vs C# パリティ (最終)

| 機能 | C++ | C# |
|------|-----|-----|
| モデル名/エイリアス自動解決 | あり | **あり** |
| 未DL時自動ダウンロード | あり | **あり** |
| `[[ phoneme ]]` 記法 | あり | **あり** |
| カスタム辞書 大小文字分離 | あり | **あり** |
| カスタム辞書 単語境界 | あり | **あり** |
| デフォルト辞書自動読み込み | あり | **あり** |

## Test plan

- [x] 829/829 テスト合格 (+54)
- [x] dotnet format クリーン
- [x] ビルド 0 エラー 0 警告
- [ ] CI 全パス