### PR TITLE
docs: PyPI プロジェクト説明を追加

### DIFF
--- a/src/python_run/README.md
+++ b/src/python_run/README.md
@@ -5,45 +5,45 @@
 [![Python](https://img.shields.io/pypi/pyversions/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A fast, high-quality neural text-to-speech (TTS) system. Built on the [VITS](https://github.com/jaywalnut310/vits/) architecture with multi-speaker support for 6 languages. A fork of [Piper](https://github.com/rhasspy/piper) with significantly enhanced Japanese support, improved voice quality, and advanced training features.
+高速・高品質なニューラルテキスト音声合成 (TTS) システム。[VITS](https://github.com/jaywalnut310/vits/) アーキテクチャを採用し、6言語マルチスピーカー音声合成に対応。[Piper](https://github.com/rhasspy/piper) のフォークで、日本語対応・音質向上・学習機能を大幅に強化しています。
 
-**[Hugging Face Demo](https://huggingface.co/spaces/ayousanz/piper-plus-demo)** | **[WebAssembly Demo](https://ayutaz.github.io/piper-plus/)** | **[GitHub](https://github.com/ayutaz/piper-plus)**
+**[Hugging Face デモ](https://huggingface.co/spaces/ayousanz/piper-plus-demo)** | **[WebAssembly デモ](https://ayutaz.github.io/piper-plus/)** | **[GitHub](https://github.com/ayutaz/piper-plus)**
 
-## Key Features
+## 主要機能
 
-- **6-Language Support** - Japanese, English, Mandarin Chinese, Spanish, French, Portuguese
-- **Japanese TTS** - OpenJTalk integration, prosody features (A1/A2/A3), context-dependent phoneme variants
-- **English TTS** - GPL-free G2P ([g2p-en](https://github.com/Kyubyong/g2p), Apache-2.0), no espeak-ng dependency
-- **Multi-speaker** - 571 speakers in base model with language-balanced sampling
-- **Custom Dictionary** - 200+ built-in technical term pronunciations
-- **Phoneme Input** - Direct phoneme specification with `[[ phonemes ]]` notation
-- **Cross-platform** - Linux (x86_64/ARM64), macOS (Apple Silicon), Windows (x64)
+- **6言語対応** — 日本語・英語・中国語・スペイン語・フランス語・ポルトガル語
+- **日本語 TTS** — OpenJTalk統合、韻律情報 (A1/A2/A3)、文脈依存音素バリアント
+- **英語 TTS** — GPL-free G2P ([g2p-en](https://github.com/Kyubyong/g2p), Apache-2.0)、espeak-ng 不要
+- **マルチスピーカー** — ベースモデル571話者、言語グループ均等サンプリング
+- **カスタム辞書** — 200+技術用語の発音辞書内蔵
+- **音素入力** — `[[ phonemes ]]` 記法による直接指定
+- **クロスプラットフォーム** — Linux (x86_64/ARM64)、macOS (Apple Silicon)、Windows (x64)
 
-## Installation
+## インストール
 
 ```bash
 pip install piper-tts-plus
 
-# GPU support
+# GPU サポート
 pip install "piper-tts-plus[gpu]"
 ```
 
-Requires Python 3.11+.
+Python 3.11+ が必要です。
 
-## Quick Start
+## クイックスタート
 
-### Command Line
+### コマンドライン
 
 ```bash
-# List available models
+# モデル一覧を表示
 piper --list-models
 piper --list-models ja
 
-# Download a model
+# モデルをダウンロード
 piper --download-model tsukuyomi
 
-# Generate speech
-piper --model tsukuyomi --text "Hello, world!" --output_file output.wav
+# 音声を生成
+piper --model tsukuyomi --text "こんにちは、今日は良い天気ですね。" --output_file output.wav
 ```
 
 ### Python API
@@ -52,44 +52,42 @@ piper --model tsukuyomi --text "Hello, world!" --output_file output.wav
 from piper import PiperVoice
 
 voice = PiperVoice.load("path/to/model.onnx", config_path="path/to/config.json")
-wav_bytes = voice.synthesize("Hello, world!")
+wav_bytes = voice.synthesize("こんにちは、今日は良い天気ですね。")
 ```
 
-## Pre-trained Models
+## 事前学習済みモデル
 
-| Model | Languages | Speakers | Download |
-|-------|-----------|----------|----------|
-| [piper-plus-base](https://huggingface.co/ayousanz/piper-plus-base) | 6 (ja/en/zh/es/fr/pt) | 571 | `piper --download-model base` |
-| [tsukuyomi-chan](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan) | 6 (ja/en/zh/es/fr/pt) | 1 | `piper --download-model tsukuyomi` |
+| モデル | 言語 | 話者数 | ダウンロード |
+|--------|------|--------|-------------|
+| [piper-plus-base](https://huggingface.co/ayousanz/piper-plus-base) | 6言語 (ja/en/zh/es/fr/pt) | 571 | `piper --download-model base` |
+| [tsukuyomi-chan](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan) | 6言語 (ja/en/zh/es/fr/pt) | 1 | `piper --download-model tsukuyomi` |
 
-## Supported Languages
+## 対応言語
 
-| Language | Code | Phonemizer | Dependency |
-|----------|------|------------|------------|
-| Japanese | ja | OpenJTalk | pyopenjtalk-plus |
-| English | en | g2p-en | g2p-en (Apache-2.0) |
-| Mandarin Chinese | zh | pypinyin | pypinyin |
-| Spanish | es | Rule-based | None |
-| French | fr | Rule-based | None |
-| Portuguese | pt | Rule-based | None |
+| 言語 | コード | Phonemizer | 依存 |
+|------|--------|------------|------|
+| 日本語 | ja | OpenJTalk | pyopenjtalk-plus |
+| 英語 | en | g2p-en | g2p-en (Apache-2.0) |
+| 中国語 | zh | pypinyin | pypinyin |
+| スペイン語 | es | 規則ベース | なし |
+| フランス語 | fr | 規則ベース | なし |
+| ポルトガル語 | pt | 規則ベース | なし |
 
-## Other Interfaces
+## その他のインターフェース
 
-Piper Plus is also available as:
+- **[C++ CLI](https://github.com/ayutaz/piper-plus/releases)** — ストリーミング、CUDA推論、カスタム辞書
+- **[Rust CLI](https://github.com/ayutaz/piper-plus/tree/dev/src/rust)** — ストリーミング、CUDA/CoreML/DirectML対応
+- **[C# CLI (.NET)](https://github.com/ayutaz/piper-plus/tree/dev/src/csharp)** — クロスプラットフォーム .NET 8/9
+- **[WebAssembly](https://ayutaz.github.io/piper-plus/)** — ブラウザ内で完全動作
+- **[Docker](https://github.com/ayutaz/piper-plus/tree/dev/docker)** — 推論・学習・WebUI イメージ
 
-- **[C++ CLI](https://github.com/ayutaz/piper-plus/releases)** - Prebuilt binaries with streaming, CUDA inference, custom dictionary
-- **[Rust CLI](https://github.com/ayutaz/piper-plus/tree/dev/src/rust)** - Streaming, CUDA/CoreML/DirectML support
-- **[C# CLI (.NET)](https://github.com/ayutaz/piper-plus/tree/dev/src/csharp)** - Cross-platform .NET 8/9
-- **[WebAssembly](https://ayutaz.github.io/piper-plus/)** - Runs entirely in browser
-- **[Docker](https://github.com/ayutaz/piper-plus/tree/dev/docker)** - Inference, training, and WebUI images
+## リンク
 
-## Links
+- [GitHub リポジトリ](https://github.com/ayutaz/piper-plus)
+- [Hugging Face デモ](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
+- [Hugging Face モデル](https://huggingface.co/ayousanz/piper-plus-base)
+- [ドキュメント](https://github.com/ayutaz/piper-plus/tree/dev/docs)
 
-- [GitHub Repository](https://github.com/ayutaz/piper-plus)
-- [Hugging Face Demo](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
-- [Hugging Face Models](https://huggingface.co/ayousanz/piper-plus-base)
-- [Documentation](https://github.com/ayutaz/piper-plus/tree/dev/docs)
+## ライセンス
 
-## License
-
-MIT License - see [LICENSE](https://github.com/ayutaz/piper-plus/blob/dev/LICENSE.md) for details.
+MIT License — 詳細は [LICENSE](https://github.com/ayutaz/piper-plus/blob/dev/LICENSE.md) を参照。

--- a/src/python_run/README.md
+++ b/src/python_run/README.md
@@ -49,10 +49,12 @@ piper --model tsukuyomi --text "こんにちは、今日は良い天気ですね
 ### Python API
 
 ```python
+import wave
 from piper import PiperVoice
 
 voice = PiperVoice.load("path/to/model.onnx", config_path="path/to/config.json")
-wav_bytes = voice.synthesize("こんにちは、今日は良い天気ですね。")
+with wave.open("output.wav", "wb") as wav_file:
+    voice.synthesize("こんにちは、今日は良い天気ですね。", wav_file)
 ```
 
 ## 事前学習済みモデル

--- a/src/python_run/README.md
+++ b/src/python_run/README.md
@@ -1,0 +1,95 @@
+# Piper Plus
+
+[![CI](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
+[![Python](https://img.shields.io/pypi/pyversions/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A fast, high-quality neural text-to-speech (TTS) system. Built on the [VITS](https://github.com/jaywalnut310/vits/) architecture with multi-speaker support for 6 languages. A fork of [Piper](https://github.com/rhasspy/piper) with significantly enhanced Japanese support, improved voice quality, and advanced training features.
+
+**[Hugging Face Demo](https://huggingface.co/spaces/ayousanz/piper-plus-demo)** | **[WebAssembly Demo](https://ayutaz.github.io/piper-plus/)** | **[GitHub](https://github.com/ayutaz/piper-plus)**
+
+## Key Features
+
+- **6-Language Support** - Japanese, English, Mandarin Chinese, Spanish, French, Portuguese
+- **Japanese TTS** - OpenJTalk integration, prosody features (A1/A2/A3), context-dependent phoneme variants
+- **English TTS** - GPL-free G2P ([g2p-en](https://github.com/Kyubyong/g2p), Apache-2.0), no espeak-ng dependency
+- **Multi-speaker** - 571 speakers in base model with language-balanced sampling
+- **Custom Dictionary** - 200+ built-in technical term pronunciations
+- **Phoneme Input** - Direct phoneme specification with `[[ phonemes ]]` notation
+- **Cross-platform** - Linux (x86_64/ARM64), macOS (Apple Silicon), Windows (x64)
+
+## Installation
+
+```bash
+pip install piper-tts-plus
+
+# GPU support
+pip install "piper-tts-plus[gpu]"
+```
+
+Requires Python 3.11+.
+
+## Quick Start
+
+### Command Line
+
+```bash
+# List available models
+piper --list-models
+piper --list-models ja
+
+# Download a model
+piper --download-model tsukuyomi
+
+# Generate speech
+piper --model tsukuyomi --text "Hello, world!" --output_file output.wav
+```
+
+### Python API
+
+```python
+from piper import PiperVoice
+
+voice = PiperVoice.load("path/to/model.onnx", config_path="path/to/config.json")
+wav_bytes = voice.synthesize("Hello, world!")
+```
+
+## Pre-trained Models
+
+| Model | Languages | Speakers | Download |
+|-------|-----------|----------|----------|
+| [piper-plus-base](https://huggingface.co/ayousanz/piper-plus-base) | 6 (ja/en/zh/es/fr/pt) | 571 | `piper --download-model base` |
+| [tsukuyomi-chan](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan) | 6 (ja/en/zh/es/fr/pt) | 1 | `piper --download-model tsukuyomi` |
+
+## Supported Languages
+
+| Language | Code | Phonemizer | Dependency |
+|----------|------|------------|------------|
+| Japanese | ja | OpenJTalk | pyopenjtalk-plus |
+| English | en | g2p-en | g2p-en (Apache-2.0) |
+| Mandarin Chinese | zh | pypinyin | pypinyin |
+| Spanish | es | Rule-based | None |
+| French | fr | Rule-based | None |
+| Portuguese | pt | Rule-based | None |
+
+## Other Interfaces
+
+Piper Plus is also available as:
+
+- **[C++ CLI](https://github.com/ayutaz/piper-plus/releases)** - Prebuilt binaries with streaming, CUDA inference, custom dictionary
+- **[Rust CLI](https://github.com/ayutaz/piper-plus/tree/dev/src/rust)** - Streaming, CUDA/CoreML/DirectML support
+- **[C# CLI (.NET)](https://github.com/ayutaz/piper-plus/tree/dev/src/csharp)** - Cross-platform .NET 8/9
+- **[WebAssembly](https://ayutaz.github.io/piper-plus/)** - Runs entirely in browser
+- **[Docker](https://github.com/ayutaz/piper-plus/tree/dev/docker)** - Inference, training, and WebUI images
+
+## Links
+
+- [GitHub Repository](https://github.com/ayutaz/piper-plus)
+- [Hugging Face Demo](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
+- [Hugging Face Models](https://huggingface.co/ayousanz/piper-plus-base)
+- [Documentation](https://github.com/ayutaz/piper-plus/tree/dev/docs)
+
+## License
+
+MIT License - see [LICENSE](https://github.com/ayutaz/piper-plus/blob/dev/LICENSE.md) for details.

--- a/src/python_run/setup.py
+++ b/src/python_run/setup.py
@@ -45,7 +45,7 @@ setup(
     version=version,
     description=(
         "A fast, high-quality neural text-to-speech system supporting "
-        "6 languages (ja/en/zh/es/fr/pt) with VITS architecture"
+        "6 languages (ja/en/zh/es/fr/pt) with VITS architecture."
     ),
     url="https://github.com/ayutaz/piper-plus",
     author="yousan",

--- a/src/python_run/setup.py
+++ b/src/python_run/setup.py
@@ -44,8 +44,8 @@ setup(
     name="piper-tts-plus",
     version=version,
     description=(
-        "A fast, local neural text to speech system that sounds great and is "
-        "optimized for the Raspberry Pi 4."
+        "A fast, high-quality neural text-to-speech system supporting "
+        "6 languages (ja/en/zh/es/fr/pt) with VITS architecture"
     ),
     url="https://github.com/ayutaz/piper-plus",
     author="yousan",


### PR DESCRIPTION
## Summary
- PyPI ページに「このパッケージの作者はプロジェクトの説明を提供していません」と表示されていた問題を修正
- `src/python_run/README.md` を新規作成し、`setup.py` の `long_description` として読み込まれるようにした
- `description` を fork元の古い文言 ("optimized for the Raspberry Pi 4") から現在のプロジェクト内容に更新

## Test plan
- [ ] 次回リリース時に PyPI ページにプロジェクト説明が表示されることを確認