### PR TITLE
fix: Go Docker — Debian化 + ORT修正 + OpenJTalk日本語G2P + serveサブコマンド

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -137,3 +137,15 @@ jobs:
       - uses: golangci/golangci-lint-action@v7
         with:
           working-directory: src/go
+
+  docker-build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: src/go
+      - name: Build Go Docker image
+        run: docker build -t piper-plus-go -f src/go/docker/Dockerfile .

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -390,7 +390,7 @@ docker run -p 8080:8080 -v /path/to/models:/models \
   piper-plus-go serve -m /models/model.onnx --addr :8080
 ```
 
-The Dockerfile uses a two-stage build (Go 1.26 Alpine builder + minimal Alpine runtime) and bundles ONNX Runtime `v1.21.0` for `x86_64` by default. Override `ORT_VERSION` and `TARGETARCH` build args for other configurations.
+The Dockerfile uses a multi-stage build: a Debian-based Go builder that compiles OpenJTalk from source for Japanese G2P support, and a `debian:trixie-slim` runtime with ONNX Runtime `v1.24.4`. Override `ORT_VERSION` for other ONNX Runtime versions.
 
 ## Environment Variables / 環境変数
 

--- a/src/go/cmd/piper-plus/main.go
+++ b/src/go/cmd/piper-plus/main.go
@@ -67,9 +67,18 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	// Persistent flags shared across subcommands (synthesize + serve).
+	pf := rootCmd.PersistentFlags()
+	pf.StringVarP(&modelPath, "model", "m", "", "path to ONNX model file (or $PIPER_DEFAULT_MODEL)")
+	pf.StringVarP(&configPath, "config", "c", "", "path to config.json (auto-detected if omitted)")
+	pf.StringVar(&device, "device", "cpu", "inference device (cpu, cuda, coreml, directml)")
+	pf.BoolVar(&debug, "debug", false, "enable debug logging")
+	pf.BoolVarP(&quiet, "quiet", "q", false, "disable all logging")
+	pf.StringArrayVar(&customDictPaths, "custom-dict", nil, "custom dictionary JSON file paths (repeatable)")
+	pf.StringVar(&modelDir, "model-dir", "", "model cache directory override")
+
+	// Local flags for synthesis mode only.
 	f := rootCmd.Flags()
-	f.StringVarP(&modelPath, "model", "m", "", "path to ONNX model file (or $PIPER_DEFAULT_MODEL)")
-	f.StringVarP(&configPath, "config", "c", "", "path to config.json (auto-detected if omitted)")
 	f.StringVarP(&textInput, "text", "t", "", "text to synthesize (single utterance mode)")
 	f.StringVar(&language, "language", "", "language code (e.g. ja, en, zh, ko)")
 	f.Int64VarP(&speakerID, "speaker", "s", 0, "speaker ID for multi-speaker models")
@@ -79,23 +88,18 @@ func init() {
 	f.Float32Var(&lengthScale, "length-scale", 1.0, "speech rate (length scale)")
 	f.Float32Var(&noiseW, "noise-w", 0.8, "duration predictor noise scale")
 	f.Float64Var(&sentenceSilence, "sentence-silence", 0.2, "silence between sentences in seconds")
-	f.StringVar(&device, "device", "cpu", "inference device (cpu, cuda, coreml, directml)")
 	f.BoolVar(&streaming, "streaming", false, "write raw PCM int16 to stdout (no WAV header)")
 	f.StringVar(&batchFile, "batch", "", "batch file with one text line per utterance")
 	f.StringVar(&timingOutput, "output-timing", "", "write phoneme timing to file")
 	f.StringVar(&timingFormat, "timing-format", "json", "timing output format (json or tsv)")
-	f.BoolVar(&debug, "debug", false, "enable debug logging")
-	f.StringArrayVar(&customDictPaths, "custom-dict", nil, "custom dictionary JSON file paths (repeatable)")
-
-	// Additional flags matching C++ implementation.
 	f.BoolVar(&version, "version", false, "print version and exit")
-	f.BoolVarP(&quiet, "quiet", "q", false, "disable all logging")
 	f.BoolVar(&outputRaw, "output-raw", false, "output raw PCM audio to stdout (no WAV header)")
 	f.BoolVar(&jsonInput, "json-input", false, "read stdin as JSON lines")
 	f.BoolVar(&listModels, "list-models", false, "list downloaded models in cache directory")
 	f.StringVar(&downloadModel, "download-model", "", "download model by URL into cache directory")
-	f.StringVar(&modelDir, "model-dir", "", "model cache directory override")
 	f.StringArrayVar(&phonemeSilence, "phoneme-silence", nil, "per-phoneme silence (format: phoneme:seconds, repeatable)")
+
+	rootCmd.AddCommand(serveCmd)
 }
 
 func main() {

--- a/src/go/cmd/piper-plus/serve.go
+++ b/src/go/cmd/piper-plus/serve.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -31,7 +34,7 @@ func init() {
 }
 
 func runServe(cmd *cobra.Command, args []string) error {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	// Configure logging.
@@ -87,16 +90,24 @@ func runServe(cmd *cobra.Command, args []string) error {
 	defer voice.Close() //nolint:errcheck
 
 	// Start server.
-	server := piperplus.NewServer(voice, logger)
+	ttsServer := piperplus.NewServer(voice, logger)
 	fmt.Fprintf(os.Stderr, "Starting TTS server on %s\n", serveAddr)
 	fmt.Fprintln(os.Stderr, "Endpoints:")
 	fmt.Fprintln(os.Stderr, "  GET/POST /synthesize?text=...&lang=...")
 	fmt.Fprintln(os.Stderr, "  GET      /health")
 	fmt.Fprintln(os.Stderr, "  GET      /info")
 
+	httpServer := &http.Server{
+		Addr:    serveAddr,
+		Handler: ttsServer.Handler(),
+	}
+
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- server.ListenAndServe(serveAddr)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+		close(errCh)
 	}()
 
 	select {
@@ -104,6 +115,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return err
 	case <-ctx.Done():
 		logger.Info("shutting down server")
-		return nil
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return httpServer.Shutdown(shutdownCtx)
 	}
 }

--- a/src/go/cmd/piper-plus/serve.go
+++ b/src/go/cmd/piper-plus/serve.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ayutaz/piper-plus/src/go/piperplus"
+)
+
+var serveAddr string
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start HTTP TTS server",
+	Long: `Start an HTTP server that exposes TTS synthesis via REST API.
+
+Endpoints:
+  GET/POST /synthesize  Synthesize text to WAV audio
+  GET      /health      Health check
+  GET      /info        Model information`,
+	RunE: runServe,
+}
+
+func init() {
+	serveCmd.Flags().StringVar(&serveAddr, "addr", ":8080", "listen address (host:port)")
+}
+
+func runServe(cmd *cobra.Command, args []string) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	// Configure logging.
+	level := slog.LevelInfo
+	if debug {
+		level = slog.LevelDebug
+	}
+	if quiet {
+		level = slog.LevelError + 1
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+
+	// Resolve model path: flag > env.
+	resolvedModel := modelPath
+	if resolvedModel == "" {
+		resolvedModel = os.Getenv("PIPER_DEFAULT_MODEL")
+	}
+	if resolvedModel == "" {
+		return fmt.Errorf("model path required: specify --model or set $PIPER_DEFAULT_MODEL")
+	}
+
+	// Try resolving model name/alias if file doesn't exist.
+	if _, err := os.Stat(resolvedModel); os.IsNotExist(err) {
+		mgr := piperplus.NewModelManager(modelDir, logger)
+		resolved, resolveErr := mgr.FindModel(resolvedModel)
+		if resolveErr != nil {
+			return fmt.Errorf("model not found: %s (try --list-models or --download-model)", resolvedModel)
+		}
+		resolvedModel = resolved
+	}
+
+	// Initialize ONNX Runtime.
+	if err := piperplus.Init(""); err != nil {
+		return fmt.Errorf("failed to initialize ONNX Runtime: %w", err)
+	}
+	defer piperplus.Shutdown() //nolint:errcheck
+
+	// Load voice.
+	var loadOpts []piperplus.LoadOption
+	if configPath != "" {
+		loadOpts = append(loadOpts, piperplus.WithConfig(configPath))
+	}
+	loadOpts = append(loadOpts, piperplus.WithDevice(device))
+	loadOpts = append(loadOpts, piperplus.WithLogger(logger))
+	if len(customDictPaths) > 0 {
+		loadOpts = append(loadOpts, piperplus.WithCustomDict(customDictPaths...))
+	}
+
+	voice, err := piperplus.LoadVoice(ctx, resolvedModel, loadOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to load voice: %w", err)
+	}
+	defer voice.Close() //nolint:errcheck
+
+	// Start server.
+	server := piperplus.NewServer(voice, logger)
+	fmt.Fprintf(os.Stderr, "Starting TTS server on %s\n", serveAddr)
+	fmt.Fprintln(os.Stderr, "Endpoints:")
+	fmt.Fprintln(os.Stderr, "  GET/POST /synthesize?text=...&lang=...")
+	fmt.Fprintln(os.Stderr, "  GET      /health")
+	fmt.Fprintln(os.Stderr, "  GET      /info")
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ListenAndServe(serveAddr)
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		logger.Info("shutting down server")
+		return nil
+	}
+}

--- a/src/go/cmd/piper-plus/serve_test.go
+++ b/src/go/cmd/piper-plus/serve_test.go
@@ -53,15 +53,10 @@ func TestServeCmd_SynthesisFlagsNotInherited(t *testing.T) {
 	}
 }
 
-func TestServeCmd_RequiresModel(t *testing.T) {
-	// Running serve without --model should fail with a clear error.
-	// Reset the global modelPath to simulate missing model.
-	origModel := modelPath
-	modelPath = ""
-	defer func() { modelPath = origModel }()
-
-	// We can't fully run the command (needs ONNX Runtime), but we can verify
-	// the command exists and has RunE set.
+func TestServeCmd_RunESet(t *testing.T) {
+	// We can't fully execute the serve command here because it depends on
+	// ONNX Runtime, but we can verify the command is configured with a RunE
+	// handler.
 	if serveCmd.RunE == nil {
 		t.Fatal("serveCmd.RunE is nil")
 	}

--- a/src/go/cmd/piper-plus/serve_test.go
+++ b/src/go/cmd/piper-plus/serve_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestServeCmd_Registered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "serve" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("serve subcommand not registered on rootCmd")
+	}
+}
+
+func TestServeCmd_AddrFlag(t *testing.T) {
+	f := serveCmd.Flags().Lookup("addr")
+	if f == nil {
+		t.Fatal("--addr flag not found on serveCmd")
+	}
+	if f.DefValue != ":8080" {
+		t.Errorf("--addr default = %q, want %q", f.DefValue, ":8080")
+	}
+}
+
+func TestServeCmd_PersistentFlagsAccessible(t *testing.T) {
+	// Persistent flags defined on rootCmd should be accessible from serveCmd.
+	persistentFlags := []string{"model", "config", "device", "debug", "quiet", "custom-dict", "model-dir"}
+	for _, name := range persistentFlags {
+		f := serveCmd.InheritedFlags().Lookup(name)
+		if f == nil {
+			t.Errorf("persistent flag --%s not accessible from serveCmd", name)
+		}
+	}
+}
+
+func TestServeCmd_SynthesisFlagsNotInherited(t *testing.T) {
+	// Synthesis-only flags (local to rootCmd) should NOT be accessible from serveCmd.
+	localFlags := []string{"text", "speaker", "output-file", "output-dir", "batch", "streaming"}
+	for _, name := range localFlags {
+		f := serveCmd.InheritedFlags().Lookup(name)
+		if f != nil {
+			t.Errorf("synthesis-only flag --%s should not be inherited by serveCmd", name)
+		}
+		f = serveCmd.Flags().Lookup(name)
+		if f != nil {
+			t.Errorf("synthesis-only flag --%s should not be on serveCmd", name)
+		}
+	}
+}
+
+func TestServeCmd_RequiresModel(t *testing.T) {
+	// Running serve without --model should fail with a clear error.
+	// Reset the global modelPath to simulate missing model.
+	origModel := modelPath
+	modelPath = ""
+	defer func() { modelPath = origModel }()
+
+	// We can't fully run the command (needs ONNX Runtime), but we can verify
+	// the command exists and has RunE set.
+	if serveCmd.RunE == nil {
+		t.Fatal("serveCmd.RunE is nil")
+	}
+}

--- a/src/go/docker/Dockerfile
+++ b/src/go/docker/Dockerfile
@@ -1,54 +1,89 @@
 # ============================================================
-# Stage 1: Build
-# Compile the Go CLI binary with CGO enabled (required for
-# ONNX Runtime C bindings). Alpine's musl-dev provides the
-# C toolchain needed for CGO.
+# Stage 1: Build OpenJTalk static library + Go binary
+# Uses Debian-based golang image for glibc compatibility with
+# ONNX Runtime. OpenJTalk is built from pyopenjtalk-plus source
+# to enable Japanese G2P via CGO bindings.
 # ============================================================
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26 AS builder
 
-RUN apk add --no-cache gcc musl-dev
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc g++ cmake make wget ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
+# Download pyopenjtalk-plus (contains OpenJTalk source + MeCab dictionary)
+ARG PYOPENJTALK_URL=https://files.pythonhosted.org/packages/82/4e/1e2c165b04dd250dbcb1c270df8517681eed5c20b755c72bec2b42853851/pyopenjtalk_plus-0.4.1.post7.tar.gz
+WORKDIR /openjtalk-src
+RUN wget -q "${PYOPENJTALK_URL}" -O pyopenjtalk-plus.tar.gz \
+    && tar xzf pyopenjtalk-plus.tar.gz --strip-components=1 \
+    && rm pyopenjtalk-plus.tar.gz
+
+# Patch CMakeLists.txt (equivalent to cmake/patch_r9y9_openjtalk.cmake):
+#   1. Enable install() on all platforms (not just non-MSVC)
+#   2. Add C++17 compatibility for MeCab's std::binary_function
+RUN sed -i 's/if(NOT MSVC)/if(1)/' \
+        /openjtalk-src/lib/open_jtalk/src/CMakeLists.txt \
+    && sed -i '/^project(openjtalk)/a\\nadd_compile_definitions(_GLIBCXX_USE_DEPRECATED=1)' \
+        /openjtalk-src/lib/open_jtalk/src/CMakeLists.txt
+
+# Build OpenJTalk as a static library
+RUN cmake -S /openjtalk-src/lib/open_jtalk/src -B /openjtalk-build \
+      -DCMAKE_INSTALL_PREFIX=/openjtalk-install \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DCHARSET=utf8 \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    && cmake --build /openjtalk-build --parallel "$(nproc)" \
+    && cmake --install /openjtalk-build
+
+# Copy MeCab dictionary for runtime
+RUN mkdir -p /openjtalk-dic \
+    && cp -r /openjtalk-src/pyopenjtalk/dictionary/* /openjtalk-dic/
+
+# Build Go binary with OpenJTalk CGO bindings
 WORKDIR /src
 COPY src/go/ ./src/go/
 
 WORKDIR /src/src/go
-RUN CGO_ENABLED=1 go build -o /piper-plus ./cmd/piper-plus
+RUN CGO_ENABLED=1 \
+    CGO_CFLAGS="-I/openjtalk-install/include/openjtalk" \
+    CGO_LDFLAGS="-L/openjtalk-install/lib -lopenjtalk -lstdc++ -lm" \
+    go build -tags openjtalk -o /piper-plus ./cmd/piper-plus
 
 # ============================================================
 # Stage 2: Runtime
-# Minimal Alpine image with only the compiled binary and
-# ONNX Runtime shared library. Suitable for both CLI usage
-# and as a base for HTTP server mode.
+# Minimal Debian image with ONNX Runtime, the compiled Go
+# binary, and OpenJTalk dictionary for Japanese G2P.
 # ============================================================
-FROM alpine:3.21
+FROM debian:trixie-slim
 
-# ca-certificates: HTTPS model downloads; libstdc++: ONNX Runtime dependency
-RUN apk add --no-cache ca-certificates libstdc++
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libstdc++6 wget \
+    && rm -rf /var/lib/apt/lists/*
 
-# Download ONNX Runtime shared library at build time.
-# Override TARGETARCH for cross-compilation (e.g. aarch64).
-ARG ORT_VERSION=1.21.0
-ARG TARGETARCH=x86_64
+# Download ONNX Runtime shared library.
+# Uses x64 naming convention (changed from x86_64 in recent releases).
+ARG ORT_VERSION=1.24.4
 RUN set -eux \
-    && wget -q https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-${TARGETARCH}-${ORT_VERSION}.tgz \
-    && tar xzf onnxruntime-linux-${TARGETARCH}-${ORT_VERSION}.tgz \
-    && cp onnxruntime-linux-${TARGETARCH}-${ORT_VERSION}/lib/libonnxruntime.so /usr/lib/ \
+    && wget -q "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+    && tar xzf "onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+    && cp "onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so" /usr/lib/ \
     && rm -rf onnxruntime-* \
-    && ldconfig /usr/lib || true
+    && ldconfig
 
-# Copy the statically-linked Go binary from the build stage
+# Copy the Go binary and OpenJTalk dictionary from the build stage
 COPY --from=builder /piper-plus /usr/local/bin/piper-plus
+COPY --from=builder /openjtalk-dic /usr/share/open_jtalk/dic
 
-# Tell the Go binary where to find the ONNX Runtime library
+# Environment configuration
 ENV ONNX_RUNTIME_SHARED_LIBRARY_PATH=/usr/lib/libonnxruntime.so
-
-# Default directory for mounting ONNX voice models
+ENV OPENJTALK_DIC_DIR=/usr/share/open_jtalk/dic
 ENV PIPER_MODEL_DIR=/models
+
 RUN mkdir -p /models
 
 # Run as non-root user for security
-RUN adduser -D -h /app piper
-RUN chown piper:piper /models
+RUN useradd -r -m -d /app piper \
+    && chown piper:piper /models
 USER piper
 
 WORKDIR /app

--- a/src/go/docker/Dockerfile
+++ b/src/go/docker/Dockerfile
@@ -12,8 +12,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Download pyopenjtalk-plus (contains OpenJTalk source + MeCab dictionary)
 ARG PYOPENJTALK_URL=https://files.pythonhosted.org/packages/82/4e/1e2c165b04dd250dbcb1c270df8517681eed5c20b755c72bec2b42853851/pyopenjtalk_plus-0.4.1.post7.tar.gz
+ARG PYOPENJTALK_SHA256=555fdf86310d6d72f4a37e92beb251cdc2114aafc133d4c77b136a07a4b17119
 WORKDIR /openjtalk-src
 RUN wget -q "${PYOPENJTALK_URL}" -O pyopenjtalk-plus.tar.gz \
+    && echo "${PYOPENJTALK_SHA256}  pyopenjtalk-plus.tar.gz" | sha256sum -c - \
     && tar xzf pyopenjtalk-plus.tar.gz --strip-components=1 \
     && rm pyopenjtalk-plus.tar.gz
 
@@ -63,8 +65,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Download ONNX Runtime shared library.
 # Uses x64 naming convention (changed from x86_64 in recent releases).
 ARG ORT_VERSION=1.24.4
+ARG ORT_SHA256=3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747
 RUN set -eux \
     && wget -q "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+    && echo "${ORT_SHA256}  onnxruntime-linux-x64-${ORT_VERSION}.tgz" | sha256sum -c - \
     && tar xzf "onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
     && cp "onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so" /usr/lib/ \
     && rm -rf onnxruntime-* \
@@ -72,11 +76,11 @@ RUN set -eux \
 
 # Copy the Go binary and OpenJTalk dictionary from the build stage
 COPY --from=builder /piper-plus /usr/local/bin/piper-plus
-COPY --from=builder /openjtalk-dic /usr/share/open_jtalk/dic
+COPY --from=builder /openjtalk-dic /usr/local/share/open_jtalk/dic
 
 # Environment configuration
 ENV ONNX_RUNTIME_SHARED_LIBRARY_PATH=/usr/lib/libonnxruntime.so
-ENV OPENJTALK_DIC_DIR=/usr/share/open_jtalk/dic
+ENV OPENJTALK_DICTIONARY_PATH=/usr/local/share/open_jtalk/dic
 ENV PIPER_MODEL_DIR=/models
 
 RUN mkdir -p /models


### PR DESCRIPTION
## Summary
- Go SDK Dockerfile を Alpine → Debian に変更し ONNX Runtime (glibc) との互換性を確保
- ORT v1.21.0 (存在しないバージョン・旧命名規則) → v1.24.4 (`go-ci.yml` と統一) に修正
- OpenJTalk を pyopenjtalk-plus から CMake ビルドし、`-tags openjtalk` で日本語G2P を有効化（辞書同梱）
- `piper-plus serve` サブコマンドを追加（HTTP TTS サーバー: `/synthesize`, `/health`, `/info`）
- Cobra の共有フラグを `PersistentFlags` に移動してサブコマンド間で共有
- pyopenjtalk-plus / ORT の SHA-256 チェックサム検証を追加
- SIGTERM ハンドリング + graceful shutdown 実装

## Changed files
| ファイル | 変更内容 |
|----------|----------|
| `src/go/docker/Dockerfile` | Debian化 + ORT 1.24.4 + OpenJTalk CMakeビルド + SHA256検証 |
| `src/go/cmd/piper-plus/serve.go` | **新規** — `serve` サブコマンド (graceful shutdown対応) |
| `src/go/cmd/piper-plus/serve_test.go` | **新規** — Cobra コマンド構造テスト (5テスト) |
| `src/go/cmd/piper-plus/main.go` | PersistentFlags 移動 + `serveCmd` 登録 |
| `.github/workflows/go-ci.yml` | `docker-build` ジョブ追加 |
| `src/go/README.md` | Docker 説明文更新 |

## Test plan
- [x] `go-ci.yml` unit-test (3 OS) で serve_test.go のテストが通ること
- [x] `go-ci.yml` docker-build で Dockerfile のビルドが成功すること
- [x] `go-ci.yml` build (3 OS) で serve.go を含むバイナリビルドが成功すること
- [x] `go-ci.yml` lint が通ること