### PR TITLE
fix: リリース前クリーンアップ — uv.lock 同期 + DotNetG2P バージョン統一

### DIFF
--- a/.github/workflows/_build-test-cpp.yml
+++ b/.github/workflows/_build-test-cpp.yml
@@ -100,7 +100,7 @@ jobs:
       # ── Build cache ───────────────────────────────────────────
       - name: Setup build cache
         if: runner.os != 'Windows'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ccache
@@ -200,7 +200,7 @@ jobs:
       - name: Cache test model
         if: ${{ inputs.run-integration-tests }}
         id: cache-test-model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test/models/
           key: test-model-multilingual-medium-v1

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -28,7 +28,7 @@ jobs:
       ONNXRUNTIME_VERSION: "1.14.0"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Cache ONNX Runtime Android
         id: cache-ort-android
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ort-android/
           key: ort-android-${{ env.ONNXRUNTIME_VERSION }}-${{ matrix.abi }}
@@ -118,7 +118,7 @@ jobs:
           cp ort-android/lib/libonnxruntime.so staging/${{ matrix.abi }}/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: piper-plus-android-${{ matrix.abi }}
           path: staging/${{ matrix.abi }}/
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download all ABI artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: piper-plus-android-*
           path: piper-plus-android/
@@ -163,7 +163,7 @@ jobs:
           find release -type f | sort
 
       - name: Upload combined artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: piper-plus-android
           path: release/piper-plus-android/

--- a/.github/workflows/build-phonemize-wheels.yml
+++ b/.github/workflows/build-phonemize-wheels.yml
@@ -233,7 +233,7 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.PIPY_TOKEN }}
           skip-existing: true
           verbose: true
 

