### PR TITLE
fix: crates.io 公開順序を修正

### DIFF
--- a/.github/workflows/dev-create-release.yml
+++ b/.github/workflows/dev-create-release.yml
@@ -439,6 +439,31 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Publish piper-plus-g2p (dependency)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        working-directory: src/rust
+        run: |
+          if [ -n "$CARGO_REGISTRY_TOKEN" ]; then
+            set +e
+            OUTPUT=$(cargo publish -p piper-plus-g2p --allow-dirty 2>&1)
+            STATUS=$?
+            set -e
+            echo "$OUTPUT"
+            if [ "$STATUS" -ne 0 ]; then
+              if echo "$OUTPUT" | grep -q "already uploaded\|already exists"; then
+                echo "⚠️ piper-plus-g2p already published on crates.io (continuing)"
+              else
+                echo "::error::Failed to publish piper-plus-g2p to crates.io"
+                exit "$STATUS"
+              fi
+            fi
+            # Wait for crates.io index to update
+            sleep 30
+          else
+            echo "⚠️ CARGO_REGISTRY_TOKEN not found, skipping crates.io publish"
+          fi
+
       - name: Publish piper-plus (core)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/g2p-rust-publish.yml
+++ b/.github/workflows/g2p-rust-publish.yml
@@ -40,8 +40,8 @@ jobs:
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/rust-g2p-v}"
           CARGO_VERSION=$(grep '^version' piper-plus-g2p/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          if [ -z "$CARGO_VERSION" ]; then
-            # workspace version
+          if [ -z "$CARGO_VERSION" ] || echo "$CARGO_VERSION" | grep -q "workspace"; then
+            # workspace version inheritance — read from workspace root
             CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           fi
           echo "Tag version: $TAG_VERSION"


### PR DESCRIPTION
## Summary
- `g2p-rust-publish.yml`: `version.workspace = true` を使うクレートのバージョン検証ロジックを修正
- `dev-create-release.yml`: `piper-plus-g2p` を `piper-plus` (core) より先に crates.io へ公開するステップを追加

## Background
v1.11.0 リリース時に `piper-plus` (core) が `piper-plus-g2p` に依存しているが、G2P が crates.io 未公開のためパブリッシュに失敗した。

## Test plan
- CI 全ジョブ pass を確認
- マージ後、`rust-g2p-v0.2.0` タグ再作成で G2P 公開を検証
- マージ後、リリースワークフロー再実行で crates.io 公開順序 (g2p → core → cli) を検証