### PR TITLE
fix: リリースワークフローのビルド失敗修正

### DIFF
--- a/.github/workflows/dev-create-release.yml
+++ b/.github/workflows/dev-create-release.yml
@@ -261,11 +261,11 @@ jobs:
       matrix:
         include:
           - rid: win-x64
-            os: windows-2022
+            os: windows-latest
             archive_ext: zip
             cross: false
           - rid: win-arm64
-            os: windows-2022
+            os: windows-latest
             archive_ext: zip
             cross: true
           - rid: linux-x64
@@ -326,6 +326,7 @@ jobs:
       - name: Upload Release Asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
           gh release upload "${{ needs.create_release.outputs.tag_name }}" \
             "piper-plus-cli-${{ matrix.rid }}.${{ matrix.archive_ext }}" \
@@ -427,12 +428,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             artifact: piper-plus-rs-cli-linux-x64
             archive_ext: tar.gz
             cross: false
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             artifact: piper-plus-rs-cli-linux-arm64
             archive_ext: tar.gz
@@ -447,7 +448,7 @@ jobs:
             artifact: piper-plus-rs-cli-osx-arm64
             archive_ext: tar.gz
             cross: false
-          - os: windows-2022
+          - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: piper-plus-rs-cli-win-x64
             archive_ext: zip
@@ -494,6 +495,7 @@ jobs:
         run: ls -lh ${{ matrix.artifact }}.${{ matrix.archive_ext }}
 
       - name: Upload Release Asset
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

v1.8.0 リリースワークフローで発生した失敗を修正。

### 修正内容

| 問題 | 原因 | 修正 |
|------|------|------|
| Rust CLI Linux ビルド失敗 | `ubuntu-22.04` の libstdc++ が古く `ort` のリンクに失敗 | `ubuntu-24.04` に変更 (PR CI と統一) |
| C#/Rust CLI Windows アップロード失敗 | PowerShell で `\` 行継続が動かない | `shell: bash` 追加 |
| Windows ランナー不整合 | リリース `windows-2022`、PR CI `windows-latest` | `windows-latest` に統一 |

### PR CI vs リリースのランナー整合性 (修正後)

| コンポーネント | PR CI | リリース | 一致 |
|-------------|-------|---------|------|
| Rust Linux | ubuntu-24.04 | **ubuntu-24.04** | ✅ |
| Rust Windows | windows-latest | **windows-latest** | ✅ |
| C# Windows | windows-latest | **windows-latest** | ✅ |
| C# Linux | ubuntu-22.04 | ubuntu-22.04 | ✅ |

### 別対応 (Secrets)
- `NUGET_API_KEY`: GitHub Secrets の更新が必要 (ワークフロー修正不要)

## Test plan
- [ ] マージ後にリリースワークフローを再実行して全ジョブ成功を確認