### PR TITLE
chore(ci): Node.js バージョンを 24 LTS に統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,7 +359,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - dev
 
+env:
+  NODE_VERSION: '24.x'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -359,7 +362,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/g2p-cross-platform-ci.yml
+++ b/.github/workflows/g2p-cross-platform-ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/g2p-cross-platform-ci.yml
+++ b/.github/workflows/g2p-cross-platform-ci.yml
@@ -24,6 +24,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  NODE_VERSION: '24.x'
+
 jobs:
   consistency-check:
     name: cross-platform consistency
@@ -40,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: ${{ env.NODE_VERSION }}
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/g2p-wasm-ci.yml
+++ b/.github/workflows/g2p-wasm-ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: src/wasm/g2p/package.json
 
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: ['20']
+        node-version: ['24']
     defaults:
       run:
         working-directory: src/wasm/g2p
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: src/wasm/g2p/package.json
 
@@ -136,7 +136,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: src/wasm/g2p/package.json
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/g2p-wasm-ci.yml
+++ b/.github/workflows/g2p-wasm-ci.yml
@@ -24,6 +24,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  NODE_VERSION: '24.x'
+
 jobs:
   lint:
     name: lint
@@ -38,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: src/wasm/g2p/package.json
 
@@ -61,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: ['24']
+        node-version: ['24.x']
     defaults:
       run:
         working-directory: src/wasm/g2p
@@ -98,7 +101,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: src/wasm/g2p/package.json
 
@@ -136,7 +139,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: src/wasm/g2p/package.json
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm install
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: https://registry.npmjs.org
 
       - name: Download WASM artifact

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'npm-v*'
 
+env:
+  NODE_VERSION: '24.x'
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -19,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install dependencies
         run: npm install
@@ -77,7 +80,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
 
       - name: Download WASM artifact

--- a/.github/workflows/test-webassembly.yml
+++ b/.github/workflows/test-webassembly.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
     
     - name: Setup Emscripten
       uses: mymindstorm/setup-emsdk@v14

--- a/.github/workflows/test-webassembly.yml
+++ b/.github/workflows/test-webassembly.yml
@@ -12,6 +12,9 @@ on:
       - 'src/wasm/**'
       - '.github/workflows/test-webassembly.yml'
 
+env:
+  NODE_VERSION: '24.x'
+
 jobs:
   test-openjtalk-web:
     runs-on: ubuntu-latest
@@ -25,7 +28,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '24'
+        node-version: ${{ env.NODE_VERSION }}
     
     - name: Setup Emscripten
       uses: mymindstorm/setup-emsdk@v14


### PR DESCRIPTION
## Summary
- CI ワークフローで混在していた Node.js 20/22 を **Node 24 LTS** (Active LTS, EOL 2028-04-30) に統一
- 対象 5 ファイル / 9 箇所を変更

## 変更一覧

| ファイル | 箇所数 | 変更前 | 変更後 |
|----------|--------|--------|--------|
| `ci.yml` | 1 | 20 | 24 |
| `test-webassembly.yml` | 1 | 20 | 24 |
| `npm-publish.yml` | 2 | 20 | 24 |
| `g2p-wasm-ci.yml` | 4 | 22/20 | 24 |
| `g2p-cross-platform-ci.yml` | 1 | 22 | 24 |

## 影響調査

- 他ワークフローに Node.js バージョン指定なし
- `package.json` の `engines: >=18.0.0` は Node 24 で問題なし
- `.nvmrc` / `.node-version` / Dockerfile に Node.js 指定なし

Closes #344