### PR TITLE
fix(npm): DictManager 辞書ダウンロードを GitHub Releases に統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `pip install piper-plus` でインストール可能に
   - 旧パッケージ `piper-tts-plus` はスタブリリースで `piper-plus` へリダイレクト予定
 
+### Fixed
+- npm: DictManager の辞書ダウンロードを GitHub Releases (r9y9/open_jtalk) に統一 — Rust/C#/C++ と同一ソース
+  - 旧: HuggingFace 個別ファイル (404 エラー) → 新: tar.gz 一括 DL + SHA-256 検証 + DecompressionStream 展開
+  - voice ファイル (mei_normal.htsvoice) を HuggingFace `piper-plus-base` にアップロード
+  - PiperPlus._init() が DictManager.loadDictionary() + IndexedDB キャッシュを使用するように修正
+  - SimpleUnifiedPhonemizer にプリロード済みデータ受け取り対応 (dictData/voiceData)
+
 ## [1.9.0] - 2026-03-28
 
 ### Added

--- a/src/wasm/openjtalk-web/src/dict-manager.js
+++ b/src/wasm/openjtalk-web/src/dict-manager.js
@@ -144,6 +144,12 @@ async function fetchWithProgress(url, onProgress) {
  * @returns {Promise<boolean>}
  */
 async function verifySha256(buffer, expectedHex) {
+  if (!globalThis.crypto?.subtle?.digest) {
+    throw new Error(
+      'Web Crypto API (crypto.subtle) is not available. ' +
+      'A secure context (HTTPS) is required for SHA-256 verification.'
+    );
+  }
   const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
   const hashArray = new Uint8Array(hashBuffer);
   let hex = '';
@@ -237,16 +243,20 @@ function parseTar(tarBuffer) {
  * @returns {Promise<Object<string, ArrayBuffer>>} filename -> ArrayBuffer
  */
 async function downloadAndExtractDict(tarGzUrl, onProgress) {
+  const isDefaultUrl = tarGzUrl === DICT_TAR_GZ_URL;
+
   // 1. Download tar.gz
   const compressedData = await fetchWithProgress(tarGzUrl, onProgress);
 
-  // 2. Verify SHA-256
-  const valid = await verifySha256(compressedData, DICT_SHA256);
-  if (!valid) {
-    throw new Error(
-      'Dictionary archive SHA-256 verification failed. ' +
-      'The downloaded file may be corrupted or tampered with.'
-    );
+  // 2. Verify SHA-256 (only for the default archive; custom URLs may differ)
+  if (isDefaultUrl) {
+    const valid = await verifySha256(compressedData, DICT_SHA256);
+    if (!valid) {
+      throw new Error(
+        'Dictionary archive SHA-256 verification failed. ' +
+        'The downloaded file may be corrupted or tampered with.'
+      );
+    }
   }
 
   // 3. Decompress gzip
@@ -256,9 +266,23 @@ async function downloadAndExtractDict(tarGzUrl, onProgress) {
   const allFiles = parseTar(tarData);
   const dictFiles = {};
 
+  // Auto-detect tar root directory by looking for the first required file
+  let rootDir = isDefaultUrl ? TAR_ROOT_DIR : '';
+  if (!isDefaultUrl) {
+    const firstFile = DICT_FILES[0];
+    for (const key of allFiles.keys()) {
+      if (key.endsWith('/' + firstFile)) {
+        rootDir = key.slice(0, -(firstFile.length + 1));
+        break;
+      } else if (key === firstFile) {
+        rootDir = '';
+        break;
+      }
+    }
+  }
+
   for (const filename of DICT_FILES) {
-    // Files in the tar are prefixed with the root directory name
-    const tarPath = `${TAR_ROOT_DIR}/${filename}`;
+    const tarPath = rootDir ? `${rootDir}/${filename}` : filename;
     const data = allFiles.get(tarPath);
     if (!data) {
       throw new Error(

--- a/src/wasm/openjtalk-web/src/dict-manager.js
+++ b/src/wasm/openjtalk-web/src/dict-manager.js
@@ -1,8 +1,9 @@
 /**
- * DictManager -- OpenJTalk dictionary dynamic download + IndexedDB cache.
+ * DictManager -- OpenJTalk dictionary download + IndexedDB cache.
  *
- * Downloads individual dictionary files from HuggingFace (or a custom URL)
- * and caches them in IndexedDB so that subsequent loads are instant.
+ * Downloads the dictionary archive from the same GitHub Release used by
+ * Rust / C# / C++ implementations, extracts individual files in the browser,
+ * verifies the SHA-256 hash, and caches them in IndexedDB.
  *
  * Usage:
  *   const dm = new DictManager();
@@ -12,6 +13,21 @@
  */
 
 // ---- Constants ----------------------------------------------------------------
+
+/**
+ * The same GitHub Release URL that Rust, C#, and C++ use.
+ * @see src/rust/piper-core/src/dictionary_manager.rs
+ * @see src/csharp/PiperPlus.Core/Config/DictionaryManager.cs
+ */
+const DICT_TAR_GZ_URL =
+  'https://github.com/r9y9/open_jtalk/releases/download/v1.11.1/open_jtalk_dic_utf_8-1.11.tar.gz';
+
+/** SHA-256 of the tar.gz archive (same hash used by Rust / C#). */
+const DICT_SHA256 =
+  'fe6ba0e43542cef98339abdffd903e062008ea170b04e7e2a35da805902f382a';
+
+/** Root directory inside the tar archive. */
+const TAR_ROOT_DIR = 'open_jtalk_dic_utf_8-1.11';
 
 const DICT_FILES = [
   'char.bin',
@@ -26,8 +42,6 @@ const DICT_FILES = [
 
 const VOICE_KEY = 'voice/mei_normal.htsvoice';
 
-const DEFAULT_DICT_BASE_URL =
-  'https://huggingface.co/ayousanz/piper-plus-base/resolve/main/dict';
 const DEFAULT_VOICE_URL =
   'https://huggingface.co/ayousanz/piper-plus-base/resolve/main/voice/mei_normal.htsvoice';
 
@@ -120,6 +134,143 @@ async function fetchWithProgress(url, onProgress) {
   return merged.buffer;
 }
 
+// ---- SHA-256 verification -----------------------------------------------------
+
+/**
+ * Verify the SHA-256 hash of an ArrayBuffer using the Web Crypto API.
+ *
+ * @param {ArrayBuffer} buffer
+ * @param {string} expectedHex - lowercase hex SHA-256 hash
+ * @returns {Promise<boolean>}
+ */
+async function verifySha256(buffer, expectedHex) {
+  const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+  const hashArray = new Uint8Array(hashBuffer);
+  let hex = '';
+  for (let i = 0; i < hashArray.length; i++) {
+    hex += hashArray[i].toString(16).padStart(2, '0');
+  }
+  return hex === expectedHex;
+}
+
+// ---- Tar extraction -----------------------------------------------------------
+
+/**
+ * Decompress a gzip buffer using the DecompressionStream API.
+ *
+ * @param {ArrayBuffer} compressedBuffer
+ * @returns {Promise<ArrayBuffer>}
+ */
+async function decompressGzip(compressedBuffer) {
+  if (typeof DecompressionStream === 'undefined') {
+    throw new Error(
+      'DecompressionStream API is not available. ' +
+      'Please use a modern browser (Chrome 80+, Firefox 113+, Safari 16.4+).'
+    );
+  }
+  const stream = new Blob([compressedBuffer]).stream();
+  const decompressed = stream.pipeThrough(new DecompressionStream('gzip'));
+  return new Response(decompressed).arrayBuffer();
+}
+
+/**
+ * Parse a POSIX tar archive and extract files as a Map of name -> ArrayBuffer.
+ *
+ * @param {ArrayBuffer} tarBuffer - Uncompressed tar data
+ * @returns {Map<string, ArrayBuffer>}
+ */
+function parseTar(tarBuffer) {
+  const files = new Map();
+  const view = new Uint8Array(tarBuffer);
+  let offset = 0;
+
+  while (offset + 512 <= view.length) {
+    const header = view.subarray(offset, offset + 512);
+    offset += 512;
+
+    // End-of-archive: zero block
+    if (header.every((b) => b === 0)) break;
+
+    // Filename (bytes 0-99)
+    let name = '';
+    for (let i = 0; i < 100 && header[i] !== 0; i++) {
+      name += String.fromCharCode(header[i]);
+    }
+
+    // UStar prefix (bytes 345-499)
+    let prefix = '';
+    for (let i = 345; i < 500 && header[i] !== 0; i++) {
+      prefix += String.fromCharCode(header[i]);
+    }
+    if (prefix) {
+      name = prefix + '/' + name;
+    }
+
+    // File size (octal, bytes 124-135)
+    let sizeStr = '';
+    for (let i = 124; i < 136 && header[i] !== 0; i++) {
+      sizeStr += String.fromCharCode(header[i]);
+    }
+    const size = parseInt(sizeStr.trim(), 8) || 0;
+
+    // Type flag (byte 156): '0' or NUL = regular file
+    const typeFlag = header[156];
+
+    if (size > 0) {
+      const paddedSize = Math.ceil(size / 512) * 512;
+      if (typeFlag === 0x30 || typeFlag === 0) {
+        files.set(name, tarBuffer.slice(offset, offset + size));
+      }
+      offset += paddedSize;
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Download the tar.gz archive, verify its SHA-256 hash, decompress and
+ * extract the required dictionary files.
+ *
+ * @param {string} tarGzUrl
+ * @param {(loaded: number, total: number) => void} [onProgress]
+ * @returns {Promise<Object<string, ArrayBuffer>>} filename -> ArrayBuffer
+ */
+async function downloadAndExtractDict(tarGzUrl, onProgress) {
+  // 1. Download tar.gz
+  const compressedData = await fetchWithProgress(tarGzUrl, onProgress);
+
+  // 2. Verify SHA-256
+  const valid = await verifySha256(compressedData, DICT_SHA256);
+  if (!valid) {
+    throw new Error(
+      'Dictionary archive SHA-256 verification failed. ' +
+      'The downloaded file may be corrupted or tampered with.'
+    );
+  }
+
+  // 3. Decompress gzip
+  const tarData = await decompressGzip(compressedData);
+
+  // 4. Parse tar and extract required files
+  const allFiles = parseTar(tarData);
+  const dictFiles = {};
+
+  for (const filename of DICT_FILES) {
+    // Files in the tar are prefixed with the root directory name
+    const tarPath = `${TAR_ROOT_DIR}/${filename}`;
+    const data = allFiles.get(tarPath);
+    if (!data) {
+      throw new Error(
+        `Required dictionary file "${filename}" not found in archive (expected "${tarPath}").`
+      );
+    }
+    dictFiles[filename] = data;
+  }
+
+  return dictFiles;
+}
+
 // ---- DictManager --------------------------------------------------------------
 
 export class DictManager {
@@ -138,93 +289,79 @@ export class DictManager {
   /**
    * Resolve dictionary and voice URLs without downloading anything.
    *
-   * Applies the same default-fallback logic used by {@link loadDictionary} so
-   * that callers (e.g. `PiperPlus._init()`) can inspect the final URLs before
-   * any network request is made.
-   *
    * @param {Object} [options]
-   * @param {string} [options.dictUrl]  - Base URL for dictionary files.
+   * @param {string} [options.dictUrl]  - Custom tar.gz URL for the dictionary archive.
    * @param {string} [options.voiceUrl] - URL for the HTS voice file.
-   * @returns {{ dictBaseUrl: string, voiceUrl: string }}
+   * @returns {{ dictUrl: string, voiceUrl: string }}
    */
   resolveUrls(options = {}) {
-    const dictBaseUrl = (options.dictUrl || DEFAULT_DICT_BASE_URL).replace(
-      /\/+$/,
-      ''
-    );
+    const dictUrl = options.dictUrl || DICT_TAR_GZ_URL;
     const voiceUrl = options.voiceUrl || DEFAULT_VOICE_URL;
-    return { dictBaseUrl, voiceUrl };
+    return { dictUrl, voiceUrl };
   }
 
   /**
    * Download (or retrieve from cache) dictionary files and the HTS voice file.
    *
+   * On the first call the full tar.gz is downloaded from GitHub Releases,
+   * its SHA-256 is verified, and the individual files are cached in IndexedDB.
+   * Subsequent calls return instantly from the cache.
+   *
    * @param {Object} [options]
-   * @param {string} [options.dictUrl]    - Base URL for dictionary files.
+   * @param {string} [options.dictUrl]    - Custom tar.gz URL (default: GitHub Releases).
    * @param {string} [options.voiceUrl]   - URL for the HTS voice file.
    * @param {Function} [options.onProgress] - Progress callback.
    *   Called with `{ phase, file, loaded, total, overallPercent }`.
    *   - phase: 'dict' | 'voice'
-   *   - file: current filename (only during 'dict' phase)
-   *   - loaded / total: bytes for the current file
-   *   - overallPercent: 0-100 across all files
+   *   - file: current filename or archive name
+   *   - loaded / total: bytes
+   *   - overallPercent: 0-100
    * @returns {Promise<{dictFiles: Object<string,ArrayBuffer>, voiceData: ArrayBuffer}>}
    */
   async loadDictionary(options = {}) {
-    const { dictBaseUrl, voiceUrl } = this.resolveUrls(options);
+    const { dictUrl, voiceUrl } = this.resolveUrls(options);
     const onProgress = options.onProgress || null;
 
     const db = await this._openDB();
 
-    // Total number of items to track (dict files + voice).
-    const totalItems = DICT_FILES.length + 1;
-    let completedItems = 0;
-
     // ---- Dictionary files ---------------------------------------------------
 
     /** @type {Object<string,ArrayBuffer>} */
-    const dictFiles = {};
+    let dictFiles = {};
+    const allCached = await this._allDictFilesCached(db);
 
-    for (const filename of DICT_FILES) {
-      const cacheKey = `dict/${filename}`;
-      const cached = await this._getFromCache(db, cacheKey);
-
-      if (cached) {
-        dictFiles[filename] = cached;
-        completedItems++;
-        if (onProgress) {
-          onProgress({
-            phase: 'dict',
-            file: filename,
-            loaded: cached.byteLength,
-            total: cached.byteLength,
-            overallPercent: Math.round((completedItems / totalItems) * 100),
-          });
-        }
-        continue;
+    if (allCached) {
+      // All files in cache — load from IndexedDB
+      for (const filename of DICT_FILES) {
+        dictFiles[filename] = await this._getFromCache(db, `dict/${filename}`);
       }
-
-      // Not cached -- download.
-      const url = `${dictBaseUrl}/${filename}`;
-      const data = await fetchWithProgress(url, (loaded, total) => {
+      if (onProgress) {
+        onProgress({
+          phase: 'dict',
+          file: 'cache',
+          loaded: 1,
+          total: 1,
+          overallPercent: 50,
+        });
+      }
+    } else {
+      // Download tar.gz, verify, extract, and cache
+      dictFiles = await downloadAndExtractDict(dictUrl, (loaded, total) => {
         if (onProgress) {
           onProgress({
             phase: 'dict',
-            file: filename,
+            file: 'open_jtalk_dic_utf_8-1.11.tar.gz',
             loaded,
             total,
-            overallPercent: Math.round(
-              ((completedItems + loaded / Math.max(total, 1)) / totalItems) * 100
-            ),
+            overallPercent: Math.round((loaded / Math.max(total, 1)) * 50),
           });
         }
       });
 
-      // Cache the downloaded file.
-      await this._putToCache(db, cacheKey, data);
-
-      dictFiles[filename] = data;
-      completedItems++;
+      // Cache individual extracted files
+      for (const filename of DICT_FILES) {
+        await this._putToCache(db, `dict/${filename}`, dictFiles[filename]);
+      }
     }
 
     // ---- Voice file ---------------------------------------------------------
@@ -234,7 +371,6 @@ export class DictManager {
 
     if (cachedVoice) {
       voiceData = cachedVoice;
-      completedItems++;
       if (onProgress) {
         onProgress({
           phase: 'voice',
@@ -252,15 +388,12 @@ export class DictManager {
             file: VOICE_KEY,
             loaded,
             total,
-            overallPercent: Math.round(
-              ((completedItems + loaded / Math.max(total, 1)) / totalItems) * 100
-            ),
+            overallPercent: 50 + Math.round((loaded / Math.max(total, 1)) * 50),
           });
         }
       });
 
       await this._putToCache(db, VOICE_KEY, voiceData);
-      completedItems++;
     }
 
     return { dictFiles, voiceData };
@@ -274,16 +407,10 @@ export class DictManager {
   async isCached() {
     try {
       const db = await this._openDB();
+      if (!(await this._allDictFilesCached(db))) return false;
+
       const tx = db.transaction(STORE_NAME, 'readonly');
       const store = tx.objectStore(STORE_NAME);
-
-      // Check every dict file key.
-      for (const filename of DICT_FILES) {
-        const result = await wrapRequest(store.get(`dict/${filename}`));
-        if (!result || !result.data) return false;
-      }
-
-      // Check voice key.
       const voiceResult = await wrapRequest(store.get(VOICE_KEY));
       if (!voiceResult || !voiceResult.data) return false;
 
@@ -306,6 +433,26 @@ export class DictManager {
   }
 
   // ---- Private helpers ------------------------------------------------------
+
+  /**
+   * Check whether all 8 dictionary files are present in the cache.
+   *
+   * @param {IDBDatabase} db
+   * @returns {Promise<boolean>}
+   */
+  async _allDictFilesCached(db) {
+    try {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const store = tx.objectStore(STORE_NAME);
+      for (const filename of DICT_FILES) {
+        const result = await wrapRequest(store.get(`dict/${filename}`));
+        if (!result || !result.data) return false;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
 
   /**
    * Lazily open (and cache) the IndexedDB connection.

--- a/src/wasm/openjtalk-web/src/index.js
+++ b/src/wasm/openjtalk-web/src/index.js
@@ -237,19 +237,28 @@ export class PiperPlus {
 
     // --- 3. Initialise phonemizer (OpenJTalk + dict + voice) -----------------
 
-    progress({ stage: 'phonemizer', progress: 0, message: 'Initializing phonemizer...' });
+    progress({ stage: 'phonemizer', progress: 0, message: 'Downloading dictionary...' });
 
     const dictManager = new DictManager();
-    const { dictBaseUrl, voiceUrl } = await dictManager.resolveUrls({
+    const { dictFiles, voiceData } = await dictManager.loadDictionary({
       dictUrl: options.dictUrl,
       voiceUrl: options.voiceUrl,
+      onProgress: ({ phase, overallPercent }) => {
+        progress({
+          stage: 'phonemizer',
+          progress: overallPercent / 100 * 0.8,
+          message: phase === 'dict' ? 'Downloading dictionary...' : 'Downloading voice...',
+        });
+      },
     });
+
+    progress({ stage: 'phonemizer', progress: 0.8, message: 'Initializing phonemizer...' });
 
     this._phonemizer = new SimpleUnifiedPhonemizer();
     await this._phonemizer.initialize({
       openjtalk: {
-        dictPath: dictBaseUrl,
-        voicePath: voiceUrl,
+        dictData: dictFiles,
+        voiceData: voiceData,
       },
     });
 

--- a/src/wasm/openjtalk-web/src/simple_unified_api.js
+++ b/src/wasm/openjtalk-web/src/simple_unified_api.js
@@ -48,43 +48,42 @@ export class SimpleUnifiedPhonemizer {
      */
     async initializeOpenJTalk(config) {
         console.log('Loading OpenJTalk WebAssembly...');
-        
-        // Import OpenJTalk module
+
+        // Import OpenJTalk module -- resolve jsPath relative to this package
         let jsPath = config.jsPath;
-        if (this.deploymentConfig.isGitHubPages && this.deploymentConfig.basePath) {
+        if (!jsPath) {
+            // Auto-resolve from package: dist/openjtalk.js is a sibling of src/
+            jsPath = new URL('../dist/openjtalk.js', import.meta.url).href;
+        } else if (this.deploymentConfig.isGitHubPages && this.deploymentConfig.basePath) {
             jsPath = this.adjustPathForDeployment(jsPath);
         }
-        
+
         const OpenJTalkModule = (await import(jsPath)).default;
-        
-        // Adjust wasmPath for GitHub Pages
+
+        // Resolve wasmPath
         let wasmPath = config.wasmPath;
-        if (window.location.hostname.includes('github.io')) {
-            // Get repository base path from URL
+        if (!wasmPath) {
+            wasmPath = new URL('../dist/openjtalk.wasm', import.meta.url).href;
+        } else if (typeof window !== 'undefined' && window.location.hostname.includes('github.io')) {
             const pathParts = window.location.pathname.split('/').filter(p => p);
             const repoName = pathParts.length > 0 ? pathParts[0] : '';
             const basePath = repoName ? `/${repoName}` : '';
-            
-            // Convert relative path to absolute path with repo base
             if (wasmPath.startsWith('./') || wasmPath.startsWith('../')) {
                 wasmPath = basePath + '/dist/openjtalk.wasm';
             }
-            console.log('GitHub Pages WASM path:', wasmPath);
         }
-        
-        // Fetch the WASM binary for GitHub Pages
+
+        // Fetch the WASM binary if needed (GitHub Pages or absolute URL)
         let wasmBinary = null;
-        if (window.location.hostname.includes('github.io')) {
-            // Use absolute URL with origin
+        if (typeof window !== 'undefined' && window.location.hostname.includes('github.io')) {
             const absoluteWasmPath = new URL(wasmPath, window.location.origin).href;
-            console.log('Fetching WASM from:', absoluteWasmPath);
             const wasmResponse = await fetch(absoluteWasmPath);
             if (!wasmResponse.ok) {
                 throw new Error(`Failed to load WASM: ${wasmResponse.status} ${wasmResponse.statusText}`);
             }
             wasmBinary = await wasmResponse.arrayBuffer();
         }
-        
+
         this.openjtalkModule = await OpenJTalkModule({
             locateFile: (path) => {
                 if (path.endsWith('.wasm')) {
@@ -94,73 +93,84 @@ export class SimpleUnifiedPhonemizer {
             },
             wasmBinary: wasmBinary
         });
-        
+
         // Create directories
         this.openjtalkModule.FS.mkdir('/dict');
         this.openjtalkModule.FS.mkdir('/voice');
-        
+
         // Load dictionary and voice files
         await this.loadOpenJTalkData(config);
-        
+
         // Initialize OpenJTalk
         const dictPtr = this.openjtalkModule.allocateUTF8('/dict');
         const voicePtr = this.openjtalkModule.allocateUTF8('/voice/voice.htsvoice');
         const result = this.openjtalkModule._openjtalk_initialize(dictPtr, voicePtr);
         this.openjtalkModule._free(dictPtr);
         this.openjtalkModule._free(voicePtr);
-        
+
         if (result !== 0) {
             throw new Error(`OpenJTalk initialization failed with code: ${result}`);
         }
-        
+
         console.log('OpenJTalk initialized');
     }
 
     /**
-     * Load OpenJTalk data files
+     * Load OpenJTalk data files.
+     *
+     * Accepts either pre-loaded ArrayBuffer data (from DictManager) or
+     * URL paths (for standalone demo usage).
      */
     async loadOpenJTalkData(config) {
-        // Adjust paths for GitHub Pages
+        const dictFileNames = [
+            'char.bin', 'matrix.bin', 'sys.dic', 'unk.dic',
+            'left-id.def', 'pos-id.def', 'rewrite.def', 'right-id.def'
+        ];
+
+        // ---- Pre-loaded data path (from DictManager.loadDictionary()) ----
+        if (config.dictData && config.voiceData) {
+            for (const file of dictFileNames) {
+                const data = config.dictData[file];
+                if (data) {
+                    this.openjtalkModule.FS.writeFile(`/dict/${file}`, new Uint8Array(data));
+                }
+            }
+            this.openjtalkModule.FS.writeFile(
+                '/voice/voice.htsvoice',
+                new Uint8Array(config.voiceData)
+            );
+            return;
+        }
+
+        // ---- URL-based path (for standalone demos) ----
         let dictPath = config.dictPath;
         let voicePath = config.voicePath;
-        
-        if (window.location.hostname.includes('github.io')) {
-            // Get repository base path from URL
+
+        if (typeof window !== 'undefined' && window.location.hostname.includes('github.io')) {
             const pathParts = window.location.pathname.split('/').filter(p => p);
             const repoName = pathParts.length > 0 ? pathParts[0] : '';
             const basePath = repoName ? `/${repoName}` : '';
-            
-            // Convert relative paths to absolute paths with repo base
+
             if (dictPath.startsWith('./') || dictPath.startsWith('../')) {
                 dictPath = basePath + '/assets/dict';
             }
             if (voicePath.startsWith('./') || voicePath.startsWith('../')) {
                 voicePath = basePath + '/assets/voice/mei_normal.htsvoice';
             }
-            console.log('GitHub Pages dict path:', dictPath);
-            console.log('GitHub Pages voice path:', voicePath);
         }
-        
-        // Convert to absolute URLs
+
         const absoluteDictPath = new URL(dictPath, window.location.origin).href;
         const absoluteVoicePath = new URL(voicePath, window.location.origin).href;
-        
-        // Load dictionary files
-        const dictFiles = [
-            'char.bin', 'matrix.bin', 'sys.dic', 'unk.dic',
-            'left-id.def', 'pos-id.def', 'rewrite.def', 'right-id.def'
-        ];
-        
-        const dictPromises = dictFiles.map(file => 
+
+        const dictPromises = dictFileNames.map(file =>
             fetch(`${absoluteDictPath}/${file}`).then(r => r.arrayBuffer())
         );
         const dictData = await Promise.all(dictPromises);
-        
-        dictFiles.forEach((file, i) => {
+
+        dictFileNames.forEach((file, i) => {
             this.openjtalkModule.FS.writeFile(`/dict/${file}`, new Uint8Array(dictData[i]));
         });
-        
-        // Load voice file
+
         const voiceResponse = await fetch(absoluteVoicePath);
         const voiceData = await voiceResponse.arrayBuffer();
         this.openjtalkModule.FS.writeFile('/voice/voice.htsvoice', new Uint8Array(voiceData));

--- a/src/wasm/openjtalk-web/src/simple_unified_api.js
+++ b/src/wasm/openjtalk-web/src/simple_unified_api.js
@@ -129,11 +129,20 @@ export class SimpleUnifiedPhonemizer {
 
         // ---- Pre-loaded data path (from DictManager.loadDictionary()) ----
         if (config.dictData && config.voiceData) {
+            // Validate all required files are present
+            const missing = dictFileNames.filter(f => !(config.dictData[f] instanceof ArrayBuffer));
+            if (missing.length > 0) {
+                throw new Error(
+                    `Missing required dictionary files: ${missing.join(', ')}. ` +
+                    'All 8 OpenJTalk dictionary files must be provided.'
+                );
+            }
+            if (!(config.voiceData instanceof ArrayBuffer)) {
+                throw new Error('voiceData must be an ArrayBuffer.');
+            }
+
             for (const file of dictFileNames) {
-                const data = config.dictData[file];
-                if (data) {
-                    this.openjtalkModule.FS.writeFile(`/dict/${file}`, new Uint8Array(data));
-                }
+                this.openjtalkModule.FS.writeFile(`/dict/${file}`, new Uint8Array(config.dictData[file]));
             }
             this.openjtalkModule.FS.writeFile(
                 '/voice/voice.htsvoice',

--- a/src/wasm/openjtalk-web/test/js/helpers/dict-mock.js
+++ b/src/wasm/openjtalk-web/test/js/helpers/dict-mock.js
@@ -1,0 +1,265 @@
+/**
+ * Shared mock utilities for DictManager tests.
+ *
+ * Creates a real gzipped tar archive containing the 8 OpenJTalk dictionary
+ * files so that DictManager's tar.gz download → decompress → extract → cache
+ * pipeline can be exercised end-to-end in Node.js tests.
+ */
+
+import { gzipSync } from 'node:zlib';
+
+// ---- Constants ----------------------------------------------------------------
+
+export const TAR_ROOT = 'open_jtalk_dic_utf_8-1.11';
+
+export const DICT_FILES = [
+  'char.bin',
+  'matrix.bin',
+  'sys.dic',
+  'unk.dic',
+  'left-id.def',
+  'right-id.def',
+  'pos-id.def',
+  'rewrite.def',
+];
+
+export const DICT_SHA256 =
+  'fe6ba0e43542cef98339abdffd903e062008ea170b04e7e2a35da805902f382a';
+
+export const DICT_TAR_GZ_URL =
+  'https://github.com/r9y9/open_jtalk/releases/download/v1.11.1/open_jtalk_dic_utf_8-1.11.tar.gz';
+
+export const VOICE_URL =
+  'https://huggingface.co/ayousanz/piper-plus-base/resolve/main/voice/mei_normal.htsvoice';
+
+// ---- Tar builder --------------------------------------------------------------
+
+function createTarEntry(filename, data) {
+  const header = new Uint8Array(512);
+  const enc = new TextEncoder();
+
+  // Filename (0-99)
+  header.set(enc.encode(filename).subarray(0, 100));
+
+  // Mode (100-107)
+  header.set(enc.encode('0000644'), 100);
+  header[107] = 0;
+
+  // UID / GID (108-123)
+  header.set(enc.encode('0000000'), 108);
+  header[115] = 0;
+  header.set(enc.encode('0000000'), 116);
+  header[123] = 0;
+
+  // Size (124-135) — octal
+  header.set(enc.encode(data.byteLength.toString(8).padStart(11, '0')), 124);
+  header[135] = 0;
+
+  // Mtime (136-147)
+  header.set(enc.encode('00000000000'), 136);
+  header[147] = 0;
+
+  // Checksum placeholder: 8 spaces (148-155)
+  for (let i = 148; i < 156; i++) header[i] = 0x20;
+
+  // Type flag: '0' = regular file
+  header[156] = 0x30;
+
+  // UStar magic (257-264)
+  header.set(enc.encode('ustar'), 257);
+  header[262] = 0;
+  header[263] = 0x30;
+  header[264] = 0x30;
+
+  // Compute checksum
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += header[i];
+  const csStr = sum.toString(8).padStart(6, '0');
+  header.set(enc.encode(csStr), 148);
+  header[154] = 0;
+  header[155] = 0x20;
+
+  // Data padded to 512-byte boundary
+  const padded = Math.ceil(data.byteLength / 512) * 512;
+  const dataBlock = new Uint8Array(padded);
+  dataBlock.set(new Uint8Array(data));
+
+  return { header, dataBlock };
+}
+
+/**
+ * Build a gzipped tar archive containing the 8 dict files.
+ *
+ * @param {number} [fileSize=64] Byte size of each mock dict file.
+ * @param {number} [fillByte=0xAB] Fill byte for mock data.
+ * @returns {ArrayBuffer}
+ */
+export function createMockTarGz(fileSize = 64, fillByte = 0xAB) {
+  const blocks = [];
+
+  for (const name of DICT_FILES) {
+    const data = new ArrayBuffer(fileSize);
+    new Uint8Array(data).fill(fillByte);
+    const entry = createTarEntry(`${TAR_ROOT}/${name}`, data);
+    blocks.push(entry.header, entry.dataBlock);
+  }
+
+  // End-of-archive marker: two 512-byte zero blocks
+  blocks.push(new Uint8Array(1024));
+
+  const total = blocks.reduce((s, b) => s + b.byteLength, 0);
+  const tar = new Uint8Array(total);
+  let off = 0;
+  for (const b of blocks) {
+    tar.set(b, off);
+    off += b.byteLength;
+  }
+
+  const gz = gzipSync(tar);
+  // Buffer.buffer may be a shared ArrayBuffer pool slice — copy to isolate.
+  return gz.buffer.slice(gz.byteOffset, gz.byteOffset + gz.byteLength);
+}
+
+// ---- IndexedDB mock -----------------------------------------------------------
+
+export class MockObjectStore {
+  constructor(store) { this._store = store; }
+
+  get(key) {
+    const result = this._store.get(key) ?? undefined;
+    return _fakeRequest(result);
+  }
+
+  put(val) {
+    this._store.set(val.key, val);
+    return _fakeRequest(undefined);
+  }
+
+  clear() {
+    this._store.clear();
+    return _fakeRequest(undefined);
+  }
+}
+
+function _fakeRequest(result) {
+  const req = { result, onsuccess: null, onerror: null };
+  Promise.resolve().then(() => { if (req.onsuccess) req.onsuccess(); });
+  return req;
+}
+
+export class MockIDBDatabase {
+  constructor() {
+    this._stores = new Map();
+    this.objectStoreNames = { contains: (n) => this._stores.has(n) };
+  }
+
+  _ensureStore(name) {
+    if (!this._stores.has(name)) this._stores.set(name, new Map());
+    return this._stores.get(name);
+  }
+
+  createObjectStore(name) { this._ensureStore(name); }
+
+  transaction(storeName) {
+    const store = this._ensureStore(storeName);
+    return { objectStore: () => new MockObjectStore(store) };
+  }
+}
+
+/**
+ * Install a global IndexedDB mock.  Returns `{ db, lastDbName }`.
+ */
+export function installIndexedDBMock() {
+  const state = { db: new MockIDBDatabase(), lastDbName: undefined };
+
+  globalThis.indexedDB = {
+    open(name) {
+      state.lastDbName = name;
+      const req = { result: null, onsuccess: null, onerror: null, onupgradeneeded: null };
+      Promise.resolve().then(() => {
+        if (req.onupgradeneeded) req.onupgradeneeded({ target: { result: state.db } });
+        req.result = state.db;
+        if (req.onsuccess) req.onsuccess();
+      });
+      return req;
+    },
+  };
+
+  return state;
+}
+
+// ---- Fetch mock ---------------------------------------------------------------
+
+/**
+ * Install a global fetch mock that returns a tar.gz for dict URLs and a
+ * plain buffer for voice URLs.
+ *
+ * @param {Object} [opts]
+ * @param {boolean} [opts.shouldFail]   - Return 404 for all fetches.
+ * @param {boolean} [opts.shouldReject] - Reject with TypeError.
+ * @param {number}  [opts.dictFileSize] - Per-file size inside the tar.
+ * @param {number}  [opts.voiceSize]    - Voice buffer size.
+ * @returns {string[]} Array that collects fetched URLs.
+ */
+export function installFetchMock({
+  shouldFail = false,
+  shouldReject = false,
+  dictFileSize = 64,
+  voiceSize = 64,
+} = {}) {
+  const mockTarGz = createMockTarGz(dictFileSize);
+  const mockVoice = new ArrayBuffer(voiceSize);
+  new Uint8Array(mockVoice).fill(0xCD);
+
+  const fetched = [];
+
+  globalThis.fetch = async (url) => {
+    fetched.push(url);
+    if (shouldReject) throw new TypeError('Failed to fetch');
+    if (shouldFail) return { ok: false, status: 404, statusText: 'Not Found' };
+
+    const body = url.includes('.tar.gz') ? mockTarGz : mockVoice;
+
+    return {
+      ok: true,
+      headers: { get: (h) => (h === 'Content-Length' ? String(body.byteLength) : null) },
+      body: null,
+      arrayBuffer: async () => body,
+    };
+  };
+
+  return fetched;
+}
+
+// ---- Crypto mock (SHA-256 always passes) --------------------------------------
+
+let _origDigest;
+
+export function installCryptoMock() {
+  // Node.js makes globalThis.crypto a getter-only property, so we
+  // monkey-patch crypto.subtle.digest instead of replacing crypto itself.
+  _origDigest = globalThis.crypto?.subtle?.digest;
+  if (globalThis.crypto?.subtle) {
+    globalThis.crypto.subtle.digest = async () => {
+      const bytes = new Uint8Array(32);
+      for (let i = 0; i < 64; i += 2) {
+        bytes[i / 2] = parseInt(DICT_SHA256.substr(i, 2), 16);
+      }
+      return bytes.buffer;
+    };
+  }
+}
+
+export function restoreCrypto() {
+  if (_origDigest && globalThis.crypto?.subtle) {
+    globalThis.crypto.subtle.digest = _origDigest;
+  }
+}
+
+// ---- Cleanup ------------------------------------------------------------------
+
+export function cleanup() {
+  delete globalThis.indexedDB;
+  delete globalThis.fetch;
+  restoreCrypto();
+}

--- a/src/wasm/openjtalk-web/test/js/test-dict-manager-boundary.js
+++ b/src/wasm/openjtalk-web/test/js/test-dict-manager-boundary.js
@@ -2,131 +2,17 @@
  * TDD Tests for DictManager -- 境界値・エラーケース
  *
  * テスト対象: src/wasm/openjtalk-web/src/dict-manager.js
- *
- * DictManager の異常系・エッジケースを網羅するテスト群。
- * ネットワークエラー、部分的失敗、IndexedDB不可、同時呼び出し等。
  */
 
 import assert from 'node:assert/strict';
 import { describe, it, beforeEach, afterEach } from 'node:test';
-
-// ---- Mock: IndexedDB -----------------------------------------------------------
-
-class MockObjectStore {
-  constructor(store) { this._store = store; }
-
-  get(key) {
-    const result = this._store.get(key) ?? undefined;
-    return _fakeRequest(result);
-  }
-
-  put(val) {
-    this._store.set(val.key, val);
-    return _fakeRequest(undefined);
-  }
-
-  clear() {
-    this._store.clear();
-    return _fakeRequest(undefined);
-  }
-}
-
-function _fakeRequest(result) {
-  const req = { result, onsuccess: null, onerror: null };
-  Promise.resolve().then(() => {
-    if (req.onsuccess) req.onsuccess();
-  });
-  return req;
-}
-
-class MockIDBDatabase {
-  constructor() {
-    this._stores = new Map();
-    this.objectStoreNames = { contains: (n) => this._stores.has(n) };
-  }
-
-  _ensureStore(name) {
-    if (!this._stores.has(name)) this._stores.set(name, new Map());
-    return this._stores.get(name);
-  }
-
-  createObjectStore(name, _opts) {
-    this._ensureStore(name);
-  }
-
-  transaction(storeName, _mode) {
-    const store = this._ensureStore(storeName);
-    return { objectStore: () => new MockObjectStore(store) };
-  }
-}
-
-let _mockDB;
-let _lastOpenedDbName;
-
-function installIndexedDBMock() {
-  _mockDB = new MockIDBDatabase();
-  _lastOpenedDbName = undefined;
-  globalThis.indexedDB = {
-    open(name, _version) {
-      _lastOpenedDbName = name;
-      const req = { result: null, onsuccess: null, onerror: null, onupgradeneeded: null };
-      Promise.resolve().then(() => {
-        if (req.onupgradeneeded) {
-          req.onupgradeneeded({ target: { result: _mockDB } });
-        }
-        req.result = _mockDB;
-        if (req.onsuccess) req.onsuccess();
-      });
-      return req;
-    },
-  };
-}
-
-// ---- Mock: fetch ---------------------------------------------------------------
-
-/** All 8 dict files + 1 voice = 9 total fetches */
-const DICT_FILES = [
-  'char.bin', 'matrix.bin', 'sys.dic', 'unk.dic',
-  'left-id.def', 'right-id.def', 'pos-id.def', 'rewrite.def',
-];
-
-/**
- * Install a configurable fetch mock.
- *
- * @param {Object} [opts]
- * @param {boolean} [opts.shouldFail]     - Return 404 for all fetches.
- * @param {boolean} [opts.shouldReject]   - Reject with TypeError.
- * @param {Set<string>} [opts.failFiles]  - Set of filenames that return 404.
- * @param {number} [opts.bodySize]        - Response ArrayBuffer size (default 64).
- * @returns {string[]}
- */
-function installFetchMock({ shouldFail = false, shouldReject = false, failFiles = null, bodySize = 64 } = {}) {
-  const fetched = [];
-  globalThis.fetch = async (url) => {
-    fetched.push(url);
-    if (shouldReject) {
-      throw new TypeError('Failed to fetch');
-    }
-    // Per-file 404 support.
-    if (failFiles) {
-      const basename = url.split('/').pop();
-      if (failFiles.has(basename)) {
-        return { ok: false, status: 404, statusText: 'Not Found' };
-      }
-    }
-    if (shouldFail) {
-      return { ok: false, status: 404, statusText: 'Not Found' };
-    }
-    const body = new ArrayBuffer(bodySize);
-    return {
-      ok: true,
-      headers: { get: () => null },
-      body: null,
-      arrayBuffer: async () => body,
-    };
-  };
-  return fetched;
-}
+import {
+  DICT_FILES,
+  installIndexedDBMock,
+  installFetchMock,
+  installCryptoMock,
+  cleanup,
+} from './helpers/dict-mock.js';
 
 // ---- Import SUT ----------------------------------------------------------------
 
@@ -140,257 +26,121 @@ try {
 
 const skip = DictManager === null;
 
-// ---- Saved globals for cleanup -------------------------------------------------
-
-let _savedIndexedDB;
-let _savedFetch;
-
 // ---- Tests ---------------------------------------------------------------------
 
 describe('DictManager 境界値・エラーケース', { skip }, () => {
-  /** @type {string[]} */
   let fetched;
 
   beforeEach(() => {
-    _savedIndexedDB = globalThis.indexedDB;
-    _savedFetch = globalThis.fetch;
     installIndexedDBMock();
+    installCryptoMock();
     fetched = installFetchMock();
   });
 
   afterEach(() => {
-    globalThis.indexedDB = _savedIndexedDB;
-    globalThis.fetch = _savedFetch;
     fetched = [];
+    cleanup();
   });
-
-  // ---------- 1. 空 cachePrefix ---------------------------------------------------
 
   it('空の cachePrefix でデフォルト値が使用される', async () => {
-    // Arrange
+    const state = installIndexedDBMock();
     const dm = new DictManager({ cachePrefix: '' });
-
-    // Act
     await dm.loadDictionary();
-
-    // Assert -- falsy '' triggers || fallback to 'piper-plus-dict'
-    assert.equal(
-      _lastOpenedDbName,
-      'piper-plus-dict',
-      'Empty cachePrefix should fall back to default DB name'
-    );
+    assert.equal(state.lastDbName, 'piper-plus-dict');
   });
 
-  // ---------- 2. ネットワークエラー (TypeError) ------------------------------------
-
-  it('ネットワークエラーで適切なエラーがスローされる', async () => {
-    // Arrange
+  it('ネットワークエラーで TypeError がスローされる', async () => {
+    cleanup();
+    installIndexedDBMock();
+    installCryptoMock();
     fetched = installFetchMock({ shouldReject: true });
-    const dm = new DictManager();
 
-    // Act & Assert
+    const dm = new DictManager();
+    await assert.rejects(() => dm.loadDictionary(), TypeError);
+  });
+
+  it('tar.gz が 404 の場合にエラー', async () => {
+    cleanup();
+    installIndexedDBMock();
+    installCryptoMock();
+    fetched = installFetchMock({ shouldFail: true });
+
+    const dm = new DictManager();
     await assert.rejects(
       () => dm.loadDictionary(),
-      (err) => {
-        assert.ok(err instanceof TypeError, 'Error should be a TypeError');
-        assert.ok(
-          err.message.includes('Failed to fetch'),
-          `Error message should contain 'Failed to fetch', got: ${err.message}`
-        );
-        return true;
-      }
+      (err) => err.message.includes('404')
     );
   });
 
-  // ---------- 3. 個別ファイル 404 -------------------------------------------------
+  it('SHA-256 不一致の場合にエラー', async () => {
+    cleanup();
+    installIndexedDBMock();
+    // Monkey-patch digest to return wrong hash (all zeros)
+    globalThis.crypto.subtle.digest = async () => new Uint8Array(32).buffer;
+    fetched = installFetchMock();
 
-  it('個別ファイルが 404 の場合にエラー', async () => {
-    // Arrange -- only sys.dic fails
-    fetched = installFetchMock({ failFiles: new Set(['sys.dic']) });
     const dm = new DictManager();
-
-    // Act & Assert
     await assert.rejects(
       () => dm.loadDictionary(),
-      (err) => {
-        assert.ok(
-          err.message.includes('Failed to fetch') || err.message.includes('404'),
-          `Error should indicate fetch failure for individual file, got: ${err.message}`
-        );
-        assert.ok(
-          err.message.includes('sys.dic'),
-          `Error should reference the failed file, got: ${err.message}`
-        );
-        return true;
-      }
+      (err) => err.message.includes('SHA-256')
     );
   });
 
-  // ---------- 4. 部分的ダウンロード失敗 -------------------------------------------
+  it('大きな辞書ファイルのダウンロード', async () => {
+    cleanup();
+    installIndexedDBMock();
+    installCryptoMock();
+    fetched = installFetchMock({ dictFileSize: 10240 });
 
-  it('部分的なダウンロード失敗でもエラーが発生する', async () => {
-    // Arrange -- last dict file fails; others succeed
-    fetched = installFetchMock({ failFiles: new Set(['rewrite.def']) });
     const dm = new DictManager();
+    const { dictFiles } = await dm.loadDictionary();
 
-    // Act & Assert -- even if 7/8 files succeed, one failure causes rejection
-    await assert.rejects(
-      () => dm.loadDictionary(),
-      (err) => {
-        assert.ok(
-          err.message.includes('Failed to fetch') || err.message.includes('404'),
-          `Partial failure should still throw, got: ${err.message}`
-        );
-        return true;
-      }
-    );
-
-    // Verify that earlier files were actually fetched before the failure
-    const fetchedBasenames = fetched.map((u) => u.split('/').pop());
-    assert.ok(
-      fetchedBasenames.includes('char.bin'),
-      'Files before the failing one should have been fetched'
-    );
-  });
-
-  // ---------- 5. 非常に大きな辞書ファイル ------------------------------------------
-
-  it('非常に大きな辞書ファイルのダウンロード', async () => {
-    // Arrange -- 10 MB mock response per file
-    const largeSize = 10 * 1024 * 1024;
-    fetched = installFetchMock({ bodySize: largeSize });
-    const dm = new DictManager();
-
-    // Act
-    const { dictFiles, voiceData } = await dm.loadDictionary();
-
-    // Assert -- all files should be present with the large size
-    for (const filename of DICT_FILES) {
-      assert.ok(dictFiles[filename], `dictFiles should contain '${filename}'`);
-      assert.equal(
-        dictFiles[filename].byteLength,
-        largeSize,
-        `${filename} should have ${largeSize} bytes`
-      );
-    }
-    assert.equal(
-      voiceData.byteLength,
-      largeSize,
-      `voiceData should have ${largeSize} bytes`
-    );
-  });
-
-  // ---------- 6. dictUrl 末尾スラッシュあり ----------------------------------------
-
-  it('dictUrl に末尾スラッシュがある場合の正規化', async () => {
-    // Arrange
-    const dm = new DictManager();
-
-    // Act
-    await dm.loadDictionary({ dictUrl: 'https://example.com/dict/' });
-
-    // Assert -- URL is constructed as `${dictBaseUrl}/${filename}`,
-    // so trailing slash produces double-slash: dict//char.bin
-    const dictUrls = fetched.filter((u) => !u.includes('voice'));
-    for (const url of dictUrls) {
-      assert.ok(
-        url.startsWith('https://example.com/dict/'),
-        `Dict URL should start with the custom base, got: ${url}`
-      );
-    }
-
-    // Verify file names are still resolvable
-    const basenames = dictUrls.map((u) => u.split('/').pop());
-    for (const filename of DICT_FILES) {
-      assert.ok(
-        basenames.includes(filename),
-        `Should fetch ${filename} even with trailing slash`
-      );
+    for (const file of DICT_FILES) {
+      assert.equal(dictFiles[file].byteLength, 10240, `${file} should be 10240 bytes`);
     }
   });
 
-  // ---------- 7. dictUrl 末尾スラッシュなし ----------------------------------------
-
-  it('dictUrl に末尾スラッシュがない場合の正規化', async () => {
-    // Arrange
+  it('indexedDB 利用不可の場合', async () => {
+    delete globalThis.indexedDB;
     const dm = new DictManager();
-
-    // Act
-    await dm.loadDictionary({ dictUrl: 'https://example.com/dict' });
-
-    // Assert -- URL constructed as 'https://example.com/dict/char.bin'
-    const dictUrls = fetched.filter((u) => !u.includes('voice'));
-    for (const url of dictUrls) {
-      assert.ok(
-        url.startsWith('https://example.com/dict/'),
-        `Dict URL should use custom base with separator, got: ${url}`
-      );
-      // Confirm no double slash
-      assert.ok(
-        !url.includes('dict//'),
-        `URL should not contain double-slash, got: ${url}`
-      );
-    }
+    await assert.rejects(() => dm.loadDictionary());
   });
-
-  // ---------- 8. indexedDB 利用不可 ------------------------------------------------
-
-  it('indexedDB が利用不可の場合の挙動', async () => {
-    // Arrange -- remove indexedDB entirely
-    globalThis.indexedDB = undefined;
-    const dm = new DictManager();
-
-    // Act & Assert -- _openDB() calls indexedDB.open() which will throw
-    await assert.rejects(
-      () => dm.loadDictionary(),
-      (err) => {
-        // TypeError because indexedDB is undefined -> cannot read .open
-        assert.ok(
-          err instanceof TypeError || err instanceof Error,
-          `Should throw when indexedDB unavailable, got: ${err.constructor.name}`
-        );
-        return true;
-      }
-    );
-  });
-
-  // ---------- 9. 同時呼び出し (race condition) ------------------------------------
 
   it('同時に loadDictionary を2回呼んだ場合', async () => {
-    // Arrange
     const dm = new DictManager();
-
-    // Act -- fire two loads concurrently
     const [result1, result2] = await Promise.all([
       dm.loadDictionary(),
       dm.loadDictionary(),
     ]);
 
-    // Assert -- both should resolve successfully with all expected keys
-    const expectedKeys = new Set(DICT_FILES);
-    assert.deepEqual(
-      new Set(Object.keys(result1.dictFiles)),
-      expectedKeys,
-      'First concurrent result should have all dict files'
-    );
-    assert.deepEqual(
-      new Set(Object.keys(result2.dictFiles)),
-      expectedKeys,
-      'Second concurrent result should have all dict files'
-    );
-    assert.ok(result1.voiceData, 'First result should have voiceData');
-    assert.ok(result2.voiceData, 'Second result should have voiceData');
+    assert.ok(result1.dictFiles);
+    assert.ok(result2.dictFiles);
 
-    // Both calls should produce valid ArrayBuffer instances
-    for (const filename of DICT_FILES) {
-      assert.ok(
-        result1.dictFiles[filename] instanceof ArrayBuffer,
-        `result1.dictFiles['${filename}'] should be ArrayBuffer`
-      );
-      assert.ok(
-        result2.dictFiles[filename] instanceof ArrayBuffer,
-        `result2.dictFiles['${filename}'] should be ArrayBuffer`
-      );
+    for (const file of DICT_FILES) {
+      assert.ok(result1.dictFiles[file] instanceof ArrayBuffer);
+      assert.ok(result2.dictFiles[file] instanceof ArrayBuffer);
     }
+  });
+
+  it('カスタム dictUrl を指定した場合', async () => {
+    const dm = new DictManager();
+    await dm.loadDictionary({
+      dictUrl: 'https://example.com/custom-dict.tar.gz',
+    });
+
+    assert.ok(
+      fetched[0] === 'https://example.com/custom-dict.tar.gz',
+      'Custom dict URL should be used'
+    );
+  });
+
+  it('カスタム voiceUrl を指定した場合', async () => {
+    const dm = new DictManager();
+    await dm.loadDictionary({
+      voiceUrl: 'https://example.com/custom-voice.htsvoice',
+    });
+
+    const voiceFetch = fetched.find((u) => u.includes('custom-voice'));
+    assert.ok(voiceFetch, 'Custom voice URL should be used');
   });
 });

--- a/src/wasm/openjtalk-web/test/js/test-dict-manager-cache.js
+++ b/src/wasm/openjtalk-web/test/js/test-dict-manager-cache.js
@@ -2,156 +2,20 @@
  * TDD Tests for DictManager cache lifecycle (isCached / clearCache)
  *
  * テスト対象: src/wasm/openjtalk-web/src/dict-manager.js
- *
- * キャッシュの初期状態、loadDictionary 後の状態遷移、clearCache による
- * 無効化、再ダウンロード、cachePrefix による独立キャッシュ、データ整合性
- * を検証する。
  */
 
 import assert from 'node:assert/strict';
 import { describe, it, beforeEach, afterEach } from 'node:test';
+import {
+  DICT_FILES,
+  installIndexedDBMock,
+  installFetchMock,
+  installCryptoMock,
+  cleanup,
+  MockIDBDatabase,
+} from './helpers/dict-mock.js';
 
-// ---- Constants (mirror source for assertions) --------------------------------
-
-const DICT_FILES = [
-  'char.bin',
-  'matrix.bin',
-  'sys.dic',
-  'unk.dic',
-  'left-id.def',
-  'right-id.def',
-  'pos-id.def',
-  'rewrite.def',
-];
-
-const VOICE_KEY = 'voice/mei_normal.htsvoice';
-
-// ---- Mock: IndexedDB (in-memory with working get/put/delete/clear) ----------
-
-/**
- * In-memory object store backed by a Map.
- * Supports get, put, clear, and delete -- all returning IDBRequest-like objects
- * whose onsuccess fires on the next microtick.
- */
-class MockObjectStore {
-  constructor(store) {
-    this._store = store;
-  }
-
-  get(key) {
-    const result = this._store.get(key) ?? undefined;
-    return _fakeRequest(result);
-  }
-
-  put(val) {
-    this._store.set(val.key, val);
-    return _fakeRequest(undefined);
-  }
-
-  delete(key) {
-    this._store.delete(key);
-    return _fakeRequest(undefined);
-  }
-
-  clear() {
-    this._store.clear();
-    return _fakeRequest(undefined);
-  }
-}
-
-function _fakeRequest(result) {
-  const req = { result, onsuccess: null, onerror: null };
-  Promise.resolve().then(() => {
-    if (req.onsuccess) req.onsuccess();
-  });
-  return req;
-}
-
-class MockIDBDatabase {
-  constructor() {
-    this._stores = new Map();
-    this.objectStoreNames = { contains: (n) => this._stores.has(n) };
-  }
-
-  _ensureStore(name) {
-    if (!this._stores.has(name)) this._stores.set(name, new Map());
-    return this._stores.get(name);
-  }
-
-  createObjectStore(name, _opts) {
-    this._ensureStore(name);
-  }
-
-  transaction(storeName, _mode) {
-    const store = this._ensureStore(storeName);
-    return { objectStore: () => new MockObjectStore(store) };
-  }
-}
-
-/**
- * Map of dbName -> MockIDBDatabase.
- * Each unique cachePrefix (dbName) gets its own isolated database instance,
- * which is essential for testing cross-prefix isolation.
- */
-let _dbInstances;
-
-function installIndexedDBMock() {
-  _dbInstances = new Map();
-  globalThis.indexedDB = {
-    open(name, _version) {
-      if (!_dbInstances.has(name)) {
-        _dbInstances.set(name, new MockIDBDatabase());
-      }
-      const db = _dbInstances.get(name);
-      const req = { result: null, onsuccess: null, onerror: null, onupgradeneeded: null };
-      Promise.resolve().then(() => {
-        if (req.onupgradeneeded) {
-          req.onupgradeneeded({ target: { result: db } });
-        }
-        req.result = db;
-        if (req.onsuccess) req.onsuccess();
-      });
-      return req;
-    },
-  };
-}
-
-function teardownIndexedDBMock() {
-  _dbInstances = null;
-  delete globalThis.indexedDB;
-}
-
-// ---- Mock: fetch (returns deterministic dummy data) -------------------------
-
-/** Dummy 64-byte buffer used as dict/voice payload. */
-const DUMMY_DATA = new ArrayBuffer(64);
-new Uint8Array(DUMMY_DATA).fill(0xAB);
-
-/**
- * Install a global fetch mock that returns copies of DUMMY_DATA.
- * Returns an array that collects all fetched URLs.
- */
-function installFetchMock() {
-  const fetched = [];
-  globalThis.fetch = async (url) => {
-    fetched.push(url);
-    // Return a fresh copy so consumers cannot mutate shared state.
-    const copy = DUMMY_DATA.slice(0);
-    return {
-      ok: true,
-      headers: { get: () => null },
-      body: null,
-      arrayBuffer: async () => copy,
-    };
-  };
-  return fetched;
-}
-
-function teardownFetchMock() {
-  delete globalThis.fetch;
-}
-
-// ---- Import SUT (TDD skip guard) -------------------------------------------
+// ---- Import SUT ----------------------------------------------------------------
 
 let DictManager;
 try {
@@ -163,186 +27,128 @@ try {
 
 const skip = DictManager === null;
 
-// ---- Tests ------------------------------------------------------------------
+// ---- Tests ---------------------------------------------------------------------
 
 describe('DictManager キャッシュライフサイクル', { skip }, () => {
-  /** @type {string[]} URLs fetched during the current test. */
   let fetched;
 
   beforeEach(() => {
     installIndexedDBMock();
+    installCryptoMock();
     fetched = installFetchMock();
   });
 
   afterEach(() => {
     fetched = [];
-    teardownFetchMock();
-    teardownIndexedDBMock();
+    cleanup();
   });
 
-  // ---------- 1. 初期状態 -------------------------------------------------------
-
-  it('初期状態で isCached は false を返す', async () => {
-    // Arrange
+  it('初期状態で isCached は false', async () => {
     const dm = new DictManager();
-
-    // Act
-    const cached = await dm.isCached();
-
-    // Assert
-    assert.equal(cached, false, 'isCached should be false before any loadDictionary call');
+    assert.equal(await dm.isCached(), false);
   });
-
-  // ---------- 2. loadDictionary 後 -----------------------------------------------
 
   it('loadDictionary 後に isCached は true を返す', async () => {
-    // Arrange
     const dm = new DictManager();
-
-    // Act
     await dm.loadDictionary();
-    const cached = await dm.isCached();
-
-    // Assert
-    assert.equal(cached, true, 'isCached should be true after successful loadDictionary');
+    assert.equal(await dm.isCached(), true);
   });
-
-  // ---------- 3. clearCache 後 ---------------------------------------------------
 
   it('clearCache 後に isCached は false を返す', async () => {
-    // Arrange
     const dm = new DictManager();
     await dm.loadDictionary();
-    assert.equal(await dm.isCached(), true, 'precondition: cache should be populated');
-
-    // Act
     await dm.clearCache();
-    const cached = await dm.isCached();
-
-    // Assert
-    assert.equal(cached, false, 'isCached should be false after clearCache');
+    assert.equal(await dm.isCached(), false);
   });
-
-  // ---------- 4. clearCache 後の再ダウンロード ------------------------------------
 
   it('clearCache 後に再度 loadDictionary すると fetch が実行される', async () => {
-    // Arrange -- load once, then clear
     const dm = new DictManager();
     await dm.loadDictionary();
-    const firstFetchCount = fetched.length;
-    assert.ok(firstFetchCount > 0, 'precondition: first load should trigger fetches');
+    const countAfterFirst = fetched.length;
 
     await dm.clearCache();
-    fetched.length = 0;
-
-    // Act -- load again after cache clear
     await dm.loadDictionary();
 
-    // Assert -- all files should be re-fetched (8 dict + 1 voice = 9)
-    assert.equal(
-      fetched.length,
-      DICT_FILES.length + 1,
-      'After clearCache, loadDictionary should fetch all files again'
+    assert.ok(
+      fetched.length > countAfterFirst,
+      'Additional fetch calls after cache clear'
     );
   });
-
-  // ---------- 5. 2回目の loadDictionary はキャッシュを使用する --------------------
 
   it('2回目の loadDictionary はキャッシュを使用する', async () => {
-    // Arrange
     const dm = new DictManager();
     await dm.loadDictionary();
-    const firstFetchCount = fetched.length;
-    assert.ok(firstFetchCount > 0, 'precondition: first load should fetch');
+    const countAfterFirst = fetched.length;
 
-    // Act -- reset URL tracker and load again
-    fetched.length = 0;
     await dm.loadDictionary();
-
-    // Assert -- zero additional fetches means cache was used
-    assert.equal(
-      fetched.length,
-      0,
-      'Second loadDictionary should not trigger any fetch (all from cache)'
-    );
+    assert.equal(fetched.length, countAfterFirst, 'No new fetches on cache hit');
   });
-
-  // ---------- 6. カスタム cachePrefix で独立したキャッシュが作られる ---------------
 
   it('カスタム cachePrefix で独立したキャッシュが作られる', async () => {
-    // Arrange -- load into prefix-A
-    const dmA = new DictManager({ cachePrefix: 'prefix-A' });
+    const dbInstances = new Map();
+    globalThis.indexedDB = {
+      open(name) {
+        if (!dbInstances.has(name)) dbInstances.set(name, new MockIDBDatabase());
+        const db = dbInstances.get(name);
+        const req = { result: null, onsuccess: null, onerror: null, onupgradeneeded: null };
+        Promise.resolve().then(() => {
+          if (req.onupgradeneeded) req.onupgradeneeded({ target: { result: db } });
+          req.result = db;
+          if (req.onsuccess) req.onsuccess();
+        });
+        return req;
+      },
+    };
+
+    const dmA = new DictManager({ cachePrefix: 'prefix-a' });
+    const dmB = new DictManager({ cachePrefix: 'prefix-b' });
+
     await dmA.loadDictionary();
-    assert.equal(await dmA.isCached(), true, 'precondition: prefix-A should be cached');
-
-    // Act -- check prefix-B (never loaded)
-    const dmB = new DictManager({ cachePrefix: 'prefix-B' });
-    const cachedB = await dmB.isCached();
-
-    // Assert -- prefix-B should be empty despite prefix-A being populated
-    assert.equal(
-      cachedB,
-      false,
-      'A different cachePrefix should have its own independent cache'
-    );
+    assert.equal(await dmB.isCached(), false);
   });
-
-  // ---------- 7. clearCache が他のキャッシュに影響しない --------------------------
 
   it('clearCache が他のキャッシュに影響しない', async () => {
-    // Arrange -- populate both prefix-A and prefix-B
-    const dmA = new DictManager({ cachePrefix: 'prefix-A' });
-    const dmB = new DictManager({ cachePrefix: 'prefix-B' });
+    const dbInstances = new Map();
+    globalThis.indexedDB = {
+      open(name) {
+        if (!dbInstances.has(name)) dbInstances.set(name, new MockIDBDatabase());
+        const db = dbInstances.get(name);
+        const req = { result: null, onsuccess: null, onerror: null, onupgradeneeded: null };
+        Promise.resolve().then(() => {
+          if (req.onupgradeneeded) req.onupgradeneeded({ target: { result: db } });
+          req.result = db;
+          if (req.onsuccess) req.onsuccess();
+        });
+        return req;
+      },
+    };
+
+    const dmA = new DictManager({ cachePrefix: 'prefix-a' });
+    const dmB = new DictManager({ cachePrefix: 'prefix-b' });
+
     await dmA.loadDictionary();
     await dmB.loadDictionary();
-    assert.equal(await dmA.isCached(), true, 'precondition: prefix-A cached');
-    assert.equal(await dmB.isCached(), true, 'precondition: prefix-B cached');
-
-    // Act -- clear only prefix-A
     await dmA.clearCache();
 
-    // Assert -- prefix-B should be unaffected
-    assert.equal(await dmA.isCached(), false, 'prefix-A should be cleared');
-    assert.equal(await dmB.isCached(), true, 'prefix-B should remain cached');
+    assert.equal(await dmA.isCached(), false);
+    assert.equal(await dmB.isCached(), true);
   });
 
-  // ---------- 8. キャッシュされた辞書ファイルが正しいデータを返す ------------------
-
   it('キャッシュされた辞書ファイルが正しいデータを返す', async () => {
-    // Arrange -- load once to populate cache
     const dm = new DictManager();
-    await dm.loadDictionary();
+    const first = await dm.loadDictionary();
+    const second = await dm.loadDictionary();
 
-    // Act -- load again (all from cache)
-    const { dictFiles, voiceData } = await dm.loadDictionary();
-
-    // Assert -- dict files
-    assert.equal(
-      Object.keys(dictFiles).length,
-      DICT_FILES.length,
-      `dictFiles should contain ${DICT_FILES.length} entries`
-    );
-    for (const filename of DICT_FILES) {
-      const buf = dictFiles[filename];
-      assert.ok(buf instanceof ArrayBuffer, `${filename} should be an ArrayBuffer`);
-      assert.equal(buf.byteLength, 64, `${filename} should be 64 bytes (matching dummy data)`);
-
-      // Verify data content matches the dummy payload (0xAB fill).
-      const bytes = new Uint8Array(buf);
+    for (const file of DICT_FILES) {
+      assert.ok(second.dictFiles[file] instanceof ArrayBuffer, `${file} is ArrayBuffer`);
       assert.equal(
-        bytes[0],
-        0xAB,
-        `${filename} first byte should be 0xAB`
-      );
-      assert.equal(
-        bytes[bytes.length - 1],
-        0xAB,
-        `${filename} last byte should be 0xAB`
+        second.dictFiles[file].byteLength,
+        first.dictFiles[file].byteLength,
+        `${file} cached size matches`
       );
     }
 
-    // Assert -- voice data
-    assert.ok(voiceData instanceof ArrayBuffer, 'voiceData should be an ArrayBuffer');
-    assert.equal(voiceData.byteLength, 64, 'voiceData should be 64 bytes');
+    assert.ok(second.voiceData instanceof ArrayBuffer);
+    assert.equal(second.voiceData.byteLength, first.voiceData.byteLength);
   });
 });

--- a/src/wasm/openjtalk-web/test/js/test-dict-manager-progress.js
+++ b/src/wasm/openjtalk-web/test/js/test-dict-manager-progress.js
@@ -7,100 +7,12 @@
 
 import assert from 'node:assert/strict';
 import { describe, it, beforeEach, afterEach } from 'node:test';
-
-// ---- Mock: IndexedDB -----------------------------------------------------------
-
-class MockObjectStore {
-  constructor(store) { this._store = store; }
-
-  get(key) {
-    const result = this._store.get(key) ?? undefined;
-    return _fakeRequest(result);
-  }
-
-  put(val) {
-    this._store.set(val.key, val);
-    return _fakeRequest(undefined);
-  }
-
-  clear() {
-    this._store.clear();
-    return _fakeRequest(undefined);
-  }
-}
-
-function _fakeRequest(result) {
-  const req = { result, onsuccess: null, onerror: null };
-  Promise.resolve().then(() => {
-    if (req.onsuccess) req.onsuccess();
-  });
-  return req;
-}
-
-class MockIDBDatabase {
-  constructor() {
-    this._stores = new Map();
-    this.objectStoreNames = { contains: (n) => this._stores.has(n) };
-  }
-
-  _ensureStore(name) {
-    if (!this._stores.has(name)) this._stores.set(name, new Map());
-    return this._stores.get(name);
-  }
-
-  createObjectStore(name, _opts) {
-    this._ensureStore(name);
-  }
-
-  transaction(storeName, _mode) {
-    const store = this._ensureStore(storeName);
-    return { objectStore: () => new MockObjectStore(store) };
-  }
-}
-
-let _mockDB;
-
-function installIndexedDBMock() {
-  _mockDB = new MockIDBDatabase();
-  globalThis.indexedDB = {
-    open(name, version) {
-      const req = { result: null, onsuccess: null, onerror: null, onupgradeneeded: null };
-      Promise.resolve().then(() => {
-        if (req.onupgradeneeded) {
-          req.onupgradeneeded({ target: { result: _mockDB } });
-        }
-        req.result = _mockDB;
-        if (req.onsuccess) req.onsuccess();
-      });
-      return req;
-    },
-  };
-}
-
-// ---- Mock: fetch ---------------------------------------------------------------
-
-/**
- * Install a global fetch mock that returns ArrayBuffers of a given size.
- * The mock has no Content-Length header and no readable body, so
- * fetchWithProgress falls back to response.arrayBuffer() and fires
- * a single onProgress(byteLength, byteLength) per file.
- *
- * @returns {string[]} Array that collects fetched URLs.
- */
-function installFetchMock() {
-  const fetched = [];
-  globalThis.fetch = async (url) => {
-    fetched.push(url);
-    const body = new ArrayBuffer(64);
-    return {
-      ok: true,
-      headers: { get: () => null },
-      body: null,
-      arrayBuffer: async () => body,
-    };
-  };
-  return fetched;
-}
+import {
+  installIndexedDBMock,
+  installFetchMock,
+  installCryptoMock,
+  cleanup,
+} from './helpers/dict-mock.js';
 
 // ---- Import SUT ----------------------------------------------------------------
 
@@ -114,220 +26,110 @@ try {
 
 const skip = DictManager === null;
 
-// ---- Constants -----------------------------------------------------------------
-
-const EXPECTED_DICT_FILES = [
-  'char.bin',
-  'matrix.bin',
-  'sys.dic',
-  'unk.dic',
-  'left-id.def',
-  'right-id.def',
-  'pos-id.def',
-  'rewrite.def',
-];
-
-const VOICE_KEY = 'voice/mei_normal.htsvoice';
-
-/** Total items tracked by DictManager: 8 dict files + 1 voice. */
-const TOTAL_ITEMS = EXPECTED_DICT_FILES.length + 1;
-
 // ---- Tests ---------------------------------------------------------------------
 
 describe('DictManager onProgress コールバック', { skip }, () => {
-  /** @type {string[]} */
   let fetched;
 
   beforeEach(() => {
     installIndexedDBMock();
+    installCryptoMock();
     fetched = installFetchMock();
   });
 
   afterEach(() => {
     fetched = [];
-    delete globalThis.indexedDB;
-    delete globalThis.fetch;
+    cleanup();
   });
-
-  // ---------- 1. onProgress が呼び出される -------------------------------------------
 
   it('onProgress が呼び出される', async () => {
-    // Arrange
     const calls = [];
     const dm = new DictManager();
-
-    // Act
     await dm.loadDictionary({
       onProgress: (info) => calls.push(info),
     });
-
-    // Assert
-    assert.ok(calls.length > 0, 'onProgress should be invoked at least once');
+    assert.ok(calls.length > 0, 'onProgress should be called at least once');
   });
 
-  // ---------- 2. onProgress に phase が含まれる --------------------------------------
-
   it('onProgress に phase が含まれる', async () => {
-    // Arrange
     const calls = [];
     const dm = new DictManager();
-
-    // Act
     await dm.loadDictionary({
       onProgress: (info) => calls.push(info),
     });
 
-    // Assert
     const phases = new Set(calls.map((c) => c.phase));
-    assert.ok(phases.has('dict'), "should include 'dict' phase");
-    assert.ok(phases.has('voice'), "should include 'voice' phase");
+    assert.ok(phases.has('dict'), 'Should have dict phase');
+    assert.ok(phases.has('voice'), 'Should have voice phase');
+
     for (const call of calls) {
       assert.ok(
         call.phase === 'dict' || call.phase === 'voice',
-        `phase should be 'dict' or 'voice', got: '${call.phase}'`
+        `phase should be dict or voice, got: ${call.phase}`
       );
     }
   });
-
-  // ---------- 3. onProgress に file 情報が含まれる -----------------------------------
 
   it('onProgress に file 情報が含まれる', async () => {
-    // Arrange
     const calls = [];
     const dm = new DictManager();
-
-    // Act
     await dm.loadDictionary({
       onProgress: (info) => calls.push(info),
     });
 
-    // Assert
     for (const call of calls) {
-      assert.equal(typeof call.file, 'string', 'file should be a string');
+      assert.ok(typeof call.file === 'string', 'file should be a string');
       assert.ok(call.file.length > 0, 'file should be non-empty');
     }
-
-    // Dict-phase calls should reference known dict filenames.
-    const dictFiles = calls
-      .filter((c) => c.phase === 'dict')
-      .map((c) => c.file);
-    for (const file of dictFiles) {
-      assert.ok(
-        EXPECTED_DICT_FILES.includes(file),
-        `dict-phase file '${file}' should be a known dictionary filename`
-      );
-    }
-
-    // Voice-phase calls should reference the voice key.
-    const voiceFiles = calls
-      .filter((c) => c.phase === 'voice')
-      .map((c) => c.file);
-    for (const file of voiceFiles) {
-      assert.equal(file, VOICE_KEY, `voice-phase file should be '${VOICE_KEY}'`);
-    }
   });
 
-  // ---------- 4. overallPercent が 0 から始まる --------------------------------------
-
-  it('onProgress の overallPercent が 0 から始まる', async () => {
-    // Arrange
+  it('overallPercent が最終的に 100 になる', async () => {
     const calls = [];
     const dm = new DictManager();
-
-    // Act
     await dm.loadDictionary({
       onProgress: (info) => calls.push(info),
     });
 
-    // Assert
-    assert.ok(calls.length > 0, 'should receive at least one callback');
-    const firstPercent = calls[0].overallPercent;
-    assert.ok(
-      firstPercent >= 0 && firstPercent <= Math.round((1 / TOTAL_ITEMS) * 100),
-      `first overallPercent should start near 0, got: ${firstPercent}`
-    );
+    const last = calls[calls.length - 1];
+    assert.equal(last.overallPercent, 100, 'Last callback should be 100%');
   });
 
-  // ---------- 5. overallPercent が最終的に 100 になる --------------------------------
-
-  it('onProgress の overallPercent が最終的に 100 になる', async () => {
-    // Arrange
+  it('overallPercent が 0 以上 100 以下の範囲', async () => {
     const calls = [];
     const dm = new DictManager();
-
-    // Act
     await dm.loadDictionary({
       onProgress: (info) => calls.push(info),
     });
 
-    // Assert
-    assert.ok(calls.length > 0, 'should receive at least one callback');
-    const lastPercent = calls[calls.length - 1].overallPercent;
-    assert.equal(lastPercent, 100, 'last overallPercent should be 100');
-  });
-
-  // ---------- 6. 全辞書ファイルに対して呼ばれる --------------------------------------
-
-  it('onProgress が全辞書ファイルに対して呼ばれる', async () => {
-    // Arrange
-    const calls = [];
-    const dm = new DictManager();
-
-    // Act
-    await dm.loadDictionary({
-      onProgress: (info) => calls.push(info),
-    });
-
-    // Assert -- dict phase should cover all 8 files
-    const dictFilesReported = new Set(
-      calls.filter((c) => c.phase === 'dict').map((c) => c.file)
-    );
-    assert.equal(
-      dictFilesReported.size,
-      EXPECTED_DICT_FILES.length,
-      `should report progress for all ${EXPECTED_DICT_FILES.length} dict files`
-    );
-    for (const expected of EXPECTED_DICT_FILES) {
-      assert.ok(
-        dictFilesReported.has(expected),
-        `should report progress for '${expected}'`
-      );
+    for (const call of calls) {
+      assert.ok(call.overallPercent >= 0, `overallPercent >= 0, got: ${call.overallPercent}`);
+      assert.ok(call.overallPercent <= 100, `overallPercent <= 100, got: ${call.overallPercent}`);
     }
+  });
 
-    // Assert -- voice phase should be present
+  it('dict phase と voice phase の両方がレポートされる', async () => {
+    const calls = [];
+    const dm = new DictManager();
+    await dm.loadDictionary({
+      onProgress: (info) => calls.push(info),
+    });
+
+    const dictCalls = calls.filter((c) => c.phase === 'dict');
     const voiceCalls = calls.filter((c) => c.phase === 'voice');
-    assert.ok(voiceCalls.length > 0, 'should report progress for voice file');
 
-    // Assert -- total unique items = 8 dict + 1 voice = 9
-    const allFilesReported = new Set(calls.map((c) => c.file));
-    assert.equal(
-      allFilesReported.size,
-      TOTAL_ITEMS,
-      `should report progress for all ${TOTAL_ITEMS} items (8 dict + 1 voice)`
-    );
+    assert.ok(dictCalls.length > 0, 'Should have dict phase callbacks');
+    assert.ok(voiceCalls.length > 0, 'Should have voice phase callbacks');
   });
-
-  // ---------- 7. onProgress を指定しなくてもエラーにならない --------------------------
 
   it('onProgress を指定しなくてもエラーにならない', async () => {
-    // Arrange
     const dm = new DictManager();
-
-    // Act & Assert -- should not throw
-    const result = await dm.loadDictionary();
-    assert.ok(result.dictFiles, 'should return dictFiles');
-    assert.ok(result.voiceData, 'should return voiceData');
+    await dm.loadDictionary();
+    // No error = pass
   });
 
-  // ---------- 8. onProgress が null でもエラーにならない ------------------------------
-
   it('onProgress が null でもエラーにならない', async () => {
-    // Arrange
     const dm = new DictManager();
-
-    // Act & Assert -- should not throw
-    const result = await dm.loadDictionary({ onProgress: null });
-    assert.ok(result.dictFiles, 'should return dictFiles');
-    assert.ok(result.voiceData, 'should return voiceData');
+    await dm.loadDictionary({ onProgress: null });
+    // No error = pass
   });
 });

--- a/src/wasm/openjtalk-web/test/js/test-dict-manager.js
+++ b/src/wasm/openjtalk-web/test/js/test-dict-manager.js
@@ -1,126 +1,20 @@
 /**
- * TDD Tests for DictManager (辞書動的ダウンロード + IndexedDB キャッシュ)
+ * TDD Tests for DictManager (tar.gz ダウンロード + IndexedDB キャッシュ)
  *
  * テスト対象: src/wasm/openjtalk-web/src/dict-manager.js
  */
 
 import assert from 'node:assert/strict';
 import { describe, it, beforeEach, afterEach } from 'node:test';
-
-// ---- Mock: IndexedDB -----------------------------------------------------------
-
-/**
- * Minimal IndexedDB mock for DictManager tests.
- *
- * DictManager uses the global `indexedDB.open()` internally (via openDB()),
- * so we inject a global mock rather than passing a factory.
- */
-class MockObjectStore {
-  constructor(store) { this._store = store; }
-
-  get(key) {
-    const result = this._store.get(key) ?? undefined;
-    return _fakeRequest(result);
-  }
-
-  put(val) {
-    this._store.set(val.key, val);
-    return _fakeRequest(undefined);
-  }
-
-  clear() {
-    this._store.clear();
-    return _fakeRequest(undefined);
-  }
-}
-
-function _fakeRequest(result) {
-  const req = { result, onsuccess: null, onerror: null };
-  // Schedule callback on microtask to match real IDB behavior.
-  Promise.resolve().then(() => {
-    if (req.onsuccess) req.onsuccess();
-  });
-  return req;
-}
-
-class MockIDBDatabase {
-  constructor() {
-    this._stores = new Map();
-    this.objectStoreNames = { contains: (n) => this._stores.has(n) };
-  }
-
-  _ensureStore(name) {
-    if (!this._stores.has(name)) this._stores.set(name, new Map());
-    return this._stores.get(name);
-  }
-
-  createObjectStore(name, _opts) {
-    this._ensureStore(name);
-  }
-
-  transaction(storeName, _mode) {
-    const store = this._ensureStore(storeName);
-    return { objectStore: () => new MockObjectStore(store) };
-  }
-}
-
-/** Singleton DB instance shared across a single test to simulate persistence. */
-let _mockDB;
-
-/** Track dbName passed to indexedDB.open() for behavior-based assertions. */
-let _lastOpenedDbName;
-
-function installIndexedDBMock() {
-  _mockDB = new MockIDBDatabase();
-  _lastOpenedDbName = undefined;
-  globalThis.indexedDB = {
-    open(name, version) {
-      _lastOpenedDbName = name;
-      const req = { result: null, onsuccess: null, onerror: null, onupgradeneeded: null };
-      Promise.resolve().then(() => {
-        // Fire upgrade on first open (simulates DB creation).
-        if (req.onupgradeneeded) {
-          req.onupgradeneeded({ target: { result: _mockDB } });
-        }
-        req.result = _mockDB;
-        if (req.onsuccess) req.onsuccess();
-      });
-      return req;
-    },
-  };
-}
-
-// ---- Mock: fetch ---------------------------------------------------------------
-
-/**
- * Install a global fetch mock that returns ArrayBuffers of a given size.
- * Tracks which URLs were requested.
- *
- * @param {Object} [opts]
- * @param {boolean} [opts.shouldFail]     - Return 404 for all fetches.
- * @param {boolean} [opts.shouldReject]   - Reject with TypeError (network error).
- * @returns {string[]} Array that collects fetched URLs.
- */
-function installFetchMock({ shouldFail = false, shouldReject = false } = {}) {
-  const fetched = [];
-  globalThis.fetch = async (url) => {
-    fetched.push(url);
-    if (shouldReject) {
-      throw new TypeError('Failed to fetch');
-    }
-    if (shouldFail) {
-      return { ok: false, status: 404, statusText: 'Not Found' };
-    }
-    const body = new ArrayBuffer(64);
-    return {
-      ok: true,
-      headers: { get: () => null },
-      body: null,
-      arrayBuffer: async () => body,
-    };
-  };
-  return fetched;
-}
+import {
+  DICT_FILES,
+  DICT_TAR_GZ_URL,
+  VOICE_URL,
+  installIndexedDBMock,
+  installFetchMock,
+  installCryptoMock,
+  cleanup,
+} from './helpers/dict-mock.js';
 
 // ---- Import SUT ----------------------------------------------------------------
 
@@ -134,35 +28,23 @@ try {
 
 const skip = DictManager === null;
 
-// ---- Expected file list --------------------------------------------------------
-
-const EXPECTED_DICT_FILES = [
-  'char.bin',
-  'matrix.bin',
-  'sys.dic',
-  'unk.dic',
-  'left-id.def',
-  'right-id.def',
-  'pos-id.def',
-  'rewrite.def',
-];
-
 // ---- Tests ---------------------------------------------------------------------
 
 describe('DictManager', { skip }, () => {
-  /** @type {string[]} URLs fetched during the current test. */
   let fetched;
 
   beforeEach(() => {
     installIndexedDBMock();
+    installCryptoMock();
     fetched = installFetchMock();
   });
 
   afterEach(() => {
     fetched = [];
+    cleanup();
   });
 
-  // ---------- 1. DictManager 構築 ------------------------------------------------
+  // ---------- 1. 構築 -------------------------------------------------------------
 
   describe('構築', () => {
     it('デフォルトオプションで構築可能', () => {
@@ -171,257 +53,152 @@ describe('DictManager', { skip }, () => {
     });
 
     it('カスタム cachePrefix を設定すると indexedDB.open に渡される', async () => {
+      const state = installIndexedDBMock();
       const dm = new DictManager({ cachePrefix: 'my-custom-prefix' });
       await dm.loadDictionary();
-      assert.equal(
-        _lastOpenedDbName,
-        'my-custom-prefix',
-        'indexedDB.open() should receive custom cachePrefix'
-      );
+      assert.equal(state.lastDbName, 'my-custom-prefix');
     });
 
     it('cachePrefix 未指定時はデフォルト名で indexedDB.open が呼ばれる', async () => {
+      const state = installIndexedDBMock();
       const dm = new DictManager();
       await dm.loadDictionary();
-      assert.equal(
-        _lastOpenedDbName,
-        'piper-plus-dict',
-        'indexedDB.open() should receive default DB name'
-      );
+      assert.equal(state.lastDbName, 'piper-plus-dict');
     });
   });
 
-  // ---------- 2. 辞書ファイルリスト -----------------------------------------------
+  // ---------- 2. resolveUrls ------------------------------------------------------
 
-  describe('辞書ファイルリスト', () => {
-    it('8ファイルが取得される', async () => {
+  describe('resolveUrls', () => {
+    it('デフォルトで GitHub Releases URL と HuggingFace voice URL を返す', () => {
       const dm = new DictManager();
-      await dm.loadDictionary();
-      // 8 dict files + 1 voice file = 9 fetches total.
-      const dictFetches = fetched.filter((u) => !u.includes('voice'));
-      assert.equal(dictFetches.length, 8);
+      const { dictUrl, voiceUrl } = dm.resolveUrls();
+      assert.ok(dictUrl.includes('github.com/r9y9/open_jtalk'));
+      assert.ok(dictUrl.endsWith('.tar.gz'));
+      assert.ok(voiceUrl.includes('huggingface.co'));
     });
 
-    it('返却される dictFiles のキー集合が期待セットと一致する', async () => {
+    it('カスタム dictUrl を渡すと上書きされる', () => {
       const dm = new DictManager();
-      const { dictFiles } = await dm.loadDictionary();
-      const actualKeys = new Set(Object.keys(dictFiles));
-      const expectedKeys = new Set(EXPECTED_DICT_FILES);
-      assert.deepEqual(actualKeys, expectedKeys);
+      const { dictUrl } = dm.resolveUrls({ dictUrl: 'https://example.com/dict.tar.gz' });
+      assert.equal(dictUrl, 'https://example.com/dict.tar.gz');
     });
 
-    // Individual file-presence tests (split from the original 8-file loop).
-    for (const filename of EXPECTED_DICT_FILES) {
-      it(`dictFiles に ${filename} が含まれる`, async () => {
-        const dm = new DictManager();
-        const { dictFiles } = await dm.loadDictionary();
-        assert.ok(dictFiles[filename], `dictFiles should contain '${filename}'`);
-      });
-    }
-
-    it('取得 URL 群が全辞書ファイルを網羅する', async () => {
+    it('カスタム voiceUrl を渡すと上書きされる', () => {
       const dm = new DictManager();
-      await dm.loadDictionary();
-      const dictFetches = fetched.filter((u) => !u.includes('voice'));
-      const fetchedBasenames = new Set(dictFetches.map((u) => u.split('/').pop()));
-      const expectedBasenames = new Set(EXPECTED_DICT_FILES);
-      assert.deepEqual(fetchedBasenames, expectedBasenames);
-    });
-  });
-
-  // ---------- 3. デフォルト URL ---------------------------------------------------
-
-  describe('デフォルト URL', () => {
-    it('dictUrl 未指定時に HuggingFace URL が使用される', async () => {
-      const dm = new DictManager();
-      await dm.loadDictionary();
-      const dictUrls = fetched.filter((u) => !u.includes('voice'));
-      for (const url of dictUrls) {
-        assert.ok(
-          url.startsWith('https://huggingface.co/'),
-          `Dict URL should start with HuggingFace origin, got: ${url}`
-        );
-      }
-    });
-
-    it('voiceUrl 未指定時にデフォルト voice URL が使用される', async () => {
-      const dm = new DictManager();
-      await dm.loadDictionary();
-      const voiceUrl = fetched.find((u) => u.includes('voice'));
-      assert.ok(voiceUrl, 'A voice URL should have been fetched');
-      assert.ok(
-        voiceUrl.startsWith('https://huggingface.co/'),
-        `Voice URL should start with HuggingFace origin, got: ${voiceUrl}`
-      );
-      assert.ok(
-        voiceUrl.includes('mei_normal.htsvoice'),
-        `Voice URL should reference mei_normal.htsvoice, got: ${voiceUrl}`
-      );
-    });
-
-    it('カスタム dictUrl を指定すると使用される', async () => {
-      const dm = new DictManager();
-      await dm.loadDictionary({ dictUrl: 'https://example.com/dict' });
-      const dictUrls = fetched.filter((u) => !u.includes('voice'));
-      for (const url of dictUrls) {
-        assert.ok(
-          url.startsWith('https://example.com/dict/'),
-          `Dict URL should use custom base, got: ${url}`
-        );
-      }
-    });
-
-    it('カスタム voiceUrl を指定すると使用される', async () => {
-      const dm = new DictManager();
-      await dm.loadDictionary({ voiceUrl: 'https://example.com/voice.htsvoice' });
-      const voiceUrl = fetched.find((u) => u.includes('example.com'));
+      const { voiceUrl } = dm.resolveUrls({ voiceUrl: 'https://example.com/voice.htsvoice' });
       assert.equal(voiceUrl, 'https://example.com/voice.htsvoice');
     });
   });
 
-  // ---------- 4. isCached() -------------------------------------------------------
+  // ---------- 3. loadDictionary ---------------------------------------------------
 
-  describe('isCached()', () => {
-    it('loadDictionary 前は false を返す', async () => {
-      const dm = new DictManager();
-      const cached = await dm.isCached();
-      assert.equal(cached, false);
-    });
-
-    it('loadDictionary 後は true を返す', async () => {
+  describe('loadDictionary', () => {
+    it('tar.gz URL と voice URL の2つだけ fetch される', async () => {
       const dm = new DictManager();
       await dm.loadDictionary();
-      const cached = await dm.isCached();
-      assert.equal(cached, true);
+      assert.equal(fetched.length, 2, 'Should fetch tar.gz + voice');
+      assert.ok(fetched[0].includes('.tar.gz'), 'First fetch is tar.gz');
+      assert.ok(fetched[1].includes('htsvoice'), 'Second fetch is voice');
+    });
+
+    it('返却される dictFiles に全8ファイルが含まれる', async () => {
+      const dm = new DictManager();
+      const { dictFiles } = await dm.loadDictionary();
+      const keys = new Set(Object.keys(dictFiles));
+      assert.deepEqual(keys, new Set(DICT_FILES));
+    });
+
+    it('返却される dictFiles の各値が ArrayBuffer である', async () => {
+      const dm = new DictManager();
+      const { dictFiles } = await dm.loadDictionary();
+      for (const file of DICT_FILES) {
+        assert.ok(dictFiles[file] instanceof ArrayBuffer, `${file} should be ArrayBuffer`);
+        assert.ok(dictFiles[file].byteLength > 0, `${file} should be non-empty`);
+      }
+    });
+
+    it('voiceData が ArrayBuffer として返却される', async () => {
+      const dm = new DictManager();
+      const { voiceData } = await dm.loadDictionary();
+      assert.ok(voiceData instanceof ArrayBuffer);
+      assert.ok(voiceData.byteLength > 0);
     });
   });
 
-  // ---------- 5. clearCache() -----------------------------------------------------
+  // ---------- 4. isCached / clearCache -------------------------------------------
 
-  describe('clearCache()', () => {
-    it('clearCache 後は isCached が false を返す', async () => {
+  describe('isCached / clearCache', () => {
+    it('初回は isCached が false', async () => {
+      const dm = new DictManager();
+      assert.equal(await dm.isCached(), false);
+    });
+
+    it('loadDictionary 後に isCached が true', async () => {
       const dm = new DictManager();
       await dm.loadDictionary();
-      // Sanity check: should be cached after load.
       assert.equal(await dm.isCached(), true);
+    });
 
+    it('clearCache 後に isCached が false に戻る', async () => {
+      const dm = new DictManager();
+      await dm.loadDictionary();
       await dm.clearCache();
-      const cached = await dm.isCached();
-      assert.equal(cached, false);
+      assert.equal(await dm.isCached(), false);
     });
   });
 
-  // ---------- 6. キャッシュ後の再取得 -----------------------------------------------
+  // ---------- 5. キャッシュヒット --------------------------------------------------
 
-  describe('キャッシュ後の再取得', () => {
-    it('2回目の loadDictionary は fetch を呼ばない (キャッシュヒット)', async () => {
+  describe('キャッシュ', () => {
+    it('2回目の loadDictionary は fetch を呼ばない', async () => {
       const dm = new DictManager();
       await dm.loadDictionary();
-      const firstFetchCount = fetched.length;
-      assert.ok(firstFetchCount > 0, 'first load should fetch');
+      const firstCount = fetched.length;
 
-      // Reset tracked URLs, but keep the same IDB / DictManager state.
-      fetched.length = 0;
       await dm.loadDictionary();
-      assert.equal(fetched.length, 0, 'second load should not fetch (all cached)');
-    });
-  });
-
-  // ---------- 7. onProgress コールバック ------------------------------------------
-
-  describe('onProgress コールバック', () => {
-    it('辞書フェーズで phase, file, overallPercent が通知される', async () => {
-      const calls = [];
-      const dm = new DictManager();
-      await dm.loadDictionary({
-        onProgress: (info) => calls.push(info),
-      });
-
-      const dictCalls = calls.filter((c) => c.phase === 'dict');
-      assert.ok(dictCalls.length > 0, 'should receive at least one dict-phase callback');
-
-      for (const call of dictCalls) {
-        assert.equal(call.phase, 'dict');
-        assert.equal(typeof call.file, 'string', 'file should be a string');
-        assert.equal(typeof call.overallPercent, 'number', 'overallPercent should be a number');
-      }
+      assert.equal(fetched.length, firstCount, 'No additional fetch on cache hit');
     });
 
-    it('voice フェーズで phase と overallPercent が通知される', async () => {
-      const calls = [];
+    it('キャッシュから返されたデータが正しい', async () => {
       const dm = new DictManager();
-      await dm.loadDictionary({
-        onProgress: (info) => calls.push(info),
-      });
+      const first = await dm.loadDictionary();
+      const second = await dm.loadDictionary();
 
-      const voiceCalls = calls.filter((c) => c.phase === 'voice');
-      assert.ok(voiceCalls.length > 0, 'should receive at least one voice-phase callback');
-      for (const call of voiceCalls) {
-        assert.equal(call.phase, 'voice');
-        assert.equal(typeof call.overallPercent, 'number');
-      }
-    });
-
-    it('最終コールバックの overallPercent が 100 である', async () => {
-      const calls = [];
-      const dm = new DictManager();
-      await dm.loadDictionary({
-        onProgress: (info) => calls.push(info),
-      });
-
-      assert.ok(calls.length > 0, 'should receive progress callbacks');
-      const last = calls[calls.length - 1];
-      assert.equal(last.overallPercent, 100, 'last callback should be 100%');
-    });
-
-    it('loaded と total がバイト値として含まれる', async () => {
-      const calls = [];
-      const dm = new DictManager();
-      await dm.loadDictionary({
-        onProgress: (info) => calls.push(info),
-      });
-
-      for (const call of calls) {
-        assert.equal(typeof call.loaded, 'number', 'loaded should be a number');
-        assert.equal(typeof call.total, 'number', 'total should be a number');
-        assert.ok(call.loaded >= 0, 'loaded should be non-negative');
-        assert.ok(call.total >= 0, 'total should be non-negative');
+      for (const file of DICT_FILES) {
+        assert.equal(
+          second.dictFiles[file].byteLength,
+          first.dictFiles[file].byteLength,
+          `${file} size should match`
+        );
       }
     });
   });
 
-  // ---------- 8. エラーケース -----------------------------------------------------
+  // ---------- 6. エラー -----------------------------------------------------------
 
-  describe('エラーケース', () => {
-    it('HTTP 404 でエラーがスローされる', async () => {
+  describe('エラー', () => {
+    it('fetch が 404 の場合にリジェクトされる', async () => {
+      cleanup();
+      installIndexedDBMock();
+      installCryptoMock();
       fetched = installFetchMock({ shouldFail: true });
+
       const dm = new DictManager();
       await assert.rejects(
-        () => dm.loadDictionary({ dictUrl: 'https://invalid.example.com/dict' }),
-        (err) => {
-          assert.ok(
-            err.message.includes('Failed to fetch') || err.message.includes('404'),
-            `Error message should indicate fetch failure, got: ${err.message}`
-          );
-          return true;
-        }
+        () => dm.loadDictionary(),
+        (err) => err.message.includes('404')
       );
     });
 
-    it('ネットワークエラー (TypeError: Failed to fetch) でエラーがスローされる', async () => {
+    it('ネットワークエラーの場合に TypeError がスローされる', async () => {
+      cleanup();
+      installIndexedDBMock();
+      installCryptoMock();
       fetched = installFetchMock({ shouldReject: true });
+
       const dm = new DictManager();
-      await assert.rejects(
-        () => dm.loadDictionary({ dictUrl: 'https://unreachable.example.com/dict' }),
-        (err) => {
-          assert.ok(err instanceof TypeError, 'should be a TypeError');
-          assert.ok(
-            err.message.includes('Failed to fetch'),
-            `Error message should be 'Failed to fetch', got: ${err.message}`
-          );
-          return true;
-        }
-      );
+      await assert.rejects(() => dm.loadDictionary(), TypeError);
     });
   });
 });

--- a/src/wasm/openjtalk-web/types/index.d.ts
+++ b/src/wasm/openjtalk-web/types/index.d.ts
@@ -223,12 +223,18 @@ export interface DictManagerOptions {
 
 /** Options for DictManager.loadDictionary(). */
 export interface LoadDictionaryOptions {
-  /** Base URL for dictionary files. */
+  /** Custom tar.gz URL for the dictionary archive (default: GitHub Releases). */
   dictUrl?: string;
   /** URL for the HTS voice file. */
   voiceUrl?: string;
   /** Progress callback. */
   onProgress?: (info: DictDownloadProgress) => void;
+}
+
+/** Result returned by DictManager.resolveUrls(). */
+export interface DictResolveResult {
+  dictUrl: string;
+  voiceUrl: string;
 }
 
 /** Result returned by DictManager.loadDictionary(). */
@@ -237,9 +243,15 @@ export interface DictLoadResult {
   voiceData: ArrayBuffer;
 }
 
-/** Download and cache OpenJTalk dictionary files and HTS voice from HuggingFace. */
+/**
+ * Download and cache OpenJTalk dictionary files from GitHub Releases
+ * (same source as Rust/C#/C++ implementations) and HTS voice file.
+ */
 export class DictManager {
   constructor(options?: DictManagerOptions);
+
+  /** Resolve dictionary and voice URLs without downloading. */
+  resolveUrls(options?: { dictUrl?: string; voiceUrl?: string }): DictResolveResult;
 
   /** Download (or retrieve from cache) dictionary files and the HTS voice file. */
   loadDictionary(options?: LoadDictionaryOptions): Promise<DictLoadResult>;


### PR DESCRIPTION
## Summary

- npm パッケージ `piper-plus` の DictManager が HuggingFace の存在しない URL (404) から辞書をダウンロードしようとしていた問題を修正
- Rust/C#/C++ と同じ `r9y9/open_jtalk` GitHub Releases からの tar.gz ダウンロードに統一
- voice ファイル (`mei_normal.htsvoice`) を HuggingFace `piper-plus-base` にアップロード済み

## Changes

### dict-manager.js
- 個別ファイル DL → tar.gz 一括 DL + `DecompressionStream` API で展開
- `crypto.subtle.digest` による SHA-256 検証 (Rust/C# と同一ハッシュ)
- IndexedDB キャッシュは展開後の個別ファイル単位で保持 (2回目以降は即座)

### index.js (PiperPlus._init)
- `resolveUrls()` のみ → `loadDictionary()` でデータ取得 + IndexedDB キャッシュ活用
- 取得済みデータを phonemizer にプリロード渡し

### simple_unified_api.js
- `dictData` / `voiceData` (ArrayBuffer) の直接受け取りに対応
- URL ベースのロード (デモ用) も後方互換で維持
- WASM パス (`jsPath` / `wasmPath`) の `import.meta.url` 自動解決

### テスト
- 共有ヘルパー `helpers/dict-mock.js` 追加 (tar.gz 生成 + mock)
- DictManager テスト 42 件全 PASS (268/271 全体、残り 3 件は既存の Windows パス問題)

## Test plan
- [x] `npm run test:npm-package:all` — 268/271 pass (3 fail は既存 Windows 問題)
- [x] DictManager 単体テスト 42/42 pass
- [x] voice ファイル URL アクセス確認 (HuggingFace LFS 302 → CDN)
- [ ] ブラウザでの E2E 動作確認 (モデル DL → 辞書 DL → 音声合成)