### PR TITLE
fix: リリースワークフロー追加修正 (crates.io重複・ARM64ディレクトリ)

### DIFF
--- a/.github/workflows/dev-create-release.yml
+++ b/.github/workflows/dev-create-release.yml
@@ -400,7 +400,19 @@ jobs:
         working-directory: src/rust
         run: |
           if [ -n "$CARGO_REGISTRY_TOKEN" ]; then
-            cargo publish -p piper-plus --allow-dirty || echo "⚠️ piper-plus already published or publish failed (continuing)"
+            set +e
+            OUTPUT=$(cargo publish -p piper-plus --allow-dirty 2>&1)
+            STATUS=$?
+            set -e
+            echo "$OUTPUT"
+            if [ "$STATUS" -ne 0 ]; then
+              if echo "$OUTPUT" | grep -q "already uploaded\|already exists"; then
+                echo "⚠️ piper-plus version already published on crates.io (continuing)"
+              else
+                echo "::error::Failed to publish piper-plus to crates.io"
+                exit "$STATUS"
+              fi
+            fi
           else
             echo "⚠️ CARGO_REGISTRY_TOKEN not found, skipping crates.io publish"
           fi
@@ -413,7 +425,19 @@ jobs:
           if [ -n "$CARGO_REGISTRY_TOKEN" ]; then
             # Wait for crates.io index to update
             sleep 30
-            cargo publish -p piper-plus-cli --allow-dirty || echo "⚠️ piper-plus-cli already published or publish failed (continuing)"
+            set +e
+            OUTPUT=$(cargo publish -p piper-plus-cli --allow-dirty 2>&1)
+            STATUS=$?
+            set -e
+            echo "$OUTPUT"
+            if [ "$STATUS" -ne 0 ]; then
+              if echo "$OUTPUT" | grep -q "already uploaded\|already exists"; then
+                echo "⚠️ piper-plus-cli version already published on crates.io (continuing)"
+              else
+                echo "::error::Failed to publish piper-plus-cli to crates.io"
+                exit "$STATUS"
+              fi
+            fi
           else
             echo "⚠️ CARGO_REGISTRY_TOKEN not found, skipping crates.io publish"
           fi

--- a/.github/workflows/dev-create-release.yml
+++ b/.github/workflows/dev-create-release.yml
@@ -400,7 +400,7 @@ jobs:
         working-directory: src/rust
         run: |
           if [ -n "$CARGO_REGISTRY_TOKEN" ]; then
-            cargo publish -p piper-plus --allow-dirty
+            cargo publish -p piper-plus --allow-dirty || echo "⚠️ piper-plus already published or publish failed (continuing)"
           else
             echo "⚠️ CARGO_REGISTRY_TOKEN not found, skipping crates.io publish"
           fi
@@ -413,7 +413,7 @@ jobs:
           if [ -n "$CARGO_REGISTRY_TOKEN" ]; then
             # Wait for crates.io index to update
             sleep 30
-            cargo publish -p piper-plus-cli --allow-dirty
+            cargo publish -p piper-plus-cli --allow-dirty || echo "⚠️ piper-plus-cli already published or publish failed (continuing)"
           else
             echo "⚠️ CARGO_REGISTRY_TOKEN not found, skipping crates.io publish"
           fi
@@ -465,6 +465,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
+          mkdir -p src/rust/.cargo
           echo '[target.aarch64-unknown-linux-gnu]' >> src/rust/.cargo/config.toml
           echo 'linker = "aarch64-linux-gnu-gcc"' >> src/rust/.cargo/config.toml
 


### PR DESCRIPTION
## Summary

v1.8.0 リリース再実行で発生した追加の失敗を修正。

### 修正内容

| 問題 | 原因 | 修正 |
|------|------|------|
| crates.io publish 失敗 | `piper-plus@0.1.0` が前回 Run で既に公開済み | `cargo publish \|\| echo` でエラーをスキップ |
| Rust ARM64 クロスコンパイル失敗 | `src/rust/.cargo/` ディレクトリが存在しない | `mkdir -p` を追加 |

### NuGet について
`NUGET_API_KEY` Secret の更新が必要です（ワークフロー修正不要）。

## Test plan
- [ ] マージ後にリリースワークフロー再実行で全ジョブ成功