### PR TITLE
fix: Pages デプロイをdevブランチに限定

### DIFF
--- a/.github/workflows/deploy-webassembly-demo.yml
+++ b/.github/workflows/deploy-webassembly-demo.yml
@@ -2,6 +2,8 @@ name: Deploy WebAssembly Demo to GitHub Pages
 
 on:
   push:
+    branches:
+      - dev
     paths:
       - 'src/wasm/**'
       - 'src/rust/piper-wasm/**'


### PR DESCRIPTION
## Summary
- `deploy-webassembly-demo.yml` の push トリガーに `branches: [dev]` を追加

## Background
`rust-g2p-v0.2.0` タグプッシュ時に paths フィルタがマッチし、github-pages 環境の保護ルールでデプロイが拒否された。タグプッシュでデモデプロイを実行する必要はないため、dev ブランチのみに制限する。

## Test plan
- CI pass 確認