### PR TITLE
docs: npm公開に伴うバージョン表記更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,7 +378,7 @@ Rust によるONNX推論エンジン。ストリーミング、CUDA/CoreML/Direc
 | 項目 | 詳細 |
 |------|------|
 | パッケージ名 | piper-plus |
-| バージョン | 0.3.0 |
+| バージョン | 0.3.1 |
 | 対応言語 | JA, EN, ZH, KO, ES, FR, PT, SV (8言語) |
 | 音素化 | piper-plus-g2p WASM (8言語、@piper-plus/g2p) |
 | 推論 | onnxruntime-web (peerDependency) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,7 +378,7 @@ Rust によるONNX推論エンジン。ストリーミング、CUDA/CoreML/Direc
 | 項目 | 詳細 |
 |------|------|
 | パッケージ名 | piper-plus |
-| バージョン | 0.2.0 |
+| バージョン | 0.3.0 |
 | 対応言語 | JA, EN, ZH, KO, ES, FR, PT, SV (8言語) |
 | 音素化 | piper-plus-g2p WASM (8言語、@piper-plus/g2p) |
 | 推論 | onnxruntime-web (peerDependency) |

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ dotnet add package PiperPlus.Core
 **Rust ライブラリ (crates.io):**
 ```toml
 [dependencies]
-piper-plus = "0.1.0"
+piper-plus = "0.2.0"
 ```
 
 ### ソースからビルド (C++)

--- a/README_DE.md
+++ b/README_DE.md
@@ -272,7 +272,7 @@ dotnet add package PiperPlus.Core
 **Rust Bibliothek (crates.io):**
 ```toml
 [dependencies]
-piper-plus = "0.1.0"
+piper-plus = "0.2.0"
 ```
 
 ### Aus Quellcode bauen (C++)

--- a/README_EN.md
+++ b/README_EN.md
@@ -273,7 +273,7 @@ dotnet add package PiperPlus.Core
 **Rust Library (crates.io):**
 ```toml
 [dependencies]
-piper-plus = "0.1.0"
+piper-plus = "0.2.0"
 ```
 
 ### Building from Source (C++)

--- a/README_ES.md
+++ b/README_ES.md
@@ -272,7 +272,7 @@ dotnet add package PiperPlus.Core
 **Biblioteca Rust (crates.io):**
 ```toml
 [dependencies]
-piper-plus = "0.1.0"
+piper-plus = "0.2.0"
 ```
 
 ### Compilar desde fuente (C++)

--- a/README_FR.md
+++ b/README_FR.md
@@ -272,7 +272,7 @@ dotnet add package PiperPlus.Core
 **Bibliotheque Rust (crates.io) :**
 ```toml
 [dependencies]
-piper-plus = "0.1.0"
+piper-plus = "0.2.0"
 ```
 
 ### Construction depuis les sources (C++)

--- a/README_HI.md
+++ b/README_HI.md
@@ -272,7 +272,7 @@ dotnet add package PiperPlus.Core
 **Rust लाइब्रेरी (crates.io):**
 ```toml
 [dependencies]
-piper-plus = "0.1.0"
+piper-plus = "0.2.0"
 ```
 
 ### सोर्स से बिल्ड (C++)

--- a/README_KO.md
+++ b/README_KO.md
@@ -272,7 +272,7 @@ dotnet add package PiperPlus.Core
 **Rust 라이브러리 (crates.io):**
 ```toml
 [dependencies]
-piper-plus = "0.1.0"
+piper-plus = "0.2.0"
 ```
 
 ### 소스에서 빌드 (C++)

--- a/README_PT.md
+++ b/README_PT.md
@@ -275,7 +275,7 @@ dotnet add package PiperPlus.Core
 **Biblioteca Rust (crates.io):**
 ```toml
 [dependencies]
-piper-plus = "0.1.0"
+piper-plus = "0.2.0"
 ```
 
 ### Compilação a partir do código-fonte (C++)

