### PR TITLE
fix(npm): config.json フォールバック追加 — HuggingFace 404 解消

### DIFF
--- a/src/wasm/openjtalk-web/src/index.js
+++ b/src/wasm/openjtalk-web/src/index.js
@@ -214,10 +214,13 @@ export class PiperPlus {
       progress({ stage: 'model', progress: 0, message: 'Resolving model...' });
 
       const modelManager = new ModelManager();
-      const { modelUrl, configUrl } = await modelManager.resolveUrls(options.model);
+      const { modelUrl, configUrl, configFallbackUrl } = await modelManager.resolveUrls(options.model);
 
       progress({ stage: 'model', progress: 0.1, message: 'Downloading config...' });
-      const configResponse = await fetch(configUrl);
+      let configResponse = await fetch(configUrl);
+      if (!configResponse.ok && configFallbackUrl) {
+        configResponse = await fetch(configFallbackUrl);
+      }
       if (!configResponse.ok) {
         throw new Error(`Failed to fetch config: ${configResponse.status} ${configResponse.statusText}`);
       }

--- a/src/wasm/openjtalk-web/src/index.js
+++ b/src/wasm/openjtalk-web/src/index.js
@@ -218,7 +218,7 @@ export class PiperPlus {
 
       progress({ stage: 'model', progress: 0.1, message: 'Downloading config...' });
       let configResponse = await fetch(configUrl);
-      if (!configResponse.ok && configFallbackUrl) {
+      if (!configResponse.ok && configResponse.status === 404 && configFallbackUrl) {
         configResponse = await fetch(configFallbackUrl);
       }
       if (!configResponse.ok) {

--- a/src/wasm/openjtalk-web/src/model-manager.js
+++ b/src/wasm/openjtalk-web/src/model-manager.js
@@ -140,9 +140,16 @@ async function resolveModelFiles(repoName) {
 
   // Resolve config: prefer sidecar {onnx}.json, fall back to config.json.
   const sidecarConfig = `${onnxFilename}.json`;
-  const configFilename = filenames.includes(sidecarConfig)
-    ? sidecarConfig
-    : 'config.json';
+  let configFilename;
+  if (filenames.includes(sidecarConfig)) {
+    configFilename = sidecarConfig;
+  } else if (filenames.includes('config.json')) {
+    configFilename = 'config.json';
+  } else {
+    throw new Error(
+      `No config file found in repository "${repoName}"; expected "${sidecarConfig}" or "config.json"`
+    );
+  }
 
   return { onnxFilename, configFilename };
 }
@@ -206,7 +213,7 @@ export class ModelManager {
    *   - Direct URL:        "https://example.com/model.onnx"
    *
    * @param {string} modelNameOrUrl
-   * @returns {Promise<{modelUrl: string, configUrl: string, cacheKey: string}>}
+   * @returns {Promise<{modelUrl: string, configUrl: string, configFallbackUrl: string|null, cacheKey: string}>}
    */
   async _resolveUrls(modelNameOrUrl) {
     // Direct URL.
@@ -239,7 +246,7 @@ export class ModelManager {
    * This is the public entry point that delegates to {@link _resolveUrls}.
    *
    * @param {string} modelNameOrUrl - Registry shortcut, HuggingFace repo, or direct URL
-   * @returns {Promise<{modelUrl: string, configUrl: string, cacheKey: string}>}
+   * @returns {Promise<{modelUrl: string, configUrl: string, configFallbackUrl: string|null, cacheKey: string}>}
    */
   async resolveUrls(modelNameOrUrl) {
     return this._resolveUrls(modelNameOrUrl);
@@ -265,12 +272,15 @@ export class ModelManager {
 
     // Download config with fallback (small, no progress tracking needed).
     let configResponse = await fetch(configUrl);
-    if (!configResponse.ok && configFallbackUrl) {
+    if (configResponse.status === 404 && configFallbackUrl) {
       configResponse = await fetch(configFallbackUrl);
     }
     if (!configResponse.ok) {
+      const tried = configFallbackUrl
+        ? `${configUrl} and ${configFallbackUrl}`
+        : configUrl;
       throw new Error(
-        `Failed to fetch model config from ${configUrl}: ${configResponse.status} ${configResponse.statusText}`
+        `Failed to fetch model config from ${tried}: ${configResponse.status} ${configResponse.statusText}`
       );
     }
     const config = await configResponse.json();

--- a/src/wasm/openjtalk-web/src/model-manager.js
+++ b/src/wasm/openjtalk-web/src/model-manager.js
@@ -106,13 +106,17 @@ async function fetchWithProgress(url, onProgress) {
 }
 
 /**
- * Query the HuggingFace API for repository metadata and find the ONNX
- * filename from the siblings list.
+ * Query the HuggingFace API for repository metadata and resolve the ONNX
+ * model filename and its companion config filename from the siblings list.
+ *
+ * Config resolution order:
+ *   1. Sidecar: `{onnxFilename}.json` (e.g. `model.onnx.json`)
+ *   2. Fallback: `config.json`
  *
  * @param {string} repoName - e.g. "ayousanz/piper-plus-tsukuyomi-chan"
- * @returns {Promise<string>} - The ONNX filename found in the repository
+ * @returns {Promise<{onnxFilename: string, configFilename: string}>}
  */
-async function resolveOnnxFilename(repoName) {
+async function resolveModelFiles(repoName) {
   const apiUrl = `${HUGGINGFACE_API_BASE}/${repoName}`;
   const response = await fetch(apiUrl);
   if (!response.ok) {
@@ -123,9 +127,8 @@ async function resolveOnnxFilename(repoName) {
 
   const metadata = await response.json();
   const siblings = metadata.siblings || [];
-  const onnxFiles = siblings
-    .map((s) => s.rfilename)
-    .filter((name) => name.endsWith('.onnx'));
+  const filenames = siblings.map((s) => s.rfilename);
+  const onnxFiles = filenames.filter((name) => name.endsWith('.onnx'));
 
   if (onnxFiles.length === 0) {
     throw new Error(`No .onnx file found in repository "${repoName}"`);
@@ -133,7 +136,15 @@ async function resolveOnnxFilename(repoName) {
 
   // If multiple ONNX files exist, prefer one with "fp16" in the name.
   const fp16File = onnxFiles.find((name) => name.includes('fp16'));
-  return fp16File || onnxFiles[0];
+  const onnxFilename = fp16File || onnxFiles[0];
+
+  // Resolve config: prefer sidecar {onnx}.json, fall back to config.json.
+  const sidecarConfig = `${onnxFilename}.json`;
+  const configFilename = filenames.includes(sidecarConfig)
+    ? sidecarConfig
+    : 'config.json';
+
+  return { onnxFilename, configFilename };
 }
 
 export class ModelManager {
@@ -202,20 +213,24 @@ export class ModelManager {
     if (/^https?:\/\//i.test(modelNameOrUrl)) {
       const modelUrl = modelNameOrUrl;
       const configUrl = modelUrl + '.json';
-      return { modelUrl, configUrl, cacheKey: modelUrl };
+      // Fallback: config.json in the same directory as the model.
+      const lastSlash = modelUrl.lastIndexOf('/');
+      const configFallbackUrl = lastSlash >= 0
+        ? modelUrl.substring(0, lastSlash + 1) + 'config.json'
+        : null;
+      return { modelUrl, configUrl, configFallbackUrl, cacheKey: modelUrl };
     }
 
     // Registry shortcut.
     const repoName = MODEL_REGISTRY[modelNameOrUrl] || modelNameOrUrl;
 
-    // Resolve the ONNX filename from the HuggingFace API.
-    const onnxFilename = await resolveOnnxFilename(repoName);
+    // Resolve ONNX and config filenames from the HuggingFace API.
+    const { onnxFilename, configFilename } = await resolveModelFiles(repoName);
 
     const modelUrl = `${HUGGINGFACE_RESOLVE_BASE}/${repoName}/resolve/main/${onnxFilename}`;
-    // Config is always "config.json" in the repo root (not "<model>.onnx.json")
-    const configUrl = `${HUGGINGFACE_RESOLVE_BASE}/${repoName}/resolve/main/config.json`;
+    const configUrl = `${HUGGINGFACE_RESOLVE_BASE}/${repoName}/resolve/main/${configFilename}`;
 
-    return { modelUrl, configUrl, cacheKey: repoName };
+    return { modelUrl, configUrl, configFallbackUrl: null, cacheKey: repoName };
   }
 
   /**
@@ -240,7 +255,7 @@ export class ModelManager {
    */
   async loadModel(modelNameOrUrl, options = {}) {
     const { onProgress } = options;
-    const { modelUrl, configUrl, cacheKey } = await this._resolveUrls(modelNameOrUrl);
+    const { modelUrl, configUrl, configFallbackUrl, cacheKey } = await this._resolveUrls(modelNameOrUrl);
 
     // Try the cache first.
     const cached = await this.getFromCache(cacheKey);
@@ -248,8 +263,11 @@ export class ModelManager {
       return cached;
     }
 
-    // Download config (small, no progress tracking needed).
-    const configResponse = await fetch(configUrl);
+    // Download config with fallback (small, no progress tracking needed).
+    let configResponse = await fetch(configUrl);
+    if (!configResponse.ok && configFallbackUrl) {
+      configResponse = await fetch(configFallbackUrl);
+    }
     if (!configResponse.ok) {
       throw new Error(
         `Failed to fetch model config from ${configUrl}: ${configResponse.status} ${configResponse.statusText}`

--- a/src/wasm/openjtalk-web/test/js/test-model-manager-boundary.js
+++ b/src/wasm/openjtalk-web/test/js/test-model-manager-boundary.js
@@ -229,7 +229,7 @@ describe('ModelManager 境界/エラーケース', { skip }, () => {
           siblings: [{ rfilename: 'model.onnx' }],
         }),
       }],
-      [/resolve\/main\/config\.json/, {
+      [/resolve\/main\/config\.json$/, {
         ok: false,
         status: 503,
         statusText: 'Service Unavailable',
@@ -299,7 +299,7 @@ describe('ModelManager 境界/エラーケース', { skip }, () => {
           siblings: [{ rfilename: 'model.onnx' }],
         }),
       }],
-      [/resolve\/main\/config\.json/, {
+      [/resolve\/main\/config\.json$/, {
         ok: true,
         json: () => { throw new SyntaxError('Unexpected token < in JSON'); },
       }],

--- a/src/wasm/openjtalk-web/test/js/test-model-manager-boundary.js
+++ b/src/wasm/openjtalk-web/test/js/test-model-manager-boundary.js
@@ -217,7 +217,7 @@ describe('ModelManager 境界/エラーケース', { skip }, () => {
   });
 
   // =====================================================================
-  // 6. config.json 取得失敗で適切なエラー
+  // 6. config.json 取得失敗で適切なエラー (siblings に config.json あり、fetch が 503)
   // =====================================================================
 
   it('config.json 取得失敗で適切なエラー', async () => {
@@ -226,7 +226,10 @@ describe('ModelManager 境界/エラーケース', { skip }, () => {
       [/huggingface\.co\/api\/models\//, {
         ok: true,
         json: () => Promise.resolve({
-          siblings: [{ rfilename: 'model.onnx' }],
+          siblings: [
+            { rfilename: 'model.onnx' },
+            { rfilename: 'config.json' },
+          ],
         }),
       }],
       [/resolve\/main\/config\.json$/, {
@@ -244,6 +247,31 @@ describe('ModelManager 境界/エラーケース', { skip }, () => {
     await assert.rejects(
       () => mgr.loadModel('some-org/some-repo'),
       (err) => err.message.includes('503'),
+    );
+  });
+
+  // =====================================================================
+  // 6b. siblings にサイドカーも config.json もない場合 resolveModelFiles でエラー
+  // =====================================================================
+
+  it('siblings にサイドカーも config.json もない場合エラーをスローする', async () => {
+    setupMocks();
+    globalThis.fetch = createMockFetch(new Map([
+      [/huggingface\.co\/api\/models\//, {
+        ok: true,
+        json: () => Promise.resolve({
+          siblings: [
+            { rfilename: 'model.onnx' },
+            { rfilename: 'README.md' },
+          ],
+        }),
+      }],
+    ]));
+    const mgr = new ModelManager();
+
+    await assert.rejects(
+      () => mgr.loadModel('some-org/no-config-repo'),
+      (err) => err.message.includes('No config file found'),
     );
   });
 
@@ -296,7 +324,7 @@ describe('ModelManager 境界/エラーケース', { skip }, () => {
       [/huggingface\.co\/api\/models\//, {
         ok: true,
         json: () => Promise.resolve({
-          siblings: [{ rfilename: 'model.onnx' }],
+          siblings: [{ rfilename: 'model.onnx' }, { rfilename: 'config.json' }],
         }),
       }],
       [/resolve\/main\/config\.json$/, {

--- a/src/wasm/openjtalk-web/test/js/test-model-manager-load.js
+++ b/src/wasm/openjtalk-web/test/js/test-model-manager-load.js
@@ -117,7 +117,7 @@ function createMockFetch(routes) {
  * @returns {Map<string|RegExp, Object>}
  */
 function createHuggingFaceRoutes(options = {}) {
-  const siblings = (options.siblings || ['model.onnx']).map((f) => ({ rfilename: f }));
+  const siblings = (options.siblings || ['model.onnx', 'config.json']).map((f) => ({ rfilename: f }));
   const config = options.config || SAMPLE_CONFIG;
   const modelBuffer = options.modelBuffer || SAMPLE_MODEL_BUFFER;
 
@@ -201,7 +201,7 @@ describe('ModelManager.loadModel() 成功ケース', { skip }, () => {
     installIndexedDBMock(mockDb);
 
     const { fetch: mockFetch } = createMockFetch(
-      createHuggingFaceRoutes({ siblings: ['tsukuyomi.onnx'] })
+      createHuggingFaceRoutes({ siblings: ['tsukuyomi.onnx', 'config.json'] })
     );
     globalThis.fetch = mockFetch;
 
@@ -227,7 +227,7 @@ describe('ModelManager.loadModel() 成功ケース', { skip }, () => {
     installIndexedDBMock(mockDb);
 
     const { fetch: mockFetch, calledUrls } = createMockFetch(
-      createHuggingFaceRoutes({ siblings: ['model-fp16.onnx', 'README.md'] })
+      createHuggingFaceRoutes({ siblings: ['model-fp16.onnx', 'README.md', 'config.json'] })
     );
     globalThis.fetch = mockFetch;
 

--- a/src/wasm/openjtalk-web/test/js/test-model-manager-load.js
+++ b/src/wasm/openjtalk-web/test/js/test-model-manager-load.js
@@ -126,7 +126,7 @@ function createHuggingFaceRoutes(options = {}) {
       ok: true,
       json: () => Promise.resolve({ siblings }),
     }],
-    [/huggingface\.co\/.*\/resolve\/main\/config\.json$/, {
+    [/huggingface\.co\/.*\/resolve\/main\/(?:.*\.onnx\.json|config\.json)$/, {
       ok: true,
       json: () => Promise.resolve(config),
     }],
@@ -583,5 +583,101 @@ describe('ModelManager.loadModel() 成功ケース', { skip }, () => {
     assert.equal(result.config.inference.noise_scale, 0.667);
     assert.equal(result.config.inference.length_scale, 1.0);
     assert.equal(result.config.inference.noise_w, 0.8);
+  });
+
+  // =====================================================================
+  // 9. HF リポジトリが config.json のみの場合にロードできる
+  // =====================================================================
+
+  it('HF リポジトリが config.json のみ（サイドカーなし）でロードできる', async () => {
+    // Arrange — 実際の ayousanz/piper-plus-tsukuyomi-chan と同じ構造
+    const mockDb = createMockIndexedDB();
+    installIndexedDBMock(mockDb);
+
+    const customConfig = { audio: { sample_rate: 22050 }, num_speakers: 1 };
+
+    const routes = new Map([
+      [/huggingface\.co\/api\/models\//, {
+        ok: true,
+        json: () => Promise.resolve({
+          siblings: [
+            { rfilename: 'tsukuyomi-chan-6lang-fp16.onnx' },
+            { rfilename: 'config.json' },
+            { rfilename: 'README.md' },
+          ],
+        }),
+      }],
+      [/resolve\/main\/config\.json$/, {
+        ok: true,
+        json: () => Promise.resolve(customConfig),
+      }],
+      [/resolve\/main\/.*\.onnx$/, {
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(64)),
+      }],
+    ]);
+
+    const { fetch: mockFetch, calledUrls } = createMockFetch(routes);
+    globalThis.fetch = mockFetch;
+
+    const mgr = new ModelManager();
+
+    // Act
+    const result = await mgr.loadModel('ayousanz/piper-plus-tsukuyomi-chan');
+
+    // Assert
+    assert.ok(result.modelData instanceof ArrayBuffer);
+    assert.deepEqual(result.config, customConfig);
+
+    // config.json が取得されていることを確認
+    const configFetch = calledUrls.find((u) => u.includes('/resolve/main/config.json'));
+    assert.ok(configFetch, 'config.json should have been fetched');
+  });
+
+  // =====================================================================
+  // 10. 直接 URL で primary config が 404 の場合フォールバックする
+  // =====================================================================
+
+  it('直接 URL で primary config 404 時に config.json にフォールバックする', async () => {
+    // Arrange
+    const mockDb = createMockIndexedDB();
+    installIndexedDBMock(mockDb);
+
+    const customConfig = { audio: { sample_rate: 22050 }, num_speakers: 1 };
+    const modelUrl = 'https://example.com/models/my-model.onnx';
+
+    const routes = new Map([
+      // Primary config URL returns 404
+      [modelUrl + '.json', {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      }],
+      // Fallback config.json succeeds
+      ['https://example.com/models/config.json', {
+        ok: true,
+        json: () => Promise.resolve(customConfig),
+      }],
+      [modelUrl, {
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(128)),
+      }],
+    ]);
+
+    const { fetch: mockFetch, calledUrls } = createMockFetch(routes);
+    globalThis.fetch = mockFetch;
+
+    const mgr = new ModelManager();
+
+    // Act
+    const result = await mgr.loadModel(modelUrl);
+
+    // Assert
+    assert.ok(result.modelData instanceof ArrayBuffer);
+    assert.deepEqual(result.config, customConfig);
+
+    // 両方のconfig URLが試行されたことを確認
+    assert.ok(calledUrls.includes(modelUrl + '.json'), 'primary config URL should be tried first');
+    assert.ok(calledUrls.includes('https://example.com/models/config.json'), 'fallback config.json should be tried');
   });
 });

--- a/src/wasm/openjtalk-web/test/js/test-model-manager.js
+++ b/src/wasm/openjtalk-web/test/js/test-model-manager.js
@@ -501,7 +501,26 @@ describe('ModelManager', { skip }, () => {
       assert.equal(urls.configUrl, 'https://example.com/model.onnx.json');
     });
 
-    it('HuggingFaceリポジトリのconfigUrlがconfig.jsonで終わる', async () => {
+    it('HuggingFaceリポジトリのconfigUrlはサイドカー.onnx.jsonを優先する', async () => {
+      globalThis.fetch = createMockFetch(new Map([
+        [/huggingface\.co\/api\/models\//, {
+          ok: true,
+          json: () => Promise.resolve({
+            siblings: [
+              { rfilename: 'model.onnx' },
+              { rfilename: 'model.onnx.json' },
+            ],
+          }),
+        }],
+      ]));
+
+      const mgr = new ModelManager();
+      const urls = await mgr._resolveUrls('ayousanz/piper-plus-base');
+
+      assert.ok(urls.configUrl.endsWith('.onnx.json'));
+    });
+
+    it('サイドカーがない場合はconfig.jsonにフォールバックする', async () => {
       globalThis.fetch = createMockFetch(new Map([
         [/huggingface\.co\/api\/models\//, {
           ok: true,
@@ -514,7 +533,30 @@ describe('ModelManager', { skip }, () => {
       const mgr = new ModelManager();
       const urls = await mgr._resolveUrls('ayousanz/piper-plus-base');
 
-      assert.ok(urls.configUrl.endsWith('config.json'));
+      assert.ok(urls.configUrl.endsWith('/config.json'));
+    });
+
+    it('直接URLのconfigFallbackUrlはconfig.jsonになる', async () => {
+      const mgr = new ModelManager();
+      const urls = await mgr._resolveUrls('https://example.com/models/model.onnx');
+
+      assert.equal(urls.configFallbackUrl, 'https://example.com/models/config.json');
+    });
+
+    it('HuggingFaceリポジトリのconfigFallbackUrlはnullになる', async () => {
+      globalThis.fetch = createMockFetch(new Map([
+        [/huggingface\.co\/api\/models\//, {
+          ok: true,
+          json: () => Promise.resolve({
+            siblings: [{ rfilename: 'model.onnx' }],
+          }),
+        }],
+      ]));
+
+      const mgr = new ModelManager();
+      const urls = await mgr._resolveUrls('ayousanz/piper-plus-base');
+
+      assert.equal(urls.configFallbackUrl, null);
     });
 
     it('HuggingFaceリポジトリのconfigUrlにhuggingface.coが含まれる', async () => {

--- a/src/wasm/openjtalk-web/test/js/test-model-manager.js
+++ b/src/wasm/openjtalk-web/test/js/test-model-manager.js
@@ -404,7 +404,7 @@ describe('ModelManager', { skip }, () => {
         [/huggingface\.co\/api\/models\//, {
           ok: true,
           json: () => Promise.resolve({
-            siblings: [{ rfilename: 'model-fp16.onnx' }],
+            siblings: [{ rfilename: 'model-fp16.onnx' }, { rfilename: 'config.json' }],
           }),
         }],
       ]));
@@ -420,7 +420,7 @@ describe('ModelManager', { skip }, () => {
         [/huggingface\.co\/api\/models\//, {
           ok: true,
           json: () => Promise.resolve({
-            siblings: [{ rfilename: 'model-fp16.onnx' }],
+            siblings: [{ rfilename: 'model-fp16.onnx' }, { rfilename: 'config.json' }],
           }),
         }],
       ]));
@@ -436,7 +436,7 @@ describe('ModelManager', { skip }, () => {
         [/huggingface\.co\/api\/models\//, {
           ok: true,
           json: () => Promise.resolve({
-            siblings: [{ rfilename: 'model-fp16.onnx' }],
+            siblings: [{ rfilename: 'model-fp16.onnx' }, { rfilename: 'config.json' }],
           }),
         }],
       ]));
@@ -452,7 +452,7 @@ describe('ModelManager', { skip }, () => {
         [/huggingface\.co\/api\/models\//, {
           ok: true,
           json: () => Promise.resolve({
-            siblings: [{ rfilename: 'model-fp16.onnx' }],
+            siblings: [{ rfilename: 'model-fp16.onnx' }, { rfilename: 'config.json' }],
           }),
         }],
       ]));
@@ -468,7 +468,7 @@ describe('ModelManager', { skip }, () => {
         [/huggingface\.co\/api\/models\/ayousanz\/piper-plus-tsukuyomi-chan/, {
           ok: true,
           json: () => Promise.resolve({
-            siblings: [{ rfilename: 'tsukuyomi.onnx' }],
+            siblings: [{ rfilename: 'tsukuyomi.onnx' }, { rfilename: 'config.json' }],
           }),
         }],
       ]));
@@ -525,7 +525,7 @@ describe('ModelManager', { skip }, () => {
         [/huggingface\.co\/api\/models\//, {
           ok: true,
           json: () => Promise.resolve({
-            siblings: [{ rfilename: 'model.onnx' }],
+            siblings: [{ rfilename: 'model.onnx' }, { rfilename: 'config.json' }],
           }),
         }],
       ]));
@@ -548,7 +548,7 @@ describe('ModelManager', { skip }, () => {
         [/huggingface\.co\/api\/models\//, {
           ok: true,
           json: () => Promise.resolve({
-            siblings: [{ rfilename: 'model.onnx' }],
+            siblings: [{ rfilename: 'model.onnx' }, { rfilename: 'config.json' }],
           }),
         }],
       ]));
@@ -564,7 +564,7 @@ describe('ModelManager', { skip }, () => {
         [/huggingface\.co\/api\/models\//, {
           ok: true,
           json: () => Promise.resolve({
-            siblings: [{ rfilename: 'model.onnx' }],
+            siblings: [{ rfilename: 'model.onnx' }, { rfilename: 'config.json' }],
           }),
         }],
       ]));
@@ -583,6 +583,7 @@ describe('ModelManager', { skip }, () => {
             siblings: [
               { rfilename: 'model.onnx' },
               { rfilename: 'model-fp16.onnx' },
+              { rfilename: 'config.json' },
             ],
           }),
         }],
@@ -605,7 +606,7 @@ describe('ModelManager', { skip }, () => {
         [/huggingface\.co\/api\/models\//, {
           ok: true,
           json: () => Promise.resolve({
-            siblings: [{ rfilename: 'model.onnx' }],
+            siblings: [{ rfilename: 'model.onnx' }, { rfilename: 'config.json' }],
           }),
         }],
       ]));
@@ -622,7 +623,7 @@ describe('ModelManager', { skip }, () => {
         [/huggingface\.co\/api\/models\//, {
           ok: true,
           json: () => Promise.resolve({
-            siblings: [{ rfilename: 'model.onnx' }],
+            siblings: [{ rfilename: 'model.onnx' }, { rfilename: 'config.json' }],
           }),
         }],
       ]));
@@ -639,7 +640,7 @@ describe('ModelManager', { skip }, () => {
         [/huggingface\.co\/api\/models\//, {
           ok: true,
           json: () => Promise.resolve({
-            siblings: [{ rfilename: 'model.onnx' }],
+            siblings: [{ rfilename: 'model.onnx' }, { rfilename: 'config.json' }],
           }),
         }],
       ]));


### PR DESCRIPTION
## Summary
- npm パッケージの `ModelManager` が config URL を `{onnx}.json` のみで構築していたため、HuggingFace リポジトリに `config.json` しかない場合に 404 エラーが発生していた（全3リポジトリが該当）
- `resolveModelFiles()` で HF API の siblings リストから config ファイル名をプロアクティブに検出（サイドカー `{onnx}.json` 優先、`config.json` フォールバック）
- 直接 URL では同ディレクトリの `config.json` へのリアクティブフォールバックを追加
- Rust/C#/C++/Go の既存実装と同じ config 解決順序に統一

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `model-manager.js` | `resolveOnnxFilename()` → `resolveModelFiles()` (config検出追加)、`_resolveUrls()` に `configFallbackUrl`、`loadModel()` にフォールバック |
| `index.js` | `_init()` に同じフォールバックロジック追加 |
| `test-model-manager.js` | サイドカー優先・config.json フォールバック・configFallbackUrl テスト追加 |
| `test-model-manager-boundary.js` | mock ルート更新 (config.json パターン対応) |
| `test-model-manager-load.js` | HF config.json のみ・直接URL フォールバックのテスト追加 |

## Test plan
- [x] 既存 ModelManager テスト全58件 PASS
- [x] キャッシュテスト全8件 PASS
- [x] 新規テスト: HF リポジトリが `config.json` のみの場合にロード成功
- [x] 新規テスト: 直接 URL で primary 404 → `config.json` フォールバック成功
- [x] 新規テスト: サイドカー `.onnx.json` がある場合はそちらを優先
- [x] 新規テスト: `configFallbackUrl` の値検証（直接URL / HFリポジトリ）
- [ ] ブラウザで `PiperPlus.initialize({ model: 'tsukuyomi' })` が 404 なく動作することを確認