### PR TITLE
feat: export_onnx で emb_lang 自動統一 (#266)

### DIFF
--- a/src/python/piper_train/export_onnx.py
+++ b/src/python/piper_train/export_onnx.py
@@ -25,6 +25,65 @@ _LOGGER = logging.getLogger("piper_train.export_onnx")
 OPSET_VERSION = 15
 
 
+def should_unify_emb_lang(
+    unify_flag: "bool | None",
+    num_speakers: int,
+    num_languages: int,
+) -> bool:
+    """Determine whether emb_lang unification should be performed.
+
+    Parameters
+    ----------
+    unify_flag : bool or None
+        CLI flag value. None means auto-detect.
+    num_speakers : int
+        Number of speakers in the model.
+    num_languages : int
+        Number of languages in the model.
+
+    Returns
+    -------
+    bool
+        True if emb_lang should be unified.
+    """
+    if unify_flag is None:
+        return (num_speakers <= 1) and (num_languages > 1)
+    return unify_flag
+
+
+def unify_emb_lang_weights(model_g, source: int = 0) -> None:
+    """Copy emb_lang[source] to all other language embeddings.
+
+    Parameters
+    ----------
+    model_g : SynthesizerTrn
+        The generator model with emb_lang attribute.
+    source : int
+        Source language index to copy from.
+
+    Raises
+    ------
+    ValueError
+        If source is out of range.
+    """
+    num_languages = model_g.n_languages
+    if source < 0 or source >= num_languages:
+        raise ValueError(
+            f"--unify-emb-lang-source must be 0..{num_languages - 1}, got {source}"
+        )
+    with torch.no_grad():
+        emb_lang = model_g.emb_lang.weight  # [num_languages, gin_channels]
+        source_emb = emb_lang[source].clone()
+        for i in range(num_languages):
+            if i != source:
+                emb_lang[i].copy_(source_emb)
+    _LOGGER.info(
+        "Unified emb_lang: copied lang[%d] to all %d languages",
+        source,
+        num_languages,
+    )
+
+
 def simplify_onnx_model(onnx_path: Path, check_n: int = 3) -> bool:
     """
     Simplify ONNX model using onnxsim-prebuilt with validation.
@@ -167,29 +226,14 @@ def main() -> None:
 
     # Unify emb_lang embeddings for single-speaker multilingual models
     # Must be done BEFORE torch.onnx.export(); EMA does not affect emb_lang
-    if args.unify_emb_lang is None:
-        should_unify = (num_speakers <= 1) and (num_languages > 1)
-    else:
-        should_unify = args.unify_emb_lang
+    do_unify = should_unify_emb_lang(args.unify_emb_lang, num_speakers, num_languages)
 
-    if should_unify and num_languages > 1:
-        source = args.unify_emb_lang_source
-        if source < 0 or source >= num_languages:
-            raise ValueError(
-                f"--unify-emb-lang-source must be 0..{num_languages - 1}, got {source}"
-            )
-        with torch.no_grad():
-            emb_lang = model_g.emb_lang.weight  # [num_languages, gin_channels]
-            source_emb = emb_lang[source].clone()
-            for i in range(num_languages):
-                if i != source:
-                    emb_lang[i].copy_(source_emb)
-        _LOGGER.info(
-            "Unified emb_lang: copied lang[%d] to all %d languages",
-            source,
-            num_languages,
-        )
-    elif should_unify and num_languages <= 1:
+    if do_unify and num_languages > 1:
+        try:
+            unify_emb_lang_weights(model_g, source=args.unify_emb_lang_source)
+        except ValueError as e:
+            parser.error(str(e))
+    elif do_unify and num_languages <= 1:
         _LOGGER.info(
             "Skipping emb_lang unification: model has only %d language(s)",
             num_languages,

--- a/src/python/piper_train/export_onnx.py
+++ b/src/python/piper_train/export_onnx.py
@@ -111,6 +111,20 @@ def main() -> None:
         action="store_true",
         help="Disable FP16 conversion (default: FP16 enabled)",
     )
+    parser.add_argument(
+        "--unify-emb-lang",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Unify emb_lang embeddings for single-speaker multilingual models. "
+        "Default: auto (enabled when num_speakers <= 1 and num_languages > 1). "
+        "Use --no-unify-emb-lang to disable.",
+    )
+    parser.add_argument(
+        "--unify-emb-lang-source",
+        type=int,
+        default=0,
+        help="Source language index for emb_lang unification (default: 0).",
+    )
     args = parser.parse_args()
 
     if args.debug:
@@ -150,6 +164,33 @@ def main() -> None:
 
     # Inference only
     model_g.eval()
+
+    # Unify emb_lang embeddings for single-speaker multilingual models
+    # Must be done BEFORE torch.onnx.export(); EMA does not affect emb_lang
+    if args.unify_emb_lang is None:
+        should_unify = (num_speakers <= 1) and (num_languages > 1)
+    else:
+        should_unify = args.unify_emb_lang
+
+    if should_unify and num_languages > 1:
+        source = args.unify_emb_lang_source
+        if source < 0 or source >= num_languages:
+            raise ValueError(
+                f"--unify-emb-lang-source must be 0..{num_languages - 1}, got {source}"
+            )
+        with torch.no_grad():
+            emb_lang = model_g.emb_lang.weight  # [num_languages, gin_channels]
+            source_emb = emb_lang[source].clone()
+            for i in range(num_languages):
+                if i != source:
+                    emb_lang[i].copy_(source_emb)
+        _LOGGER.info(
+            "Unified emb_lang: copied lang[%d] to all %d languages",
+            source,
+            num_languages,
+        )
+    elif should_unify and num_languages <= 1:
+        _LOGGER.info("Skipping emb_lang unification: model has only %d language(s)", num_languages)
 
     # Apply EMA weights to decoder if available (always applied when present)
     # IMPORTANT: EMA must be applied BEFORE remove_weight_norm(), because EMA shadow

--- a/src/python/piper_train/export_onnx.py
+++ b/src/python/piper_train/export_onnx.py
@@ -190,7 +190,10 @@ def main() -> None:
             num_languages,
         )
     elif should_unify and num_languages <= 1:
-        _LOGGER.info("Skipping emb_lang unification: model has only %d language(s)", num_languages)
+        _LOGGER.info(
+            "Skipping emb_lang unification: model has only %d language(s)",
+            num_languages,
+        )
 
     # Apply EMA weights to decoder if available (always applied when present)
     # IMPORTANT: EMA must be applied BEFORE remove_weight_norm(), because EMA shadow

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -336,17 +336,16 @@ def temp_onnx_model_unified_emb_lang(mock_vits_model_multilingual, tmp_path_fact
     """emb_lang統一後にONNXエクスポートしたマルチリンガルモデル"""
     import torch
 
+    from piper_train.export_onnx import unify_emb_lang_weights
     from piper_train.vits import commons
 
     model = mock_vits_model_multilingual
 
-    # emb_lang 統一処理 (export_onnx.py と同一ロジック)
-    with torch.no_grad():
-        emb_lang = model.emb_lang.weight
-        source_emb = emb_lang[0].clone()
-        for i in range(model.n_languages):
-            if i != 0:
-                emb_lang[i].copy_(source_emb)
+    # Save original weights to restore after export (avoid leaking into other tests)
+    original_emb_lang = model.emb_lang.weight.data.clone()
+
+    # emb_lang 統一処理 (export_onnx.py のヘルパー関数を使用)
+    unify_emb_lang_weights(model, source=0)
 
     tmp_dir = tmp_path_factory.mktemp("models_unified")
     onnx_path = tmp_dir / "mock_model_unified.onnx"
@@ -437,9 +436,12 @@ def temp_onnx_model_unified_emb_lang(mock_vits_model_multilingual, tmp_path_fact
         )
     except (SystemError, Exception) as e:
         model.forward = _orig_forward
+        model.emb_lang.weight.data.copy_(original_emb_lang)
         pytest.skip(f"ONNX export not supported: {e}")
 
     model.forward = _orig_forward
+    # Restore original weights so mock_vits_model_multilingual is not polluted
+    model.emb_lang.weight.data.copy_(original_emb_lang)
     return onnx_path
 
 

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -286,6 +286,150 @@ def temp_onnx_model_stochastic(mock_vits_model, tmp_path_factory):
     return onnx_path
 
 
+@pytest.fixture(scope="module")
+def mock_vits_model_multilingual():
+    """マルチリンガル対応モックVITSモデルを作成（n_speakers=1, n_languages=2）"""
+    import torch
+
+    from piper_train.vits.models import SynthesizerTrn
+
+    torch.manual_seed(42)
+
+    model = SynthesizerTrn(
+        n_vocab=50,
+        spec_channels=513,
+        segment_size=8192,
+        inter_channels=192,
+        hidden_channels=192,
+        filter_channels=768,
+        n_heads=2,
+        n_layers=6,
+        kernel_size=3,
+        p_dropout=0.1,
+        resblock="1",
+        resblock_kernel_sizes=[3, 7, 11],
+        resblock_dilation_sizes=[[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+        upsample_rates=[8, 8, 2, 2],
+        upsample_initial_channel=512,
+        upsample_kernel_sizes=[16, 16, 4, 4],
+        n_speakers=1,
+        n_languages=2,
+        gin_channels=512,
+        use_sdp=True,
+        prosody_dim=16,
+    )
+
+    # 各言語に異なる初期値を設定（統一テスト用）
+    with torch.no_grad():
+        model.emb_lang.weight[0].fill_(1.0)
+        model.emb_lang.weight[1].fill_(2.0)
+
+    model.eval()
+    with torch.no_grad():
+        model.dec.remove_weight_norm()
+
+    return model
+
+
+@pytest.fixture(scope="module")
+def temp_onnx_model_unified_emb_lang(mock_vits_model_multilingual, tmp_path_factory):
+    """emb_lang統一後にONNXエクスポートしたマルチリンガルモデル"""
+    import torch
+
+    from piper_train.vits import commons
+
+    model = mock_vits_model_multilingual
+
+    # emb_lang 統一処理 (export_onnx.py と同一ロジック)
+    with torch.no_grad():
+        emb_lang = model.emb_lang.weight
+        source_emb = emb_lang[0].clone()
+        for i in range(model.n_languages):
+            if i != 0:
+                emb_lang[i].copy_(source_emb)
+
+    tmp_dir = tmp_path_factory.mktemp("models_unified")
+    onnx_path = tmp_dir / "mock_model_unified.onnx"
+
+    dummy_input_length = 10
+    sequences = torch.randint(0, 50, (1, dummy_input_length), dtype=torch.long)
+    sequence_lengths = torch.LongTensor([dummy_input_length])
+    scales = torch.FloatTensor([0.667, 1.0, 0.8])
+    sid = torch.LongTensor([0])
+    lid = torch.LongTensor([0])
+    prosody_features = torch.zeros(1, dummy_input_length, 3, dtype=torch.long)
+
+    model.onnx_export_mode = True
+    if hasattr(model, "dp"):
+        model.dp.onnx_export_mode = True
+
+    def infer_forward(
+        input_tensor, input_lengths, scales_tensor, sid_tensor, lid_tensor,
+        prosody_features_tensor,
+    ):
+        length_scale = scales_tensor[1]
+        noise_scale_w = scales_tensor[2]
+
+        g = model._get_global_conditioning(sid_tensor, lid_tensor)
+        x, m_p, logs_p, x_mask = model.enc_p(input_tensor, input_lengths, g=g)
+
+        x_dp = model._prepare_prosody_input(x, x_mask, prosody_features_tensor, lid=lid_tensor)
+        if model.use_sdp:
+            logw = model.dp(x_dp, x_mask, g=g, reverse=True, noise_scale=noise_scale_w)
+        else:
+            logw = model.dp(x_dp, x_mask, g=g)
+
+        w = torch.exp(logw) * x_mask * length_scale
+        durations = w.squeeze(1)
+
+        w_ceil = torch.ceil(w)
+        y_lengths = torch.clamp_min(torch.sum(w_ceil, [1, 2]), 1).long()
+        y_mask = torch.unsqueeze(
+            commons.sequence_mask(y_lengths, y_lengths.max()), 1
+        ).type_as(x_mask)
+        attn_mask = torch.unsqueeze(x_mask, 2) * torch.unsqueeze(y_mask, -1)
+        attn = commons.generate_path(w_ceil, attn_mask)
+
+        m_p = torch.matmul(attn.squeeze(1), m_p.transpose(1, 2)).transpose(1, 2)
+        logs_p = torch.matmul(attn.squeeze(1), logs_p.transpose(1, 2)).transpose(1, 2)
+
+        z_p = m_p  # deterministic
+        z = model.flow(z_p, y_mask, g=g, reverse=True)
+        o = model.dec((z * y_mask), g=g)
+
+        return o, durations
+
+    _orig_forward = model.forward
+    model.forward = infer_forward
+
+    try:
+        torch.onnx.export(
+            model,
+            (sequences, sequence_lengths, scales, sid, lid, prosody_features),
+            str(onnx_path),
+            opset_version=15,
+            input_names=["input", "input_lengths", "scales", "sid", "lid", "prosody_features"],
+            output_names=["output", "durations"],
+            dynamic_axes={
+                "input": {0: "batch_size", 1: "phonemes"},
+                "input_lengths": {0: "batch_size"},
+                "sid": {0: "batch_size"},
+                "lid": {0: "batch_size"},
+                "prosody_features": {0: "batch_size", 1: "phonemes"},
+                "output": {0: "batch_size", 2: "time"},
+                "durations": {0: "batch_size", 1: "phonemes"},
+            },
+            verbose=False,
+            dynamo=False,
+        )
+    except (SystemError, Exception) as e:
+        model.forward = _orig_forward
+        pytest.skip(f"ONNX export not supported: {e}")
+
+    model.forward = _orig_forward
+    return onnx_path
+
+
 @pytest.fixture
 def sample_phoneme_ids():
     """標準的なテスト用音素ID列"""

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -364,7 +364,11 @@ def temp_onnx_model_unified_emb_lang(mock_vits_model_multilingual, tmp_path_fact
         model.dp.onnx_export_mode = True
 
     def infer_forward(
-        input_tensor, input_lengths, scales_tensor, sid_tensor, lid_tensor,
+        input_tensor,
+        input_lengths,
+        scales_tensor,
+        sid_tensor,
+        lid_tensor,
         prosody_features_tensor,
     ):
         length_scale = scales_tensor[1]
@@ -373,7 +377,9 @@ def temp_onnx_model_unified_emb_lang(mock_vits_model_multilingual, tmp_path_fact
         g = model._get_global_conditioning(sid_tensor, lid_tensor)
         x, m_p, logs_p, x_mask = model.enc_p(input_tensor, input_lengths, g=g)
 
-        x_dp = model._prepare_prosody_input(x, x_mask, prosody_features_tensor, lid=lid_tensor)
+        x_dp = model._prepare_prosody_input(
+            x, x_mask, prosody_features_tensor, lid=lid_tensor
+        )
         if model.use_sdp:
             logw = model.dp(x_dp, x_mask, g=g, reverse=True, noise_scale=noise_scale_w)
         else:
@@ -408,7 +414,14 @@ def temp_onnx_model_unified_emb_lang(mock_vits_model_multilingual, tmp_path_fact
             (sequences, sequence_lengths, scales, sid, lid, prosody_features),
             str(onnx_path),
             opset_version=15,
-            input_names=["input", "input_lengths", "scales", "sid", "lid", "prosody_features"],
+            input_names=[
+                "input",
+                "input_lengths",
+                "scales",
+                "sid",
+                "lid",
+                "prosody_features",
+            ],
             output_names=["output", "durations"],
             dynamic_axes={
                 "input": {0: "batch_size", 1: "phonemes"},

--- a/src/python/tests/test_export_onnx.py
+++ b/src/python/tests/test_export_onnx.py
@@ -189,100 +189,57 @@ def _make_mock_model_g(n_speakers, n_languages, gin_channels=512):
 
 @pytest.mark.unit
 class TestUnifyEmbLang:
-    """emb_lang 統一のテスト"""
+    """emb_lang 統一のテスト（export_onnx のヘルパー関数を直接テスト）"""
 
     def test_auto_enabled_single_speaker_multilingual(self):
         """num_speakers=1, num_languages>1 → 自動有効化"""
-        model_g = _make_mock_model_g(n_speakers=1, n_languages=6)
-        num_speakers = model_g.n_speakers
-        num_languages = model_g.n_languages
+        from piper_train.export_onnx import should_unify_emb_lang
 
-        # auto判定ロジック (export_onnx.py と同一)
-        unify_emb_lang = None  # auto
-        if unify_emb_lang is None:
-            should_unify = (num_speakers <= 1) and (num_languages > 1)
-        else:
-            should_unify = unify_emb_lang
-
-        assert should_unify is True
+        assert should_unify_emb_lang(None, num_speakers=1, num_languages=6) is True
 
     def test_auto_disabled_multi_speaker(self):
         """num_speakers>1, num_languages>1 → 自動無効化"""
-        model_g = _make_mock_model_g(n_speakers=2, n_languages=6)
-        num_speakers = model_g.n_speakers
-        num_languages = model_g.n_languages
+        from piper_train.export_onnx import should_unify_emb_lang
 
-        unify_emb_lang = None
-        if unify_emb_lang is None:
-            should_unify = (num_speakers <= 1) and (num_languages > 1)
-        else:
-            should_unify = unify_emb_lang
-
-        assert should_unify is False
+        assert should_unify_emb_lang(None, num_speakers=2, num_languages=6) is False
 
     def test_explicit_enable_overrides_auto(self):
         """--unify-emb-lang でマルチスピーカーでも有効化"""
-        model_g = _make_mock_model_g(n_speakers=2, n_languages=6)
-        num_speakers = model_g.n_speakers
-        num_languages = model_g.n_languages
+        from piper_train.export_onnx import should_unify_emb_lang
 
-        unify_emb_lang = True  # explicit
-        if unify_emb_lang is None:
-            should_unify = (num_speakers <= 1) and (num_languages > 1)
-        else:
-            should_unify = unify_emb_lang
-
-        assert should_unify is True
+        assert should_unify_emb_lang(True, num_speakers=2, num_languages=6) is True
 
     def test_explicit_disable_overrides_auto(self):
         """--no-unify-emb-lang でシングルスピーカー多言語でも無効化"""
-        model_g = _make_mock_model_g(n_speakers=1, n_languages=6)
-        num_speakers = model_g.n_speakers
-        num_languages = model_g.n_languages
+        from piper_train.export_onnx import should_unify_emb_lang
 
-        unify_emb_lang = False  # explicit disable
-        if unify_emb_lang is None:
-            should_unify = (num_speakers <= 1) and (num_languages > 1)
-        else:
-            should_unify = unify_emb_lang
-
-        assert should_unify is False
+        assert should_unify_emb_lang(False, num_speakers=1, num_languages=6) is False
 
     def test_unify_copies_source_to_all(self):
         """統一後に全言語のembeddingがsourceと同一"""
+        from piper_train.export_onnx import unify_emb_lang_weights
+
         num_languages = 6
         model_g = _make_mock_model_g(n_speakers=1, n_languages=num_languages)
-        source = 0
 
         # 統一前: 各言語は異なる値
-        with torch.no_grad():
-            for i in range(num_languages):
-                assert model_g.emb_lang.weight[i][0].item() == float(i + 1)
+        for i in range(num_languages):
+            assert model_g.emb_lang.weight[i][0].item() == float(i + 1)
 
-        # 統一処理 (export_onnx.py と同一ロジック)
-        with torch.no_grad():
-            emb_lang = model_g.emb_lang.weight
-            source_emb = emb_lang[source].clone()
-            for i in range(num_languages):
-                if i != source:
-                    emb_lang[i].copy_(source_emb)
+        unify_emb_lang_weights(model_g, source=0)
 
         # 統一後: 全言語がsource (=1.0) と同一
         for i in range(num_languages):
-            assert torch.equal(model_g.emb_lang.weight[i], model_g.emb_lang.weight[source])
+            assert torch.equal(model_g.emb_lang.weight[i], model_g.emb_lang.weight[0])
 
     def test_unify_with_custom_source(self):
         """--unify-emb-lang-source 2 で言語2基準のコピー"""
+        from piper_train.export_onnx import unify_emb_lang_weights
+
         num_languages = 6
         model_g = _make_mock_model_g(n_speakers=1, n_languages=num_languages)
-        source = 2
 
-        with torch.no_grad():
-            emb_lang = model_g.emb_lang.weight
-            source_emb = emb_lang[source].clone()
-            for i in range(num_languages):
-                if i != source:
-                    emb_lang[i].copy_(source_emb)
+        unify_emb_lang_weights(model_g, source=2)
 
         # 全言語がsource (=3.0) と同一
         for i in range(num_languages):
@@ -290,14 +247,12 @@ class TestUnifyEmbLang:
 
     def test_invalid_source_raises_error(self):
         """範囲外のsourceでValueError"""
-        num_languages = 6
-        source = 10
+        from piper_train.export_onnx import unify_emb_lang_weights
+
+        model_g = _make_mock_model_g(n_speakers=1, n_languages=6)
 
         with pytest.raises(ValueError, match="must be 0..5"):
-            if source < 0 or source >= num_languages:
-                raise ValueError(
-                    f"--unify-emb-lang-source must be 0..{num_languages - 1}, got {source}"
-                )
+            unify_emb_lang_weights(model_g, source=10)
 
 
 @pytest.mark.inference
@@ -312,7 +267,10 @@ class TestUnifyEmbLangOnnxExport:
         assert os.path.getsize(temp_onnx_model_unified_emb_lang) > 0
 
     def test_onnx_inference_with_different_lid(
-        self, temp_onnx_model_unified_emb_lang, sample_phoneme_ids, sample_prosody_features
+        self,
+        temp_onnx_model_unified_emb_lang,
+        sample_phoneme_ids,
+        sample_prosody_features,
     ):
         """emb_lang統一後は異なるlidでも同一の音声出力"""
         import onnxruntime
@@ -322,7 +280,9 @@ class TestUnifyEmbLangOnnxExport:
 
         text = np.expand_dims(np.array(sample_phoneme_ids, dtype=np.int64), 0)
         text_lengths = np.array([text.shape[1]], dtype=np.int64)
-        scales = np.array([0.0, 1.0, 0.8], dtype=np.float32)  # noise_scale=0 for determinism
+        scales = np.array(
+            [0.0, 1.0, 0.8], dtype=np.float32
+        )  # noise_scale=0 for determinism
 
         pf = []
         for feat in sample_prosody_features:
@@ -347,6 +307,7 @@ class TestUnifyEmbLangOnnxExport:
 
         # emb_lang統一後は出力が同一であるべき
         np.testing.assert_array_equal(
-            audio_lid0, audio_lid1,
+            audio_lid0,
+            audio_lid1,
             err_msg="After emb_lang unification, different lid values should produce identical output",
         )

--- a/src/python/tests/test_export_onnx.py
+++ b/src/python/tests/test_export_onnx.py
@@ -1,8 +1,10 @@
-"""Tests for export_onnx stochastic/deterministic export modes and EMA weight application."""
+"""Tests for export_onnx stochastic/deterministic export modes, EMA weight application,
+and emb_lang unification."""
 
 import numpy as np
 import pytest
 import torch
+from torch import nn
 
 
 def _onnx_inference(onnx_path, phoneme_ids, prosody_features, noise_scale=0.667):
@@ -166,3 +168,133 @@ class TestEMAWeightApplication:
         ckpt = torch.load(str(ckpt_path), map_location="cpu")
         ema_state = ckpt.get("ema_generator_state")
         assert ema_state is None, "Should not have EMA state"
+
+
+def _make_mock_model_g(n_speakers, n_languages, gin_channels=512):
+    """emb_lang テスト用の簡易モックモデルを作成"""
+
+    class MockModelG:
+        def __init__(self, n_speakers, n_languages, gin_channels):
+            self.n_speakers = n_speakers
+            self.n_languages = n_languages
+            if n_languages > 1:
+                self.emb_lang = nn.Embedding(n_languages, gin_channels)
+                # 各言語に異なる初期値を設定
+                with torch.no_grad():
+                    for i in range(n_languages):
+                        self.emb_lang.weight[i].fill_(float(i + 1))
+
+    return MockModelG(n_speakers, n_languages, gin_channels)
+
+
+@pytest.mark.unit
+class TestUnifyEmbLang:
+    """emb_lang 統一のテスト"""
+
+    def test_auto_enabled_single_speaker_multilingual(self):
+        """num_speakers=1, num_languages>1 → 自動有効化"""
+        model_g = _make_mock_model_g(n_speakers=1, n_languages=6)
+        num_speakers = model_g.n_speakers
+        num_languages = model_g.n_languages
+
+        # auto判定ロジック (export_onnx.py と同一)
+        unify_emb_lang = None  # auto
+        if unify_emb_lang is None:
+            should_unify = (num_speakers <= 1) and (num_languages > 1)
+        else:
+            should_unify = unify_emb_lang
+
+        assert should_unify is True
+
+    def test_auto_disabled_multi_speaker(self):
+        """num_speakers>1, num_languages>1 → 自動無効化"""
+        model_g = _make_mock_model_g(n_speakers=2, n_languages=6)
+        num_speakers = model_g.n_speakers
+        num_languages = model_g.n_languages
+
+        unify_emb_lang = None
+        if unify_emb_lang is None:
+            should_unify = (num_speakers <= 1) and (num_languages > 1)
+        else:
+            should_unify = unify_emb_lang
+
+        assert should_unify is False
+
+    def test_explicit_enable_overrides_auto(self):
+        """--unify-emb-lang でマルチスピーカーでも有効化"""
+        model_g = _make_mock_model_g(n_speakers=2, n_languages=6)
+        num_speakers = model_g.n_speakers
+        num_languages = model_g.n_languages
+
+        unify_emb_lang = True  # explicit
+        if unify_emb_lang is None:
+            should_unify = (num_speakers <= 1) and (num_languages > 1)
+        else:
+            should_unify = unify_emb_lang
+
+        assert should_unify is True
+
+    def test_explicit_disable_overrides_auto(self):
+        """--no-unify-emb-lang でシングルスピーカー多言語でも無効化"""
+        model_g = _make_mock_model_g(n_speakers=1, n_languages=6)
+        num_speakers = model_g.n_speakers
+        num_languages = model_g.n_languages
+
+        unify_emb_lang = False  # explicit disable
+        if unify_emb_lang is None:
+            should_unify = (num_speakers <= 1) and (num_languages > 1)
+        else:
+            should_unify = unify_emb_lang
+
+        assert should_unify is False
+
+    def test_unify_copies_source_to_all(self):
+        """統一後に全言語のembeddingがsourceと同一"""
+        num_languages = 6
+        model_g = _make_mock_model_g(n_speakers=1, n_languages=num_languages)
+        source = 0
+
+        # 統一前: 各言語は異なる値
+        with torch.no_grad():
+            for i in range(num_languages):
+                assert model_g.emb_lang.weight[i][0].item() == float(i + 1)
+
+        # 統一処理 (export_onnx.py と同一ロジック)
+        with torch.no_grad():
+            emb_lang = model_g.emb_lang.weight
+            source_emb = emb_lang[source].clone()
+            for i in range(num_languages):
+                if i != source:
+                    emb_lang[i].copy_(source_emb)
+
+        # 統一後: 全言語がsource (=1.0) と同一
+        for i in range(num_languages):
+            assert torch.equal(model_g.emb_lang.weight[i], model_g.emb_lang.weight[source])
+
+    def test_unify_with_custom_source(self):
+        """--unify-emb-lang-source 2 で言語2基準のコピー"""
+        num_languages = 6
+        model_g = _make_mock_model_g(n_speakers=1, n_languages=num_languages)
+        source = 2
+
+        with torch.no_grad():
+            emb_lang = model_g.emb_lang.weight
+            source_emb = emb_lang[source].clone()
+            for i in range(num_languages):
+                if i != source:
+                    emb_lang[i].copy_(source_emb)
+
+        # 全言語がsource (=3.0) と同一
+        for i in range(num_languages):
+            assert model_g.emb_lang.weight[i][0].item() == 3.0
+
+    def test_invalid_source_raises_error(self):
+        """範囲外のsourceでValueError"""
+        num_languages = 6
+        source = 10
+
+        with pytest.raises(ValueError, match="must be 0..5"):
+            if source < 0 or source >= num_languages:
+                raise ValueError(
+                    f"--unify-emb-lang-source must be 0..{num_languages - 1}, got {source}"
+                )

--- a/src/python/tests/test_export_onnx.py
+++ b/src/python/tests/test_export_onnx.py
@@ -298,3 +298,55 @@ class TestUnifyEmbLang:
                 raise ValueError(
                     f"--unify-emb-lang-source must be 0..{num_languages - 1}, got {source}"
                 )
+
+
+@pytest.mark.inference
+class TestUnifyEmbLangOnnxExport:
+    """emb_lang 統一後の ONNX エクスポート統合テスト"""
+
+    def test_onnx_export_succeeds(self, temp_onnx_model_unified_emb_lang):
+        """emb_lang統一後のモデルが正常にONNXエクスポートできる"""
+        import os
+
+        assert temp_onnx_model_unified_emb_lang.exists()
+        assert os.path.getsize(temp_onnx_model_unified_emb_lang) > 0
+
+    def test_onnx_inference_with_different_lid(
+        self, temp_onnx_model_unified_emb_lang, sample_phoneme_ids, sample_prosody_features
+    ):
+        """emb_lang統一後は異なるlidでも同一の音声出力"""
+        import onnxruntime
+
+        session = onnxruntime.InferenceSession(str(temp_onnx_model_unified_emb_lang))
+        input_names = {inp.name for inp in session.get_inputs()}
+
+        text = np.expand_dims(np.array(sample_phoneme_ids, dtype=np.int64), 0)
+        text_lengths = np.array([text.shape[1]], dtype=np.int64)
+        scales = np.array([0.0, 1.0, 0.8], dtype=np.float32)  # noise_scale=0 for determinism
+
+        pf = []
+        for feat in sample_prosody_features:
+            if feat is None:
+                pf.append([0, 0, 0])
+            else:
+                pf.append([feat["a1"], feat["a2"], feat["a3"]])
+        prosody = np.expand_dims(np.array(pf, dtype=np.int64), 0)
+
+        def _build_inputs(lid_val):
+            inputs = {"input": text, "input_lengths": text_lengths, "scales": scales}
+            if "sid" in input_names:
+                inputs["sid"] = np.array([0], dtype=np.int64)
+            if "lid" in input_names:
+                inputs["lid"] = np.array([lid_val], dtype=np.int64)
+            if "prosody_features" in input_names:
+                inputs["prosody_features"] = prosody
+            return inputs
+
+        audio_lid0 = session.run(None, _build_inputs(0))[0].squeeze()
+        audio_lid1 = session.run(None, _build_inputs(1))[0].squeeze()
+
+        # emb_lang統一後は出力が同一であるべき
+        np.testing.assert_array_equal(
+            audio_lid0, audio_lid1,
+            err_msg="After emb_lang unification, different lid values should produce identical output",
+        )


### PR DESCRIPTION
## Summary

- `export_onnx.py` に `--unify-emb-lang` / `--no-unify-emb-lang` オプションを追加
- シングルスピーカー多言語モデル (`num_speakers <= 1 && num_languages > 1`) の場合、自動的に `emb_lang[source]` を全言語にコピーして声質を統一
- `--unify-emb-lang-source` でコピー元言語インデックスを指定可能（デフォルト: 0）
- 手動の後処理スクリプトが不要になる

Closes #266

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `export_onnx.py` | CLI引数追加 + emb_lang統一ロジック（EMA適用前に挿入） |
| `conftest.py` | マルチリンガルモックモデル + ONNX統合テストフィクスチャ追加 |
| `test_export_onnx.py` | ユニットテスト7件 + ONNX統合テスト2件 追加 |

## Test plan

- [x] auto判定: `num_speakers=1, num_languages>1` → 自動有効化
- [x] auto判定: `num_speakers>1` → 自動無効化
- [x] `--unify-emb-lang` で明示的有効化（マルチスピーカーでも）
- [x] `--no-unify-emb-lang` で明示的無効化
- [x] source指定テスト (`--unify-emb-lang-source`)
- [x] weight検証: 統一後に全言語のembeddingが同一
- [x] 範囲外sourceでValueError
- [x] ONNX出力検証: 統一後のモデルが正常にエクスポートできる
- [x] ONNX推論検証: 異なるlidで同一出力になる