### PR TITLE
fix: piper-tts-plus stub の pyproject.toml classifiers 配置修正

### DIFF
--- a/src/python_stub/pyproject.toml
+++ b/src/python_stub/pyproject.toml
@@ -13,11 +13,6 @@ authors = [
     {name = "yousan", email = "rabbitcats77@gmail.com"},
 ]
 dependencies = ["piper-plus"]
-
-[project.optional-dependencies]
-gpu = ["piper-plus[gpu]"]
-http = ["piper-plus[http]"]
-
 classifiers = [
     "Development Status :: 7 - Inactive",
     "Intended Audience :: Developers",
@@ -28,6 +23,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 keywords = ["piper", "tts", "deprecated", "renamed"]
+
+[project.optional-dependencies]
+gpu = ["piper-plus[gpu]"]
+http = ["piper-plus[http]"]
 
 [project.urls]
 Homepage = "https://github.com/ayutaz/piper-plus"


### PR DESCRIPTION
## Summary

- `src/python_stub/pyproject.toml` の `classifiers` と `keywords` が `[project.optional-dependencies]` セクション内に配置されていたため、stub パッケージのビルドが失敗していた
- `[project]` セクションに移動して修正

## 原因

v1.10.0 Manual Release の「Publish PyPI Stub (piper-tts-plus)」ジョブが以下のエラーで失敗:
```
ValueError: invalid pyproject.toml config: `project.optional-dependencies.classifiers[0]`.
configuration error: `project.optional-dependencies.classifiers[0]` must be pep508
```

## Test plan
- [x] pyproject.toml の構文確認
- [ ] CI pass