### PR TITLE
fix(cpp): UTF-8 コードポイントベースの文分割に置換

### DIFF
--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -10,7 +10,6 @@
 #include <filesystem>
 #include <thread>
 #include <unordered_map>
-#include <regex>
 
 #include <onnxruntime_cxx_api.h>
 #ifdef __APPLE__

--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -30,6 +30,7 @@
 #include "json.hpp"
 #include "piper.hpp"
 #include "utf8.h"
+#include "utf8_utils.hpp"
 #include "wavfile.hpp"
 #include "openjtalk_phonemize.hpp"
 #include "phoneme_parser.hpp"
@@ -2044,24 +2045,41 @@ void phonemesToWavFile(PiperConfig &config, Voice &voice,
                   
 } /* phonemesToWavFile */
 
-// Helper function for calculating dynamic chunk size based on text characteristics
-static size_t calculateDynamicChunkSize(const std::string& text, size_t baseSize = 50) {
-  // Short texts should not be chunked
-  if (text.length() < baseSize * 2) {
-    return text.length();
+// Helper: is a codepoint a punctuation mark used for density calculation?
+static bool isPunctCodepoint(char32_t c) {
+  switch (c) {
+    case U'\u3002': // 。
+    case U'\u3001': // 、
+    case U'\uFF01': // ！
+    case U'\uFF1F': // ？
+    case U'.': case U'!': case U'?': case U',': case U';': case U':':
+      return true;
+    default:
+      return false;
   }
-  
-  // Calculate punctuation density
+}
+
+// Helper function for calculating dynamic chunk size based on text characteristics.
+// Operates on codepoints (not bytes) to correctly handle CJK text.
+static size_t calculateDynamicChunkSize(const std::vector<char32_t>& cps,
+                                        size_t baseSize = 50) {
+  size_t cpLen = cps.size();
+
+  // Short texts should not be chunked
+  if (cpLen < baseSize * 2) {
+    return cpLen;
+  }
+
+  // Calculate punctuation density (codepoint-level)
   size_t punctCount = 0;
-  const std::string punctMarks = u8"。、！？.!?,;:";
-  for (size_t i = 0; i < text.length(); ++i) {
-    if (punctMarks.find(text[i]) != std::string::npos) {
+  for (char32_t c : cps) {
+    if (isPunctCodepoint(c)) {
       punctCount++;
     }
   }
-  
+
   // Adjust chunk size based on punctuation density
-  float punctDensity = static_cast<float>(punctCount) / text.length();
+  float punctDensity = static_cast<float>(punctCount) / static_cast<float>(cpLen);
   if (punctDensity > 0.05f) {  // More than 5% punctuation - use smaller chunks
     return baseSize;
   } else if (punctDensity < 0.02f) {  // Less than 2% punctuation - use larger chunks
@@ -2070,7 +2088,10 @@ static size_t calculateDynamicChunkSize(const std::string& text, size_t baseSize
   return baseSize * 2;  // Medium density
 }
 
-// Split text into sentences at natural boundaries (public API)
+// Split text into sentences at natural boundaries (public API).
+// Uses codepoint-level iteration via utf8_utils to correctly handle
+// multibyte UTF-8 characters (CJK punctuation, etc.).
+// Fixes: https://github.com/ayutaz/piper-plus/issues/343
 std::vector<std::string> splitTextToSentences(
     const std::string &text,
     PhonemeType phonemeType,
@@ -2080,50 +2101,82 @@ std::vector<std::string> splitTextToSentences(
     return {};
   }
 
+  using utf8_util::toCodepoints;
+  using utf8_util::cpsToUtf8;
+
+  auto cps = toCodepoints(text);
+  size_t cpLen = cps.size();
+
   size_t baseSize = maxChunkSize > 0 ? maxChunkSize : 50;
-  size_t dynamicChunkSize = calculateDynamicChunkSize(text, baseSize);
+  size_t dynamicChunkSize = calculateDynamicChunkSize(cps, baseSize);
 
-  static const std::regex japaneseSentenceBoundary(u8"([。！？、]+)");
-  static const std::regex englishSentenceBoundary("([.!?,;:]+|\\s+(?:and|or|but|because|while|when|if|that|which)\\s+)");
+  // Classify whether a codepoint is a boundary punctuation mark
+  auto isBoundaryPunct = [&](char32_t c) -> bool {
+    if (phonemeType == MultilingualPhonemes) {
+      // Multilingual: CJK fullwidth + ASCII sentence-end + ellipsis
+      return c == U'\u3002' || c == U'\uFF01' || c == U'\uFF1F' ||
+             c == U'.' || c == U'!' || c == U'?' ||
+             c == U'\u2026'; // …
+    } else if (usesOpenJTalk(phonemeType)) {
+      // Japanese: fullwidth sentence-end + ideographic comma
+      return c == U'\u3002' || c == U'\uFF01' || c == U'\uFF1F' ||
+             c == U'\u3001'; // 、
+    } else {
+      // English/other: ASCII punctuation
+      return c == U'.' || c == U'!' || c == U'?' || c == U',' ||
+             c == U';' || c == U':';
+    }
+  };
 
-  // Multilingual pattern: JA/ZH fullwidth + EN/ES/FR/PT ASCII sentence-end punctuation.
-  // Note: usesOpenJTalk() returns true for MultilingualPhonemes too, so we must
-  // check phonemeType directly to avoid falling into the JA-only branch.
-  static const std::regex multilingualSentenceEnd(
-      u8"([。！？.!?]+|[…]+|[\\.]{3,})"
-  );
-
-  const std::regex& sentenceBoundary =
-    (phonemeType == MultilingualPhonemes)
-    ? multilingualSentenceEnd
-    : (usesOpenJTalk(phonemeType))
-      ? japaneseSentenceBoundary
-      : englishSentenceBoundary;
+  // Check if a codepoint is a sentence terminator (triggers immediate split)
+  auto isSentenceTerminator = [&](char32_t c) -> bool {
+    if (phonemeType == MultilingualPhonemes) {
+      return c == U'\u3002' || c == U'\uFF01' || c == U'\uFF1F' ||
+             c == U'.' || c == U'!' || c == U'?';
+    } else if (usesOpenJTalk(phonemeType)) {
+      // For Japanese, 、 (comma) is boundary but NOT a terminator
+      return c == U'\u3002' || c == U'\uFF01' || c == U'\uFF1F';
+    } else {
+      return c == U'.' || c == U'!' || c == U'?';
+    }
+  };
 
   std::vector<std::string> chunks;
-  std::sregex_token_iterator iter(text.begin(), text.end(), sentenceBoundary, {-1, 1});
-  std::sregex_token_iterator end;
+  size_t sentenceStart = 0;
 
-  std::string currentChunk;
-  for (; iter != end; ++iter) {
-    std::string token = *iter;
-    if (token.empty()) continue;
+  for (size_t i = 0; i < cpLen; ++i) {
+    char32_t c = cps[i];
 
-    if (std::regex_match(token, sentenceBoundary)) {
-      currentChunk += token;
-      if (!currentChunk.empty() &&
-          (token.find_first_of(u8"。！？.!?") != std::string::npos ||
-           currentChunk.length() > dynamicChunkSize)) {
-        chunks.push_back(currentChunk);
-        currentChunk.clear();
+    if (isBoundaryPunct(c)) {
+      // Consume the entire run of boundary punctuation
+      bool hasTerminator = isSentenceTerminator(c);
+      size_t punctEnd = i + 1;
+      while (punctEnd < cpLen && isBoundaryPunct(cps[punctEnd])) {
+        if (isSentenceTerminator(cps[punctEnd])) {
+          hasTerminator = true;
+        }
+        punctEnd++;
       }
-    } else {
-      currentChunk += token;
+      i = punctEnd - 1; // advance past punctuation run (for-loop will ++)
+
+      // Split if this contains a sentence terminator, or chunk is too long
+      size_t chunkLen = punctEnd - sentenceStart;
+      if (hasTerminator || chunkLen > dynamicChunkSize) {
+        std::string chunk = cpsToUtf8(cps, sentenceStart, chunkLen);
+        if (!chunk.empty()) {
+          chunks.push_back(chunk);
+        }
+        sentenceStart = punctEnd;
+      }
     }
   }
 
-  if (!currentChunk.empty()) {
-    chunks.push_back(currentChunk);
+  // Emit any remaining text
+  if (sentenceStart < cpLen) {
+    std::string remaining = cpsToUtf8(cps, sentenceStart, cpLen - sentenceStart);
+    if (!remaining.empty()) {
+      chunks.push_back(remaining);
+    }
   }
 
   return chunks;

--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -2100,6 +2100,13 @@ std::vector<std::string> splitTextToSentences(
     return {};
   }
 
+  // Guard against invalid UTF-8: toCodepoints() uses utf8::unchecked
+  // internally and requires well-formed input.
+  if (!utf8::is_valid(text.begin(), text.end())) {
+    spdlog::warn("splitTextToSentences: invalid UTF-8 input, returning as single chunk");
+    return {text};
+  }
+
   using utf8_util::toCodepoints;
   using utf8_util::cpsToUtf8;
 

--- a/src/cpp/tests/CMakeLists.txt
+++ b/src/cpp/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ set(TEST_SOURCES
     test_multilingual_g2p.cpp
     test_swedish_phonemize.cpp
     test_short_text_mitigation.cpp
+    test_split_sentences.cpp
 )
 
 # Add Unix-only tests (require open_jtalk binary or Unix APIs)
@@ -121,6 +122,13 @@ foreach(test_source ${TEST_SOURCES})
         )
     endif()
     
+    # Link utf8_utils.hpp include path for split sentences test
+    if(${test_name} STREQUAL "test_split_sentences")
+        target_include_directories(${test_name} PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/..
+        )
+    endif()
+
     # Link additional dependencies for custom dictionary test
     if(${test_name} STREQUAL "test_custom_dictionary")
         target_sources(${test_name} PRIVATE

--- a/src/cpp/tests/test_split_sentences.cpp
+++ b/src/cpp/tests/test_split_sentences.cpp
@@ -1,0 +1,408 @@
+// Comprehensive unit tests for splitTextToSentences() codepoint-based
+// implementation (Issue #343 fix).
+//
+// These tests mirror the algorithm in piper.cpp but are self-contained
+// (no ONNX Runtime dependency). The integration path is covered by
+// test_streaming.cpp which calls textToAudioStreaming() -> splitTextToSentences().
+
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+#include <cstdint>
+#include <functional>
+
+#include "utf8_utils.hpp"
+
+// Local copies of PhonemeType / usesOpenJTalk to avoid pulling in piper.hpp
+// (which requires onnxruntime_cxx_api.h).
+namespace {
+
+enum TestPhonemeType {
+  OpenJTalkPhonemes = 0,
+  MultilingualPhonemes = 1,
+  // Synthetic value for English-only tests
+  EnglishPhonemes = 99,
+};
+
+bool usesOpenJTalk(TestPhonemeType type) {
+  return type == OpenJTalkPhonemes || type == MultilingualPhonemes;
+}
+
+// ---- Mirror of piper.cpp isPunctCodepoint ----
+bool isPunctCodepoint(char32_t c) {
+  switch (c) {
+    case U'\u3002': case U'\u3001': case U'\uFF01': case U'\uFF1F':
+    case U'.': case U'!': case U'?': case U',': case U';': case U':':
+      return true;
+    default:
+      return false;
+  }
+}
+
+// ---- Mirror of piper.cpp calculateDynamicChunkSize ----
+size_t calculateDynamicChunkSize(const std::vector<char32_t>& cps,
+                                  size_t baseSize = 50) {
+  size_t cpLen = cps.size();
+  if (cpLen < baseSize * 2) return cpLen;
+  size_t punctCount = 0;
+  for (char32_t c : cps) {
+    if (isPunctCodepoint(c)) punctCount++;
+  }
+  float punctDensity = static_cast<float>(punctCount) / static_cast<float>(cpLen);
+  if (punctDensity > 0.05f) return baseSize;
+  if (punctDensity < 0.02f) return baseSize * 3;
+  return baseSize * 2;
+}
+
+// ---- Mirror of piper.cpp splitTextToSentences ----
+std::vector<std::string> splitTextToSentences(
+    const std::string &text,
+    TestPhonemeType phonemeType,
+    size_t maxChunkSize = 0) {
+
+  if (text.empty()) return {};
+
+  using piper::utf8_util::toCodepoints;
+  using piper::utf8_util::cpsToUtf8;
+
+  auto cps = toCodepoints(text);
+  size_t cpLen = cps.size();
+
+  size_t baseSize = maxChunkSize > 0 ? maxChunkSize : 50;
+  size_t dynamicChunkSize = calculateDynamicChunkSize(cps, baseSize);
+
+  auto isBoundaryPunct = [&](char32_t c) -> bool {
+    if (phonemeType == MultilingualPhonemes) {
+      return c == U'\u3002' || c == U'\uFF01' || c == U'\uFF1F' ||
+             c == U'.' || c == U'!' || c == U'?' ||
+             c == U'\u2026';
+    } else if (usesOpenJTalk(phonemeType)) {
+      return c == U'\u3002' || c == U'\uFF01' || c == U'\uFF1F' ||
+             c == U'\u3001';
+    } else {
+      return c == U'.' || c == U'!' || c == U'?' || c == U',' ||
+             c == U';' || c == U':';
+    }
+  };
+
+  auto isSentenceTerminator = [&](char32_t c) -> bool {
+    if (phonemeType == MultilingualPhonemes) {
+      return c == U'\u3002' || c == U'\uFF01' || c == U'\uFF1F' ||
+             c == U'.' || c == U'!' || c == U'?';
+    } else if (usesOpenJTalk(phonemeType)) {
+      return c == U'\u3002' || c == U'\uFF01' || c == U'\uFF1F';
+    } else {
+      return c == U'.' || c == U'!' || c == U'?';
+    }
+  };
+
+  std::vector<std::string> chunks;
+  size_t sentenceStart = 0;
+
+  for (size_t i = 0; i < cpLen; ++i) {
+    char32_t c = cps[i];
+    if (isBoundaryPunct(c)) {
+      bool hasTerminator = isSentenceTerminator(c);
+      size_t punctEnd = i + 1;
+      while (punctEnd < cpLen && isBoundaryPunct(cps[punctEnd])) {
+        if (isSentenceTerminator(cps[punctEnd])) hasTerminator = true;
+        punctEnd++;
+      }
+      i = punctEnd - 1;
+      size_t chunkLen = punctEnd - sentenceStart;
+      if (hasTerminator || chunkLen > dynamicChunkSize) {
+        std::string chunk = cpsToUtf8(cps, sentenceStart, chunkLen);
+        if (!chunk.empty()) chunks.push_back(chunk);
+        sentenceStart = punctEnd;
+      }
+    }
+  }
+
+  if (sentenceStart < cpLen) {
+    std::string remaining = cpsToUtf8(cps, sentenceStart, cpLen - sentenceStart);
+    if (!remaining.empty()) chunks.push_back(remaining);
+  }
+
+  return chunks;
+}
+
+} // anonymous namespace
+
+// ========================================================================
+// Issue #343 core regression: Japanese text must NOT be byte-shredded
+// ========================================================================
+
+TEST(SplitSentencesTest, JapaneseBasic) {
+  auto result = splitTextToSentences(
+      u8"こんにちは。今日はいい天気ですね。ありがとう！",
+      OpenJTalkPhonemes);
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_EQ(result[0], u8"こんにちは。");
+  EXPECT_EQ(result[1], u8"今日はいい天気ですね。");
+  EXPECT_EQ(result[2], u8"ありがとう！");
+}
+
+TEST(SplitSentencesTest, JapaneseQuestionMark) {
+  auto result = splitTextToSentences(
+      u8"元気ですか？はい、元気です。",
+      OpenJTalkPhonemes);
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0], u8"元気ですか？");
+  EXPECT_EQ(result[1], u8"はい、元気です。");
+}
+
+TEST(SplitSentencesTest, JapaneseCommaIsNotTerminator) {
+  // 、(ideographic comma) is boundary punct but NOT a sentence terminator
+  // for OpenJTalk. It should only split if chunk exceeds dynamicChunkSize.
+  auto result = splitTextToSentences(
+      u8"今日は、天気がいい。",
+      OpenJTalkPhonemes);
+  // Short text (10 codepoints), dynamicChunkSize = 10 (< 100)
+  // 、 is not a terminator, so no split there. 。 is terminator -> split.
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], u8"今日は、天気がいい。");
+}
+
+// ========================================================================
+// English text
+// ========================================================================
+
+TEST(SplitSentencesTest, EnglishBasic) {
+  auto result = splitTextToSentences(
+      "Hello world. This is a test. Multiple sentences here!",
+      EnglishPhonemes);
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_EQ(result[0], "Hello world.");
+  EXPECT_EQ(result[1], " This is a test.");
+  EXPECT_EQ(result[2], " Multiple sentences here!");
+}
+
+TEST(SplitSentencesTest, EnglishSingleSentence) {
+  auto result = splitTextToSentences(
+      "Just one sentence.",
+      EnglishPhonemes);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], "Just one sentence.");
+}
+
+TEST(SplitSentencesTest, EnglishCommaNotTerminator) {
+  // Commas are boundary punct but not terminators for English.
+  // Short text, so no split at comma.
+  auto result = splitTextToSentences(
+      "Hello, world.",
+      EnglishPhonemes);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], "Hello, world.");
+}
+
+// ========================================================================
+// Multilingual (MultilingualPhonemes)
+// ========================================================================
+
+TEST(SplitSentencesTest, MultilingualJapanese) {
+  auto result = splitTextToSentences(
+      u8"こんにちは。今日はいい天気ですね。",
+      MultilingualPhonemes);
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0], u8"こんにちは。");
+  EXPECT_EQ(result[1], u8"今日はいい天気ですね。");
+}
+
+TEST(SplitSentencesTest, MultilingualEnglish) {
+  auto result = splitTextToSentences(
+      "Hello. World!",
+      MultilingualPhonemes);
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0], "Hello.");
+  EXPECT_EQ(result[1], " World!");
+}
+
+TEST(SplitSentencesTest, MultilingualMixed) {
+  auto result = splitTextToSentences(
+      u8"こんにちは。Hello! 你好。",
+      MultilingualPhonemes);
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_EQ(result[0], u8"こんにちは。");
+  EXPECT_EQ(result[1], u8"Hello!");
+  EXPECT_EQ(result[2], u8" 你好。");
+}
+
+// ========================================================================
+// Chinese text
+// ========================================================================
+
+TEST(SplitSentencesTest, ChineseBasic) {
+  auto result = splitTextToSentences(
+      u8"你好。今天天气很好。谢谢！",
+      MultilingualPhonemes);
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_EQ(result[0], u8"你好。");
+  EXPECT_EQ(result[1], u8"今天天气很好。");
+  EXPECT_EQ(result[2], u8"谢谢！");
+}
+
+TEST(SplitSentencesTest, ChineseQuestionMark) {
+  auto result = splitTextToSentences(
+      u8"你好吗？我很好。",
+      MultilingualPhonemes);
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0], u8"你好吗？");
+  EXPECT_EQ(result[1], u8"我很好。");
+}
+
+// ========================================================================
+// Edge cases
+// ========================================================================
+
+TEST(SplitSentencesTest, EmptyText) {
+  auto result = splitTextToSentences("", OpenJTalkPhonemes);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(SplitSentencesTest, NoPunctuation) {
+  auto result = splitTextToSentences(
+      u8"こんにちは世界",
+      OpenJTalkPhonemes);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], u8"こんにちは世界");
+}
+
+TEST(SplitSentencesTest, OnlyPunctuation) {
+  auto result = splitTextToSentences(
+      u8"。！？",
+      OpenJTalkPhonemes);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], u8"。！？");
+}
+
+TEST(SplitSentencesTest, ConsecutivePunctuation) {
+  // Multiple terminators in a row should be consumed as one run
+  auto result = splitTextToSentences(
+      u8"本当に！？信じられない。",
+      OpenJTalkPhonemes);
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0], u8"本当に！？");
+  EXPECT_EQ(result[1], u8"信じられない。");
+}
+
+TEST(SplitSentencesTest, TrailingTextAfterPunctuation) {
+  auto result = splitTextToSentences(
+      u8"テスト。残りのテキスト",
+      OpenJTalkPhonemes);
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0], u8"テスト。");
+  EXPECT_EQ(result[1], u8"残りのテキスト");
+}
+
+TEST(SplitSentencesTest, SingleCharacter) {
+  auto result = splitTextToSentences(u8"あ", OpenJTalkPhonemes);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], u8"あ");
+}
+
+TEST(SplitSentencesTest, SinglePunctuation) {
+  auto result = splitTextToSentences(u8"。", OpenJTalkPhonemes);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], u8"。");
+}
+
+// ========================================================================
+// Issue #343 reproduction: the exact debug output from the bug report
+// ========================================================================
+
+TEST(SplitSentencesTest, Issue343Reproduction) {
+  // This text was reported to produce 13 broken byte fragments.
+  // After fix: should produce exactly 2 sentences.
+  std::string text = u8"こんにちは。今日はいい天気ですね。";
+  auto result = splitTextToSentences(text, OpenJTalkPhonemes);
+
+  ASSERT_EQ(result.size(), 2u)
+      << "Issue #343: text must NOT be byte-shredded into fragments";
+  EXPECT_EQ(result[0], u8"こんにちは。");
+  EXPECT_EQ(result[1], u8"今日はいい天気ですね。");
+
+  // Verify no fragment contains invalid UTF-8
+  for (size_t i = 0; i < result.size(); ++i) {
+    EXPECT_FALSE(result[i].empty())
+        << "Sentence " << i << " must not be empty";
+    // Each sentence should start with a valid multibyte character, not a
+    // bare continuation byte (0x80-0xBF).
+    unsigned char firstByte = static_cast<unsigned char>(result[i][0]);
+    EXPECT_FALSE(firstByte >= 0x80 && firstByte <= 0xBF)
+        << "Sentence " << i << " starts with a UTF-8 continuation byte (broken)";
+  }
+}
+
+TEST(SplitSentencesTest, Issue343MultilingualReproduction) {
+  // Same text but through MultilingualPhonemes path
+  std::string text = u8"こんにちは。今日はいい天気ですね。";
+  auto result = splitTextToSentences(text, MultilingualPhonemes);
+
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0], u8"こんにちは。");
+  EXPECT_EQ(result[1], u8"今日はいい天気ですね。");
+}
+
+// ========================================================================
+// Ellipsis handling (Multilingual mode)
+// ========================================================================
+
+TEST(SplitSentencesTest, MultilingualEllipsis) {
+  // U+2026 (…) is boundary punct but NOT a sentence terminator (consistent
+  // with the original regex which only checked 。！？.!? as terminators).
+  // Short text -> no split at ellipsis.
+  auto result = splitTextToSentences(
+      u8"そうですか…次の話題。",
+      MultilingualPhonemes);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], u8"そうですか…次の話題。");
+}
+
+TEST(SplitSentencesTest, AsciiEllipsis) {
+  auto result = splitTextToSentences(
+      "Really... I see.",
+      MultilingualPhonemes);
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0], "Really...");
+  EXPECT_EQ(result[1], " I see.");
+}
+
+// ========================================================================
+// calculateDynamicChunkSize codepoint-level tests
+// ========================================================================
+
+TEST(DynamicChunkSizeTest, ShortASCII) {
+  auto cps = piper::utf8_util::toCodepoints("Hello!");
+  EXPECT_EQ(calculateDynamicChunkSize(cps), 6u);
+}
+
+TEST(DynamicChunkSizeTest, ShortCJK) {
+  // 17 codepoints (not 51 bytes)
+  auto cps = piper::utf8_util::toCodepoints(u8"こんにちは。今日はいい天気ですね。");
+  EXPECT_EQ(cps.size(), 17u);
+  EXPECT_EQ(calculateDynamicChunkSize(cps), 17u);
+}
+
+TEST(DynamicChunkSizeTest, LowPunctDensity) {
+  // 110 codepoints (all ASCII), 1 period = ~0.9% density -> 3x base
+  std::string text = "This is a very long text with minimal punctuation that goes on and on without many stops or breaks in the flow";
+  auto cps = piper::utf8_util::toCodepoints(text);
+  EXPECT_EQ(calculateDynamicChunkSize(cps), 150u);
+}
+
+TEST(DynamicChunkSizeTest, HighPunctDensityCJK) {
+  // Build a long CJK text with high punctuation density (>100 codepoints).
+  // Each "X。" pair = 2 codepoints. We need > 100, so 52 pairs = 104 codepoints.
+  std::string text =
+      u8"あ。い。う。え。お。か。き。く。け。こ。"   // 20 cp
+      u8"さ。し。す。せ。そ。た。ち。つ。て。と。"   // 20 cp
+      u8"な。に。ぬ。ね。の。は。ひ。ふ。へ。ほ。"   // 20 cp
+      u8"ま。み。む。め。も。や。ゆ。よ。ら。り。"   // 20 cp
+      u8"る。れ。ろ。わ。を。ん。が。ぎ。ぐ。げ。"   // 20 cp
+      u8"ご。ざ。";                                     // 4 cp = 104 total
+  auto cps = piper::utf8_util::toCodepoints(text);
+  EXPECT_EQ(cps.size(), 104u);
+  // 52 periods out of 104 = 50% density > 5% -> should return baseSize (50)
+  size_t result = calculateDynamicChunkSize(cps);
+  EXPECT_EQ(result, 50u);
+}

