### PR TITLE
feat(webui): entrypoint 自動モデルDL — PIPER_MODEL 環境変数で起動時取得

### DIFF
--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -22,8 +22,10 @@ COPY src/python_run/requirements_webui.txt /app/requirements_webui.txt
 RUN uv pip install --system "/app/src/python[inference,multilingual]" && \
     uv pip install --system -r /app/requirements_webui.txt
 
-# Copy WebUI application
+# Copy WebUI application and entrypoint
 COPY docker/webui/app.py /app/app.py
+COPY docker/webui/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 # Create models directory
 RUN mkdir -p /models /output
@@ -35,5 +37,4 @@ EXPOSE 7860
 ENV GRADIO_SERVER_NAME=0.0.0.0
 ENV GRADIO_SERVER_PORT=7860
 
-# Run the WebUI
-CMD ["python", "/app/app.py", "--model-dir", "/models", "--output-dir", "/output"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/webui/docker-compose.yml
+++ b/docker/webui/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - ${MODELS_DIR:-./models}:/models
       - ${OUTPUT_DIR:-./output}:/output
     environment:
+      - PIPER_MODEL=${PIPER_MODEL:-}
+      - PIPER_MODEL_DIR=/models
       - GRADIO_SERVER_NAME=0.0.0.0
       - GRADIO_SERVER_PORT=7860
       - PYTHONUNBUFFERED=1

--- a/docker/webui/entrypoint.sh
+++ b/docker/webui/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+MODEL_DIR="${PIPER_MODEL_DIR:-/models}"
+
+# Download model if PIPER_MODEL is specified
+if [ -n "$PIPER_MODEL" ]; then
+    echo "Checking model: $PIPER_MODEL"
+    python -c "
+from piper_train.model_manager import resolve_model_path, download_model
+import sys, os
+
+model_name = os.environ['PIPER_MODEL']
+model_dir = os.environ.get('PIPER_MODEL_DIR', '/models')
+
+# Already downloaded?
+path = resolve_model_path(model_name, model_dir)
+if path:
+    print(f'Model ready: {path}', file=sys.stderr)
+    sys.exit(0)
+
+# Download
+if not download_model(model_name, model_dir):
+    print(f'Failed to download model: {model_name}', file=sys.stderr)
+    sys.exit(1)
+"
+fi
+
+exec python /app/app.py --model-dir "$MODEL_DIR" --output-dir "${PIPER_OUTPUT_DIR:-/output}" "$@"

--- a/docker/webui/test_entrypoint.sh
+++ b/docker/webui/test_entrypoint.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -e
+
+# Tests for docker/webui/entrypoint.sh
+# Run from repository root: bash docker/webui/test_entrypoint.sh
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local test_name="$1"
+    local test_command="$2"
+
+    echo -n "Testing $test_name... "
+    if eval "$test_command" > /tmp/entrypoint_test.log 2>&1; then
+        echo -e "${GREEN}PASSED${NC}"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}FAILED${NC}"
+        cat /tmp/entrypoint_test.log
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENTRYPOINT="$SCRIPT_DIR/entrypoint.sh"
+
+# 1. entrypoint.sh exists and is executable
+run_test "entrypoint.sh exists" "test -f '$ENTRYPOINT'"
+run_test "entrypoint.sh is executable" "test -x '$ENTRYPOINT' || chmod +x '$ENTRYPOINT' && test -x '$ENTRYPOINT'"
+
+# 2. entrypoint.sh has LF line endings (not CRLF — Docker requirement)
+run_test "LF line endings" "! grep -qP '\r' '$ENTRYPOINT'"
+
+# 3. Starts with bash shebang
+run_test "bash shebang" "head -1 '$ENTRYPOINT' | grep -q '#!/bin/bash'"
+
+# 4. Uses set -e for fail-fast
+run_test "set -e present" "grep -q 'set -e' '$ENTRYPOINT'"
+
+# 5. Uses exec to replace shell process
+run_test "exec used for app launch" "grep -q 'exec python' '$ENTRYPOINT'"
+
+# 6. References PIPER_MODEL env var
+run_test "PIPER_MODEL check" "grep -q 'PIPER_MODEL' '$ENTRYPOINT'"
+
+# 7. References PIPER_MODEL_DIR with default
+run_test "PIPER_MODEL_DIR default /models" "grep -q 'PIPER_MODEL_DIR:-/models' '$ENTRYPOINT'"
+
+# 8. Passes model-dir and output-dir to app.py
+run_test "passes --model-dir" "grep -q '\-\-model-dir' '$ENTRYPOINT'"
+run_test "passes --output-dir" "grep -q '\-\-output-dir' '$ENTRYPOINT'"
+
+# 9. Forwards extra args via \$@
+run_test "forwards extra args" 'grep -q '\''"$@"'\'' "$ENTRYPOINT"'
+
+# 10. Python download snippet uses resolve_model_path and download_model
+run_test "uses resolve_model_path" "grep -q 'resolve_model_path' '$ENTRYPOINT'"
+run_test "uses download_model" "grep -q 'download_model' '$ENTRYPOINT'"
+
+# 11. Dockerfile references entrypoint.sh
+DOCKERFILE="$SCRIPT_DIR/Dockerfile"
+run_test "Dockerfile copies entrypoint.sh" "grep -q 'entrypoint.sh' '$DOCKERFILE'"
+run_test "Dockerfile sets ENTRYPOINT" "grep -q 'ENTRYPOINT' '$DOCKERFILE'"
+
+# 12. docker-compose.yml passes PIPER_MODEL
+COMPOSE="$SCRIPT_DIR/docker-compose.yml"
+run_test "compose passes PIPER_MODEL" "grep -q 'PIPER_MODEL' '$COMPOSE'"
+run_test "compose passes PIPER_MODEL_DIR" "grep -q 'PIPER_MODEL_DIR' '$COMPOSE'"
+
+echo ""
+echo "=== Summary ==="
+echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+
+if [ "$TESTS_FAILED" -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed!${NC}"
+    exit 1
+fi

--- a/docker/webui/test_entrypoint.sh
+++ b/docker/webui/test_entrypoint.sh
@@ -34,7 +34,7 @@ run_test "entrypoint.sh exists" "test -f '$ENTRYPOINT'"
 run_test "entrypoint.sh is executable" "test -x '$ENTRYPOINT' || chmod +x '$ENTRYPOINT' && test -x '$ENTRYPOINT'"
 
 # 2. entrypoint.sh has LF line endings (not CRLF — Docker requirement)
-run_test "LF line endings" "! grep -qP '\r' '$ENTRYPOINT'"
+run_test "LF line endings" "! grep -qU $'\r' '$ENTRYPOINT'"
 
 # 3. Starts with bash shebang
 run_test "bash shebang" "head -1 '$ENTRYPOINT' | grep -q '#!/bin/bash'"

--- a/src/python/tests/test_model_manager.py
+++ b/src/python/tests/test_model_manager.py
@@ -3,11 +3,12 @@
 import os
 import sys
 import tempfile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from piper_train.model_manager import (
+    download_model,
     find_voice,
     get_default_model_dir,
     list_models,
@@ -107,3 +108,93 @@ class TestResolveModelPath:
         # No model file exists
         result = resolve_model_path("tsukuyomi", str(tmp_path))
         assert result is None
+
+
+class TestDownloadModel:
+    def test_unknown_model_returns_false(self, capsys):
+        assert download_model("nonexistent-model-xyz") is False
+        captured = capsys.readouterr()
+        assert "not found" in captured.err
+
+    def test_skips_existing_file_with_matching_size(self, tmp_path, capsys):
+        voice = find_voice("tsukuyomi")
+        assert voice is not None
+
+        # Create files with matching sizes
+        for filename, file_info in voice["files"].items():
+            f = tmp_path / filename
+            f.write_bytes(b"\x00" * file_info["size_bytes"])
+
+        with patch("piper_train.model_manager.hf_hub_download", side_effect=AssertionError("should not be called")) if False else patch.dict("sys.modules", {}):
+            # hf_hub_download is imported lazily; mock it at call site
+            mock_dl = MagicMock()
+            with patch.dict("sys.modules", {"huggingface_hub": MagicMock(hf_hub_download=mock_dl)}):
+                result = download_model("tsukuyomi", str(tmp_path))
+
+        assert result is True
+        mock_dl.assert_not_called()
+        captured = capsys.readouterr()
+        assert "already exists" in captured.err
+
+    def test_downloads_missing_files(self, tmp_path, capsys):
+        mock_dl = MagicMock()
+        mock_hf = MagicMock(hf_hub_download=mock_dl)
+
+        with patch.dict("sys.modules", {"huggingface_hub": mock_hf}):
+            result = download_model("tsukuyomi", str(tmp_path))
+
+        assert result is True
+        voice = find_voice("tsukuyomi")
+        assert mock_dl.call_count == len(voice["files"])
+        for call_args in mock_dl.call_args_list:
+            assert call_args.kwargs["repo_id"] == voice["repo_id"]
+            assert call_args.kwargs["local_dir"] == str(tmp_path)
+
+    def test_downloads_file_with_wrong_size(self, tmp_path):
+        voice = find_voice("tsukuyomi")
+        # Create files with wrong sizes
+        for filename in voice["files"]:
+            (tmp_path / filename).write_bytes(b"\x00" * 100)
+
+        mock_dl = MagicMock()
+        mock_hf = MagicMock(hf_hub_download=mock_dl)
+
+        with patch.dict("sys.modules", {"huggingface_hub": mock_hf}):
+            result = download_model("tsukuyomi", str(tmp_path))
+
+        assert result is True
+        assert mock_dl.call_count == len(voice["files"])
+
+    def test_returns_false_on_download_error(self, tmp_path, capsys):
+        mock_dl = MagicMock(side_effect=Exception("network error"))
+        mock_hf = MagicMock(hf_hub_download=mock_dl)
+
+        with patch.dict("sys.modules", {"huggingface_hub": mock_hf}):
+            result = download_model("tsukuyomi", str(tmp_path))
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Failed" in captured.err
+
+    def test_uses_default_model_dir_when_none(self):
+        mock_dl = MagicMock()
+        mock_hf = MagicMock(hf_hub_download=mock_dl)
+
+        with patch.dict("sys.modules", {"huggingface_hub": mock_hf}), \
+             patch("piper_train.model_manager.get_default_model_dir", return_value="/tmp/piper-test-models"):
+            download_model("tsukuyomi")
+
+        for call_args in mock_dl.call_args_list:
+            assert call_args.kwargs["local_dir"] == "/tmp/piper-test-models"
+
+    def test_creates_model_dir(self, tmp_path):
+        target = tmp_path / "sub" / "dir"
+        assert not target.exists()
+
+        mock_dl = MagicMock()
+        mock_hf = MagicMock(hf_hub_download=mock_dl)
+
+        with patch.dict("sys.modules", {"huggingface_hub": mock_hf}):
+            download_model("tsukuyomi", str(target))
+
+        assert target.exists()

--- a/src/python/tests/test_model_manager.py
+++ b/src/python/tests/test_model_manager.py
@@ -120,16 +120,15 @@ class TestDownloadModel:
         voice = find_voice("tsukuyomi")
         assert voice is not None
 
-        # Create files with matching sizes
+        # Create files with matching sizes (sparse files to avoid ~39MB allocation)
         for filename, file_info in voice["files"].items():
             f = tmp_path / filename
-            f.write_bytes(b"\x00" * file_info["size_bytes"])
+            f.touch()
+            os.truncate(f, file_info["size_bytes"])
 
-        with patch("piper_train.model_manager.hf_hub_download", side_effect=AssertionError("should not be called")) if False else patch.dict("sys.modules", {}):
-            # hf_hub_download is imported lazily; mock it at call site
-            mock_dl = MagicMock()
-            with patch.dict("sys.modules", {"huggingface_hub": MagicMock(hf_hub_download=mock_dl)}):
-                result = download_model("tsukuyomi", str(tmp_path))
+        mock_dl = MagicMock()
+        with patch.dict("sys.modules", {"huggingface_hub": MagicMock(hf_hub_download=mock_dl)}):
+            result = download_model("tsukuyomi", str(tmp_path))
 
         assert result is True
         mock_dl.assert_not_called()
@@ -176,16 +175,17 @@ class TestDownloadModel:
         captured = capsys.readouterr()
         assert "Failed" in captured.err
 
-    def test_uses_default_model_dir_when_none(self):
+    def test_uses_default_model_dir_when_none(self, tmp_path):
         mock_dl = MagicMock()
         mock_hf = MagicMock(hf_hub_download=mock_dl)
+        default_model_dir = str(tmp_path)
 
         with patch.dict("sys.modules", {"huggingface_hub": mock_hf}), \
-             patch("piper_train.model_manager.get_default_model_dir", return_value="/tmp/piper-test-models"):
+             patch("piper_train.model_manager.get_default_model_dir", return_value=default_model_dir):
             download_model("tsukuyomi")
 
         for call_args in mock_dl.call_args_list:
-            assert call_args.kwargs["local_dir"] == "/tmp/piper-test-models"
+            assert call_args.kwargs["local_dir"] == default_model_dir
 
     def test_creates_model_dir(self, tmp_path):
         target = tmp_path / "sub" / "dir"


### PR DESCRIPTION
## Summary

- WebUI Docker コンテナ起動時に `PIPER_MODEL` 環境変数でモデルを自動ダウンロードする entrypoint を追加
- HuggingFace TGI / Coqui TTS 等の業界標準パターン（起動時にモデル名指定→未DLなら自動取得）に準拠
- 2回目以降は volume キャッシュにより即起動

### 使い方

```bash
# ビルド（1回のみ）
docker build -t piper-webui -f docker/webui/Dockerfile .

# 起動（モデルが未ダウンロードなら自動取得）
docker run -p 7860:7860 -e PIPER_MODEL=css10 -v ./models:/models piper-webui

# docker-compose
PIPER_MODEL=tsukuyomi docker compose -f docker/webui/docker-compose.yml up
```

### 変更内容

| ファイル | 変更 |
|---------|------|
| `docker/webui/entrypoint.sh` | 新規 — `PIPER_MODEL` 指定時に ModelManager 経由で自動DL、`exec` でアプリ起動 |
| `docker/webui/Dockerfile` | `CMD` → `ENTRYPOINT` に変更、entrypoint.sh コピー |
| `docker/webui/docker-compose.yml` | `PIPER_MODEL` / `PIPER_MODEL_DIR` 環境変数追加 |
| `src/python/tests/test_model_manager.py` | `TestDownloadModel` 7テスト追加 |
| `docker/webui/test_entrypoint.sh` | entrypoint.sh 構造検証 17テスト追加 |

## Test plan

- [x] `uv run pytest src/python/tests/test_model_manager.py` — 24 passed
- [x] `bash docker/webui/test_entrypoint.sh` — 17 passed
- [ ] `docker build -t piper-webui -f docker/webui/Dockerfile .` でビルド確認
- [ ] `docker run -p 7860:7860 -e PIPER_MODEL=css10 -v ./models:/models piper-webui` で自動DL確認
- [ ] `PIPER_MODEL` 未指定で従来通りの動作確認