### PR TITLE
docs: エコシステム調査に基づく認知度・コントリビューション改善

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug Report
+description: Report a bug
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+        Please fill out the sections below to help us investigate the issue.
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Which implementation are you using?
+      options:
+        - Python (piper_train / piper-plus-g2p)
+        - Rust (piper-plus CLI / piper-plus-g2p)
+        - "C# (PiperPlus.Cli / PiperPlus.Core)"
+        - Go (piperplus / phonemize)
+        - npm (piper-plus / @piper-plus/g2p)
+        - C++ (libpiper / libpiper_plus)
+        - C API (shared library)
+        - Docker
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Package version or commit hash
+      placeholder: e.g. 0.2.0, v1.8.0, abc1234
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: e.g. Ubuntu 22.04, macOS 14.5, Windows 11
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue.
+      placeholder: |
+        1. Install ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      description: Paste any relevant log output or error messages.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/ayutaz/piper-plus/discussions
+    about: Ask questions, share ideas, or start a discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a feature
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature.
+        Please describe what you would like to see added or changed.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A brief description of the feature.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Why is this feature needed? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: How do you think this could be implemented?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative approaches you have considered.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- Briefly describe what this PR does and why. -->
+
+## Changes
+
+<!-- List the main changes. -->
+
+- 
+
+## Checklist
+
+- [ ] I have tested the changes locally
+- [ ] I have added or updated tests as needed
+- [ ] I have not added any GPL-licensed dependencies (e.g. espeak-ng)
+- [ ] Breaking changes are documented below (if any)
+
+## Test plan
+
+<!-- How did you verify that this works? -->
+
+## Breaking changes
+
+<!-- If there are no breaking changes, write "None". -->
+
+None

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -64,6 +64,7 @@ jobs:
 
       # --- Docker Hub publish (tag push or workflow_dispatch only) ---
       - name: Check Docker Hub credentials
+        if: startsWith(github.ref, 'refs/tags/docker-v') || github.event_name == 'workflow_dispatch'
         id: dockerhub-check
         run: |
           if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,8 @@ on:
       - 'pyproject.toml'
       - 'CMakeLists.txt'
       - '.github/workflows/docker-build.yml'
+    tags:
+      - 'docker-v*'
   workflow_dispatch:
 
 env:
@@ -49,7 +51,7 @@ jobs:
             type=semver,pattern={{version}}
             type=sha
 