--- a/src/cpp/tests/test_streaming_simple.cpp
+++ b/src/cpp/tests/test_streaming_simple.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <cstdint>
 
+#include "utf8_utils.hpp"
+
 // Simple test for streaming text chunking logic
 TEST(StreamingSimpleTest, TextChunkingEnglish) {
     std::string text = "Hello world. This is a test. Multiple sentences here!";
@@ -138,6 +140,7 @@ TEST(StreamingSimpleTest, SingleSentenceProducesOneChunk) {
 TEST(StreamingSimpleTest, DynamicChunkSizeCalculation) {
     // Codepoint-level helper that mirrors the fixed calculateDynamicChunkSize
     // in piper.cpp (Issue #343: byte-level was broken for CJK text).
+    using piper::utf8_util::toCodepoints;
     auto isPunctCodepoint = [](char32_t c) -> bool {
         switch (c) {
             case U'\u3002': case U'\u3001': case U'\uFF01': case U'\uFF1F':
@@ -145,19 +148,6 @@ TEST(StreamingSimpleTest, DynamicChunkSizeCalculation) {
                 return true;
             default: return false;
         }
-    };
-    auto toCodepoints = [](const std::string &s) -> std::vector<char32_t> {
-        std::vector<char32_t> cps;
-        for (size_t i = 0; i < s.size(); ) {
-            char32_t cp = 0;
-            unsigned char c = static_cast<unsigned char>(s[i]);
-            if (c < 0x80) { cp = c; i += 1; }
-            else if (c < 0xE0) { cp = (c & 0x1F) << 6 | (s[i+1] & 0x3F); i += 2; }
-            else if (c < 0xF0) { cp = (c & 0x0F) << 12 | (s[i+1] & 0x3F) << 6 | (s[i+2] & 0x3F); i += 3; }
-            else { cp = (c & 0x07) << 18 | (s[i+1] & 0x3F) << 12 | (s[i+2] & 0x3F) << 6 | (s[i+3] & 0x3F); i += 4; }
-            cps.push_back(cp);
-        }
-        return cps;
     };
     auto calculateDynamicChunkSize = [&](const std::string& text, size_t baseSize = 50) -> size_t {
         auto cps = toCodepoints(text);

--- a/src/cpp/tests/test_streaming_simple.cpp
+++ b/src/cpp/tests/test_streaming_simple.cpp
@@ -134,49 +134,64 @@ TEST(StreamingSimpleTest, SingleSentenceProducesOneChunk) {
     EXPECT_EQ(chunks[0], "This is a single sentence.");
 }
 
-// Test dynamic chunk size calculation
+// Test dynamic chunk size calculation (codepoint-based, mirrors piper.cpp)
 TEST(StreamingSimpleTest, DynamicChunkSizeCalculation) {
-    // Helper function to calculate dynamic chunk size (simplified version)
-    auto calculateDynamicChunkSize = [](const std::string& text, size_t baseSize = 50) -> size_t {
-        if (text.length() < baseSize * 2) {
-            return text.length();
+    // Codepoint-level helper that mirrors the fixed calculateDynamicChunkSize
+    // in piper.cpp (Issue #343: byte-level was broken for CJK text).
+    auto isPunctCodepoint = [](char32_t c) -> bool {
+        switch (c) {
+            case U'\u3002': case U'\u3001': case U'\uFF01': case U'\uFF1F':
+            case U'.': case U'!': case U'?': case U',': case U';': case U':':
+                return true;
+            default: return false;
         }
-        
+    };
+    auto toCodepoints = [](const std::string &s) -> std::vector<char32_t> {
+        std::vector<char32_t> cps;
+        for (size_t i = 0; i < s.size(); ) {
+            char32_t cp = 0;
+            unsigned char c = static_cast<unsigned char>(s[i]);
+            if (c < 0x80) { cp = c; i += 1; }
+            else if (c < 0xE0) { cp = (c & 0x1F) << 6 | (s[i+1] & 0x3F); i += 2; }
+            else if (c < 0xF0) { cp = (c & 0x0F) << 12 | (s[i+1] & 0x3F) << 6 | (s[i+2] & 0x3F); i += 3; }
+            else { cp = (c & 0x07) << 18 | (s[i+1] & 0x3F) << 12 | (s[i+2] & 0x3F) << 6 | (s[i+3] & 0x3F); i += 4; }
+            cps.push_back(cp);
+        }
+        return cps;
+    };
+    auto calculateDynamicChunkSize = [&](const std::string& text, size_t baseSize = 50) -> size_t {
+        auto cps = toCodepoints(text);
+        size_t cpLen = cps.size();
+        if (cpLen < baseSize * 2) return cpLen;
         size_t punctCount = 0;
-        const std::string punctMarks = u8"。、！？.!?,;:";
-        for (size_t i = 0; i < text.length(); ++i) {
-            if (punctMarks.find(text[i]) != std::string::npos) {
-                punctCount++;
-            }
-        }
-        
-        float punctDensity = static_cast<float>(punctCount) / text.length();
-        if (punctDensity > 0.05f) {
-            return baseSize;
-        } else if (punctDensity < 0.02f) {
-            return baseSize * 3;
-        }
+        for (char32_t c : cps) { if (isPunctCodepoint(c)) punctCount++; }
+        float punctDensity = static_cast<float>(punctCount) / static_cast<float>(cpLen);
+        if (punctDensity > 0.05f) return baseSize;
+        if (punctDensity < 0.02f) return baseSize * 3;
         return baseSize * 2;
     };
-    
-    // Test short text
+
+    // Test short ASCII text (12 codepoints < 100)
     std::string shortText = "Hello world!";
-    EXPECT_EQ(calculateDynamicChunkSize(shortText), shortText.length());
-    
-    // Test high punctuation density (text length is 46, so it returns length)
+    EXPECT_EQ(calculateDynamicChunkSize(shortText), 12u);
+
+    // Test short ASCII text with punctuation (46 codepoints < 100)
     std::string highPunctText = "Hello! How are you? I'm fine, thanks. And you?";
     size_t highPunctSize = calculateDynamicChunkSize(highPunctText);
-    EXPECT_EQ(highPunctSize, highPunctText.length()) << "Short text should return its length";
-    
+    EXPECT_EQ(highPunctSize, 46u) << "Short text should return codepoint count";
+
     // Test low punctuation density with longer text
     std::string lowPunctText = "This is a very long text with minimal punctuation that goes on and on without many stops or breaks in the flow";
     size_t lowPunctSize = calculateDynamicChunkSize(lowPunctText);
-    EXPECT_EQ(lowPunctSize, 150) << "Low punctuation density should use 3x base size";
-    
-    // Test medium punctuation density (text length is 65, so it returns length)
-    std::string mediumPunctText = "This is a normal text. It has some punctuation, but not too much.";
-    size_t mediumPunctSize = calculateDynamicChunkSize(mediumPunctText);
-    EXPECT_EQ(mediumPunctSize, mediumPunctText.length()) << "Short text should return its length";
+    EXPECT_EQ(lowPunctSize, 150u) << "Low punctuation density should use 3x base size";
+
+    // Test Japanese text: codepoint count should be used, not byte count
+    // "こんにちは。今日はいい天気ですね。" = 17 codepoints (< 100), should return 17
+    std::string jaText = u8"こんにちは。今日はいい天気ですね。";
+    auto jaCps = toCodepoints(jaText);
+    EXPECT_EQ(jaCps.size(), 17u) << "Japanese text should have 17 codepoints";
+    size_t jaSize = calculateDynamicChunkSize(jaText);
+    EXPECT_EQ(jaSize, 17u) << "Short CJK text should return codepoint count, not byte count";
 }
 
 // Test crossfade functionality


### PR DESCRIPTION
## Summary

- `splitTextToSentences()` が `std::regex` の `sregex_token_iterator` をバイトレベルで操作していたため、日本語等マルチバイト UTF-8 テキストが壊れたバイト断片に分割され `--output-raw --streaming` で 0 バイト出力になっていた問題を修正
- `calculateDynamicChunkSize()` もバイト長からコードポイント数ベースに変更
- 不要になった `#include <regex>` を削除

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `src/cpp/piper.cpp` | `splitTextToSentences()` を `utf8_utils.hpp` のコードポイントベース実装に置換、`calculateDynamicChunkSize()` をコードポイント数ベースに変更、`isPunctCodepoint()` ヘルパー追加、`#include <regex>` 削除 |
| `src/cpp/tests/test_split_sentences.cpp` | 新規 26 テスト (JA/EN/ZH/多言語混合/エッジケース/Issue #343 再現) |
| `src/cpp/tests/test_streaming_simple.cpp` | `DynamicChunkSizeCalculation` をコードポイントベースに更新 |
| `src/cpp/tests/CMakeLists.txt` | `test_split_sentences` 追加 + include パス設定 |

## Test plan

- [x] `test_split_sentences` 26 テスト全 PASS (ONNX Runtime 不要の軽量テスト)
- [x] `test_streaming_simple` 11 テスト全 PASS (既存テストのリグレッションなし)
- [ ] CI で全 C++ テストが PASS すること
- [ ] `--output-raw --streaming` で日本語テキストが正常に合成されること

Closes #343
Related: #346 (CJK 閉じ括弧対応は別 Issue)