### PR TITLE
fix(wavlm): safetensors 未公開モデルに合わせて use_safetensors=False に変更

### DIFF
--- a/src/python/piper_train/vits/models.py
+++ b/src/python/piper_train/vits/models.py
@@ -590,8 +590,11 @@ class WavLMDiscriminator(torch.nn.Module):
         self.source_sample_rate = source_sample_rate
         self.hidden_size = 768  # WavLM base hidden size
 
-        # microsoft/wavlm-base-plus publishes pytorch_model.bin, not safetensors.
-        self.wavlm = WavLMModel.from_pretrained(model_name, use_safetensors=False)
+        # Let transformers pick whichever weight file the configured model ships
+        # (microsoft/wavlm-base-plus has only pytorch_model.bin; custom models may
+        # ship safetensors). Previously hard-coded use_safetensors=True broke the
+        # default model.
+        self.wavlm = WavLMModel.from_pretrained(model_name)
 
         # Enable gradient checkpointing for memory efficiency
         self.wavlm.gradient_checkpointing_enable()

--- a/src/python/piper_train/vits/models.py
+++ b/src/python/piper_train/vits/models.py
@@ -590,8 +590,8 @@ class WavLMDiscriminator(torch.nn.Module):
         self.source_sample_rate = source_sample_rate
         self.hidden_size = 768  # WavLM base hidden size
 
-        # Load WavLM model (use safetensors for compatibility with torch < 2.6)
-        self.wavlm = WavLMModel.from_pretrained(model_name, use_safetensors=True)
+        # microsoft/wavlm-base-plus publishes pytorch_model.bin, not safetensors.
+        self.wavlm = WavLMModel.from_pretrained(model_name, use_safetensors=False)
 
         # Enable gradient checkpointing for memory efficiency
         self.wavlm.gradient_checkpointing_enable()


### PR DESCRIPTION
## Summary

- `WavLMDiscriminator` の `WavLMModel.from_pretrained(..., use_safetensors=True)` を `use_safetensors=False` に修正
- `microsoft/wavlm-base-plus` は `pytorch_model.bin` のみ公開しており、safetensors ファイルは存在しない ([HuggingFace siblings 参照](https://huggingface.co/api/models/microsoft/wavlm-base-plus))
- 現状 `use_safetensors=True` のままだと、WavLM 有効時 (`--no-wavlm` を付けない学習) に読み込みエラーとなる潜在バグ

## 背景

fork 調査中に [`yusuke-ai/piper-plus` の feature/2026-04-14-2312-peav-style-conditioning ブランチ](https://github.com/yusuke-ai/piper-plus/commits/feature/2026-04-14-2312-peav-style-conditioning/) で同一の修正が含まれているのを発見。該当ファイル/行は `src/python/piper_train/vits/models.py:594`。

このブランチは style conditioning 等の大きな機能追加も含むが、WavLM の safetensors 修正のみは独立して価値がある最小修正のため、本 PR で取り込む。

## Test plan

- [x] 差分は1ファイル2行のみ (コメント1行 + コード1行)
- [ ] `microsoft/wavlm-base-plus` の HuggingFace Hub 上のファイル一覧で `pytorch_model.bin` のみ存在 / `model.safetensors` が存在しないことを再確認
- [ ] `--no-wavlm` なしで学習開始し、以前エラーになっていたモデル読み込みが成功することを確認 (CI では `--no-wavlm` 前提のため手動確認推奨)