### PR TITLE
feat(api): OpenAI互換 TTS API エンドポイント追加

### DIFF
--- a/docker/python-inference/inference.py
+++ b/docker/python-inference/inference.py
@@ -387,7 +387,9 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
 
     @app.get("/v1/audio/speech/languages")
     def speech_languages():
-        languages = sorted(engine.language_id_map.keys()) if engine.language_id_map else []
+        languages = (
+            sorted(engine.language_id_map.keys()) if engine.language_id_map else []
+        )
         return {"languages": languages}
 
     return app

--- a/docker/python-inference/inference.py
+++ b/docker/python-inference/inference.py
@@ -28,11 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # FastAPI (optional)
 try:
-    import uvicorn
-    from fastapi import FastAPI, HTTPException, Query
-    from fastapi.middleware.cors import CORSMiddleware
-    from fastapi.responses import StreamingResponse
-    from pydantic import BaseModel, Field
+    import uvicorn  # noqa: F401
 
     FASTAPI_AVAILABLE = True
 except ImportError:
@@ -395,6 +391,8 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
 
 def _run_server(engine: PiperInferenceEngine, args):
     """Run FastAPI server."""
+    import uvicorn  # noqa: PLC0415
+
     app = create_app(engine, args.model)
     uvicorn.run(app, host="0.0.0.0", port=args.port)
 

--- a/docker/python-inference/inference.py
+++ b/docker/python-inference/inference.py
@@ -30,7 +30,9 @@ _LOGGER = logging.getLogger(__name__)
 try:
     import uvicorn
     from fastapi import FastAPI, HTTPException, Query
+    from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import StreamingResponse
+    from pydantic import BaseModel, Field
 
     FASTAPI_AVAILABLE = True
 except ImportError:
@@ -277,9 +279,38 @@ def main():
         print(f"Audio saved to: {args.output}")
 
 
-def _run_server(engine: PiperInferenceEngine, args):
-    """Run FastAPI server."""
+def create_app(engine: PiperInferenceEngine, model_path: str):
+    """Create the FastAPI application with all endpoints."""
+    from fastapi import FastAPI, HTTPException, Query  # noqa: PLC0415
+    from fastapi.middleware.cors import CORSMiddleware  # noqa: PLC0415
+    from fastapi.responses import StreamingResponse  # noqa: PLC0415
+    from pydantic import BaseModel, Field  # noqa: PLC0415
+
+    class SpeechRequest(BaseModel):
+        """OpenAI-compatible TTS request schema."""
+
+        model: str = "piper-plus"
+        input: str
+        voice: str = "default"
+        response_format: str = "wav"
+        speed: float = Field(default=1.0, gt=0.0, le=4.0)
+        # piper-plus extensions
+        speaker_id: int = 0
+        language: str = "ja"
+        noise_scale: float = 0.667
+        noise_w: float = 0.8
+
     app = FastAPI(title="piper-plus API")
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    model_created = int(Path(model_path).stat().st_mtime)
 
     @app.get("/health")
     def health_check():
@@ -310,6 +341,61 @@ def _run_server(engine: PiperInferenceEngine, args):
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e)) from e
 
+    # --- OpenAI-compatible endpoints ---
+
+    @app.post("/v1/audio/speech")
+    def openai_speech(req: SpeechRequest):
+        if not req.input or not req.input.strip():
+            raise HTTPException(status_code=400, detail="input is required")
+        if req.response_format != "wav":
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported response_format: {req.response_format}. Only 'wav' is supported.",
+            )
+
+        length_scale = 1.0 / req.speed
+
+        try:
+            audio = engine.synthesize(
+                req.input,
+                language=req.language,
+                speaker_id=req.speaker_id,
+                noise_scale=req.noise_scale,
+                length_scale=length_scale,
+                noise_scale_w=req.noise_w,
+            )
+            buf = io.BytesIO()
+            sf.write(buf, audio, engine.sample_rate, format="WAV")
+            buf.seek(0)
+            return StreamingResponse(buf, media_type="audio/wav")
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e)) from e
+
+    @app.get("/v1/models")
+    def openai_models():
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": "piper-plus",
+                    "object": "model",
+                    "created": model_created,
+                    "owned_by": "piper-plus",
+                }
+            ],
+        }
+
+    @app.get("/v1/audio/speech/languages")
+    def speech_languages():
+        languages = sorted(engine.language_id_map.keys()) if engine.language_id_map else []
+        return {"languages": languages}
+
+    return app
+
+
+def _run_server(engine: PiperInferenceEngine, args):
+    """Run FastAPI server."""
+    app = create_app(engine, args.model)
     uvicorn.run(app, host="0.0.0.0", port=args.port)
 
 

--- a/docker/python-inference/inference.py
+++ b/docker/python-inference/inference.py
@@ -301,12 +301,15 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
-        allow_credentials=True,
+        allow_credentials=False,
         allow_methods=["*"],
         allow_headers=["*"],
     )
 