--- a/README_RU.md
+++ b/README_RU.md
@@ -272,7 +272,7 @@ dotnet add package PiperPlus.Core
 **Rust библиотека (crates.io):**
 ```toml
 [dependencies]
-piper-plus = "0.1.0"
+piper-plus = "0.2.0"
 ```
 
 ### Сборка из исходников (C++)

--- a/README_SV.md
+++ b/README_SV.md
@@ -272,7 +272,7 @@ dotnet add package PiperPlus.Core
 **Rust-bibliotek (crates.io):**
 ```toml
 [dependencies]
-piper-plus = "0.1.0"
+piper-plus = "0.2.0"
 ```
 
 ### Bygga från källkod (C++)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -284,7 +284,7 @@ dotnet add package PiperPlus.Core
 **Rust 库 (crates.io):**
 ```toml
 [dependencies]
-piper-plus = "0.1.0"
+piper-plus = "0.2.0"
 ```
 
 ### 从源码构建 (C++)

--- a/android/README.md
+++ b/android/README.md
@@ -89,7 +89,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.piperplus:piper-plus:0.1.0")
+    implementation("com.piperplus:piper-plus:0.2.0")
 }
 ```
 

--- a/android/README.md
+++ b/android/README.md
@@ -89,7 +89,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.piperplus:piper-plus:0.2.0")
+    implementation("com.piperplus:piper-plus:0.1.0")
 }
 ```
 

--- a/src/wasm/g2p/CHANGELOG.md
+++ b/src/wasm/g2p/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-07
+
+### Changed
+
+- Published to npm as `@piper-plus/g2p` under `@piper-plus` Organization
+- Korean G2P and Swedish G2P added
+
 ## [0.1.0] - 2026-04-01
 
 ### Added

--- a/src/wasm/openjtalk-web/package-lock.json
+++ b/src/wasm/openjtalk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@piper-plus/g2p": "file:../g2p"
+        "@piper-plus/g2p": "^0.2.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -18,17 +18,14 @@
         "onnxruntime-web": ">=1.21.0"
       }
     },
-    "../g2p": {
-      "name": "@piper-plus/g2p",
+    "node_modules/@piper-plus/g2p": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@piper-plus/g2p/-/g2p-0.2.0.tgz",
+      "integrity": "sha512-z4hJG82vIeVFjSw2CKSectpenya0743Cd6OoAQHrqMCeaXM7KkbkQJ6ryrb8SSbOLs5oEjyw01KzxTBqzdnlTw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/@piper-plus/g2p": {
-      "resolved": "../g2p",
-      "link": true
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -95,9 +92,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"

--- a/src/wasm/openjtalk-web/package-lock.json
+++ b/src/wasm/openjtalk-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "piper-plus",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "piper-plus",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@piper-plus/g2p": "^0.2.0"

--- a/src/wasm/openjtalk-web/package.json
+++ b/src/wasm/openjtalk-web/package.json
@@ -59,7 +59,7 @@
     "prepublishOnly": "echo 'Ready to publish'"
   },
   "dependencies": {
-    "@piper-plus/g2p": "file:../g2p"
+    "@piper-plus/g2p": "^0.2.0"
   },
   "peerDependencies": {
     "onnxruntime-web": ">=1.21.0"

--- a/src/wasm/openjtalk-web/package.json
+++ b/src/wasm/openjtalk-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "piper-plus",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Browser-based multilingual neural TTS with VITS. Supports Japanese, English, Chinese, Korean, Spanish, French, Portuguese, and Swedish.",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- CLAUDE.md: piper-plus npm バージョン 0.2.0 → 0.3.0
- 多言語README (11ファイル): Rust piper-plus 依存 0.1.0 → 0.2.0
- android/README.md: Kotlin 依存 0.1.0 → 0.2.0
- package.json: @piper-plus/g2p 依存を file:../g2p → ^0.2.0 に変更

## Test plan
- [ ] ドキュメント内のバージョン表記が正しいことを確認
- [ ] npm install piper-plus で @piper-plus/g2p が正しく解決されることを確認