--- a/.github/workflows/build-wasm-reusable.yml
+++ b/.github/workflows/build-wasm-reusable.yml
@@ -21,7 +21,7 @@ jobs:
       wasm-size-ja: ${{ steps.size-ja.outputs.size }}
       wasm-size-ja-lite: ${{ steps.size-ja-lite.outputs.size }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/build-wasm-reusable.yml
+++ b/.github/workflows/build-wasm-reusable.yml
@@ -85,19 +85,19 @@ jobs:
           echo "size=$SIZE" >> "$GITHUB_OUTPUT"
           echo "WASM ja-lite size: $SIZE bytes ($(( SIZE / 1048576 )) MB)"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: piper-plus-wasm
           path: src/wasm/openjtalk-web/dist/rust-wasm/
           retention-days: 7
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: piper-plus-wasm-ja
           path: src/wasm/openjtalk-web/dist/rust-wasm-ja/
           retention-days: 7
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: piper-plus-wasm-ja-lite
           path: src/wasm/openjtalk-web/dist/rust-wasm-ja-lite/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/cpp-lint.yml
+++ b/.github/workflows/cpp-lint.yml
@@ -9,7 +9,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check formatting
         run: |
           find src/cpp -name '*.cpp' -o -name '*.h' -o -name '*.c' | \

--- a/.github/workflows/deploy-webassembly-demo.yml
+++ b/.github/workflows/deploy-webassembly-demo.yml
@@ -37,7 +37,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/dev-create-release.yml
+++ b/.github/workflows/dev-create-release.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.PIPY_TOKEN }}
         run: |
           # Only publish if we have the token and wheels
           if [ -n "$TWINE_PASSWORD" ] && ls dist/*.whl 1> /dev/null 2>&1; then
@@ -287,7 +287,7 @@ jobs:
       - name: Publish stub to PyPI
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.PIPY_TOKEN }}
         run: |
           if [ -n "$TWINE_PASSWORD" ]; then
             twine upload --skip-existing src/python_stub/dist/*

--- a/.github/workflows/dev-create-release.yml
+++ b/.github/workflows/dev-create-release.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PIPY_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           # Only publish if we have the token and wheels
           if [ -n "$TWINE_PASSWORD" ] && ls dist/*.whl 1> /dev/null 2>&1; then
@@ -287,7 +287,7 @@ jobs:
       - name: Publish stub to PyPI
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PIPY_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           if [ -n "$TWINE_PASSWORD" ]; then
             twine upload --skip-existing src/python_stub/dist/*

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -67,11 +67,12 @@ jobs:
 
       - name: Inference test - Japanese
         run: |
-          mkdir -p /tmp/output
+          mkdir -p /tmp/output && chmod 777 /tmp/output
           docker run --rm \
             -v ${{ github.workspace }}/test/models:/models \
             -v /tmp/output:/output \
             -e CUDA_VISIBLE_DEVICES="" \
+            -e PIPER_DISABLE_CACHE=1 \
             piper-python-inference:test \
             python inference.py \
               --model /models/multilingual-test-medium.onnx \
@@ -96,6 +97,7 @@ jobs:
             -v ${{ github.workspace }}/test/models:/models \
             -v /tmp/output:/output \
             -e CUDA_VISIBLE_DEVICES="" \
+            -e PIPER_DISABLE_CACHE=1 \
             piper-python-inference:test \
             python inference.py \
               --model /models/multilingual-test-medium.onnx \
@@ -121,6 +123,7 @@ jobs:
             -v ${{ github.workspace }}/test/models:/models \
             -v /tmp/output:/output \
             -e CUDA_VISIBLE_DEVICES="" \
+            -e PIPER_DISABLE_CACHE=1 \
             piper-python-inference:test \
             python inference.py \
               --model /models/multilingual-test-medium.onnx \
@@ -150,6 +153,7 @@ jobs:
             -v /tmp/fallback-test:/models/fallback \
             -v /tmp/output:/output \
             -e CUDA_VISIBLE_DEVICES="" \
+            -e PIPER_DISABLE_CACHE=1 \
             piper-python-inference:test \
             python inference.py \
               --model /models/fallback/multilingual-test-medium.onnx \
@@ -177,6 +181,7 @@ jobs:
             -v /tmp/noconfig:/models/noconfig \
             -v /tmp/output:/output \
             -e CUDA_VISIBLE_DEVICES="" \
+            -e PIPER_DISABLE_CACHE=1 \
             piper-python-inference:test \
             python inference.py \
               --model /models/noconfig/multilingual-test-medium.onnx \
@@ -229,7 +234,7 @@ jobs:
 
       - name: Inference test - English
         run: |
-          mkdir -p /tmp/output
+          mkdir -p /tmp/output && chmod 777 /tmp/output
           echo "Hello, how are you today?" | docker run --rm -i \
             -v ${{ github.workspace }}/test/models:/models \
             -v /tmp/output:/output \

--- a/.github/workflows/g2p-cross-platform-ci.yml
+++ b/.github/workflows/g2p-cross-platform-ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/g2p-go-publish.yml
+++ b/.github/workflows/g2p-go-publish.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         working-directory: src/go
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             src/go
@@ -36,7 +36,7 @@ jobs:
     name: golangci-lint (phonemize)
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
@@ -49,7 +49,7 @@ jobs:
     needs: [test, lint]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/g2p-wasm-ci.yml
+++ b/.github/workflows/g2p-wasm-ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -58,7 +58,7 @@ jobs:
           go-version: '1.26'
           cache-dependency-path: src/go/go.sum
       - name: Cache ONNX Runtime
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: onnxruntime
           key: onnxruntime-linux-x64-${{ env.ORT_VERSION }}
@@ -114,7 +114,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: src/go/${{ matrix.artifact }}${{ matrix.goos == 'windows' && '.exe' || '' }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -29,7 +29,7 @@ jobs:
       run:
         working-directory: src/go
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # NOTE: sparse-checkout only fetches src/go/. Integration tests that
           # reference test models outside this path (e.g. test/models/) will not
@@ -52,7 +52,7 @@ jobs:
       run:
         working-directory: src/go
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
@@ -101,7 +101,7 @@ jobs:
       run:
         working-directory: src/go
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: src/go
       - uses: actions/setup-go@v5
@@ -126,7 +126,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # NOTE: sparse-checkout only fetches src/go/. This is sufficient for
           # linting since golangci-lint only needs the Go source files.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -81,7 +81,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Download WASM artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: piper-plus-wasm
           path: src/wasm/openjtalk-web/dist/rust-wasm/

--- a/.github/workflows/release-shared-lib.yml
+++ b/.github/workflows/release-shared-lib.yml
@@ -32,7 +32,7 @@ jobs:
             archive_ext: zip
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/release-shared-lib.yml
+++ b/.github/workflows/release-shared-lib.yml
@@ -80,7 +80,7 @@ jobs:
           Compress-Archive -Path "${{ github.workspace }}/install/*" -DestinationPath "${{ github.workspace }}/${{ matrix.artifact }}.zip"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: ${{ github.workspace }}/${{ matrix.artifact }}.${{ matrix.archive_ext }}
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts/
 

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -22,7 +22,7 @@ jobs:
     needs: wasm-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -46,19 +46,19 @@ jobs:
         run: cargo check -p piper-plus-wasm --target wasm32-unknown-unknown
 
       - name: Download WASM artifact (multilingual)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: piper-plus-wasm
           path: src/wasm/openjtalk-web/dist/rust-wasm/
 
       - name: Download WASM artifact (ja-only)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: piper-plus-wasm-ja
           path: src/wasm/openjtalk-web/dist/rust-wasm-ja/
 
       - name: Download WASM artifact (ja-lite)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: piper-plus-wasm-ja-lite
           path: src/wasm/openjtalk-web/dist/rust-wasm-ja-lite/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,7 +330,7 @@ Validation頻度削減、DataLoader最適化 (num_workers=2, pin_memory)、LRス
 |------|------|
 | TFM | PiperPlus.Core: net8.0, PiperPlus.Cli: net9.0 |
 | 対応言語 | JA, EN, ZH, KO, ES, FR, PT, SV (8言語) |
-| G2P依存 | DotNetG2P v1.8.0 (JA), DotNetG2P.MeCab v1.8.0 (JA), DotNetG2P.English v1.8.0 (EN), DotNetG2P.Chinese/Spanish/French/Portuguese v1.7.0 |
+| G2P依存 | DotNetG2P v1.8.0 (JA), DotNetG2P.MeCab v1.8.0 (JA), DotNetG2P.English v1.8.0 (EN), DotNetG2P.Chinese/Spanish/French/Portuguese v1.8.0 |
 | テスト | ~1000テスト (xUnit v3) |
 | CI | 3 OS (csharp-ci.yml) |
 | ビルド | `dotnet build src/csharp/PiperPlus.sln` |

--- a/docker/cpp-dev/Dockerfile
+++ b/docker/cpp-dev/Dockerfile
@@ -104,6 +104,10 @@ RUN echo "=== Running build-time tests ===" && \
     ldconfig -p | grep -E "HTSEngine" || echo "Some libraries in /usr/local/lib" && \
     echo "=== Build-time tests passed ==="
 
+# Create non-root user and transfer ownership of workspace
+RUN useradd -m -u 1000 piper && chown -R piper:piper /workspace
+USER piper
+
 # Ensure we're in a valid directory
 WORKDIR /workspace
 

--- a/docker/cpp-inference/Dockerfile
+++ b/docker/cpp-inference/Dockerfile
@@ -89,5 +89,10 @@ RUN test -d /usr/local/share/open_jtalk/dic && \
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD piper --version || exit 1
 
+# Run as non-root user for security
+RUN useradd -m -u 1000 piper && \
+    chown -R piper:piper /app
+USER piper
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/docker/cpp-inference/Dockerfile.test
+++ b/docker/cpp-inference/Dockerfile.test
@@ -47,6 +47,10 @@ RUN echo "=== BUILT TEST EXECUTABLES ===" && \
 RUN echo "=== BUILD ERRORS ===" && \
     grep -E "FAILED:|error:" /tmp/build.log 2>/dev/null || echo "No build errors found"
 
+# Create non-root user and transfer ownership of workspace
+RUN useradd -m -u 1000 piper && chown -R piper:piper /workspace
+USER piper
+
 # Run tests - allow failure to see results
 RUN cd build && ctest --output-on-failure --timeout 60 2>&1; \
     echo "=== TEST EXIT CODE: $? ==="

--- a/docker/python-inference/Dockerfile
+++ b/docker/python-inference/Dockerfile
@@ -62,4 +62,9 @@ RUN python --version && \
     python -c "import piper_train; print('piper_train installed')" && \
     python -c "import gradio; print(f'Gradio: {gradio.__version__}')"
 
+# Run as non-root user for security
+RUN useradd -m -u 1000 piper && \
+    chown -R piper:piper /app/models /app/output
+USER piper
+
 CMD ["echo", "Container started successfully"]

--- a/docker/python-inference/Dockerfile
+++ b/docker/python-inference/Dockerfile
@@ -36,7 +36,9 @@ COPY src/python_run/requirements_webui.txt /app/requirements_webui.txt
 RUN uv pip install --system -r /app/requirements_webui.txt
 
 # Pre-download NLTK data for g2p-en (both old and new resource names for NLTK compatibility)
-RUN python -c "import nltk; nltk.download('averaged_perceptron_tagger'); nltk.download('averaged_perceptron_tagger_eng'); nltk.download('cmudict')"
+# Use a shared path so data is accessible after USER switch to non-root
+ENV NLTK_DATA=/usr/share/nltk_data
+RUN python -c "import nltk; nltk.download('averaged_perceptron_tagger', download_dir='/usr/share/nltk_data'); nltk.download('averaged_perceptron_tagger_eng', download_dir='/usr/share/nltk_data'); nltk.download('cmudict', download_dir='/usr/share/nltk_data')"
 
 # Create directories for models and output
 RUN mkdir -p /app/models /app/output

--- a/docker/python-train/Dockerfile
+++ b/docker/python-train/Dockerfile
@@ -116,6 +116,11 @@ RUN echo "=== Running build-time tests ===" && \
     cd /opt/piper/src/python && python -c "import piper_train; print('piper_train accessible')" && \
     echo "=== Build-time tests passed ==="
 
+# Create non-root user and transfer ownership of working directories
+RUN useradd -m -u 1000 piper && \
+    chown -R piper:piper /workspace /opt/venv /opt/piper
+USER piper
+
 # Ensure we have a valid working directory
 WORKDIR /workspace
 

--- a/docker/python-train/Dockerfile
+++ b/docker/python-train/Dockerfile
@@ -106,7 +106,9 @@ RUN mkdir -p /workspace/datasets /workspace/checkpoints /workspace/logs
 EXPOSE 6006 8888
 
 # Download NLTK data required by g2p-en (English phonemizer)
-RUN python -c "import nltk; nltk.download('averaged_perceptron_tagger'); nltk.download('averaged_perceptron_tagger_eng'); nltk.download('cmudict')"
+# Use a shared path so data is accessible after USER switch to non-root
+ENV NLTK_DATA=/usr/share/nltk_data
+RUN python -c "import nltk; nltk.download('averaged_perceptron_tagger', download_dir='/usr/share/nltk_data'); nltk.download('averaged_perceptron_tagger_eng', download_dir='/usr/share/nltk_data'); nltk.download('cmudict', download_dir='/usr/share/nltk_data')"
 
 # Run tests during build to verify the container is working
 RUN echo "=== Running build-time tests ===" && \

--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -23,7 +23,9 @@ RUN uv pip install --system "/app/src/python[inference]" && \
     uv pip install --system -r /app/requirements_webui.txt
 
 # Download NLTK data required by g2p-en (English phonemizer)
-RUN python -c "import nltk; nltk.download('averaged_perceptron_tagger'); nltk.download('averaged_perceptron_tagger_eng'); nltk.download('cmudict')"
+# Use a shared path so data is accessible after USER switch to non-root
+ENV NLTK_DATA=/usr/share/nltk_data
+RUN python -c "import nltk; nltk.download('averaged_perceptron_tagger', download_dir='/usr/share/nltk_data'); nltk.download('averaged_perceptron_tagger_eng', download_dir='/usr/share/nltk_data'); nltk.download('cmudict', download_dir='/usr/share/nltk_data')"
 
 # Copy WebUI application and entrypoint
 COPY docker/webui/app.py /app/app.py

--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -40,4 +40,9 @@ EXPOSE 7860
 ENV GRADIO_SERVER_NAME=0.0.0.0
 ENV GRADIO_SERVER_PORT=7860
 
+# Run as non-root user for security
+RUN useradd -m -u 1000 piper && \
+    chown -R piper:piper /models /output /app
+USER piper
+
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "piper-plus"
 dynamic = ["version"]
 description = "Training environment for piper-plus"
+license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
     "huggingface-hub>=0.30.0,<1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "piper-plus"
 dynamic = ["version"]
 description = "Training environment for piper-plus"
-license = "MIT"
+license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
     "huggingface-hub>=0.30.0,<1.0",

--- a/src/cpp/tests/CMakeLists.txt
+++ b/src/cpp/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ set(TEST_SOURCES
     test_openjtalk_optimized.cpp
     test_gpu_device_id.cpp
     test_phoneme_parser.cpp
+    test_streaming.cpp
     test_streaming_simple.cpp
     test_streaming_raw_phonemes.cpp
     test_n_variants.cpp
@@ -211,6 +212,89 @@ foreach(test_source ${TEST_SOURCES})
             Threads::Threads
         )
         link_openjtalk_to_test(${test_name})
+    endif()
+
+    # Link additional dependencies for streaming test
+    if(${test_name} STREQUAL "test_streaming")
+        target_sources(${test_name} PRIVATE
+            ../piper.cpp
+            ../phoneme_parser.cpp
+            ../custom_dictionary.cpp
+            ../model_manager.cpp
+            ../library_path.c
+            ../language_detector.cpp
+            ../english_phonemize.cpp
+            ../chinese_phonemize.cpp
+            ../korean_phonemize.cpp
+            ../spanish_phonemize.cpp
+            ../french_phonemize.cpp
+            ../portuguese_phonemize.cpp
+            ../swedish_phonemize.cpp
+            ../openjtalk_phonemize.cpp
+            ../openjtalk_phonemize_utils.cpp
+            ../openjtalk_wrapper.c
+            ../openjtalk_dictionary_manager.c
+            ../openjtalk_error.c
+            ../openjtalk_security.c
+            ../openjtalk_optimized.c
+            ../openjtalk_api.c
+        )
+
+        # Include directories
+        target_include_directories(${test_name} PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/..
+            ${CMAKE_BINARY_DIR}/fi/include
+            ${CMAKE_BINARY_DIR}/si/include
+            ${ORT_INCLUDE_DIR}
+            ${CMAKE_BINARY_DIR}/oj/include
+            ${CMAKE_BINARY_DIR}/oj/include/openjtalk
+            ${CMAKE_BINARY_DIR}/hts_stub/include
+        )
+
+        # Add library directories
+        target_link_directories(${test_name} PRIVATE
+            ${CMAKE_BINARY_DIR}/fi/lib
+            ${CMAKE_BINARY_DIR}/si/lib
+            ${ORT_LIB_DIR}
+        )
+
+        # Platform-specific library linking (same as main piper)
+        if(WIN32)
+            # Windows: Link libraries directly
+            target_link_libraries(${test_name}
+                optimized ${CMAKE_BINARY_DIR}/fi/lib/fmt.lib
+                debug ${CMAKE_BINARY_DIR}/fi/lib/fmtd.lib
+                optimized ${CMAKE_BINARY_DIR}/si/lib/spdlog.lib
+                debug ${CMAKE_BINARY_DIR}/si/lib/spdlogd.lib
+                ${ORT_LIB_DIR}/onnxruntime.lib
+            )
+        else()
+            # Unix: Use library names and let CMake find them in link directories
+            target_link_libraries(${test_name}
+                fmt
+                spdlog
+                onnxruntime
+            )
+        endif()
+
+        # Platform-specific linking
+        if(UNIX)
+            find_package(Threads REQUIRED)
+            target_link_libraries(${test_name} Threads::Threads)
+            # library_path.c uses dladdr which requires libdl on Linux
+            if(NOT APPLE)
+                target_link_libraries(${test_name} dl)
+            endif()
+        endif()
+
+        # Link OpenJTalk static library
+        link_openjtalk_to_test(${test_name})
+
+        # Add dependencies to ensure build order
+        add_dependencies(${test_name}
+            fmt_external
+            spdlog_external
+        )
     endif()
 
     # Link additional dependencies for streaming test - using same approach as test_piper

--- a/src/csharp/PiperPlus.Cli/PiperPlus.Cli.csproj
+++ b/src/csharp/PiperPlus.Cli/PiperPlus.Cli.csproj
@@ -37,10 +37,10 @@
     <PackageReference Include="DotNetG2P" Version="1.8.0" />
     <PackageReference Include="DotNetG2P.MeCab" Version="1.8.0" />
     <PackageReference Include="DotNetG2P.English" Version="1.8.0" />
-    <PackageReference Include="DotNetG2P.Chinese" Version="1.7.0" />
-    <PackageReference Include="DotNetG2P.Spanish" Version="1.7.0" />
-    <PackageReference Include="DotNetG2P.French" Version="1.7.0" />
-    <PackageReference Include="DotNetG2P.Portuguese" Version="1.7.0" />
+    <PackageReference Include="DotNetG2P.Chinese" Version="1.8.0" />
+    <PackageReference Include="DotNetG2P.Spanish" Version="1.8.0" />
+    <PackageReference Include="DotNetG2P.French" Version="1.8.0" />
+    <PackageReference Include="DotNetG2P.Portuguese" Version="1.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/csharp/PiperPlus.Cli/PiperPlus.Cli.csproj
+++ b/src/csharp/PiperPlus.Cli/PiperPlus.Cli.csproj
@@ -17,7 +17,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>PiperPlus.Cli</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>ayousanz</Authors>
     <Description>Piper Plus TTS — C# CLI for neural text-to-speech synthesis</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/csharp/PiperPlus.Core/PiperPlus.Core.csproj
+++ b/src/csharp/PiperPlus.Core/PiperPlus.Core.csproj
@@ -6,7 +6,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>PiperPlus.Core</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>ayousanz</Authors>
     <Description>Piper Plus TTS Core library — ONNX inference, phonemization, config</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/go/LICENSE
+++ b/src/go/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2022 Michael Hansen
+Copyright (c) 2025 ayutaz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/go/cmd/piper-plus/main.go
+++ b/src/go/cmd/piper-plus/main.go
@@ -117,7 +117,7 @@ func stdinHasData() bool {
 func runSynthesize(cmd *cobra.Command, args []string) error {
 	// --version: print version and exit immediately.
 	if version {
-		fmt.Println("piper-plus (Go) v0.1.0")
+		fmt.Println("piper-plus (Go) v0.2.0")
 		return nil
 	}
 

--- a/src/python/g2p/piper_plus_g2p/__init__.py
+++ b/src/python/g2p/piper_plus_g2p/__init__.py
@@ -1,6 +1,6 @@
 """piper-g2p: Multilingual G2P for TTS."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from .base import Phonemizer, ProsodyInfo
 from .encode.encoder import PiperEncoder

--- a/src/python/g2p/pyproject.toml
+++ b/src/python/g2p/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "piper-plus-g2p"
-version = "0.1.0"
+version = "0.2.0"
 description = "Multilingual G2P (Grapheme-to-Phoneme) for TTS — eSpeak-ng free, MIT licensed"
 requires-python = ">=3.11"
 license = { text = "MIT" }

--- a/src/python/piper_train/ort_utils.py
+++ b/src/python/piper_train/ort_utils.py
@@ -208,14 +208,20 @@ def create_session_with_cache(
 
     # First run or cache rebuild
     _cache_requested = False
-    try:
-        opts.optimized_model_filepath = str(cache_path)
-        _cache_requested = True
-    except Exception as exc:
-        _LOGGER.warning(
-            "Could not set optimized model path %s: %s (continuing without cache)",
-            cache_path,
-            exc,
+    cache_dir = cache_path.parent
+    if os.access(cache_dir, os.W_OK):
+        try:
+            opts.optimized_model_filepath = str(cache_path)
+            _cache_requested = True
+        except Exception as exc:
+            _LOGGER.warning(
+                "Could not set optimized model path %s: %s (continuing without cache)",
+                cache_path,
+                exc,
+            )
+    else:
+        _LOGGER.info(
+            "Model directory %s is not writable, skipping ORT cache", cache_dir
         )
 
     session = onnxruntime.InferenceSession(

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "piper-train"
 version = "1.11.0"
 description = "A fast and local neural text to speech system"
-license = "MIT"
+license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
     "numpy<2.3",

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "piper-train"
 version = "1.11.0"
 description = "A fast and local neural text to speech system"
+license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
     "numpy<2.3",

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -41,27 +41,12 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -74,15 +59,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -234,9 +210,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -298,7 +274,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -604,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -614,11 +590,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -643,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
@@ -868,9 +844,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -881,7 +857,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -929,12 +904,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -942,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -955,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -969,15 +945,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -989,15 +965,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1037,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -1064,9 +1040,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1089,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -1135,7 +1111,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1144,9 +1120,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1278,10 +1276,12 @@ checksum = "542a5a9f9480726692efe8e932348b17bb8c70c8019a40f1be5a5fff13693f11"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1311,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -1333,9 +1333,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -1512,9 +1512,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1651,7 +1651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
  "bitflags 2.11.0",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys",
  "num_enum",
@@ -1670,7 +1670,7 @@ version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -1835,7 +1835,7 @@ dependencies = [
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq 3.2.0",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -1846,7 +1846,7 @@ checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
- "ureq 3.2.0",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -1904,14 +1904,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper-plus"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "flate2",
@@ -1935,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "piper-plus-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1947,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "piper-plus-g2p"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "jpreprocess",
@@ -1960,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "piper-plus-python"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "numpy",
  "piper-plus",
@@ -1969,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "piper-plus-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -2013,9 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2181,7 +2175,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2404,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustfft"
@@ -2538,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2625,9 +2619,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -2875,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2900,9 +2894,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -2924,18 +2918,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2945,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -3121,9 +3115,9 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
  "log",
@@ -3132,15 +3126,15 @@ dependencies = [
  "rustls-pki-types",
  "socks",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
  "http",
@@ -3161,10 +3155,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3235,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3248,23 +3242,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3272,9 +3262,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3285,18 +3275,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.64"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
+checksum = "941c102b3f0c15b6d72a53205e09e6646aafcf2991e18412cc331dbac1806bc0"
 dependencies = [
  "async-trait",
  "cast",
@@ -3316,9 +3306,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.64"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
+checksum = "a26bd6570f39bb1440fd8f01b63461faaf2a3f6078a508e4e54efa99363108d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3327,9 +3317,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
+checksum = "1c29582b14d5bf030b02fa232b9b57faf2afc322d2c61964dd80bad02bf76207"
 
 [[package]]
 name = "wasm-encoder"
@@ -3378,9 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3500,6 +3490,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3531,11 +3530,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3551,6 +3567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,6 +3583,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3575,10 +3603,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3593,6 +3633,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,6 +3649,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3617,6 +3669,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3629,10 +3687,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "1.0.0"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -3727,9 +3791,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -3749,9 +3813,9 @@ checksum = "aed111bd9e48a802518765906cbdadf0b45afb72b9c81ab049a3b86252adffdd"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3760,9 +3824,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3772,18 +3836,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3792,18 +3856,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3819,9 +3883,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3830,9 +3894,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3841,9 +3905,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["piper-plus-g2p", "piper-core", "piper-cli", "piper-python", "piper-w
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/src/rust/piper-cli/Cargo.toml
+++ b/src/rust/piper-cli/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "CLI tool for Piper Plus neural text-to-speech synthesis"
 
 [dependencies]
-piper-plus = { path = "../piper-core", version = "0.1.0", features = ["naist-jdic", "dict-download", "onnx"] }
+piper-plus = { path = "../piper-core", version = "0.2.0", features = ["naist-jdic", "dict-download", "onnx"] }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 serde_json = "1"

--- a/src/rust/piper-core/Cargo.toml
+++ b/src/rust/piper-core/Cargo.toml
@@ -26,7 +26,7 @@ directml = []
 tensorrt = []
 
 [dependencies]
-piper-plus-g2p = { path = "../piper-plus-g2p", features = ["all-languages"] }
+piper-plus-g2p = { path = "../piper-plus-g2p", version = "0.2.0", features = ["all-languages"] }
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "tracing", "download-binaries", "tls-rustls", "copy-dylibs", "api-24"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/rust/piper-python/Cargo.toml
+++ b/src/rust/piper-python/Cargo.toml
@@ -16,7 +16,7 @@ name = "piper_plus"
 crate-type = ["cdylib"]
 
 [dependencies]
-piper_core = { package = "piper-plus", path = "../piper-core", version = "0.1.0", features = ["naist-jdic", "onnx"] }
+piper_core = { package = "piper-plus", path = "../piper-core", version = "0.2.0", features = ["naist-jdic", "onnx"] }
 pyo3 = { version = "0.24", features = ["extension-module"] }
 numpy = "0.24"
 

--- a/src/rust/piper-python/pyproject.toml
+++ b/src/rust/piper-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "piper-plus"
-version = "0.1.0"
+version = "0.2.0"
 description = "High-quality neural text-to-speech with 7-language support"
 requires-python = ">=3.8"
 license = "MIT"

--- a/src/rust/piper-wasm/Cargo.toml
+++ b/src/rust/piper-wasm/Cargo.toml
@@ -42,8 +42,8 @@ wasm-bindgen = "0.2"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-piper-plus = { path = "../piper-core", default-features = false }
-piper-plus-g2p = { path = "../piper-plus-g2p", default-features = false }
+piper-plus = { path = "../piper-core", version = "0.2.0", default-features = false }
+piper-plus-g2p = { path = "../piper-plus-g2p", version = "0.2.0", default-features = false }
 web-sys = "0.3"
 console_error_panic_hook = "0.1"
 log = "0.4"

--- a/src/wasm/g2p/package.json
+++ b/src/wasm/g2p/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piper-plus/g2p",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Multilingual G2P (Grapheme-to-Phoneme) for TTS — eSpeak-ng free, MIT licensed",
   "type": "module",
   "main": "src/index.js",

--- a/src/wasm/openjtalk-web/package-lock.json
+++ b/src/wasm/openjtalk-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "piper-plus",
-  "version": "0.2.0-alpha.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "piper-plus",
-      "version": "0.2.0-alpha.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@piper-plus/g2p": "file:../g2p"
@@ -20,7 +20,7 @@
     },
     "../g2p": {
       "name": "@piper-plus/g2p",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/src/wasm/openjtalk-web/package.json
+++ b/src/wasm/openjtalk-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "piper-plus",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Browser-based multilingual neural TTS with VITS. Supports Japanese, English, Chinese, Korean, Spanish, French, Portuguese, and Swedish.",
   "type": "module",
   "main": "src/index.js",

--- a/uv.lock
+++ b/uv.lock
@@ -2947,7 +2947,7 @@ dev = [
 
 [[package]]
 name = "piper-plus-g2p"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "src/python/g2p" }
 
 [package.optional-dependencies]
@@ -4512,18 +4512,18 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:85ed7944655ea6fd69377692e9cbfd7bba28d99696ceae79985e7caa99cf0a95" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:1d01ffaebf64715c0f507a39463149cb19e596ff702bd4bcf862601f2881dabc" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bdbcc703382f948e951c063448c9406bf38ce66c41dd698d9e2733fcf96c037a" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7b4bd23ed63de97456fcc81c26fea9f02ee02ce1112111c4dac0d8cfe574b23e" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f1f8b840c64b645a4bc61a393db48effb9c92b2dc26c8373873911f0750d1ea7" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:23f58258012bcf1c349cb22af387e33aadca7f83ea617b080e774eb41e4fe8ff" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:c42377bc2607e3e1c60da71b792fb507c3938c87fd6edab8b21c59c91473c36d" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:37d71feea068776855686a1512058df3f19f6f040a151f055aa746601678744f" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:777461f50b2daf77e4bdd8e2ad34bdfc5a993bf1bdf2ab9ef39f5edfe4e9c12b" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7bcba6a7c5f0987a13298b1ca843155dcceceac758fa3c7ccd5c7af4059a1080" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:85ed7944655ea6fd69377692e9cbfd7bba28d99696ceae79985e7caa99cf0a95" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:1d01ffaebf64715c0f507a39463149cb19e596ff702bd4bcf862601f2881dabc" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bdbcc703382f948e951c063448c9406bf38ce66c41dd698d9e2733fcf96c037a" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7b4bd23ed63de97456fcc81c26fea9f02ee02ce1112111c4dac0d8cfe574b23e" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f1f8b840c64b645a4bc61a393db48effb9c92b2dc26c8373873911f0750d1ea7" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:23f58258012bcf1c349cb22af387e33aadca7f83ea617b080e774eb41e4fe8ff" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:c42377bc2607e3e1c60da71b792fb507c3938c87fd6edab8b21c59c91473c36d" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:37d71feea068776855686a1512058df3f19f6f040a151f055aa746601678744f" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:777461f50b2daf77e4bdd8e2ad34bdfc5a993bf1bdf2ab9ef39f5edfe4e9c12b" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7bcba6a7c5f0987a13298b1ca843155dcceceac758fa3c7ccd5c7af4059a1080" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2995,7 +2995,7 @@ provides-extras = ["ja", "en", "zh", "ko", "es", "fr", "pt", "sv", "all", "dev"]
 
 [[package]]
 name = "piper-train"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "src/python" }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- `uv.lock`: piper-train のバージョンを 1.10.0 → 1.11.0 に同期（v1.11.0 リリース時のコミット漏れ）
- C# `DotNetG2P.Chinese/Spanish/French/Portuguese`: 1.7.0 → 1.8.0 に統一（DotNetG2P/MeCab/English と揃える）
- 各パッケージのバージョンアップ（v1.11.0 変更分反映）
  - Rust ワークスペース: 0.1.0 → 0.2.0
  - C# Core/Cli: 0.1.0 → 0.2.0
  - npm piper-plus: 0.2.0 → 0.3.0
  - npm @piper-plus/g2p: 0.1.0 → 0.2.0
  - Rust piper-python pyproject.toml: 0.1.0 → 0.2.0
- Rust 内部依存 (piper-cli, piper-python) のバージョンを 0.2.0 に統一
- **追加監査で検出された問題を修正:**
  - Python G2P (`piper-plus-g2p`): 0.1.0 → 0.2.0 に統一（Rust/C#/npm と一致）
  - `actions/checkout@v4` → `@v6` に統一（7ワークフロー、12箇所）
  - `package-lock.json`: ステールバージョン (0.2.0-alpha.0) を 0.3.0 に更新

## Verification
- [x] `uv sync` が正常に完了すること
- [x] C# ビルド: `dotnet build src/csharp/PiperPlus.sln` が成功すること
- [x] C# テスト: `dotnet test src/csharp/PiperPlus.Core.Tests/` が成功すること (1006 tests passed)
- [x] CI: 56/56 ジョブ全 PASS（Rust 内部依存修正後）
- [ ] CI: 追加修正後の再確認待ち

## Test plan
- CI 全ジョブ PASS を確認
- `uv sync` でロックファイル整合性を確認
- C# ビルド + テスト (1006件) PASS を確認