-    model_created = int(Path(model_path).stat().st_mtime)
+    try:
+        model_created = int(Path(model_path).stat().st_mtime)
+    except OSError:
+        model_created = int(time.time())
 
     @app.get("/health")
     def health_check():
@@ -364,8 +367,9 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
             sf.write(buf, audio, engine.sample_rate, format="WAV")
             buf.seek(0)
             return StreamingResponse(buf, media_type="audio/wav")
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=str(e)) from e
+        except Exception:
+            _LOGGER.exception("Synthesis failed for /v1/audio/speech")
+            raise HTTPException(status_code=500, detail="Synthesis failed") from None
 
     @app.get("/v1/models")
     def openai_models():

--- a/docker/python-inference/test_openai_api.py
+++ b/docker/python-inference/test_openai_api.py
@@ -7,15 +7,18 @@ so no ONNX model is required.
 """
 
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+from fastapi.testclient import TestClient
+
 
 # Ensure inference.py can be imported from this directory
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from inference import create_app  # noqa: E402
 
 
 @pytest.fixture()
@@ -34,10 +37,6 @@ def mock_engine():
 @pytest.fixture()
 def client(mock_engine):
     """Create a FastAPI TestClient backed by the mocked engine."""
-    from fastapi.testclient import TestClient
-
-    from inference import create_app
-
     # Use this test file as a stand-in for stat().st_mtime
     app = create_app(mock_engine, __file__)
     return TestClient(app)

--- a/docker/python-inference/test_openai_api.py
+++ b/docker/python-inference/test_openai_api.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Tests for OpenAI-compatible API endpoints in inference.py.
+
+Uses FastAPI TestClient with a mocked PiperInferenceEngine
+so no ONNX model is required.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+# Ensure inference.py can be imported from this directory
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+@pytest.fixture()
+def mock_engine():
+    """Create a mocked PiperInferenceEngine."""
+    engine = MagicMock()
+    engine.sample_rate = 22050
+    engine.language_id_map = {"ja": 0, "en": 1, "zh": 2, "es": 3, "fr": 4, "pt": 5}
+
+    # synthesize returns 0.5s of silence as int16
+    samples = int(engine.sample_rate * 0.5)
+    engine.synthesize.return_value = np.zeros(samples, dtype=np.int16)
+    return engine
+
+
+@pytest.fixture()
+def client(mock_engine):
+    """Create a FastAPI TestClient backed by the mocked engine."""
+    from fastapi.testclient import TestClient
+
+    from inference import create_app
+
+    # Use this test file as a stand-in for stat().st_mtime
+    app = create_app(mock_engine, __file__)
+    return TestClient(app)
+
+
+# ---- /v1/audio/speech ----
+
+
+class TestOpenAISpeech:
+    def test_basic_synthesis(self, client, mock_engine):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "こんにちは"},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "audio/wav"
+        assert len(resp.content) > 0
+        mock_engine.synthesize.assert_called_once()
+
+    def test_speed_to_length_scale(self, client, mock_engine):
+        """speed=2.0 should become length_scale=0.5."""
+        client.post(
+            "/v1/audio/speech",
+            json={"input": "test", "speed": 2.0},
+        )
+        call_kwargs = mock_engine.synthesize.call_args
+        assert call_kwargs.kwargs["length_scale"] == pytest.approx(0.5)
+
+    def test_speed_half(self, client, mock_engine):
+        """speed=0.5 should become length_scale=2.0."""
+        client.post(
+            "/v1/audio/speech",
+            json={"input": "test", "speed": 0.5},
+        )
+        call_kwargs = mock_engine.synthesize.call_args
+        assert call_kwargs.kwargs["length_scale"] == pytest.approx(2.0)
+
+    def test_custom_language(self, client, mock_engine):
+        client.post(
+            "/v1/audio/speech",
+            json={"input": "hello", "language": "en"},
+        )
+        call_kwargs = mock_engine.synthesize.call_args
+        assert call_kwargs.kwargs["language"] == "en"
+
+    def test_custom_speaker_id(self, client, mock_engine):
+        client.post(
+            "/v1/audio/speech",
+            json={"input": "hello", "speaker_id": 5},
+        )
+        call_kwargs = mock_engine.synthesize.call_args
+        assert call_kwargs.kwargs["speaker_id"] == 5
+
+    def test_custom_noise_params(self, client, mock_engine):
+        client.post(
+            "/v1/audio/speech",
+            json={"input": "test", "noise_scale": 0.3, "noise_w": 0.5},
+        )
+        call_kwargs = mock_engine.synthesize.call_args
+        assert call_kwargs.kwargs["noise_scale"] == pytest.approx(0.3)
+        assert call_kwargs.kwargs["noise_scale_w"] == pytest.approx(0.5)
+
+    def test_empty_input_returns_400(self, client):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": ""},
+        )
+        assert resp.status_code == 400
+
+    def test_whitespace_input_returns_400(self, client):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "   "},
+        )
+        assert resp.status_code == 400
+
+    def test_unsupported_format_returns_400(self, client):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "test", "response_format": "mp3"},
+        )
+        assert resp.status_code == 400
+        assert "mp3" in resp.json()["detail"]
+
+    def test_speed_zero_returns_422(self, client):
+        """speed must be > 0."""
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "test", "speed": 0.0},
+        )
+        assert resp.status_code == 422
+
+    def test_speed_over_max_returns_422(self, client):
+        """speed must be <= 4.0."""
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "test", "speed": 5.0},
+        )
+        assert resp.status_code == 422
+
+    def test_engine_error_returns_500(self, client, mock_engine):
+        mock_engine.synthesize.side_effect = RuntimeError("ONNX error")
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "test"},
+        )
+        assert resp.status_code == 500
+
+    def test_model_and_voice_ignored(self, client, mock_engine):
+        """model and voice fields are accepted but don't affect synthesis."""
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "test", "model": "tts-1", "voice": "alloy"},
+        )
+        assert resp.status_code == 200
+
+
+# ---- /v1/models ----
+
+
+class TestOpenAIModels:
+    def test_models_list(self, client):
+        resp = client.get("/v1/models")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["object"] == "list"
+        assert len(data["data"]) == 1
+        model = data["data"][0]
+        assert model["id"] == "piper-plus"
+        assert model["object"] == "model"
+        assert model["owned_by"] == "piper-plus"
+        assert isinstance(model["created"], int)
+
+
+# ---- /v1/audio/speech/languages ----
+
+
+class TestLanguages:
+    def test_languages_list(self, client):
+        resp = client.get("/v1/audio/speech/languages")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["languages"] == ["en", "es", "fr", "ja", "pt", "zh"]
+
+    def test_languages_sorted(self, client):
+        resp = client.get("/v1/audio/speech/languages")
+        languages = resp.json()["languages"]
+        assert languages == sorted(languages)
+
+
+# ---- existing endpoints still work ----
+
+
+class TestExistingEndpoints:
+    def test_health(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "healthy"}
+
+    def test_synthesize_get(self, client, mock_engine):
+        resp = client.get("/synthesize", params={"text": "hello"})
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "audio/wav"
+        mock_engine.synthesize.assert_called_once()
+
+
+# ---- CORS ----
+
+
+class TestCORS:
+    def test_cors_headers(self, client):
+        resp = client.options(
+            "/v1/audio/speech",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert resp.headers.get("access-control-allow-origin") is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,8 @@ dev-dependencies = [
     "pytest==7.4.3",
     "pytest-timeout>=2.2.0",
     "black==26.3.1",
+    "fastapi>=0.135.1",
+    "httpx>=0.28.1",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1202,6 +1202,34 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2814,6 +2842,8 @@ train = [
 [package.dev-dependencies]
 dev = [
     { name = "black" },
+    { name = "fastapi" },
+    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-timeout" },
     { name = "ruff" },
@@ -2908,6 +2938,8 @@ provides-extras = ["preprocess", "inference", "inference-gpu", "multilingual", "
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = "==26.3.1" },
+    { name = "fastapi", specifier = ">=0.135.1" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pytest", specifier = "==7.4.3" },
     { name = "pytest-timeout", specifier = ">=2.2.0" },
     { name = "ruff", specifier = "==0.12.5" },


### PR DESCRIPTION
## Summary

- [Melon-cream/piper-plus-api](https://github.com/Melon-cream/piper-plus-api) が piper-plus の古いコード (v1.6.0) を vendoring して提供していた OpenAI `/v1/audio/speech` 互換 API を、piper-plus 本体に統合
- 既存の `docker/python-inference/inference.py` の FastAPI サーバーに OpenAI 互換エンドポイントを追加し、Open WebUI / Project AIRI 等のクライアントから直接利用可能に
- 既存の `/health`, `/synthesize` エンドポイントは変更なし（後方互換）

## 追加エンドポイント

| エンドポイント | 説明 |
|---|---|
| `POST /v1/audio/speech` | OpenAI TTS API 互換 (`speed`→`length_scale` 変換、`language`/`speaker_id`/`noise_scale`/`noise_w` 拡張パラメータ) |
| `GET /v1/models` | OpenAI形式のモデル一覧 |
| `GET /v1/audio/speech/languages` | ロード済みモデルの対応言語一覧 |

## その他の変更

- CORSミドルウェア追加（ブラウザフロントエンドからのアクセス対応）
- `_run_server` を `create_app` + `_run_server` に分離（テスタビリティ向上）
- `fastapi`, `httpx` を dev dependencies に追加

## Test plan

- [x] テスト19件追加・全通過 (`docker/python-inference/test_openai_api.py`)
  - `/v1/audio/speech`: 基本合成、speed変換、言語/speaker_id/noise指定、空入力400、未対応format400、speed範囲外422、エンジンエラー500
  - `/v1/models`: OpenAI形式レスポンス検証
  - `/v1/audio/speech/languages`: 言語一覧・ソート順
  - 既存エンドポイント後方互換: `/health`, `/synthesize`
  - CORS ヘッダー