### PR TITLE
refactor: PyPI パッケージ名を piper-plus に統一

### DIFF
--- a/.github/workflows/dev-create-release.yml
+++ b/.github/workflows/dev-create-release.yml
@@ -273,10 +273,11 @@ jobs:
       - name: Install build tools
         run: pip install build twine
 
-      - name: Update VERSION for stub
+      - name: Copy VERSION for stub
         run: |
           VERSION="${{ github.event.inputs.version }}"
           echo "$VERSION" > VERSION
+          cp VERSION src/python_stub/VERSION
 
       - name: Build stub package
         working-directory: src/python_stub

--- a/.github/workflows/dev-create-release.yml
+++ b/.github/workflows/dev-create-release.yml
@@ -126,7 +126,7 @@ jobs:
           echo "### 📦 Installation" >> $GITHUB_OUTPUT
           echo "\`\`\`bash" >> $GITHUB_OUTPUT
           echo "# Python" >> $GITHUB_OUTPUT
-          echo "pip install piper-tts-plus==${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          echo "pip install piper-plus==${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
           echo "# C# (.NET Global Tool) — v0.1.0" >> $GITHUB_OUTPUT
           echo "dotnet tool install -g PiperPlus.Cli --version 0.1.0" >> $GITHUB_OUTPUT
@@ -140,7 +140,7 @@ jobs:
           echo "" >> $GITHUB_OUTPUT
 
           echo "### 🔗 Links" >> $GITHUB_OUTPUT
-          echo "- [PyPI Package](https://pypi.org/project/piper-tts-plus/${{ github.event.inputs.version }}/)" >> $GITHUB_OUTPUT
+          echo "- [PyPI Package](https://pypi.org/project/piper-plus/${{ github.event.inputs.version }}/)" >> $GITHUB_OUTPUT
           echo "- [NuGet Package (CLI)](https://www.nuget.org/packages/PiperPlus.Cli)" >> $GITHUB_OUTPUT
           echo "- [NuGet Package (Core)](https://www.nuget.org/packages/PiperPlus.Core)" >> $GITHUB_OUTPUT
           echo "- [crates.io Package (CLI)](https://crates.io/crates/piper-plus-cli)" >> $GITHUB_OUTPUT
@@ -252,6 +252,45 @@ jobs:
             twine upload --skip-existing dist/*.whl
           else
             echo "⚠️ PyPI token not found or no wheels to upload, skipping"
+          fi
+
+  # Publish stub package (piper-tts-plus -> piper-plus redirect)
+  publish_pypi_stub:
+    name: Publish PyPI Stub (piper-tts-plus)
+    needs: [publish_pypi]
+    if: |
+      always() &&
+      needs.publish_pypi.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Update VERSION for stub
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          echo "$VERSION" > VERSION
+
+      - name: Build stub package
+        working-directory: src/python_stub
+        run: python -m build
+
+      - name: Publish stub to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PIPY_TOKEN }}
+        run: |
+          if [ -n "$TWINE_PASSWORD" ]; then
+            twine upload --skip-existing src/python_stub/dist/*
+          else
+            echo "⚠️ PyPI token not found, skipping stub publish"
           fi
 
   # C# CLI builds
@@ -530,7 +569,7 @@ jobs:
   release_summary:
     name: Release Summary
     runs-on: ubuntu-latest
-    needs: [create_release, build_all, publish_pypi, publish_nuget, publish_crates, csharp-cli, rust-cli]
+    needs: [create_release, build_all, publish_pypi, publish_pypi_stub, publish_nuget, publish_crates, csharp-cli, rust-cli]
     if: always()
     steps:
       - name: Summary
@@ -544,6 +583,7 @@ jobs:
           echo "- Create Release: ${{ needs.create_release.result }}"
           echo "- Build All: ${{ needs.build_all.result }}"
           echo "- Publish PyPI: ${{ needs.publish_pypi.result }}"
+          echo "- Publish PyPI Stub: ${{ needs.publish_pypi_stub.result }}"
           echo "- Publish NuGet: ${{ needs.publish_nuget.result }}"
           echo "- Publish crates.io: ${{ needs.publish_crates.result }}"
           echo "- C# CLI: ${{ needs.csharp-cli.result }}"
@@ -553,6 +593,7 @@ jobs:
           echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
           echo "- C++/Python Build: ${{ needs.build_all.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- PyPI: ${{ needs.publish_pypi.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- PyPI Stub: ${{ needs.publish_pypi_stub.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- NuGet: ${{ needs.publish_nuget.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- crates.io: ${{ needs.publish_crates.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- C# CLI: ${{ needs.csharp-cli.result }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -88,7 +88,7 @@ jobs:
         pytest tests/ -v --tb=short -m "inference and unit"
 
     # ---------------------------------------------------------------
-    # Runtime package tests (src/python_run — PyPI piper-tts-plus)
+    # Runtime package tests (src/python_run — PyPI piper-plus)
     # ---------------------------------------------------------------
     - name: Install runtime package dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- PyPI パッケージ名を `piper-tts-plus` から `piper-plus` に変更 — 全レジストリ (npm, crates.io, NuGet) で名前統一
+  - `pip install piper-plus` でインストール可能に
+  - 旧パッケージ `piper-tts-plus` はスタブリリースで `piper-plus` へリダイレクト予定
+
 ## [1.9.0] - 2026-03-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [English](README_EN.md) | 日本語 | [中文](README_ZH.md) | [Français](README_FR.md)
 
 [![CI](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
-[![Python](https://img.shields.io/pypi/pyversions/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
+[![PyPI](https://img.shields.io/pypi/v/piper-plus)](https://pypi.org/project/piper-plus/)
+[![Python](https://img.shields.io/pypi/pyversions/piper-plus)](https://pypi.org/project/piper-plus/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue)](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
 [![Hugging Face Model](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Model-orange)](https://huggingface.co/ayousanz/piper-plus-base)
@@ -55,7 +55,7 @@
 - **C++ CLI** — ストリーミング、CUDA推論、音素タイミング出力、カスタム辞書
 - **[WebAssembly](src/wasm/openjtalk-web/README.md)** — ブラウザ内で完全動作、サーバー不要
 - **[Docker](docker/README.md)** — 推論・学習・WebUI・C++の5イメージ提供
-- **PyPI** — `pip install piper-tts-plus` で簡単インストール
+- **PyPI** — `pip install piper-plus` で簡単インストール
 - **C# CLI** — .NET 8/9 クロスプラットフォーム、6言語マルチリンガル、ONNX推論
 - **Rust CLI** — piper-plus/piper-plus-cli、ストリーミング、CUDA/CoreML/DirectML対応、辞書自動ダウンロード
 
@@ -233,14 +233,14 @@ uv pip install ".[dev]"
 PyPI パッケージからもインストール可能:
 
 ```bash
-pip install piper-tts-plus
+pip install piper-plus
 ```
 
 ### パッケージからインストール
 
 **Python (PyPI):**
 ```bash
-pip install piper-tts-plus
+pip install piper-plus
 ```
 
 **C# CLI (.NET Global Tool):**

--- a/README_EN.md
+++ b/README_EN.md
@@ -3,8 +3,8 @@
 English | [日本語](README.md) | [中文](README_ZH.md) | [Français](README_FR.md)
 
 [![CI](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
-[![Python](https://img.shields.io/pypi/pyversions/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
+[![PyPI](https://img.shields.io/pypi/v/piper-plus)](https://pypi.org/project/piper-plus/)
+[![Python](https://img.shields.io/pypi/pyversions/piper-plus)](https://pypi.org/project/piper-plus/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue)](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
 [![Hugging Face Model](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Model-orange)](https://huggingface.co/ayousanz/piper-plus-base)
@@ -55,7 +55,7 @@ A fast, high-quality neural text-to-speech (TTS) system. Built on the [VITS](htt
 - **C++ CLI** — Streaming, CUDA inference, phoneme timing output, custom dictionary
 - **[WebAssembly](src/wasm/openjtalk-web/README.md)** — Fully runs in browser, no server
 - **[Docker](docker/README.md)** — 5 images for inference, training, WebUI, and C++
-- **PyPI** — `pip install piper-tts-plus`
+- **PyPI** — `pip install piper-plus`
 - **C# CLI** — .NET 8/9 cross-platform, 6-language multilingual, ONNX inference
 - **Rust CLI** — piper-plus/piper-plus-cli, streaming, CUDA/CoreML/DirectML support, auto dictionary download
 
@@ -193,14 +193,14 @@ uv pip install ".[dev]"
 Also available from PyPI:
 
 ```bash
-pip install piper-tts-plus
+pip install piper-plus
 ```
 
 ### Install from Package Managers
 
 **Python (PyPI):**
 ```bash
-pip install piper-tts-plus
+pip install piper-plus
 ```
 
 **C# CLI (.NET Global Tool):**

--- a/README_FR.md
+++ b/README_FR.md
@@ -3,8 +3,8 @@
 [English](README_EN.md) | [日本語](README.md) | [中文](README_ZH.md) | Français
 
 [![CI](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
-[![Python](https://img.shields.io/pypi/pyversions/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
+[![PyPI](https://img.shields.io/pypi/v/piper-plus)](https://pypi.org/project/piper-plus/)
+[![Python](https://img.shields.io/pypi/pyversions/piper-plus)](https://pypi.org/project/piper-plus/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue)](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
 [![Hugging Face Model](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Model-orange)](https://huggingface.co/ayousanz/piper-plus-base)
@@ -57,7 +57,7 @@ Systeme de synthese vocale neuronale (TTS) rapide et de haute qualite. Base sur 
 - **CLI Rust** — piper-plus/piper-plus-cli, streaming, CUDA/CoreML/DirectML, telechargement automatique des dictionnaires
 - **[WebAssembly](src/wasm/openjtalk-web/README.md)** — Fonctionne entierement dans le navigateur, sans serveur
 - **[Docker](docker/README.md)** — 5 images pour l'inference, l'entrainement, WebUI et C++
-- **PyPI** — `pip install piper-tts-plus`
+- **PyPI** — `pip install piper-plus`
 
 ### Plateformes
 
@@ -178,14 +178,14 @@ uv pip install ".[dev]"
 Egalement disponible sur PyPI :
 
 ```bash
-pip install piper-tts-plus
+pip install piper-plus
 ```
 
 ### Installation depuis les gestionnaires de paquets
 
 **Python (PyPI) :**
 ```bash
-pip install piper-tts-plus
+pip install piper-plus
 ```
 
 **C# CLI (Outil global .NET) :**

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -3,8 +3,8 @@
 [English](README_EN.md) | [日本語](README.md) | 中文 | [Français](README_FR.md)
 
 [![CI](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
-[![Python](https://img.shields.io/pypi/pyversions/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
+[![PyPI](https://img.shields.io/pypi/v/piper-plus)](https://pypi.org/project/piper-plus/)
+[![Python](https://img.shields.io/pypi/pyversions/piper-plus)](https://pypi.org/project/piper-plus/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue)](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
 [![Hugging Face Model](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Model-orange)](https://huggingface.co/ayousanz/piper-plus-base)
@@ -55,7 +55,7 @@
 - **C++ CLI** — 流式处理、CUDA 推理、音素时间输出、自定义词典
 - **[WebAssembly](src/wasm/openjtalk-web/README.md)** — 完全在浏览器中运行，无需服务器
 - **[Docker](docker/README.md)** — 提供推理、训练、WebUI、C++ 共 5 个镜像
-- **PyPI** — `pip install piper-tts-plus`
+- **PyPI** — `pip install piper-plus`
 - **C# CLI** — .NET 8/9 跨平台，6语言多语言支持，ONNX 推理
 - **Rust CLI** — piper-plus/piper-plus-cli，流式处理，CUDA/CoreML/DirectML 支持，词典自动下载
 
@@ -242,14 +242,14 @@ uv pip install ".[dev]"
 也可从 PyPI 安装：
 
 ```bash
-pip install piper-tts-plus
+pip install piper-plus
 ```
 
 ### 从包管理器安装
 
 **Python (PyPI):**
 ```bash
-pip install piper-tts-plus
+pip install piper-plus
 ```
 
 **C# CLI (.NET 全局工具):**

--- a/src/python_run/README.md
+++ b/src/python_run/README.md
@@ -1,8 +1,8 @@
 # Piper Plus
 
 [![CI](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/ayutaz/piper-plus/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
-[![Python](https://img.shields.io/pypi/pyversions/piper-tts-plus)](https://pypi.org/project/piper-tts-plus/)
+[![PyPI](https://img.shields.io/pypi/v/piper-plus)](https://pypi.org/project/piper-plus/)
+[![Python](https://img.shields.io/pypi/pyversions/piper-plus)](https://pypi.org/project/piper-plus/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 高速・高品質なニューラルテキスト音声合成 (TTS) システム。[VITS](https://github.com/jaywalnut310/vits/) アーキテクチャを採用し、6言語マルチスピーカー音声合成に対応。[Piper](https://github.com/rhasspy/piper) のフォークで、日本語対応・音質向上・学習機能を大幅に強化しています。
@@ -22,10 +22,10 @@
 ## インストール
 
 ```bash
-pip install piper-tts-plus
+pip install piper-plus
 
 # GPU サポート
-pip install "piper-tts-plus[gpu]"
+pip install "piper-plus[gpu]"
 ```
 
 Python 3.11+ が必要です。

--- a/src/python_run/piper/__init__.py
+++ b/src/python_run/piper/__init__.py
@@ -4,7 +4,7 @@ from .voice import PiperVoice
 
 
 try:
-    __version__ = version("piper-tts-plus")
+    __version__ = version("piper-plus")
 except PackageNotFoundError:
     # Fallback for development (running from source tree)
     from pathlib import Path

--- a/src/python_run/piper/phonemize/__init__.py
+++ b/src/python_run/piper/phonemize/__init__.py
@@ -1,4 +1,4 @@
-"""Phonemization modules for piper-tts-plus inference."""
+"""Phonemization modules for piper-plus inference."""
 
 from .chinese import phonemize_chinese
 from .english import phonemize_english

--- a/src/python_run/piper/phonemize/chinese.py
+++ b/src/python_run/piper/phonemize/chinese.py
@@ -1,6 +1,6 @@
 """Chinese (Mandarin) phonemizer using pypinyin for Piper TTS.
 
-Runtime version for piper-tts-plus inference.
+Runtime version for piper-plus inference.
 Converts Chinese text to IPA phonemes via pinyin intermediate representation.
 G2P logic is identical to the training side (piper_train.phonemize.chinese).
 """

--- a/src/python_run/piper/phonemize/english.py
+++ b/src/python_run/piper/phonemize/english.py
@@ -1,6 +1,6 @@
 """English G2P module using g2p-en (Apache-2.0 licensed).
 
-Runtime version for piper-tts-plus inference.
+Runtime version for piper-plus inference.
 Converts English text to phoneme tokens after map_sequence conversion.
 G2P logic is identical to the training side (piper_train.phonemize.english).
 """

--- a/src/python_run/piper/phonemize/french.py
+++ b/src/python_run/piper/phonemize/french.py
@@ -1,6 +1,6 @@
 """Rule-based French phonemizer for Piper TTS.
 
-Runtime version for piper-tts-plus inference.
+Runtime version for piper-plus inference.
 Converts French text to IPA phonemes using grapheme-to-phoneme rules.
 G2P logic is identical to the training side (piper_train.phonemize.french).
 No external G2P engine required.

--- a/src/python_run/piper/phonemize/portuguese.py
+++ b/src/python_run/piper/phonemize/portuguese.py
@@ -1,6 +1,6 @@
 """Rule-based Brazilian Portuguese phonemizer for Piper TTS.
 
-Runtime version for piper-tts-plus inference.
+Runtime version for piper-plus inference.
 Converts Brazilian Portuguese text to IPA phonemes using grapheme-to-phoneme
 rules. G2P logic is identical to the training side
 (piper_train.phonemize.portuguese). No external G2P engine required.

--- a/src/python_run/piper/phonemize/spanish.py
+++ b/src/python_run/piper/phonemize/spanish.py
@@ -1,6 +1,6 @@
 """Rule-based Spanish G2P (grapheme-to-phoneme) module.
 
-Runtime version for piper-tts-plus inference.
+Runtime version for piper-plus inference.
 Converts Spanish text to IPA phonemes using orthographic rules.
 G2P logic is identical to the training side (piper_train.phonemize.spanish).
 

--- a/src/python_run/setup.py
+++ b/src/python_run/setup.py
@@ -41,7 +41,7 @@ data_files = [module_dir / "voices.json"]
 # -----------------------------------------------------------------------------
 
 setup(
-    name="piper-tts-plus",
+    name="piper-plus",
     version=version,
     description=(
         "A fast, high-quality neural text-to-speech system supporting "

--- a/src/python_run/tests/test_japanese_phonemization.py
+++ b/src/python_run/tests/test_japanese_phonemization.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Test Japanese phonemization functionality for piper-tts-plus"""
+"""Test Japanese phonemization functionality for piper-plus"""
 
 import json
 from unittest.mock import MagicMock, patch

--- a/src/python_stub/README.md
+++ b/src/python_stub/README.md
@@ -1,0 +1,16 @@
+# piper-tts-plus has been renamed to piper-plus
+
+This package has been renamed to **[piper-plus](https://pypi.org/project/piper-plus/)**.
+
+Please update your dependencies:
+
+```bash
+pip install piper-plus
+```
+
+If you have `piper-tts-plus` in your `requirements.txt` or `pyproject.toml`, replace it with `piper-plus`.
+
+All future releases will be published under the new name.
+
+- [PyPI (piper-plus)](https://pypi.org/project/piper-plus/)
+- [GitHub](https://github.com/ayutaz/piper-plus)

--- a/src/python_stub/pyproject.toml
+++ b/src/python_stub/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "piper-tts-plus"
+dynamic = ["version"]
+description = "This package has been renamed to piper-plus. Install piper-plus instead."
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+    {name = "yousan", email = "rabbitcats77@gmail.com"},
+]
+dependencies = ["piper-plus"]
+classifiers = [
+    "Development Status :: 7 - Inactive",
+    "Intended Audience :: Developers",
+    "Topic :: Text Processing :: Linguistic",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+keywords = ["piper", "tts", "deprecated", "renamed"]
+
+[project.urls]
+Homepage = "https://github.com/ayutaz/piper-plus"
+"New Package" = "https://pypi.org/project/piper-plus/"
+
+[tool.setuptools.dynamic]
+version = {file = "../../VERSION"}

--- a/src/python_stub/pyproject.toml
+++ b/src/python_stub/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "MIT"}
 authors = [
     {name = "yousan", email = "rabbitcats77@gmail.com"},
 ]
-dependencies = ["piper-plus"]
+dependencies = ["piper-plus>=1.10.0"]
 classifiers = [
     "Development Status :: 7 - Inactive",
     "Intended Audience :: Developers",

--- a/src/python_stub/pyproject.toml
+++ b/src/python_stub/pyproject.toml
@@ -12,7 +12,12 @@ license = {text = "MIT"}
 authors = [
     {name = "yousan", email = "rabbitcats77@gmail.com"},
 ]
-dependencies = ["piper-plus>=1.10.0"]
+dependencies = ["piper-plus"]
+
+[project.optional-dependencies]
+gpu = ["piper-plus[gpu]"]
+http = ["piper-plus[http]"]
+
 classifiers = [
     "Development Status :: 7 - Inactive",
     "Intended Audience :: Developers",
@@ -29,4 +34,4 @@ Homepage = "https://github.com/ayutaz/piper-plus"
 "New Package" = "https://pypi.org/project/piper-plus/"
 
 [tool.setuptools.dynamic]
-version = {file = "../../VERSION"}
+version = {file = "VERSION"}


### PR DESCRIPTION
## Summary

- PyPI パッケージ名を `piper-tts-plus` から `piper-plus` に変更し、全レジストリ (npm, crates.io, NuGet, GitHub) で名前を統一
- 旧パッケージ `piper-tts-plus` 用のスタブパッケージを作成 (`dependencies = ["piper-plus>=1.10.0"]` でリダイレクト)
- リリースCIにスタブ自動公開ジョブを追加

### 変更内容 (19ファイル)

| カテゴリ | 変更 |
|---------|------|
| パッケージ名 | `setup.py` の `name`、`__init__.py` の `version()` |
| docstring | phonemizer 6ファイル + テスト1ファイル |
| CI/CD | リリースノート・PyPIリンク更新、スタブ公開ジョブ追加 |
| ドキュメント | README 5ファイル (4言語 + python_run)、CHANGELOG |
| 新規 | `src/python_stub/` (スタブパッケージ: pyproject.toml + README.md) |

### リリースフロー

```
1. piper-plus vX.Y.Z を PyPI に公開 (本体)
2. piper-tts-plus vX.Y.Z をスタブとして公開 (自動リダイレクト)
```

## Test plan

- [ ] `piper-tts-plus` の参照がコード・CI・ドキュメントから除去されていることを確認 (CHANGELOG歴史的エントリとスタブ関連を除く)
- [ ] スタブパッケージ `src/python_stub/` が `python -m build` でビルドできることを確認
- [ ] リリース前に `PIPY_TOKEN` のスコープがアカウント全体であることを確認 (プロジェクトスコープの場合、新パッケージへのアップロードが失敗する)
- [ ] 初回リリース後、`pip install piper-tts-plus` で `piper-plus` が自動インストールされることを確認