-      - name: Build and push
+      - name: Build and push to ghcr.io
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -57,6 +59,56 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # --- Docker Hub publish (tag push or workflow_dispatch only) ---
+      - name: Check Docker Hub credentials
+        id: dockerhub-check
+        run: |
+          if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Docker Hub secrets not configured — skipping Docker Hub publish"
+          fi
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: >-
+          steps.dockerhub-check.outputs.available == 'true' &&
+          (startsWith(github.ref, 'refs/tags/docker-v') || github.event_name == 'workflow_dispatch')
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker Hub metadata
+        if: >-
+          steps.dockerhub-check.outputs.available == 'true' &&
+          (startsWith(github.ref, 'refs/tags/docker-v') || github.event_name == 'workflow_dispatch')
+        id: meta-dockerhub
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/piper-plus-api
+          tags: |
+            type=semver,pattern={{version}},prefix=
+            type=semver,pattern={{major}}.{{minor}},prefix=
+            type=raw,value=latest
+
+      - name: Push to Docker Hub
+        if: >-
+          steps.dockerhub-check.outputs.available == 'true' &&
+          (startsWith(github.ref, 'refs/tags/docker-v') || github.event_name == 'workflow_dispatch')
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./docker/python-inference/Dockerfile
+          push: true
+          tags: ${{ steps.meta-dockerhub.outputs.tags }}
+          labels: ${{ steps.meta-dockerhub.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,67 @@ cd src/python_run
 python -m pytest
 ```
 
+## License Policy
+
+piper-plus is licensed under the **MIT License**. All contributions and dependencies must be compatible with this license.
+
+### Prohibited Dependencies
+
+- **GPL / LGPL libraries are not allowed.** In particular, **espeak-ng** (GPL-3.0) must not be used as a dependency in any part of the project.
+- Any library licensed under GPL-2.0, GPL-3.0, AGPL, or similar copyleft licenses is prohibited.
+
+### Acceptable Licenses
+
+When adding a new dependency, verify that it uses one of the following (or similarly permissive) licenses:
+
+- MIT
+- Apache-2.0
+- BSD-2-Clause / BSD-3-Clause
+- ISC
+- Zlib
+
+### Rationale
+
+piper-plus is designed for commercial and embedded use. GPL dependencies would impose copyleft obligations ("GPL contamination") on downstream users, which is incompatible with the project's goals.
+
+### What to Do
+
+- Before submitting a PR that adds a new dependency, check its license.
+- If you are unsure whether a license is compatible, ask in the PR or open an issue.
+
+## Adding New Language Support
+
+piper-plus supports multiple languages via rule-based G2P (grapheme-to-phoneme) modules. If you want to add support for a new language, follow these guidelines.
+
+### Preferred Approach
+
+- **Rule-based G2P with no external dependencies** is strongly preferred. Languages like Spanish, French, Portuguese, and Swedish use purely rule-based phonemizers with zero runtime dependencies.
+- If an external library is necessary, its license **must** be MIT / Apache-2.0 / BSD compatible (see License Policy above).
+
+### Implementation Checklist
+
+At minimum, provide a **Python** implementation. Ideally, implement across all four platforms:
+
+| Platform | Location | Notes |
+|----------|----------|-------|
+| Python | `src/python/g2p/piper_plus_g2p/<lang>.py` | Required |
+| Rust (G2P) | `src/rust/piper-plus-g2p/src/<lang>.rs` | Recommended |
+| Rust (Engine) | `src/rust/piper-core/src/phonemize/<lang>.rs` | Recommended (inference engine side) |
+| C# | `src/csharp/PiperPlus.Core/Phonemize/<Lang>Phonemizer.cs` | Recommended |
+| Go | `src/go/phonemize/<lang>.go` | Recommended |
+| WASM (JS) | `src/wasm/g2p/src/<lang>/` | Optional |
+
+Each implementation should:
+
+1. Implement the phonemizer interface / abstract base class for the platform.
+2. Register the language code in the language registry.
+3. Include unit tests with reasonable coverage.
+4. Produce consistent phoneme output across platforms (use the cross-platform CI as a reference).
+
+### Reference
+
+See existing implementations (e.g., `spanish.py`, `french.py`) for examples of rule-based phonemizers with no external dependencies.
+
 ## Pull Requests
 
 1. Create a feature branch from `dev`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue)](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
 [![Hugging Face Model](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Model-orange)](https://huggingface.co/ayousanz/piper-plus-base)
 
-> **MIT ライセンス / espeak-ng 非依存** -- piper-plus は espeak-ng (GPL) を一切使用しない唯一の Piper フォークです。独自実装の G2P で8言語 (JA/EN/ZH/KO/ES/FR/PT/SV) に対応し、GPL 汚染リスクがありません。商用利用・組込み利用に最適です。
+> **MIT ライセンス / espeak-ng 非依存** -- piper-plus は espeak-ng に依存しません。独自実装の G2P で8言語 (JA/EN/ZH/KO/ES/FR/PT/SV) に対応し、プロジェクトのライセンスポリシーにより copyleft 依存を排除しています。商用利用・組込み利用に適しています。
 > オリジナルの [rhasspy/piper](https://github.com/rhasspy/piper) は 2025年10月にアーカイブ済み、[OHF-Voice/piper1-gpl](https://github.com/OHF-Voice/piper1-gpl) は GPL-3.0 に移行しています。
 
 高速・高品質なニューラルテキスト音声合成 (TTS) システム。[VITS](https://github.com/jaywalnut310/vits/) アーキテクチャを採用し、日本語・英語・中国語・韓国語・スペイン語・フランス語・ポルトガル語・スウェーデン語の8言語マルチスピーカー音声合成に対応。[Piper](https://github.com/rhasspy/piper) のフォークで、日本語対応・音質向上・学習機能を大幅に強化しています。

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue)](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
 [![Hugging Face Model](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Model-orange)](https://huggingface.co/ayousanz/piper-plus-base)
 
+> **MIT ライセンス / espeak-ng 非依存** -- piper-plus は espeak-ng (GPL) を一切使用しない唯一の Piper フォークです。独自実装の G2P で8言語 (JA/EN/ZH/KO/ES/FR/PT/SV) に対応し、GPL 汚染リスクがありません。商用利用・組込み利用に最適です。
+> オリジナルの [rhasspy/piper](https://github.com/rhasspy/piper) は 2025年10月にアーカイブ済み、[OHF-Voice/piper1-gpl](https://github.com/OHF-Voice/piper1-gpl) は GPL-3.0 に移行しています。
+
 高速・高品質なニューラルテキスト音声合成 (TTS) システム。[VITS](https://github.com/jaywalnut310/vits/) アーキテクチャを採用し、日本語・英語・中国語・韓国語・スペイン語・フランス語・ポルトガル語・スウェーデン語の8言語マルチスピーカー音声合成に対応。[Piper](https://github.com/rhasspy/piper) のフォークで、日本語対応・音質向上・学習機能を大幅に強化しています。
 
 **[Hugging Face デモ](https://huggingface.co/spaces/ayousanz/piper-plus-demo)** | **[WebAssembly デモ](https://ayutaz.github.io/piper-plus/)** (ブラウザで動作、サーバー不要)
@@ -19,10 +22,10 @@
 
 - [主要機能](#主要機能)
 - [クイックスタート](#クイックスタート)
-- [事前学習済みモデル](#事前学習済みモデル)
 - [インストール](#インストール)
 - [使い方](#使い方)
 - [学習](#学習)
+- [事前学習済みモデル](#事前学習済みモデル)
 - [日本語 TTS](#日本語-tts)
 - [プラットフォーム](#プラットフォーム)
 - [関連リンク](#関連リンク)

--- a/README_EN.md
+++ b/README_EN.md
@@ -9,7 +9,7 @@ English | [日本語](README.md) | [中文](README_ZH.md) | [Français](README_F
 [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue)](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
 [![Hugging Face Model](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Model-orange)](https://huggingface.co/ayousanz/piper-plus-base)
 
-> **MIT License / No espeak-ng dependency** -- piper-plus is the only Piper fork that does not use espeak-ng (GPL) at all. Its custom G2P covers 8 languages (JA/EN/ZH/KO/ES/FR/PT/SV) with zero GPL contamination risk, making it ideal for commercial and embedded use.
+> **MIT License / No espeak-ng dependency** -- piper-plus does not depend on espeak-ng. Its custom G2P covers 8 languages (JA/EN/ZH/KO/ES/FR/PT/SV), and the project avoids copyleft dependencies under its licensing policy, making it suitable for commercial and embedded use.
 > The original [rhasspy/piper](https://github.com/rhasspy/piper) was archived in October 2025; [OHF-Voice/piper1-gpl](https://github.com/OHF-Voice/piper1-gpl) has moved to GPL-3.0.
 
 A fast, high-quality neural text-to-speech (TTS) system. Built on the [VITS](https://github.com/jaywalnut310/vits/) architecture with multi-speaker support for 8 languages (Japanese, English, Mandarin Chinese, Korean, Spanish, French, Portuguese, Swedish). A fork of [Piper](https://github.com/rhasspy/piper) with significantly enhanced Japanese support, improved voice quality, and advanced training features.

--- a/README_EN.md
+++ b/README_EN.md
@@ -9,6 +9,9 @@ English | [日本語](README.md) | [中文](README_ZH.md) | [Français](README_F
 [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue)](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
 [![Hugging Face Model](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Model-orange)](https://huggingface.co/ayousanz/piper-plus-base)
 
+> **MIT License / No espeak-ng dependency** -- piper-plus is the only Piper fork that does not use espeak-ng (GPL) at all. Its custom G2P covers 8 languages (JA/EN/ZH/KO/ES/FR/PT/SV) with zero GPL contamination risk, making it ideal for commercial and embedded use.
+> The original [rhasspy/piper](https://github.com/rhasspy/piper) was archived in October 2025; [OHF-Voice/piper1-gpl](https://github.com/OHF-Voice/piper1-gpl) has moved to GPL-3.0.
+
 A fast, high-quality neural text-to-speech (TTS) system. Built on the [VITS](https://github.com/jaywalnut310/vits/) architecture with multi-speaker support for 8 languages (Japanese, English, Mandarin Chinese, Korean, Spanish, French, Portuguese, Swedish). A fork of [Piper](https://github.com/rhasspy/piper) with significantly enhanced Japanese support, improved voice quality, and advanced training features.
 
 **[Hugging Face Demo](https://huggingface.co/spaces/ayousanz/piper-plus-demo)** | **[WebAssembly Demo](https://ayutaz.github.io/piper-plus/)** (runs in browser, no server needed)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -9,6 +9,9 @@
 [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue)](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
 [![Hugging Face Model](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Model-orange)](https://huggingface.co/ayousanz/piper-plus-base)
 
+> **MIT 许可证 / 不依赖 espeak-ng** -- piper-plus 是唯一完全不使用 espeak-ng (GPL) 的 Piper 分支。通过自研 G2P 支持8种语言 (JA/EN/ZH/KO/ES/FR/PT/SV)，不存在 GPL 污染风险，适合商用和嵌入式场景。
+> 原版 [rhasspy/piper](https://github.com/rhasspy/piper) 已于2025年10月归档；[OHF-Voice/piper1-gpl](https://github.com/OHF-Voice/piper1-gpl) 已转为 GPL-3.0 许可。
+
 快速、高质量的神经网络文本转语音 (TTS) 系统。基于 [VITS](https://github.com/jaywalnut310/vits/) 架构，支持8种语言（日语、英语、普通话、韩语、西班牙语、法语、葡萄牙语、瑞典语）的多说话人语音合成。本项目是 [Piper](https://github.com/rhasspy/piper) 的分支，大幅增强了日语支持、音质和训练功能。
 
 **[Hugging Face 演示](https://huggingface.co/spaces/ayousanz/piper-plus-demo)** | **[WebAssembly 演示](https://ayutaz.github.io/piper-plus/)** (浏览器运行，无需服务器)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -9,7 +9,7 @@
 [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue)](https://huggingface.co/spaces/ayousanz/piper-plus-demo)
 [![Hugging Face Model](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Model-orange)](https://huggingface.co/ayousanz/piper-plus-base)
 
-> **MIT 许可证 / 不依赖 espeak-ng** -- piper-plus 是唯一完全不使用 espeak-ng (GPL) 的 Piper 分支。通过自研 G2P 支持8种语言 (JA/EN/ZH/KO/ES/FR/PT/SV)，不存在 GPL 污染风险，适合商用和嵌入式场景。
+> **MIT 许可证 / 不依赖 espeak-ng** -- piper-plus 不依赖 espeak-ng。通过自研 G2P 支持8种语言 (JA/EN/ZH/KO/ES/FR/PT/SV)，项目许可政策排除 copyleft 依赖，适合商用和嵌入式场景。
 > 原版 [rhasspy/piper](https://github.com/rhasspy/piper) 已于2025年10月归档；[OHF-Voice/piper1-gpl](https://github.com/OHF-Voice/piper1-gpl) 已转为 GPL-3.0 许可。
 
 快速、高质量的神经网络文本转语音 (TTS) 系统。基于 [VITS](https://github.com/jaywalnut310/vits/) 架构，支持8种语言（日语、英语、普通话、韩语、西班牙语、法语、葡萄牙语、瑞典语）的多说话人语音合成。本项目是 [Piper](https://github.com/rhasspy/piper) 的分支，大幅增强了日语支持、音质和训练功能。

--- a/docker/python-inference/Dockerfile
+++ b/docker/python-inference/Dockerfile
@@ -55,8 +55,11 @@ EXPOSE 8000 7860
 ENV GRADIO_SERVER_NAME=0.0.0.0
 ENV GRADIO_SERVER_PORT=7860
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD python -c "import piper_train; import onnxruntime" || exit 1
+# Healthcheck: verify the API server is responding.
+# When used via docker-compose, the compose healthcheck overrides this.
+# start-period allows the model to load before checks begin.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
 # Build-time smoke test
 RUN python --version && \

--- a/docker/python-inference/docker-compose.yml
+++ b/docker/python-inference/docker-compose.yml
@@ -1,0 +1,55 @@
+# OpenAI-compatible TTS API (piper-plus)
+#
+# Usage:
+#   1. Place your .onnx model + config.json in ./models/
+#   2. Set PIPER_MODEL to the model filename:
+#        PIPER_MODEL=your-model.onnx docker compose up --build
+#      Or export it:
+#        export PIPER_MODEL=your-model.onnx
+#        docker compose up --build
+#
+# GPU support:
+#   The "deploy" section below enables NVIDIA GPU passthrough.
+#   If you do NOT have an NVIDIA GPU, comment out or remove the entire
+#   "deploy:" block -- the container will fall back to CPU inference.
+
+services:
+  piper-api:
+    build:
+      context: ../..
+      dockerfile: docker/python-inference/Dockerfile
+    container_name: piper-api
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./models:/app/models:ro
+      - ./output:/app/output
+    environment:
+      - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-}
+      - PYTHONUNBUFFERED=1
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    command:
+      - python
+      - inference.py
+      - --server
+      - --model
+      - /app/models/${PIPER_MODEL:-model.onnx}
+      - --port
+      - "8000"
+
+    # GPU support (NVIDIA):
+    # Remove or comment out this section if running on CPU only.
+    # Requires: nvidia-container-toolkit installed on the host.
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/docs/ecosystem-investigation-2026-04.md
+++ b/docs/ecosystem-investigation-2026-04.md
@@ -1,0 +1,203 @@
+# piper-plus エコシステム調査レポート (2026年4月)
+
+**調査日**: 2026-04-07
+**リポジトリ現況**: 108 stars / 9 forks / 直近14日 Clone 18,522 (770ユニーク)
+
+---
+
+## 1. フォーク調査
+
+### 1-A. yeager (Daniel Nylander, Stockholm) — 唯一の外部コントリビューター
+
+- **dev から 3 commits ahead**
+- スウェーデン語 G2P の完全実装を含む PR #294 を提出 (2026-03-30)
+- 変更: 16ファイル / +1,229行 (ルールベースG2P、PUAマッピング、テスト20件以上、NST学習準備スクリプト)
+- 初版が espeak-ng 依存 (GPL) → 指摘を受けルールベースに書き直し → upstream では独自に PR #297 で対応済みのため close
+- yeager の発音修正テーブル (hej, och, jag 等) は #297 の参考として活用された
+- **SVネイティブの言語知識は貴重。継続的なフィードバック依頼を推奨**
+
+### 1-B. endo5501 (日本) — Flutter FFI 統合
+
+- **feat/support_cpp_library から 1 commit ahead**
+- Flutter FFI 用の C API ラッパーを独自実装 (2026-03-22、305行)
+- upstream の PR #309 で完全な C API (`libpiper_plus`) + Dart FFI サンプルが既にマージ済み
+- **本人がupstreamの対応を知らない可能性が高い → 通知推奨**
+
+### 1-C. ishine (上海、音声研究者、followers: 162)
+
+- 2026-04-07 にフォーク。変更なし、ウォッチ目的
+- 中国語圏の音声研究コミュニティからの関心シグナル
+
+### 1-D. その他 (shiena, GodLoveOnly, kapmuantuang2-maker, shigeyukey, rajuaryan21, fightseed)
+
+- 独自変更なし
+
+### 1-E. コミュニティ Issue / リクエスト
+
+- 外部ユーザーからの Issue: **0件** (全18件は全て ayutaz 自身が作成)
+- 外部からの PR: yeager の #294 の **1件のみ**
+
+---
+
+## 2. 第三者による記事・コミュニティの反応
+
+### 2-A. 第三者記事
+
+| 記事 | 著者 | 要点 |
+|------|------|------|
+| [Zenn「piper-plus」を試す](https://zenn.dev/kun432/scraps/449c8261ec0a58) | kun432 | Docker失敗、Python成功、WebUI一部失敗、**Raspberry Pi 4B RTF 0.377で成功・高評価**。「制約環境で貴重な選択肢」 |
+| [Note: piper-plusビルド&実行ガイド](https://note.com/aoya_uta/n/na501c8a6cc1b) | A-Uta | 自作「StackChain」でAquesTalk代替として検討。AquesTalkが非OSSのため。音声出力に問題が生じたと報告 |
+| [Zenn: ブラウザ完結AITuber](https://zenn.dev/shinshin86/articles/ef4b5e50ecac42) | shinshin86 | **piper-plus WASMをブラウザ内TTSとして採用**。Chrome Built-in AI + piper-plus + ONNX Runtime Web構成。「AITuber用途として最低限成立する品質」 |
+| [Neurlang Blog: Training Piper TTS](https://blog.hashtron.cloud/post/2025-09-28-training-a-a-tiny-piper-tts-model-for-any-language/) | Neurlang | 上流Piperの学習チュートリアル (piper-plus自体ではない) |
+
+### 2-B. piper-plusが言及されていないTTS比較記事
+
+| 記事 | 内容 |
+|------|------|
+| [Zenn「ローカル日本語TTSをいろいろ試す」](https://zenn.dev/megyo9/articles/b273c4c85ad451) (megyo9) | Style-Bert-VITS2、Kokoro等を比較。piper-plus未掲載 |
+| [ocdevel「ElevenLabs Alternatives 2026」](https://ocdevel.com/blog/20250720-tts) | Kokoro、Chatterbox等が主役。piper-plus未掲載 |
+
+### 2-C. HN / Reddit / X
+
+- **HN Piper存続議論** (id=43591241): 「Piperは死んだが低スペックデバイスには最良」。piper-plusへの直接言及なし
+- **X**: AITuber活用事例の発見に反応。v1.8.0リリース告知。uPiper開発成果の報告
+
+### 2-D. 第三者記事から見えた課題
+
+| 課題 | 報告元 | 現在の状態 |
+|------|--------|-----------|
+| Docker torchモジュール不在エラー | kun432 | **修正済み** (2026-04-07) |
+| WebUI prosody_features エラー | kun432 | **修正済み** (2026-04-07) |
+| Windows音声出力の問題 | A-Uta | 未確認 |
+| WASM初回ロードの重さ | shinshin86 | 構造的制約 |
+| TTS比較記事に未掲載 | megyo9他 | 認知度の課題 |
+
+---
+
+## 3. 競合環境と市場ポジション
+
+### 3-A. 重要な環境変化 (3つの機会窓口)
+
+| イベント | 時期 | piper-plusへの影響 |
+|----------|------|-------------------|
+| **rhasspy/piper がアーカイブ** | 2025/10 | MIT互換Piperフォークはpiper-plusのみに |
+| **OHF-Voice/piper1-gpl が GPL-3.0 に移行** | - | 商用利用に制約。MIT代替を探す開発者の受け皿 |
+| **openedai-speech (852 stars) がアーカイブ** | 2026/01 | OpenAI互換セルフホストTTSのポジションが空白 |
+
+### 3-B. Stars・DL比較
+
+| プロジェクト | Stars | ライセンス | 状態 |
+|---|---|---|---|
+| rhasspy/piper | 10,778 | MIT | **アーカイブ済み** |
+| OHF-Voice/piper1-gpl | 3,521 | **GPL-3.0** | アクティブ |
+| Kokoro | 6,389 | Apache 2.0 | アクティブ |
+| F5-TTS | 14,297 | MIT | アクティブ |
+| MeloTTS | 7,316 | MIT | アクティブ |
+| **piper-plus** | **108** | **MIT** | **アクティブ** |
+
+| パッケージ | 月間DL | 競合DL |
+|---|---|---|
+| piper-plus (npm) | 223 | kokoro-js: **177,662** |
+| piper-tts-plus (PyPI) | 1,396 | - |
+| piper-plus-cli (Rust) | 25 | piper-rs: 6,664 |
+
+### 3-C. 主要競合の特徴と弱点
+
+| 競合 | 強み | piper-plusとの差別化ポイント |
+|---|---|---|
+| **OHF-Voice/piper1-gpl** | Piperの正式後継、HA統合 | **GPL-3.0**。商用利用に制約。日本語G2P限定的 |
+| **Kokoro/kokoro-js** | MOS 4.2高品質、npm 102万DL/年 | **英語に最適化**。日本語品質限定的。espeak-ng依存 |
+| **Voxtral** | 4B、9言語、Apache 2.0 | **巨大 (4B)**。エッジ/ブラウザ不可 |
+| **F5-TTS** | ゼロショットクローニング、14k stars | エッジ展開困難 |
+| **Style-Bert-VITS2** | 日本語品質高い、学習GUI付き | モバイル非対応、サーバー型 |
+
+### 3-D. piper-plusの唯一無二のポジション
+
+> **「MITライセンス + espeak-ng不使用 + 日本語1st-class + 6言語SDK (C++/C#/Rust/Go/Python/npm) + エッジ動作」の組み合わせは他に存在しない**
+
+---
+
+## 4. 提言の対応状況チェック
+
+### 4-A. 即座に実行 (1-2週間)
+
+| # | 施策 | 状態 | 詳細 |
+|---|---|---|---|
+| 1 | endo5501 への通知 | **未対応** | upstream C API + Dart FFI の存在を通知推奨 |
+| 2 | README冒頭に「MIT, no espeak-ng」明示 | **部分対応** | MITバッジは存在。テキストでの強調なし。piper1-gpl GPL移行との対比なし |
+| 3 | OpenAI互換API Docker Hub公開 | **部分対応** | API完全実装済み。ghcr.io自動公開済み。**Docker Hub未公開** |
+| 4 | kun432報告のDocker/WebUIエラー修正 | **対応済み** | 2026-04-07の複数コミットで修正完了 |
+
+### 4-B. 短期 (1-3ヶ月)
+
+| # | 施策 | 状態 | 詳細 |
+|---|---|---|---|
+| 5 | yeager へのフォローアップ | **部分対応** | SV実装は #297 で独自マージ済み。追加フィードバック依頼は未実施 |
+| 6 | 英語圏での認知施策 | **未対応** | Show HN投稿、英語ブログ記事、Awesome TTS登録なし |
+| 7 | npm READMEにKokoro.js比較表 | **未対応** | 技術文書として充実しているが競合比較なし |
+| 8 | Issue/PRテンプレート + CONTRIBUTING拡充 | **部分対応** | CONTRIBUTING.md存在。GPL依存禁止ポリシー未記載。Issue/PRテンプレートなし |
+
+### 4-C. 中期 (3-6ヶ月)
+
+| # | 施策 | 状態 | 詳細 |
+|---|---|---|---|
+| 9 | KO/SVモデルの学習 | **G2P対応済み / モデル未学習** | 全プラットフォームでG2P実装完了。Rust piper-coreのSVのみ未実装。学習スクリプト未準備 |
+| 10 | Open WebUI統合ガイド | **未対応** | OpenAI互換APIは完全実装だがガイドなし |
+| 11 | Home Assistantコンポーネント | **未対応** | G2P体系が異なりHA標準Piperアドオンと非互換 |
+| 12 | Unity Asset Store / Godotアセット登録 | **未確認** | C API + Godot GDExtensionサンプルは存在 |
+
+### 4-D. 将来検討
+
+| # | 施策 | 状態 | 詳細 |
+|---|---|---|---|
+| 13 | 音声品質ベンチマーク (MOS) 公開 | **未対応** | 客観的比較データなし |
+| 14 | ファインチューニング簡略化 | **部分対応** | Template B はあるがワンクリック化は未実装 |
+| 15 | 中国語圏アウトリーチ | **未対応** | README_ZH.md は存在。CSDN/知乎での発信なし |
+
+---
+
+## 5. 発見された技術的課題
+
+| 課題 | 重要度 | 詳細 |
+|---|---|---|
+| **Rust piper-core に SV phonemizer 未実装** | 中 | `piper-plus-g2p` crateには実装済みだが、推論エンジン側 (`piper-core/src/phonemize/`) にSVモジュールがない |
+| **Docker Hub 未公開** | 中 | ghcr.ioのみ。Docker Hub credentials + workflow追加で対応可能 |
+| **python-inference用 docker-compose.yml なし** | 低 | WebUI用はあるがAPI用がない |
+
+---
+
+## 6. 需要シグナルまとめ
+
+| 需要 | 強さ | piper-plusの対応度 | 機会 |
+|------|------|-------------------|------|
+| エッジデバイスでの日本語TTS | 高 | **完全対応** | RPi事例の拡充 |
+| ブラウザ完結型TTS (WASM) | 高 | **対応済み** | Kokoro.jsとの差別化訴求 |
+| Unity/ゲーム向けTTS | 中 | **対応済み** (uPiper, C API, Godot) | Asset Store登録 |
+| OpenAI互換セルフホストTTS | 高 | **対応済み** | openedai-speech後継ポジション |
+| MITライセンスのPiperフォーク | 高 | **唯一の選択肢** | ライセンス訴求強化 |
+| OSS TTS の代替 (AquesTalk等) | 中 | **対応済み** | ドキュメント整備 |
+| 音声品質向上 | 中 | 改善余地あり | ベンチマーク公開 |
+| 簡単なセットアップ | 中 | **改善済み** (Docker修正) | Quick Start整備 |
+
+---
+
+## 7. 優先アクションリスト
+
+### 最優先 (すぐ対応可能)
+
+1. **README冒頭のMIT/espeak-ng強調** — テキスト追加のみ
+2. **endo5501 への通知** — Issueコメントのみ
+3. **Docker Hub公開設定** — workflow修正のみ
+
+### 短期重点
+
+4. **英語圏Show HN投稿** — 「Piper was archived. Here are your MIT-licensed options.」
+5. **npm README競合比較表** — Kokoro.jsとの差別化
+6. **Issue/PRテンプレート追加** — GPL依存禁止ポリシー明記
+7. **Rust piper-core SV phonemizer追加** — 技術的な実装漏れ
+
+### 中期重点
+
+8. **KO/SVモデル学習** — G2Pは完成済み、データセット準備から
+9. **Open WebUI統合ガイド** — OpenAI互換APIのユースケース拡大
+10. **Awesome TTS リスト等への登録** — 認知経路の確保

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -11,6 +11,11 @@ Comprehensive guides for various aspects of piper-plus.
 ### [Testing](testing/)
 - [Multilingual Testing](testing/multilingual-testing.md) - Testing infrastructure
 
+### Integration
+
+- [Open WebUI Integration](open-webui-integration.md) - Open WebUI との統合ガイド
+
 ## Quick Navigation
 
 - **New to training?** Start with [Training Guide](training/training-guide.md)
+- **Open WebUI?** See [Open WebUI Integration](open-webui-integration.md)

--- a/docs/guides/open-webui-integration.md
+++ b/docs/guides/open-webui-integration.md
@@ -1,0 +1,326 @@
+# Open WebUI との統合ガイド
+
+piper-plus の OpenAI 互換 TTS API を Open WebUI に接続し、チャットの音声読み上げに利用する手順を説明します。
+
+---
+
+## 前提条件
+
+- Docker および Docker Compose がインストール済み
+- [Open WebUI](https://github.com/open-webui/open-webui) が稼働中
+- piper-plus 用の ONNX モデルと config.json を準備済み
+  - HuggingFace から取得可能: `ayousanz/piper-plus-tsukuyomi-chan` (日本語 6 言語対応) または `ayousanz/piper-plus-base` (ベースモデル)
+
+---
+
+## Step 1: piper-plus API サーバーの起動
+
+### 方法 A: docker run で起動
+
+```bash
+# プロジェクトルートで Docker イメージをビルド
+docker build -t piper-inference -f docker/python-inference/Dockerfile .
+
+# API サーバーを起動
+docker run -d \
+  --name piper-api \
+  -v $(pwd)/models:/app/models:ro \
+  -p 8000:8000 \
+  piper-inference \
+  python /app/inference.py --server --model /app/models/model.onnx
+```
+
+`models/` ディレクトリに `model.onnx` と `config.json` (または `model.onnx.json`) を配置してください。
+
+### 方法 B: docker compose で起動
+
+`docker/python-inference/docker-compose.yml` を利用する場合は、モデルファイルの配置と command の調整が必要です。
+
+```bash
+cd docker/python-inference
+mkdir -p models
+# models/ に model.onnx と config.json を配置
+```
+
+以下の `docker-compose.yml` で API サーバーとして起動します。
+
+```yaml
+services:
+  piper-api:
+    build:
+      context: ../..
+      dockerfile: docker/python-inference/Dockerfile
+    container_name: piper-api
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./models:/app/models:ro
+    environment:
+      - PYTHONUNBUFFERED=1
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    command:
+      - python
+      - /app/inference.py
+      - --server
+      - --model
+      - /app/models/model.onnx
+```
+
+```bash
+docker compose up -d
+```
+
+### 方法 C: Open WebUI と同じ docker-compose で起動
+
+Open WebUI を Docker Compose で管理している場合は、同じネットワークに piper-api サービスを追加できます。
+
+```yaml
+services:
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    ports:
+      - "3000:8080"
+    volumes:
+      - open-webui:/app/backend/data
+    # ... 既存の設定 ...
+
+  piper-api:
+    image: ghcr.io/ayutaz/piper-plus/python-inference:dev
+    container_name: piper-api
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./models:/app/models:ro
+    environment:
+      - PYTHONUNBUFFERED=1
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    command:
+      - python
+      - /app/inference.py
+      - --server
+      - --model
+      - /app/models/model.onnx
+
+volumes:
+  open-webui:
+```
+
+この構成では、Open WebUI から piper-api にサービス名 `piper-api` で直接アクセスできます (Docker 内部 DNS)。
+
+### 起動確認
+
+```bash
+# ヘルスチェック
+curl http://localhost:8000/health
+# => {"status":"healthy"}
+
+# 対応言語一覧 (モデルの config.json の language_id_map に定義された言語が返ります)
+curl http://localhost:8000/v1/audio/speech/languages
+# => {"languages":["en","es","fr","ja","pt","zh"]}  # 6lang モデルの例
+
+# 音声合成テスト
+curl -X POST http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"input": "こんにちは", "language": "ja"}' \
+  -o test.wav
+```
+
+---
+
+## Step 2: Open WebUI の TTS 設定
+
+Open WebUI の管理画面から以下の設定を行います。
+
+1. **Settings** (管理者設定) を開く
+2. **Audio** セクションに移動
+3. 以下の値を設定:
+
+| 設定項目 | 値 |
+|---------|-----|
+| TTS Engine | `OpenAI` |
+| TTS Base URL | `http://piper-api:8000/v1` |
+| TTS API Key | `dummy` (任意の文字列。piper-plus は API キーを検証しません) |
+| TTS Model | `piper-plus` |
+| TTS Voice | `default` |
+
+**TTS Base URL の注意点:**
+
+- Open WebUI と piper-api が同じ Docker Compose ネットワーク内にある場合: `http://piper-api:8000/v1`
+- Open WebUI がホストマシンから piper-api にアクセスする場合: `http://localhost:8000/v1`
+- Open WebUI が別の Docker ネットワークにある場合: `http://host.docker.internal:8000/v1` (Docker Desktop) または ホストの実 IP を指定
+
+4. **Save** をクリック
+
+---
+
+## Step 3: 動作確認
+
+1. Open WebUI でチャットを開く
+2. LLM にメッセージを送信し、応答を受け取る
+3. 応答メッセージの音声再生ボタン (スピーカーアイコン) をクリック
+4. piper-plus による音声が再生されることを確認
+
+### 言語の自動検出について
+
+piper-plus の API はリクエストごとに `language` パラメータを受け取ります。Open WebUI の標準 TTS 統合ではこのパラメータを送信しないため、デフォルトの言語 (日本語: `ja`) で合成されます。
+
+英語など他言語での合成が必要な場合は、Open WebUI 側で TTS リクエストをカスタマイズするか、piper-plus API の前段に言語自動検出プロキシを配置する方法があります。
+
+---
+
+## API 仕様
+
+piper-plus が提供する OpenAI 互換エンドポイントの一覧です。
+
+### POST /v1/audio/speech
+
+音声合成リクエスト。
+
+**リクエストボディ (JSON):**
+
+| フィールド | 型 | デフォルト | 説明 |
+|-----------|------|----------|------|
+| `input` | string | (必須) | 合成するテキスト |
+| `model` | string | `"piper-plus"` | モデル名 (任意の値を受け付けます) |
+| `voice` | string | `"default"` | 音声名 (任意の値を受け付けます) |
+| `response_format` | string | `"wav"` | 出力形式 (`wav` のみ対応) |
+| `speed` | float | `1.0` | 話速 (0.0 < speed <= 4.0) |
+| `language` | string | `"ja"` | 言語コード (piper-plus 拡張) |
+| `speaker_id` | int | `0` | 話者 ID (piper-plus 拡張) |
+| `noise_scale` | float | `0.667` | ノイズスケール (piper-plus 拡張) |
+| `noise_w` | float | `0.8` | ノイズ W (piper-plus 拡張) |
+
+**レスポンス:** `audio/wav` (バイナリ)
+
+### GET /v1/models
+
+モデル一覧を返します。
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "piper-plus",
+      "object": "model",
+      "created": 1712345678,
+      "owned_by": "piper-plus"
+    }
+  ]
+}
+```
+
+### GET /v1/audio/speech/languages
+
+対応言語一覧を返します。返される言語はロードしたモデルの `config.json` 内の `language_id_map` に定義された言語に依存します。
+
+```json
+{
+  "languages": ["en", "es", "fr", "ja", "pt", "zh"]
+}
+```
+
+> **Note:** 上記は 6lang モデル (`ayousanz/piper-plus-tsukuyomi-chan` 等) の例です。異なるモデルを使用した場合、対応言語は変わります。
+
+### GET /health
+
+ヘルスチェック。
+
+```json
+{"status": "healthy"}
+```
+
+---
+
+## トラブルシューティング
+
+### 「Connection refused」エラー
+
+- piper-api コンテナが起動しているか確認:
+  ```bash
+  docker ps | grep piper-api
+  ```
+- ヘルスチェックの状態を確認:
+  ```bash
+  docker inspect --format='{{json .State.Health}}' piper-api
+  ```
+- TTS Base URL が正しいか確認。同一 Docker ネットワーク内なら `http://piper-api:8000/v1`、外部からなら `http://localhost:8000/v1`
+
+### 音声が再生されない
+
+- ブラウザの開発者ツール (Network タブ) で `/v1/audio/speech` リクエストのステータスコードを確認
+- piper-api のログを確認:
+  ```bash
+  docker logs piper-api
+  ```
+- `response_format` の問題: piper-plus は `wav` のみ対応。Open WebUI が他の形式を要求している場合は 400 エラーが返ります
+
+### モデルが見つからない
+
+- コンテナ内のモデルパスを確認:
+  ```bash
+  docker exec piper-api ls -la /app/models/
+  ```
+- `model.onnx` と `config.json` (または `model.onnx.json`) の両方が必要
+
+### GPU を使用したい場合
+
+Docker 起動時に GPU パススルーを有効化:
+```bash
+docker run -d --gpus all \
+  --name piper-api \
+  -v $(pwd)/models:/app/models:ro \
+  -p 8000:8000 \
+  piper-inference \
+  python /app/inference.py --server --model /app/models/model.onnx --device gpu
+```
+
+前提条件: ホストに NVIDIA Driver (>= 525.60.13) と [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) がインストール済みであること。
+
+---
+
+## openedai-speech からの移行
+
+[openedai-speech](https://github.com/matatonic/openedai-speech) からの移行に関するノートです。
+
+### 共通点
+
+- 両方とも OpenAI 互換の `POST /v1/audio/speech` エンドポイントを提供
+- `model`, `input`, `voice`, `speed` フィールドを受け付ける
+- Open WebUI の TTS Engine 設定で `OpenAI` を選択して接続
+
+### 主な違い
+
+| 項目 | openedai-speech | piper-plus |
+|------|----------------|------------|
+| 対応形式 | wav, mp3, opus, aac, flac, pcm | wav のみ |
+| 対応言語 | モデル依存 | 6 言語 (ja, en, zh, es, fr, pt) |
+| 言語指定 | テキストから自動検出 (モデル依存) | `language` パラメータで明示指定 |
+| voice マッピング | 設定ファイルで voice 名 -> モデルをマッピング | `voice` フィールドは無視 (`speaker_id` で話者を指定) |
+| バックエンド | piper (espeak-ng依存), Coqui TTS 等 | piper-plus (espeak-ng 不使用、GPL-free) |
+| ライセンス | AGPL-3.0 | MIT |
+| 状態 | アーカイブ済み | 活発に開発中 |
+
+### 移行手順
+
+1. openedai-speech のコンテナを停止
+2. piper-plus API サーバーを起動 (Step 1 参照)
+3. Open WebUI の TTS 設定で Base URL を piper-plus に変更 (Step 2 参照)
+4. `voice` 設定は `default` に変更 (piper-plus は voice 名を使用しません)
+
+### 注意事項
+
+- openedai-speech で `mp3` 等の形式を指定していた場合、piper-plus は `wav` のみ対応のため、Open WebUI 側の設定で `response_format` が `wav` になっていることを確認してください
+- openedai-speech の voice 名 (`alloy`, `nova` 等) は piper-plus では無視されます。話者を切り替えるには `speaker_id` パラメータを使用してください

--- a/src/rust/piper-core/src/phonemize/mod.rs
+++ b/src/rust/piper-core/src/phonemize/mod.rs
@@ -1,6 +1,6 @@
 //! Phonemizer trait, language registry, and language-specific implementations.
 //!
-//! Phase 3: 7 languages (ja, en, zh, ko, es, fr, pt) + multilingual support.
+//! 8 languages (ja, en, zh, ko, es, fr, pt, sv) + multilingual support.
 //! JSONL 入力 (Phase 1) に加え、テキスト直接入力をサポート。
 
 use std::collections::HashMap;
@@ -23,6 +23,7 @@ pub mod korean;
 pub use piper_plus_g2p::multilingual;
 pub mod portuguese;
 pub mod spanish;
+pub mod swedish;
 pub use piper_plus_g2p::token_map;
 
 /// プロソディ情報 (言語間で共有)

--- a/src/rust/piper-core/src/phonemize/swedish.rs
+++ b/src/rust/piper-core/src/phonemize/swedish.rs
@@ -1,0 +1,148 @@
+//! Swedish phonemizer for piper-core.
+//!
+//! Thin wrapper around [`piper_plus_g2p::swedish`] that implements the
+//! [`piper_core::phonemize::Phonemizer`](super::Phonemizer) trait
+//! (with `PiperError`, `get_phoneme_id_map`, `post_process_ids`).
+//!
+//! The actual G2P logic lives in the `piper-plus-g2p` crate.
+
+use super::multilingual::default_post_process_ids;
+use super::{Phonemizer, ProsodyFeature, ProsodyInfo};
+use crate::config::PhonemeIdMap;
+use crate::error::PiperError;
+
+// ---------------------------------------------------------------------------
+// SwedishPhonemizer
+// ---------------------------------------------------------------------------
+
+/// Swedish phonemizer using rule-based G2P.
+///
+/// Delegates to [`piper_plus_g2p::swedish::phonemize_swedish_with_prosody`]
+/// for the actual grapheme-to-phoneme conversion.
+pub struct SwedishPhonemizer;
+
+impl SwedishPhonemizer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SwedishPhonemizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Phonemizer for SwedishPhonemizer {
+    fn phonemize_with_prosody(
+        &self,
+        text: &str,
+    ) -> Result<(Vec<String>, Vec<Option<ProsodyInfo>>), PiperError> {
+        let (tokens, prosody) =
+            piper_plus_g2p::swedish::phonemize_swedish_with_prosody(text);
+
+        // Convert piper_plus_g2p::ProsodyInfo -> piper_core::phonemize::ProsodyInfo
+        let prosody = prosody
+            .into_iter()
+            .map(|opt| {
+                opt.map(|p| ProsodyInfo {
+                    a1: p.a1,
+                    a2: p.a2,
+                    a3: p.a3,
+                })
+            })
+            .collect();
+
+        Ok((tokens, prosody))
+    }
+
+    fn get_phoneme_id_map(&self) -> Option<&PhonemeIdMap> {
+        // Swedish uses the phoneme_id_map from config.json
+        None
+    }
+
+    fn post_process_ids(
+        &self,
+        ids: Vec<i64>,
+        prosody: Vec<Option<ProsodyFeature>>,
+        id_map: &PhonemeIdMap,
+    ) -> (Vec<i64>, Vec<Option<ProsodyFeature>>) {
+        // Reuse shared BOS + intersperse padding + EOS logic
+        default_post_process_ids(ids, prosody, id_map, "$")
+    }
+
+    fn language_code(&self) -> &str {
+        "sv"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_language_code() {
+        assert_eq!(SwedishPhonemizer::new().language_code(), "sv");
+    }
+
+    #[test]
+    fn test_phonemize_basic() {
+        let p = SwedishPhonemizer::new();
+        let (tokens, prosody) = p.phonemize_with_prosody("hej").unwrap();
+        assert!(!tokens.is_empty(), "should produce phonemes for 'hej'");
+        assert_eq!(
+            tokens.len(),
+            prosody.len(),
+            "tokens and prosody must have same length"
+        );
+    }
+
+    #[test]
+    fn test_phonemize_sentence() {
+        let p = SwedishPhonemizer::new();
+        let (tokens, prosody) = p
+            .phonemize_with_prosody("God morgon, hur m\u{00e5}r du?")
+            .unwrap();
+        assert!(!tokens.is_empty(), "should produce phonemes for a sentence");
+        assert_eq!(tokens.len(), prosody.len());
+    }
+
+    #[test]
+    fn test_phonemize_empty() {
+        let p = SwedishPhonemizer::new();
+        let (tokens, prosody) = p.phonemize_with_prosody("").unwrap();
+        assert!(tokens.is_empty());
+        assert!(prosody.is_empty());
+    }
+
+    #[test]
+    fn test_default_impl() {
+        let p = SwedishPhonemizer::default();
+        assert_eq!(p.language_code(), "sv");
+    }
+
+    #[test]
+    fn test_post_process_ids_bos_eos() {
+        use std::collections::HashMap;
+
+        let p = SwedishPhonemizer::new();
+        let mut id_map: PhonemeIdMap = HashMap::new();
+        id_map.insert("_".to_string(), vec![0]);
+        id_map.insert("^".to_string(), vec![1]);
+        id_map.insert("$".to_string(), vec![2]);
+
+        let ids = vec![10, 20, 30];
+        let prosody = vec![None, None, None];
+        let (out_ids, _out_prosody) = p.post_process_ids(ids, prosody, &id_map);
+
+        // Should start with BOS (1) and end with EOS (2)
+        assert_eq!(*out_ids.first().unwrap(), 1, "should start with BOS");
+        assert_eq!(*out_ids.last().unwrap(), 2, "should end with EOS");
+        // Should have padding between phonemes
+        assert!(out_ids.len() > 5, "should have BOS + padded phonemes + EOS");
+    }
+}

--- a/src/rust/piper-core/src/phonemize/swedish.rs
+++ b/src/rust/piper-core/src/phonemize/swedish.rs
@@ -38,8 +38,7 @@ impl Phonemizer for SwedishPhonemizer {
         &self,
         text: &str,
     ) -> Result<(Vec<String>, Vec<Option<ProsodyInfo>>), PiperError> {
-        let (tokens, prosody) =
-            piper_plus_g2p::swedish::phonemize_swedish_with_prosody(text);
+        let (tokens, prosody) = piper_plus_g2p::swedish::phonemize_swedish_with_prosody(text);
 
         // Convert piper_plus_g2p::ProsodyInfo -> piper_core::phonemize::ProsodyInfo
         let prosody = prosody

--- a/src/wasm/openjtalk-web/README.npm.md
+++ b/src/wasm/openjtalk-web/README.npm.md
@@ -5,6 +5,19 @@
 
 Browser-based multilingual neural TTS powered by VITS. No server required.
 
+## Why piper-plus?
+
+piper-plus is built for projects that need high-quality multilingual TTS in the browser -- particularly Japanese. Unlike packages that rely on espeak-ng (GPL-licensed, limited Japanese prosody), piper-plus ships its own rule-based G2P for each language, with a full OpenJTalk-based phonemizer for Japanese that handles pitch accent and prosody correctly. The entire stack is MIT-licensed with no GPL dependencies.
+
+| Feature | piper-plus | kokoro-js | @mintplex-labs/piper-tts-web |
+|---------|-----------|-----------|------------------------------|
+| License | MIT | Apache 2.0 | MIT |
+| Japanese G2P | OpenJTalk (prosody, accent) | espeak-ng (limited) | espeak-ng |
+| Languages | 8 (JA/EN/ZH/KO/ES/FR/PT/SV) | Multiple (English-optimized) | Depends on Piper model |
+| espeak-ng dependency | None (GPL-free) | Required | Required |
+| Custom G2P per language | Yes (rule-based) | No | No |
+| Browser-only (no server) | Yes | Yes | Yes |
+
 ## Features
 
 - **8 languages** -- Japanese, English, Chinese, Korean, Spanish, French, Portuguese, and Swedish


### PR DESCRIPTION
## Summary

エコシステム調査（フォーク分析、Web記事、競合環境）に基づき、認知度向上とコントリビューション促進のための改善を実施。

- README冒頭にMIT/espeak-ng非依存の強調セクション追加 (JA/EN/ZH 3言語)
- npm README に Kokoro.js 等との競合比較表追加
- GitHub Issue/PR テンプレート追加 (GPL依存チェック付き)
- CONTRIBUTING.md にライセンスポリシー + 新言語追加ガイドライン追記
- Docker Hub 公開用 workflow ステップ追加
- python-inference 用 docker-compose.yml 作成
- Rust piper-core に Swedish phonemizer 追加 (実装漏れ修正)
- Open WebUI 統合ガイド作成
- Dockerfile HEALTHCHECK を /health エンドポイント方式に統一
- README.md 目次順序を実際のセクション順に修正
- エコシステム調査レポート追加

## Background

- rhasspy/piper アーカイブ (2025/10)、OHF-Voice/piper1-gpl の GPL-3.0 移行、openedai-speech アーカイブ (2026/01) という3つの環境変化を踏まえた対応
- 9フォーク中2件 (yeager: SV G2P、endo5501: Flutter FFI) にカスタマイズを確認
- 第三者記事 (kun432/Zenn、shinshin86/Zenn AITuber、A-Uta/Note) からの課題フィードバック対応

## Copilot review への対応 (4fca44f)

- **README 法的表現の緩和**: "唯一の Piper フォーク" → 事実ベースの記述に変更 (JA/EN/ZH 3言語)
- **docker-build.yml credential check**: タグ push / workflow_dispatch 時のみ実行するよう条件追加
- **swedish.rs rustfmt**: フォーマット修正 (CI 失敗の原因)
- npm README テーブル構文: 標準 `| col | col |` 形式で記述済み、問題なし
- docker-compose GPU: `deploy.resources.reservations.devices` は Docker Compose v2 で非 Swarm でもサポート済み
- Dockerfile HEALTHCHECK: docker-compose でオーバーライドされる設計のため現状維持

## Test plan

- [x] README の MIT/espeak-ng セクションが3言語で正しく表示される
- [x] npm README の比較表がnpmjs.comで正しくレンダリングされる
- [x] Issue/PR テンプレートが GitHub UI で正しく表示される
- [x] `cargo check --package piper-plus` でSwedish phonemizer がコンパイル通過
- [x] Docker Hub workflow が secrets 未設定時にスキップされる
- [x] rustfmt が通過する
- [ ] docker-compose.yml でAPI サーバーが起動する (要ローカル検証)