### PR TITLE
docs(readme): 「30秒で試す」を OS 別ワンライナー化 + CLI バイナリ選択ガイド追加 (#359)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
 - [使い方](#使い方)
 - [学習](#学習)
 - [事前学習済みモデル](#事前学習済みモデル)
-- [日本語 TTS](#日本語-tts)
 - [プラットフォーム](#プラットフォーム)
 - [関連リンク](#関連リンク)
 
@@ -86,28 +85,7 @@
 
 ### ランタイム別機能サポート
 
-| 機能 | Python | Rust | C++ | C# | Go | WASM/JS |
-|---|---|---|---|---|---|---|
-| 多言語 TTS (8言語) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **音素タイミング (JSON/TSV/SRT)** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| ストリーミング合成 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Voice Cloning | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| SSML サポート | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| HTTP API サーバー | ✅ | ❌ | ❌ | ❌ | ✅ | N/A |
-| カスタム辞書 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-
-### プラットフォーム
-
-| プラットフォーム | アーキテクチャ | 備考 |
-|---|---|---|
-| Linux | x86_64 / ARM64 / ARMv7 | フルサポート |
-| macOS | ARM64 (Apple Silicon) のみ | M1/M2/M3+ |
-| Windows | x64 | フルサポート |
-| C API (FFI) | Linux x64/ARM64, macOS ARM64, Windows x64 | 共有ライブラリ、Android AAR |
-| Web | WebAssembly | Chrome/Edge/Firefox/Safari |
-| C# (.NET) | x64 / ARM64 | .NET 8/9、Linux/macOS/Windows |
-| Rust | Linux x64, macOS ARM64, Windows x64 | Linux/macOS/Windows、CUDA/CoreML/DirectML |
-| Go | Linux x64, macOS ARM64, Windows x64 | Linux/macOS/Windows、HTTP API、Docker |
+6 ランタイム (Python/Rust/C#/Go/JS-WASM/C++) で同等の8言語マルチリンガル合成を実現。音素タイミング・ストリーミング・Voice Cloning・カスタム辞書は全ランタイム対応。SSML は Python/Rust/C#/Go の4ランタイム対応、HTTP API は Python/Go の2ランタイム対応。
 
 ---
 
@@ -320,428 +298,45 @@ dotnet add package PiperPlus.Core
 piper-plus = "0.2.0"
 ```
 
-### ソースからビルド (C++)
+### ソースからビルド
 
-```bash
-git clone https://github.com/ayutaz/piper-plus.git
-cd piper-plus
-mkdir build && cd build
-cmake ..
-cmake --build . --config Release
-```
-
-前提条件: C++17対応コンパイラ、CMake 3.15+
-
-- **Linux**: 依存関係 (ONNX Runtime, OpenJTalk 等) は CMake が自動ダウンロード
-- **Windows**: [Windows セットアップガイド](docs/getting-started/windows-setup.md) を参照
-- **macOS**: 依存関係は自動ダウンロード
-
-### ソースからビルド (C#)
-
-```bash
-# C# CLI ビルド
-dotnet build src/csharp/PiperPlus.sln -c Release
-# テスト
-dotnet test src/csharp/PiperPlus.Core.Tests/
-```
-
-前提条件: .NET 8 SDK 以上
-
-#### C# CLI 使用例
-
-```bash
-# モデル名で推論 (自動ダウンロード対応、--output-file 省略で output.wav に出力)
-piper-plus --model tsukuyomi --text "こんにちは" --language ja
-
-# 英語
-piper-plus --model model.onnx --text "Hello world" --language en
-
-# マルチリンガル (自動言語検出)
-piper-plus --model model.onnx --text "こんにちはHello你好" --language ja-en-zh
-
-# インライン音素記法 (テキスト中に直接音素を指定)
-piper-plus --model model.onnx --text "Hello [[ h ə l oʊ ]] world" --language en
-
-# ストリーミング (文ごとに逐次PCM出力)
-piper-plus --model model.onnx --text "最初の文。次の文。" --language ja --streaming | aplay -r 22050 -f S16_LE
-
-# カスタム辞書 (JSON v1/v2 または TSV)
-piper-plus --model model.onnx --text "AI技術" --language ja --custom-dict my_dict.json
-
-# モデルダウンロード
-piper-plus --download-model tsukuyomi
-piper-plus --list-models ja
-
-# テストモード (ONNX推論なしで phoneme IDs を確認)
-piper-plus --model model.onnx --test-mode --text "こんにちは" --language ja
-```
-
-#### Rust CLI 使用例
-
-```bash
-# モデル名で推論 (自動ダウンロード対応)
-piper-plus-cli --model tsukuyomi --text "こんにちは" --language ja
-
-# 英語
-piper-plus-cli --model model.onnx --text "Hello world" --language en
-
-# モデルダウンロード・管理
-piper-plus-cli --download-model tsukuyomi
-piper-plus-cli --list-models ja
-
-# ストリーミング (文ごとに逐次合成)
-piper-plus-cli --model model.onnx --text "First sentence. Second sentence." --stream --output-dir chunks/
-
-# カスタム辞書
-piper-plus-cli --model model.onnx --text "AI技術" --custom-dict my_dict.json
-
-# GPU推論
-piper-plus-cli --model model.onnx --text "Hello" --device cuda
-
-# テストモード・静音モード
-piper-plus-cli --model model.onnx --test-mode --text "hello" --language en
-piper-plus-cli --model model.onnx --text "hello" --language en --quiet
-
-# raw PCM出力 (WAVヘッダなし)
-piper-plus-cli --model model.onnx --text "hello" --language en --output-raw | aplay -r 22050 -f S16_LE
-```
-
-> **Note:** C# CLI は `dotnet tool install -g PiperPlus.Cli` で、Rust CLI は `cargo install piper-plus-cli` でインストールできます。両方とも8言語対応・カスタム辞書・ストリーミングをサポートしています。
-
-### ソースからビルド (Rust)
-
-```bash
-# Rust CLI ビルド
-cargo build --release -p piper-plus-cli
-# テスト
-cargo test -p piper-plus
-```
-
-前提条件: Rust 1.88+、cargo
+プリビルドバイナリが提供されていないプラットフォームで使う場合や piper-plus を改変したい場合は、ソースからビルドできます。C++ / C# / Rust の各ランタイムのビルド手順は **[ソースからのビルドガイド](docs/guides/building-from-source.md)** を参照してください。
 
 ---
 
 ## 使い方
 
-### C++ CLI
+C++ CLI の詳細なコマンドラインオプション、JSON 入力フォーマット、モデル管理、環境変数、Windows ヘルパースクリプトの使い方は **[CLI 使用ガイド](docs/guides/cli-usage.md)** を参照してください。
 
-#### テキスト直接入力 (推奨)
-
-`--text` オプションでパイプなしにテキストを直接入力できます:
-
-```sh
-# テキストから音声生成
-./bin/piper --model model.onnx --text "Hello, how are you?" -f output.wav
-
-# 日本語テキスト (Windowsでのエンコーディング問題を回避)
-bin\piper.exe --model models\tsukuyomi.onnx --text "こんにちは、今日は良い天気ですね。" -f output.wav
-
-# 話者指定
-./bin/piper --model model.onnx --text "Hello" --speaker 3 -f output.wav
-```
-
-#### パイプ入力
-
-```sh
-# 基本
-echo "こんにちは" | ./bin/piper --model ja_model.onnx --output_file output.wav
-
-# ストリーミング (低レイテンシ)
-echo "長いテキスト..." | ./bin/piper --model ja_model.onnx --output_file output.wav --streaming
-
-# GPU推論
-echo "Hello" | ./bin/piper --model en_model.onnx --use-cuda --output_file output.wav
-
-# 音素タイミング出力 (リップシンク・字幕同期用)
-echo "Hello world" | ./bin/piper --model en_model.onnx -f speech.wav --output-timing timing.json
-
-# カスタム辞書
-echo "DockerとGitHubを使います" | ./bin/piper --model ja_model.onnx --custom-dict my_dict.json -f output.wav
-
-# インライン音素入力
-echo 'Hello [[ h ə l oʊ ]] world' | ./bin/piper --model en_model.onnx -f output.wav
-
-# 生の音素入力
-echo 'h ə l oʊ _ w ɜː l d' | ./bin/piper --model en_model.onnx --raw-phonemes -f output.wav
-
-# ストリーミング (raw audio 出力)
-echo 'Long text...' | ./bin/piper --model en_model.onnx --output-raw | \
-  aplay -r 22050 -f S16_LE -t raw -
-```
-
-主なオプション:
-
-| オプション | 説明 | デフォルト |
-|---|---|---|
-| `--model PATH\|NAME` | モデルファイルのパス、またはモデル名 (ダウンロード済みモデルを自動解決) | - |
-| `--text TEXT` | テキスト直接入力 (パイプ不要) | - |
-| `--streaming` | チャンクベースのストリーミングモード | off |
-| `--use-cuda` | CUDA GPU推論を有効化 | off |
-| `--gpu-device-id NUM` | GPU デバイスID | 0 |
-| `--length-scale VAL` | 話速調整 (小さい=速い) | 1.0 |
-| `--noise-scale VAL` | 音声バリエーション制御 | 0.667 |
-| `--noise-w VAL` | 音素長バリエーション制御 | 0.8 |
-| `--sentence-silence SEC` | 文間の無音 (秒) | 0.2 |
-| `--speaker NUM` | マルチスピーカーモデルの話者番号 | 0 |
-| `--phoneme-silence PHONEME SEC` | 特定音素の無音時間設定 | - |
-| `--raw-phonemes` | 入力を音素として解釈 | off |
-| `--output-timing FILE` | 音素タイミング情報をファイル出力 (JSON/TSV) | - |
-| `--custom-dict FILE` | カスタム辞書 (カンマ区切りで複数指定可) | - |
-| `--json-input` | JSON入力モード | off |
-| `--list-models [LANG]` | 利用可能なモデル一覧を表示 | - |
-| `--download-model NAME` | モデルをダウンロード | - |
-| `--model-dir DIR` | モデルのダウンロード先ディレクトリ | - |
-| `--version` | バージョン表示 | - |
-| `--config PATH` / `-c` | 設定ファイルパス | - |
-| `--output_file PATH` / `-f` | 出力WAVファイルパス | - |
-| `--output_dir PATH` / `-d` | 出力ディレクトリ | - |
-| `--output-raw` | raw PCM音声を標準出力に出力 | off |
-| `--language LANG` / `-l` | 言語コード | - |
-| `--timing-format FMT` | タイミング出力形式 (json/tsv) | json |
-| `--test-mode` | テストモード (ONNX推論スキップ) | off |
-| `--debug` | デバッグログ有効化 | off |
-| `--quiet` / `-q` | ログ無効化 | off |
-
-`piper --help` で全オプションを確認できます。
-
-> **WavLMモデルの推奨設定:** WavLM Discriminatorで学習されたモデルは `--noise-scale 0.5` を推奨します (デフォルトは 0.667)。
->
-> ```sh
-> echo "こんにちは" | ./bin/piper --model tsukuyomi.onnx --config config.json --noise-scale 0.5 -f output.wav
-> ```
-
-### JSON入力
-
-`--json-input` フラグでJSON入力を受け付けます:
-
-```json
-{ "text": "First speaker.", "speaker_id": 0, "output_file": "/tmp/speaker_0.wav" }
-{ "text": "Second speaker.", "speaker_id": 1, "output_file": "/tmp/speaker_1.wav" }
-```
-
-### モデル管理
-
-#### モデル一覧の表示
+簡単な使用例:
 
 ```bash
-# 利用可能なモデル一覧を表示
-./bin/piper --list-models
-
-# 言語でフィルタリング
-./bin/piper --list-models ja
-./bin/piper --list-models en
-```
-
-#### モデルのダウンロード
-
-```bash
-# モデル名を指定してダウンロード (エイリアスも使用可能)
-./bin/piper --download-model tsukuyomi
-./bin/piper --download-model en_US-lessac-medium
-
-# ダウンロード先ディレクトリを指定
-./bin/piper --download-model tsukuyomi --model-dir /path/to/models
-
-# ダウンロード後、モデル名で推論 (フルパス不要)
-./bin/piper --model tsukuyomi --text "こんにちは"
-```
-
-### 環境変数 (C++ CLI)
-
-| 変数名 | 説明 | 例 |
-|---|---|---|
-| `PIPER_DEFAULT_MODEL` | `--model` 未指定時のデフォルトモデルパス | `/path/to/model.onnx` |
-| `PIPER_DEFAULT_CONFIG` | `--config` 未指定時のデフォルト設定ファイルパス | `/path/to/config.json` |
-| `PIPER_MODEL_DIR` | ダウンロードモデルの保存先ディレクトリ | `~/.local/share/piper/models` |
-| `PIPER_GPU_DEVICE_ID` | CUDA GPUデバイスID | `0` |
-
-### ヘルパースクリプト (Windows)
-
-Windows ユーザー向けに `scripts/` ディレクトリにヘルパースクリプトを提供しています。
-
-**PowerShell:**
-
-```powershell
-.\scripts\speak.ps1 "こんにちは、今日は良い天気ですね。"
-.\scripts\speak.ps1 -Model "models\tsukuyomi.onnx" -Text "テスト"
-```
-
-**コマンドプロンプト:**
-
-```cmd
-scripts\speak.bat "こんにちは、今日は良い天気ですね。"
-scripts\speak.bat --model models\tsukuyomi.onnx "テスト"
+./bin/piper --model tsukuyomi --text "こんにちは" --output_file hello.wav
 ```
 
 ---
 
 ## 学習
 
-詳細は [学習ガイド](docs/guides/training/training-guide.md) を参照。
+ピパープラスモデルの学習・ファインチューニング方法 (基本設定、マルチスピーカー / マルチ GPU、ONNX 変換、チェックポイント管理、音声評価) は **[学習ガイド](docs/guides/training.md)** を参照してください。
 
-### 基本
-
-```bash
-uv pip install ".[train]"
-
-uv run python -m piper_train \
-  --dataset-dir /path/to/dataset \
-  --accelerator gpu --devices 1 --precision 16-mixed \
-  --max_epochs 200 --batch-size 16 \
-  --quality medium \
-  --prosody-dim 16 \
-  --ema-decay 0.9995
-```
-
-### マルチスピーカー・マルチGPU
-
-```bash
-NCCL_DEBUG=WARN NCCL_P2P_DISABLE=1 NCCL_IB_DISABLE=1 \
-uv run python -m piper_train \
-  --dataset-dir /path/to/dataset \
-  --prosody-dim 16 \
-  --accelerator gpu --devices 4 --precision 16-mixed \
-  --max_epochs 200 --batch-size 12 --samples-per-speaker 2 \
-  --checkpoint-epochs 1 --quality medium \
-  --base_lr 2e-4 --disable_auto_lr_scaling \
-  --ema-decay 0.9995
-```
-
-マルチGPUでは DDP (Distributed Data Parallel) が自動設定されます。NCCL環境変数の設定が必要です。詳細はマルチGPU学習ガイドを参照。
-
-### ONNX変換
-
-デフォルトでFP16変換が適用され、モデルサイズが約50%削減されます。`--no-fp16` で無効化可能。数値安定性のため LayerNormalization, Sigmoid, Softmax は FP32 のまま保持されます。
-
-```bash
-# 標準モデル (FP16出力)
-CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
-  /path/to/checkpoint.ckpt /path/to/output.onnx
-
-# FP32出力
-CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
-  --no-fp16 /path/to/checkpoint.ckpt /path/to/output.onnx
-
-# deterministic エクスポート (デバッグ用)
-CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
-  --no-stochastic /path/to/checkpoint.ckpt /path/to/output.onnx
-```
-
-### チェックポイント管理
-
-- `--resume_from_checkpoint` — チェックポイントからの学習再開
-- `--resume_from_single_speaker_checkpoint` — シングルスピーカーモデルからマルチスピーカーへの変換
-- `--resume-from-multispeaker-checkpoint` — マルチスピーカーからシングルスピーカーへの転移学習 (自動で `--freeze-dp` 有効化)
-
-### 音声評価
-
-`scripts/evaluation/` に評価用テストテキストがあります。
+実運用向けの 6 言語事前学習・つくよみちゃんファインチューニングのコマンドテンプレートは [CLAUDE.md](CLAUDE.md) にあります。
 
 ---
 
 ## 事前学習済みモデル
 
-推論用の音声合成モデルを Hugging Face で公開しています。
+公開されている piper-plus モデルの一覧、ダウンロード方法、6 言語ベースモデルの特徴、日本語 TTS の詳細は **[モデルガイド](docs/guides/pretrained-models.md)** を参照してください。
 
-**推論用モデル (すぐに使えます):**
-
-| モデル | 言語 | 話者数 | 説明 | ダウンロード |
-|---|---|---|---|---|
-| つくよみちゃん 6lang | JA/EN/ZH/ES/FR/PT | 1 | つくよみちゃん音声、6言語対応、FP16 | [HuggingFace](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan) |
-| CSS10 日本語 6lang | JA/EN/ZH/ES/FR/PT | 1 | CSS10日本語音声、6言語対応、FP16 | [HuggingFace](https://huggingface.co/ayousanz/piper-plus-css10-ja-6lang) |
-
-**学習用ベースモデル (ファインチューニング用):**
-
-| モデル | 言語 | 話者数 | 説明 | ダウンロード |
-|---|---|---|---|---|
-| 6言語ベースモデル | JA/EN/ZH/ES/FR/PT | 571 | マルチリンガル事前学習済み (508,187発話, VITS + Prosody) | [HuggingFace](https://huggingface.co/ayousanz/piper-plus-base) |
-
-### モデルのダウンロード
-
-**つくよみちゃんモデル:**
-
-**Windows (PowerShell):**
-
-```powershell
-mkdir models
-Invoke-WebRequest -Uri "https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/tsukuyomi-chan-6lang-fp16.onnx" -OutFile models/tsukuyomi.onnx
-Invoke-WebRequest -Uri "https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/config.json" -OutFile models/config.json
-```
-
-**macOS / Linux:**
-
-```bash
-mkdir -p models
-curl -L -o models/tsukuyomi.onnx https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/tsukuyomi-chan-6lang-fp16.onnx
-curl -L -o models/config.json https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/config.json
-```
-
-### 6言語ベースモデルの特徴 (学習用)
-
-- アーキテクチャ: VITS + Prosody Features
-- 学習データ: 508,187発話 (571話者, 6言語)
-- サンプリングレート: 22,050 Hz
-- シンボル数: 173
-- Prosody Features: A1/A2/A3 韻律情報 (日本語)
-- 言語グループ均等サンプリング: 自動有効化
-
-**対応言語:**
-
-| 言語 | コード | language_id | 話者数 | 発話数 | ソース |
-|---|---|---|---|---|---|
-| 日本語 | ja | 0 | 20 | 60,148 | MOE-Speech |
-| 英語 | en | 1 | 310 | 74,912 | LibriTTS-R |
-| 中国語 | zh | 2 | 142 | 63,223 | AISHELL-3 |
-| スペイン語 | es | 3 | 63 | 168,374 | CML-TTS |
-| フランス語 | fr | 4 | 28 | 107,464 | CML-TTS |
-| ポルトガル語 | pt | 5 | 8 | 34,066 | CML-TTS |
-
-> **Note:** piper-plus は独自のアーキテクチャ拡張 (多言語埋め込み、Prosody A1/A2/A3、173シンボル) を行っているため、upstream Piper のチェックポイント/ONNXモデルとの互換性はありません。piper-plus 専用のモデルをご利用ください。
-
----
-
-## 日本語 TTS
-
-OpenJTalk 統合による高品質な日本語音声合成。辞書・ボイスファイルは初回実行時に自動ダウンロードされます。
-
-**環境変数 (オプション):**
-
-| 変数名 | 説明 |
-|---|---|
-| `OPENJTALK_DICTIONARY_PATH` | OpenJTalk辞書パス (未設定時は自動ダウンロード) |
-| `PIPER_AUTO_DOWNLOAD_DICT` | `0` で自動ダウンロード無効化 |
-| `PIPER_OFFLINE_MODE` | `1` でオフラインモード |
-
-詳細は日本語音声合成ガイドおよび [音素マッピングリファレンス](docs/api-reference/phoneme-mapping.md) を参照。
+主要モデル: `tsukuyomi` (日本語), `multilingual-6lang` (8 言語ベース), `bilingual-ja-en-v4` (日英 2 言語) — 詳細は HuggingFace の [ayousanz/piper-plus-base](https://huggingface.co/ayousanz/piper-plus-base) や [ayousanz/piper-plus-tsukuyomi-chan](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan) を参照。
 
 ---
 
 ## プラットフォーム
 
-### macOS
-
-**Apple Silicon (M1/M2/M3+) のみサポート。** Intel Mac は Docker またはソースビルドをご利用ください。
-
-初回実行時のセキュリティ警告:
-
-```bash
-xattr -cr piper/
-```
-
-### Windows
-
-詳細は [Windows セットアップガイド](docs/getting-started/windows-setup.md) を参照。
-
-```cmd
-piper.exe --model model.onnx -f output.wav
-```
-
-### WebAssembly
-
-ブラウザで直接動作する日本語 TTS。サーバー不要、オフライン対応。
-
-- **[オンラインデモ](https://ayutaz.github.io/piper-plus/)**
-- **[技術詳細・統合ガイド](src/wasm/openjtalk-web/README.npm.md)**
+- **macOS**: Apple Silicon (arm64) ネイティブ対応。詳細は [macOS セットアップ](docs/getting-started/binary-selection.md#macos-開発元を確認できないため開けません) 参照
+- **Windows**: x64 / arm64 対応。OpenJTalk セットアップは [Windows セットアップガイド](docs/getting-started/windows-setup.md)
+- **WebAssembly**: ブラウザで完全オフライン実行。[デモ](https://ayutaz.github.io/piper-plus/) | [npm パッケージ](https://www.npmjs.com/package/piper-plus)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ OS に合わせて以下をコピペで実行してください。約30秒で音
 ```bash
 curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-macos-arm64.tar.gz | tar xz
 cd piper
-./piper --download-model tsukuyomi
-./piper --model tsukuyomi --text "こんにちは" -f hello.wav
+./bin/piper --download-model tsukuyomi
+./bin/piper --model tsukuyomi --text "こんにちは" -f hello.wav
 ```
 
 #### Linux (x86_64)
@@ -54,8 +54,8 @@ cd piper
 ```bash
 curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-x64.tar.gz | tar xz
 cd piper
-./piper --download-model tsukuyomi
-./piper --model tsukuyomi --text "こんにちは" -f hello.wav
+./bin/piper --download-model tsukuyomi
+./bin/piper --model tsukuyomi --text "こんにちは" -f hello.wav
 ```
 
 #### Linux (ARM64, Raspberry Pi 4/5 等)
@@ -63,8 +63,8 @@ cd piper
 ```bash
 curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz | tar xz
 cd piper
-./piper --download-model tsukuyomi
-./piper --model tsukuyomi --text "こんにちは" -f hello.wav
+./bin/piper --download-model tsukuyomi
+./bin/piper --model tsukuyomi --text "こんにちは" -f hello.wav
 ```
 
 #### Windows (PowerShell)
@@ -73,8 +73,8 @@ cd piper
 Invoke-WebRequest "https://github.com/ayutaz/piper-plus/releases/latest/download/piper-windows-x64.zip" -OutFile piper.zip
 Expand-Archive piper.zip -DestinationPath .
 cd piper
-.\piper.exe --download-model tsukuyomi
-.\piper.exe --model tsukuyomi --text "こんにちは" -f hello.wav
+.\bin\piper.exe --download-model tsukuyomi
+.\bin\piper.exe --model tsukuyomi --text "こんにちは" -f hello.wav
 ```
 
 > **どのバイナリを選べばよい？** Releases には `piper-*` (C++) のほか、`piper-plus-cli-*` (C# .NET) と `piper-plus-rs-cli-*` (Rust) のCLIもあります。Quick Start で使っている **C++ CLI (`piper-*`)** が最も多くのプラットフォームに対応していて推奨です。詳しくは [CLIバイナリの選び方](docs/getting-started/binary-selection.md) を参照。

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
 
 ## 目次
 
-- [30秒で試す](#30秒で試す)
 - [ベンチマーク](#ベンチマーク)
 - [主要機能](#主要機能)
 - [クイックスタート](#クイックスタート)
@@ -33,100 +32,6 @@
 - [関連リンク](#関連リンク)
 
 ---
-
-## 30秒で試す
-
-### 方法1: プリビルドバイナリ (推奨)
-
-OS に合わせて以下をコピペで実行してください。約30秒で音声合成が動きます。
-
-#### macOS (Apple Silicon, M1/M2/M3 以降)
-
-```bash
-curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-macos-arm64.tar.gz | tar xz
-cd piper
-./bin/piper --download-model tsukuyomi
-./bin/piper --model tsukuyomi --text "こんにちは" -f hello.wav
-```
-
-#### Linux (x86_64)
-
-```bash
-curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-x64.tar.gz | tar xz
-cd piper
-./bin/piper --download-model tsukuyomi
-./bin/piper --model tsukuyomi --text "こんにちは" -f hello.wav
-```
-
-#### Linux (ARM64, Raspberry Pi 4/5 等)
-
-```bash
-curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz | tar xz
-cd piper
-./bin/piper --download-model tsukuyomi
-./bin/piper --model tsukuyomi --text "こんにちは" -f hello.wav
-```
-
-#### Windows (PowerShell)
-
-```powershell
-Invoke-WebRequest "https://github.com/ayutaz/piper-plus/releases/latest/download/piper-windows-x64.zip" -OutFile piper.zip
-Expand-Archive piper.zip -DestinationPath .
-cd piper
-.\bin\piper.exe --download-model tsukuyomi
-.\bin\piper.exe --model tsukuyomi --text "こんにちは" -f hello.wav
-```
-
-> **どのバイナリを選べばよい？** Releases には `piper-*` (C++) のほか、`piper-plus-cli-*` (C# .NET) と `piper-plus-rs-cli-*` (Rust) のCLIもあります。Quick Start で使っている **C++ CLI (`piper-*`)** が最も多くのプラットフォームに対応していて推奨です。詳しくは [CLIバイナリの選び方](docs/getting-started/binary-selection.md) を参照。
-
-### 方法2: Python
-
-```bash
-pip install piper-plus
-uv run python -c "from piper_plus import PiperPlus; PiperPlus('tsukuyomi').tts_to_file('こんにちは', 'hello.wav')"
-```
-
-<details>
-<summary>CLI でも利用できます</summary>
-
-```bash
-pip install piper-tts-plus
-python -m piper --download-model tsukuyomi
-python -m piper --model tsukuyomi --text "こんにちは" -f hello.wav
-```
-
-</details>
-
-### 方法3: ブラウザ (インストール不要)
-
-**[WebAssembly デモを開く →](https://ayutaz.github.io/piper-plus/)**
-
-npm で自分のアプリに組み込むこともできます:
-
-```js
-import { PiperPlus } from "piper-plus";
-const piper = await PiperPlus.initialize("tsukuyomi");
-const audio = await piper.synthesize("Hello, world!");
-audio.play();
-```
-
-> **Note:** npm パッケージはブラウザ専用です。Node.js 環境では Python または Rust CLI をお使いください。
-
-<details>
-<summary>🔊 サンプル音声を聴く</summary>
-
-| 言語 | テキスト | 音声 |
-|------|---------|------|
-| 日本語 | こんにちは、つくよみちゃんです。 | [再生](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/ja.wav) |
-| English | Hello, how are you today? | [再生](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/en.wav) |
-| 中文 | 你好，今天天气很好。 | [再生](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/zh.wav) |
-| Español | ¿Hola, cómo estás hoy? | [再生](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/es.wav) |
-| Français | Bonjour, comment allez-vous? | [再生](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/fr.wav) |
-| Português | Olá, como você está hoje? | [再生](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/pt.wav) |
-
-> サンプル音声は [ayousanz/piper-plus-tsukuyomi-chan](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan) モデルで生成されています。
-
-</details>
 
 ## ベンチマーク
 
@@ -208,8 +113,6 @@ audio.play();
 
 ## クイックスタート
 
-> 💡 初めての方は [30秒で試す](#30秒で試す) セクションから始めることをお勧めします。
-
 ### プリビルドバイナリ (ビルド不要)
 
 [GitHub Releases](https://github.com/ayutaz/piper-plus/releases) からプリビルドバイナリをダウンロードして、すぐに音声合成を開始できます。
@@ -243,6 +146,14 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
+**Linux (ARM64, Raspberry Pi 4/5):**
+
+```bash
+curl -L -o piper.tar.gz https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz
+tar xzf piper.tar.gz
+cd piper
+```
+
 **2. モデルをダウンロード & 音声を生成**
 
 ```sh
@@ -256,6 +167,8 @@ cd piper
 > **Windows cmd のコードページについて:** `--text` オプションは内部で `GetCommandLineW()` (UTF-16) を使用するため、コードページに依存せずそのまま動作します。パイプ入力（`echo ... | piper`）を使う場合のみ、事前に `chcp 65001` で UTF-8 に切り替えてください。
 >
 > **output.wav の出力先:** カレントディレクトリ（`cd piper` した場所）に生成されます。
+
+> **どのバイナリを選べばよい？** Releases には `piper-*` (C++) のほか、`piper-plus-cli-*` (C# .NET) と `piper-plus-rs-cli-*` (Rust) のCLIもあります。上記のクイックスタートで使っている **C++ CLI (`piper-*`)** が最も多くのプラットフォームに対応していて推奨です。詳しくは [CLIバイナリの選び方](docs/getting-started/binary-selection.md) を参照。
 
 ### Python推論
 

--- a/README.md
+++ b/README.md
@@ -38,19 +38,46 @@
 
 ### 方法1: プリビルドバイナリ (推奨)
 
-[GitHub Releases](https://github.com/ayutaz/piper-plus/releases) からダウンロードしてすぐに使えます。
+OS に合わせて以下をコピペで実行してください。約30秒で音声合成が動きます。
+
+#### macOS (Apple Silicon, M1/M2/M3 以降)
 
 ```bash
-# macOS / Linux
+curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-macos-arm64.tar.gz | tar xz
+cd piper
 ./piper --download-model tsukuyomi
 ./piper --model tsukuyomi --text "こんにちは" -f hello.wav
 ```
 
+#### Linux (x86_64)
+
+```bash
+curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-x64.tar.gz | tar xz
+cd piper
+./piper --download-model tsukuyomi
+./piper --model tsukuyomi --text "こんにちは" -f hello.wav
+```
+
+#### Linux (ARM64, Raspberry Pi 4/5 等)
+
+```bash
+curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz | tar xz
+cd piper
+./piper --download-model tsukuyomi
+./piper --model tsukuyomi --text "こんにちは" -f hello.wav
+```
+
+#### Windows (PowerShell)
+
 ```powershell
-# Windows (PowerShell)
+Invoke-WebRequest "https://github.com/ayutaz/piper-plus/releases/latest/download/piper-windows-x64.zip" -OutFile piper.zip
+Expand-Archive piper.zip -DestinationPath .
+cd piper
 .\piper.exe --download-model tsukuyomi
 .\piper.exe --model tsukuyomi --text "こんにちは" -f hello.wav
 ```
+
+> **どのバイナリを選べばよい？** Releases には `piper-*` (C++) のほか、`piper-plus-cli-*` (C# .NET) と `piper-plus-rs-cli-*` (Rust) のCLIもあります。Quick Start で使っている **C++ CLI (`piper-*`)** が最も多くのプラットフォームに対応していて推奨です。詳しくは [CLIバイナリの選び方](docs/getting-started/binary-selection.md) を参照。
 
 ### 方法2: Python
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -111,6 +111,14 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
+**Linux (ARM64, Raspberry Pi 4/5):**
+
+```bash
+curl -L -o piper.tar.gz https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz
+tar xzf piper.tar.gz
+cd piper
+```
+
 **2. Modell herunterladen & Sprache generieren**
 
 ```sh
@@ -124,6 +132,8 @@ cd piper
 > **Hinweis zur Windows cmd-Codepage:** Die Option `--text` verwendet intern `GetCommandLineW()` (UTF-16) und funktioniert daher unabhaengig von der Codepage. Nur bei Pipe-Eingabe (`echo ... | piper`) muessen Sie vorher mit `chcp 65001` auf UTF-8 umschalten.
 >
 > **Ausgabeort von output.wav:** Die Datei wird im aktuellen Verzeichnis erstellt (dort, wo Sie `cd piper` ausgefuehrt haben).
+
+> **Welches Binary soll ich waehlen?** Die Releases enthalten ausserdem `piper-plus-cli-*` (C# .NET) und `piper-plus-rs-cli-*` (Rust) CLIs. Der obige Schnellstart verwendet **C++ CLI (`piper-*`)**, das die breiteste Plattformunterstuetzung bietet und fuer die meisten Nutzer empfohlen wird. Details siehe [Auswahl eines CLI-Binarys](docs/getting-started/binary-selection.md).
 
 ### Python-Inferenz
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -38,19 +38,46 @@ A fast, high-quality neural text-to-speech (TTS) system. Built on the [VITS](htt
 
 ### Option 1: Prebuilt Binary (Recommended)
 
-Download from [GitHub Releases](https://github.com/ayutaz/piper-plus/releases) and start right away.
+Pick the command for your OS and paste it. You should hear synthesized speech in about 30 seconds.
+
+#### macOS (Apple Silicon, M1/M2/M3+)
 
 ```bash
-# macOS / Linux
+curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-macos-arm64.tar.gz | tar xz
+cd piper
 ./piper --download-model tsukuyomi
-./piper --model tsukuyomi --text "Hello, how are you?" -f hello.wav
+./piper --model tsukuyomi --text "Hello, world." -f hello.wav
 ```
 
-```powershell
-# Windows (PowerShell)
-.\piper.exe --download-model tsukuyomi
-.\piper.exe --model tsukuyomi --text "Hello, how are you?" -f hello.wav
+#### Linux (x86_64)
+
+```bash
+curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-x64.tar.gz | tar xz
+cd piper
+./piper --download-model tsukuyomi
+./piper --model tsukuyomi --text "Hello, world." -f hello.wav
 ```
+
+#### Linux (ARM64, Raspberry Pi 4/5)
+
+```bash
+curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz | tar xz
+cd piper
+./piper --download-model tsukuyomi
+./piper --model tsukuyomi --text "Hello, world." -f hello.wav
+```
+
+#### Windows (PowerShell)
+
+```powershell
+Invoke-WebRequest "https://github.com/ayutaz/piper-plus/releases/latest/download/piper-windows-x64.zip" -OutFile piper.zip
+Expand-Archive piper.zip -DestinationPath .
+cd piper
+.\piper.exe --download-model tsukuyomi
+.\piper.exe --model tsukuyomi --text "Hello, world." -f hello.wav
+```
+
+> **Which binary should I pick?** Releases also include `piper-plus-cli-*` (C# .NET) and `piper-plus-rs-cli-*` (Rust) CLIs. The Quick Start above uses **C++ CLI (`piper-*`)**, which has the widest platform support and is recommended for most users. See [Choosing a CLI binary](docs/getting-started/binary-selection.md) for details.
 
 ### Option 2: Python
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -45,8 +45,8 @@ Pick the command for your OS and paste it. You should hear synthesized speech in
 ```bash
 curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-macos-arm64.tar.gz | tar xz
 cd piper
-./piper --download-model tsukuyomi
-./piper --model tsukuyomi --text "Hello, world." -f hello.wav
+./bin/piper --download-model tsukuyomi
+./bin/piper --model tsukuyomi --text "Hello, world." -f hello.wav
 ```
 
 #### Linux (x86_64)
@@ -54,8 +54,8 @@ cd piper
 ```bash
 curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-x64.tar.gz | tar xz
 cd piper
-./piper --download-model tsukuyomi
-./piper --model tsukuyomi --text "Hello, world." -f hello.wav
+./bin/piper --download-model tsukuyomi
+./bin/piper --model tsukuyomi --text "Hello, world." -f hello.wav
 ```
 
 #### Linux (ARM64, Raspberry Pi 4/5)
@@ -63,8 +63,8 @@ cd piper
 ```bash
 curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz | tar xz
 cd piper
-./piper --download-model tsukuyomi
-./piper --model tsukuyomi --text "Hello, world." -f hello.wav
+./bin/piper --download-model tsukuyomi
+./bin/piper --model tsukuyomi --text "Hello, world." -f hello.wav
 ```
 
 #### Windows (PowerShell)
@@ -73,8 +73,8 @@ cd piper
 Invoke-WebRequest "https://github.com/ayutaz/piper-plus/releases/latest/download/piper-windows-x64.zip" -OutFile piper.zip
 Expand-Archive piper.zip -DestinationPath .
 cd piper
-.\piper.exe --download-model tsukuyomi
-.\piper.exe --model tsukuyomi --text "Hello, world." -f hello.wav
+.\bin\piper.exe --download-model tsukuyomi
+.\bin\piper.exe --model tsukuyomi --text "Hello, world." -f hello.wav
 ```
 
 > **Which binary should I pick?** Releases also include `piper-plus-cli-*` (C# .NET) and `piper-plus-rs-cli-*` (Rust) CLIs. The Quick Start above uses **C++ CLI (`piper-*`)**, which has the widest platform support and is recommended for most users. See [Choosing a CLI binary](docs/getting-started/binary-selection.md) for details.

--- a/README_EN.md
+++ b/README_EN.md
@@ -20,7 +20,6 @@ A fast, high-quality neural text-to-speech (TTS) system. Built on the [VITS](htt
 
 ## Table of Contents
 
-- [Try in 30 Seconds](#try-in-30-seconds)
 - [Benchmark](#benchmark)
 - [Key Features](#key-features)
 - [Quick Start](#quick-start)
@@ -33,100 +32,6 @@ A fast, high-quality neural text-to-speech (TTS) system. Built on the [VITS](htt
 - [Related Links](#related-links)
 
 ---
-
-## Try in 30 Seconds
-
-### Option 1: Prebuilt Binary (Recommended)
-
-Pick the command for your OS and paste it. You should hear synthesized speech in about 30 seconds.
-
-#### macOS (Apple Silicon, M1/M2/M3+)
-
-```bash
-curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-macos-arm64.tar.gz | tar xz
-cd piper
-./bin/piper --download-model tsukuyomi
-./bin/piper --model tsukuyomi --text "Hello, world." -f hello.wav
-```
-
-#### Linux (x86_64)
-
-```bash
-curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-x64.tar.gz | tar xz
-cd piper
-./bin/piper --download-model tsukuyomi
-./bin/piper --model tsukuyomi --text "Hello, world." -f hello.wav
-```
-
-#### Linux (ARM64, Raspberry Pi 4/5)
-
-```bash
-curl -L https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz | tar xz
-cd piper
-./bin/piper --download-model tsukuyomi
-./bin/piper --model tsukuyomi --text "Hello, world." -f hello.wav
-```
-
-#### Windows (PowerShell)
-
-```powershell
-Invoke-WebRequest "https://github.com/ayutaz/piper-plus/releases/latest/download/piper-windows-x64.zip" -OutFile piper.zip
-Expand-Archive piper.zip -DestinationPath .
-cd piper
-.\bin\piper.exe --download-model tsukuyomi
-.\bin\piper.exe --model tsukuyomi --text "Hello, world." -f hello.wav
-```
-
-> **Which binary should I pick?** Releases also include `piper-plus-cli-*` (C# .NET) and `piper-plus-rs-cli-*` (Rust) CLIs. The Quick Start above uses **C++ CLI (`piper-*`)**, which has the widest platform support and is recommended for most users. See [Choosing a CLI binary](docs/getting-started/binary-selection.md) for details.
-
-### Option 2: Python
-
-```bash
-pip install piper-plus
-uv run python -c "from piper_plus import PiperPlus; PiperPlus('tsukuyomi').tts_to_file('Hello, how are you?', 'hello.wav')"
-```
-
-<details>
-<summary>CLI is also available</summary>
-
-```bash
-pip install piper-tts-plus
-python -m piper --download-model tsukuyomi
-python -m piper --model tsukuyomi --text "Hello, how are you?" -f hello.wav
-```
-
-</details>
-
-### Option 3: Browser (No Install Required)
-
-**[Open WebAssembly Demo →](https://ayutaz.github.io/piper-plus/)**
-
-You can also embed it in your own app via npm:
-
-```js
-import { PiperPlus } from "piper-plus";
-const piper = await PiperPlus.initialize("tsukuyomi");
-const audio = await piper.synthesize("Hello, world!");
-audio.play();
-```
-
-> **Note:** The npm package is browser-only. For Node.js environments, use the Python or Rust CLI.
-
-<details>
-<summary>🔊 Listen to Sample Audio</summary>
-
-| Language | Text | Audio |
-|----------|------|-------|
-| 日本語 | こんにちは、つくよみちゃんです。 | [Play](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/ja.wav) |
-| English | Hello, how are you today? | [Play](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/en.wav) |
-| 中文 | 你好，今天天气很好。 | [Play](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/zh.wav) |
-| Español | ¿Hola, cómo estás hoy? | [Play](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/es.wav) |
-| Français | Bonjour, comment allez-vous? | [Play](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/fr.wav) |
-| Português | Olá, como você está hoje? | [Play](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/samples/pt.wav) |
-
-> Sample audio generated with [ayousanz/piper-plus-tsukuyomi-chan](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan) model.
-
-</details>
 
 ## Benchmark
 
@@ -207,8 +112,6 @@ audio.play();
 ---
 
 ## Quick Start
-
-> 💡 New here? Start with the [Try in 30 Seconds](#try-in-30-seconds) section above.
 
 ### Python Inference
 
@@ -291,6 +194,14 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
+**Linux (ARM64, Raspberry Pi 4/5):**
+
+```bash
+curl -L -o piper.tar.gz https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz
+tar xzf piper.tar.gz
+cd piper
+```
+
 **2. Download a model & generate speech**
 
 ```sh
@@ -304,6 +215,8 @@ cd piper
 > **Windows cmd code page note:** The `--text` option internally uses `GetCommandLineW()` (UTF-16), so it works regardless of code page. Only when using pipe input (`echo ... | piper`) do you need to switch to UTF-8 first with `chcp 65001`.
 >
 > **output.wav location:** Generated in the current directory (where you ran `cd piper`).
+
+> **Which binary should I pick?** Releases also include `piper-plus-cli-*` (C# .NET) and `piper-plus-rs-cli-*` (Rust) CLIs. The Quick Start above uses **C++ CLI (`piper-*`)**, which has the widest platform support and is recommended for most users. See [Choosing a CLI binary](docs/getting-started/binary-selection.md) for details.
 
 ### Docker
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -27,7 +27,6 @@ A fast, high-quality neural text-to-speech (TTS) system. Built on the [VITS](htt
 - [Usage](#usage)
 - [Training](#training)
 - [Pre-trained Models](#pre-trained-models)
-- [Japanese TTS](#japanese-tts)
 - [Platforms](#platforms)
 - [Related Links](#related-links)
 
@@ -83,31 +82,7 @@ A fast, high-quality neural text-to-speech (TTS) system. Built on the [VITS](htt
 - **C# CLI** — .NET 8/9 cross-platform, 8-language multilingual, ONNX inference, **phoneme timing output (JSON/TSV/SRT)**
 - **Rust CLI** — piper-plus/piper-plus-cli, streaming, CUDA/CoreML/DirectML support, **phoneme timing output (JSON/TSV/SRT)**, auto dictionary download
 - **[Go CLI](src/go/README.md)** — HTTP API server, session pooling, Docker, single binary, **phoneme timing output (JSON/TSV/SRT)**
-
-### Feature Support by Runtime
-
-| Feature | Python | Rust | C++ | C# | Go | WASM/JS |
-|---|---|---|---|---|---|---|
-| Multilingual TTS (8 langs) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Phoneme Timing (JSON/TSV/SRT)** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Streaming Synthesis | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Voice Cloning | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| SSML Support | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| HTTP API Server | ✅ | ❌ | ❌ | ❌ | ✅ | N/A |
-| Custom Dictionary | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-
-### Platforms
-
-| Platform | Architecture | Notes |
-|---|---|---|
-| Linux | x86_64 / ARM64 / ARMv7 | Full support |
-| macOS | ARM64 (Apple Silicon) only | M1/M2/M3+ |
-| Windows | x64 | Full support |
-| C API (FFI) | Linux x64/ARM64, macOS ARM64, Windows x64 | Shared library, Android AAR |
-| Web | WebAssembly | Chrome/Edge/Firefox/Safari |
-| C# (.NET) | x64 / ARM64 | .NET 8/9, Linux/macOS/Windows |
-| Rust | Linux x64, macOS ARM64, Windows x64 | Linux/macOS/Windows, CUDA/CoreML/DirectML |
-| Go | Linux x64, macOS ARM64, Windows x64 | Linux/macOS/Windows, HTTP API, Docker |
+- Equivalent 8-language multilingual synthesis across 6 runtimes (Python/Rust/C#/Go/JS-WASM/C++).
 
 ---
 
@@ -318,414 +293,45 @@ dotnet add package PiperPlus.Core
 piper-plus = "0.2.0"
 ```
 
-### Building from Source (C++)
+### Building from Source
 
-```bash
-git clone https://github.com/ayutaz/piper-plus.git
-cd piper-plus
-mkdir build && cd build
-cmake ..
-cmake --build . --config Release
-```
-
-Prerequisites: C++17 compiler, CMake 3.15+
-
-- **Linux**: Dependencies (ONNX Runtime, OpenJTalk, etc.) are downloaded automatically by CMake
-- **Windows**: See [Windows Setup Guide](docs/getting-started/windows-setup.md)
-- **macOS**: Dependencies are downloaded automatically
-
-### Building from Source (C#)
-
-```bash
-# C# CLI build
-dotnet build src/csharp/PiperPlus.sln -c Release
-# Test
-dotnet test src/csharp/PiperPlus.Core.Tests/
-```
-
-Prerequisites: .NET 8 SDK or later
-
-#### C# CLI Usage Examples
-
-```bash
-# Inference with model name (auto-download supported, defaults to output.wav)
-piper-plus --model tsukuyomi --text "こんにちは" --language ja
-
-# English
-piper-plus --model model.onnx --text "Hello world" --language en
-
-# Multilingual (automatic language detection)
-piper-plus --model model.onnx --text "こんにちはHello你好" --language ja-en-zh
-
-# Inline phoneme notation
-piper-plus --model model.onnx --text "Hello [[ h ə l oʊ ]] world" --language en
-
-# Streaming (progressive PCM output per sentence)
-piper-plus --model model.onnx --text "First sentence. Second sentence." --language en --streaming | aplay -r 22050 -f S16_LE
-
-# Custom dictionary (JSON v1/v2 or TSV)
-piper-plus --model model.onnx --text "AI technology" --language en --custom-dict my_dict.json
-
-# Model management
-piper-plus --download-model tsukuyomi
-piper-plus --list-models ja
-
-# Test mode (verify phoneme IDs without ONNX inference)
-piper-plus --model model.onnx --test-mode --text "hello" --language en
-```
-
-#### Rust CLI Usage Examples
-
-```bash
-# Inference with model name (auto-download supported)
-piper-plus-cli --model tsukuyomi --text "こんにちは" --language ja
-
-# English
-piper-plus-cli --model model.onnx --text "Hello world" --language en
-
-# Model management
-piper-plus-cli --download-model tsukuyomi
-piper-plus-cli --list-models ja
-
-# Streaming (sentence-by-sentence synthesis)
-piper-plus-cli --model model.onnx --text "First sentence. Second sentence." --stream --output-dir chunks/
-
-# Custom dictionary
-piper-plus-cli --model model.onnx --text "AI technology" --custom-dict my_dict.json
-
-# GPU inference
-piper-plus-cli --model model.onnx --text "Hello" --device cuda
-
-# Test mode / quiet mode
-piper-plus-cli --model model.onnx --test-mode --text "hello" --language en
-piper-plus-cli --model model.onnx --text "hello" --language en --quiet
-
-# Raw PCM output (no WAV header)
-piper-plus-cli --model model.onnx --text "hello" --language en --output-raw | aplay -r 22050 -f S16_LE
-```
-
-> **Note:** Install C# CLI with `dotnet tool install -g PiperPlus.Cli` and Rust CLI with `cargo install piper-plus-cli`. Both support 8 languages, custom dictionaries, and streaming.
-
-### Building from Source (Rust)
-
-```bash
-# Rust CLI build
-cargo build --release -p piper-plus-cli
-# Test
-cargo test -p piper-plus
-```
-
-Prerequisites: Rust 1.88+, cargo
+If pre-built binaries aren't available for your platform or you need to modify piper-plus, build from source. See **[Building from Source Guide](docs/guides/building-from-source.md)** for C++, C#, and Rust runtime build instructions.
 
 ---
 
 ## Usage
 
-### C++ CLI
+For detailed C++ CLI command-line options, JSON input format, model management, environment variables, and Windows helper scripts, see **[CLI Usage Guide](docs/guides/cli-usage.md)**.
 
-#### Direct Text Input (Recommended)
-
-The `--text` option allows direct text input without piping:
-
-```sh
-# Simple text-to-speech
-./bin/piper --model model.onnx --text "Hello, how are you?" -f output.wav
-
-# Japanese text (no encoding issues on Windows)
-bin\piper.exe --model models\tsukuyomi.onnx --text "こんにちは、今日は良い天気ですね。" -f output.wav
-
-# With speaker selection
-./bin/piper --model model.onnx --text "Hello" --speaker 3 -f output.wav
-```
-
-#### Pipe Input
-
-```sh
-# Basic usage
-echo "Hello world" | ./bin/piper --model en_model.onnx --output_file output.wav
-
-# Streaming (low latency)
-echo "Long text..." | ./bin/piper --model en_model.onnx --output_file output.wav --streaming
-
-# GPU inference
-echo "Hello" | ./bin/piper --model en_model.onnx --use-cuda --output_file output.wav
-
-# Phoneme timing output (for lip-sync, subtitles)
-echo "Hello world" | ./bin/piper --model en_model.onnx -f speech.wav --output-timing timing.json
-
-# Custom dictionary
-echo "DockerとGitHubを使います" | ./bin/piper --model ja_model.onnx --custom-dict my_dict.json -f output.wav
-
-# Inline phoneme input
-echo 'Hello [[ h ə l oʊ ]] world' | ./bin/piper --model en_model.onnx -f output.wav
-
-# Raw phoneme input
-echo 'h ə l oʊ _ w ɜː l d' | ./bin/piper --model en_model.onnx --raw-phonemes -f output.wav
-
-# Streaming raw audio output
-echo 'Long text...' | ./bin/piper --model en_model.onnx --output-raw | \
-  aplay -r 22050 -f S16_LE -t raw -
-```
-
-Key options:
-
-| Option | Description | Default |
-|---|---|---|
-| `--model PATH\|NAME` | Model file path, or model name (auto-resolves downloaded models) | - |
-| `--config/-c PATH` | Model config file path (auto-detected if not specified) | - |
-| `--text TEXT` | Direct text input (no piping required) | - |
-| `--output_file/-f FILE` | Output WAV file path | - |
-| `--output_dir/-d DIR` | Output directory (one WAV per utterance) | - |
-| `--output-raw` | Output raw PCM audio (no WAV header) | off |
-| `--streaming` | Chunk-based streaming mode | off |
-| `--use-cuda` | Enable CUDA GPU inference | off |
-| `--gpu-device-id NUM` | GPU device ID | 0 |
-| `--language/-l LANG` | Language code(s) (e.g. `ja`, `en`, `ja-en-zh`) | - |
-| `--length-scale VAL` | Speech speed (smaller = faster) | 1.0 |
-| `--noise-scale VAL` | Audio variation control | 0.667 |
-| `--noise-w VAL` | Phoneme duration variation | 0.8 |
-| `--sentence-silence SEC` | Silence between sentences | 0.2 |
-| `--speaker NUM` | Speaker number for multi-speaker models | 0 |
-| `--phoneme-silence PHONEME SEC` | Silence duration for specific phonemes | - |
-| `--raw-phonemes` | Interpret input as phonemes | off |
-| `--output-timing FILE` | Phoneme timing output (JSON/TSV) | - |
-| `--timing-format FORMAT` | Timing output format (`json` or `tsv`) | json |
-| `--custom-dict FILE` | Custom dictionary (comma-separated for multiple) | - |
-| `--json-input` | JSON input mode | off |
-| `--list-models [LANG]` | List available models | - |
-| `--download-model NAME` | Download a model | - |
-| `--model-dir DIR` | Model download directory | - |
-| `--test-mode` | Verify phoneme IDs without running ONNX inference | off |
-| `--debug` | Enable debug logging | off |
-| `--quiet/-q` | Suppress non-essential output | off |
-| `--version` | Show version | - |
-
-Run `piper --help` for all options.
-
-### JSON Input
-
-Use `--json-input` flag for JSON input:
-
-```json
-{ "text": "First speaker.", "speaker_id": 0, "output_file": "/tmp/speaker_0.wav" }
-{ "text": "Second speaker.", "speaker_id": 1, "output_file": "/tmp/speaker_1.wav" }
-```
-
-### Model Management
-
-#### List Available Models
+Simple example:
 
 ```bash
-# List all available models
-./bin/piper --list-models
-
-# Filter by language
-./bin/piper --list-models ja
-./bin/piper --list-models en
-```
-
-#### Download Models
-
-```bash
-# Download a model by name (aliases also work)
-./bin/piper --download-model tsukuyomi
-./bin/piper --download-model en_US-lessac-medium
-
-# Specify download directory
-./bin/piper --download-model tsukuyomi --model-dir /path/to/models
-
-# After download, use by model name (no full path needed)
-./bin/piper --model tsukuyomi --text "こんにちは"
-```
-
-### Environment Variables (C++ CLI)
-
-| Variable | Description | Example |
-|---|---|---|
-| `PIPER_DEFAULT_MODEL` | Default model path when `--model` is not specified | `/path/to/model.onnx` |
-| `PIPER_DEFAULT_CONFIG` | Default config path when `--config` is not specified | `/path/to/config.json` |
-| `PIPER_MODEL_DIR` | Directory for downloaded models | `~/.local/share/piper/models` |
-| `PIPER_GPU_DEVICE_ID` | GPU device ID for CUDA | `0` |
-
-### Helper Scripts (Windows)
-
-For Windows users, helper scripts are provided in the `scripts/` directory:
-
-**PowerShell:**
-
-```powershell
-.\scripts\speak.ps1 "こんにちは、今日は良い天気ですね。"
-.\scripts\speak.ps1 -Model "models\tsukuyomi.onnx" -Text "テスト"
-```
-
-**Command Prompt:**
-
-```cmd
-scripts\speak.bat "こんにちは、今日は良い天気ですね。"
-scripts\speak.bat --model models\tsukuyomi.onnx "テスト"
+./bin/piper --model tsukuyomi --text "Hello" --output_file hello.wav
 ```
 
 ---
 
 ## Training
 
-See the [Training Guide](docs/guides/training/training-guide.md) for detailed instructions.
+For training and fine-tuning piper-plus models (basic setup, multi-speaker / multi-GPU, ONNX export, checkpoint management, voice evaluation), see **[Training Guide](docs/guides/training.md)**.
 
-### Basic
-
-```bash
-uv pip install ".[train]"
-
-uv run python -m piper_train \
-  --dataset-dir /path/to/dataset \
-  --accelerator gpu --devices 1 --precision 16-mixed \
-  --max_epochs 200 --batch-size 16 \
-  --quality medium \
-  --prosody-dim 16 \
-  --ema-decay 0.9995
-```
-
-### Multi-speaker / Multi-GPU
-
-```bash
-NCCL_DEBUG=WARN NCCL_P2P_DISABLE=1 NCCL_IB_DISABLE=1 \
-uv run python -m piper_train \
-  --dataset-dir /path/to/dataset \
-  --prosody-dim 16 \
-  --accelerator gpu --devices 4 --precision 16-mixed \
-  --max_epochs 200 --batch-size 12 --samples-per-speaker 2 \
-  --checkpoint-epochs 1 --quality medium \
-  --base_lr 2e-4 --disable_auto_lr_scaling \
-  --ema-decay 0.9995
-```
-
-Multi-GPU automatically configures DDP (Distributed Data Parallel). NCCL environment variables are required. See the Multi-GPU Training Guide for details.
-
-### ONNX Export
-
-FP16 conversion is applied by default, reducing model size by ~50%. Use `--no-fp16` to disable.
-
-```bash
-# Standard model (FP16 by default)
-CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
-  /path/to/checkpoint.ckpt /path/to/output.onnx
-
-# Full precision (FP32)
-CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
-  --no-fp16 /path/to/checkpoint.ckpt /path/to/output.onnx
-
-# WavLM model (--stochastic enabled by default)
-CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
-  --stochastic /path/to/checkpoint.ckpt /path/to/output.onnx
-```
-
-### Checkpoint Management
-
-- `--resume_from_checkpoint` — Resume training from checkpoint
-- `--resume_from_single_speaker_checkpoint` — Convert single-speaker to multi-speaker model
-- `--resume-from-multispeaker-checkpoint` — Convert multi-speaker to single-speaker for fine-tuning (auto-enables `--freeze-dp`)
-
-### Voice Evaluation
-
-`scripts/evaluation/` contains evaluation test texts.
+Production-grade pretraining and fine-tuning command templates (6-language pretraining, Tsukuyomi-chan fine-tuning) are in [CLAUDE.md](CLAUDE.md).
 
 ---
 
 ## Pre-trained Models
 
-Pre-trained models for multilingual TTS and fine-tuning are available on Hugging Face.
+For the list of available piper-plus models, download instructions, 6-language base model details, and Japanese TTS specifics, see **[Pre-trained Models Guide](docs/guides/pretrained-models.md)**.
 
-**Inference Models (ready to use):**
-
-| Model | Languages | Speakers | Description | Download |
-|---|---|---|---|---|
-| Tsukuyomi-chan 6lang | JA/EN/ZH/ES/FR/PT | 1 | Tsukuyomi-chan voice, 6-language, FP16 | [HuggingFace](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan) |
-| CSS10 Japanese 6lang | JA/EN/ZH/ES/FR/PT | 1 | CSS10 Japanese voice, 6-language, FP16 | [HuggingFace](https://huggingface.co/ayousanz/piper-plus-css10-ja-6lang) |
-
-**Base Models (for fine-tuning):**
-
-| Model | Languages | Speakers | Description | Download |
-|---|---|---|---|---|
-| 6-Language Base | JA/EN/ZH/ES/FR/PT | 571 | Multilingual pre-trained (508,187 utterances, VITS + Prosody) | [HuggingFace](https://huggingface.co/ayousanz/piper-plus-base) |
-
-### Model Downloads
-
-**Tsukuyomi-chan model:**
-
-**Windows (PowerShell):**
-
-```powershell
-mkdir models
-Invoke-WebRequest -Uri "https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/tsukuyomi-chan-6lang-fp16.onnx" -OutFile models/tsukuyomi.onnx
-Invoke-WebRequest -Uri "https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/config.json" -OutFile models/config.json
-```
-
-**macOS / Linux:**
-
-```bash
-mkdir -p models
-curl -L -o models/tsukuyomi.onnx https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/tsukuyomi-chan-6lang-fp16.onnx
-curl -L -o models/config.json https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/config.json
-```
-
-**6-Language Base Model features:**
-
-- Architecture: VITS + Prosody Features
-- Training data: 508,187 utterances (571 speakers across 6 languages)
-- Languages: Japanese (20 speakers), English (310 speakers), Mandarin Chinese (142 speakers), Spanish (63 speakers), French (28 speakers), Portuguese (8 speakers)
-- Language codes: ja=0, en=1, zh=2, es=3, fr=4, pt=5
-- Sample rate: 22,050 Hz
-- Phonemes: 173 symbols (unified multilingual phoneme inventory)
-- Prosody Features: A1/A2/A3 prosody information (Japanese)
-- Extended phonemes: Question markers, context-dependent "N" variants
-
-> **Note:** piper-plus has custom architecture extensions (multilingual embeddings, Prosody A1/A2/A3, 173 symbols) that make it incompatible with upstream Piper checkpoints/ONNX models. Please use piper-plus specific models.
-
----
-
-## Japanese TTS
-
-High-quality Japanese speech synthesis with OpenJTalk integration. Dictionary and voice files are automatically downloaded on first run.
-
-**Environment Variables (optional):**
-
-| Variable | Description |
-|---|---|
-| `OPENJTALK_DICTIONARY_PATH` | OpenJTalk dictionary path (auto-downloads if not set) |
-| `PIPER_AUTO_DOWNLOAD_DICT` | Set to `0` to disable auto-download |
-| `PIPER_OFFLINE_MODE` | Set to `1` for offline mode |
-
-See the Japanese Usage Guide and [Phoneme Mapping Reference](docs/api-reference/phoneme-mapping.md).
+Main models: `tsukuyomi` (Japanese), `multilingual-6lang` (8-language base), `bilingual-ja-en-v4` (Japanese-English) — see HuggingFace [ayousanz/piper-plus-base](https://huggingface.co/ayousanz/piper-plus-base) and [ayousanz/piper-plus-tsukuyomi-chan](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan).
 
 ---
 
 ## Platforms
 
-### macOS
-
-**Apple Silicon (M1/M2/M3+) only.** Intel Mac users should use Docker or build from source.
-
-For security warnings on first run:
-
-```bash
-xattr -cr piper/
-```
-
-### Windows
-
-The espeak-ng-data directory is required. See [Windows Setup Guide](docs/getting-started/windows-setup.md) for details.
-
-```cmd
-set ESPEAK_DATA_PATH=C:\path\to\espeak-ng-data
-piper.exe --model en_US-lessac-medium.onnx -f output.wav
-```
-
-### WebAssembly
-
-Japanese TTS running directly in browsers. No server needed, offline capable.
-
-- **[Online Demo](https://ayutaz.github.io/piper-plus/)**
-- **[Technical Details & Integration Guide](src/wasm/openjtalk-web/README.npm.md)**
+- **macOS**: Apple Silicon (arm64) native support. See [macOS notes](docs/getting-started/binary-selection.md#macos-開発元を確認できないため開けません) for Gatekeeper troubleshooting
+- **Windows**: x64 / arm64 supported. For OpenJTalk setup, see [Windows Setup](docs/getting-started/windows-setup.md)
+- **WebAssembly**: Fully offline in-browser inference. [Demo](https://ayutaz.github.io/piper-plus/) | [npm package](https://www.npmjs.com/package/piper-plus)
 
 ---
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -111,6 +111,14 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
+**Linux (ARM64, Raspberry Pi 4/5):**
+
+```bash
+curl -L -o piper.tar.gz https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz
+tar xzf piper.tar.gz
+cd piper
+```
+
 **2. Descargar un modelo y generar audio**
 
 ```sh
@@ -124,6 +132,8 @@ cd piper
 > **Sobre el code page en Windows cmd:** La opcion `--text` utiliza internamente `GetCommandLineW()` (UTF-16), por lo que funciona independientemente del code page. Solo si usa entrada por pipe (`echo ... | piper`) necesita cambiar a UTF-8 previamente con `chcp 65001`.
 >
 > **Ubicacion de output.wav:** Se genera en el directorio actual (donde ejecuto `cd piper`).
+
+> **¿Que binario debo elegir?** Las releases tambien incluyen los CLIs `piper-plus-cli-*` (C# .NET) y `piper-plus-rs-cli-*` (Rust). El Inicio rapido anterior utiliza el **CLI de C++ (`piper-*`)**, que tiene el soporte de plataformas mas amplio y es el recomendado para la mayoria de los usuarios. Consulta [Como elegir un binario CLI](docs/getting-started/binary-selection.md) para mas detalles.
 
 ### Inferencia con Python
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -161,6 +161,14 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
+**Linux (ARM64, Raspberry Pi 4/5) :**
+
+```bash
+curl -L -o piper.tar.gz https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz
+tar xzf piper.tar.gz
+cd piper
+```
+
 **2. Telecharger un modele et generer de l'audio**
 
 ```sh
@@ -174,6 +182,8 @@ cd piper
 > **Page de code Windows cmd :** L'option `--text` utilise `GetCommandLineW()` (UTF-16) en interne et fonctionne independamment de la page de code. Pour l'entree par pipe (`echo ... | piper`), basculez d'abord en UTF-8 avec `chcp 65001`.
 >
 > **Emplacement de output.wav :** Le fichier est genere dans le repertoire courant (l'endroit ou vous avez execute `cd piper`).
+
+> **Quel binaire choisir ?** Les releases incluent egalement les CLI `piper-plus-cli-*` (C# .NET) et `piper-plus-rs-cli-*` (Rust). Le Demarrage rapide ci-dessus utilise le **CLI C++ (`piper-*`)**, qui dispose de la prise en charge de plateformes la plus large et est recommande pour la plupart des utilisateurs. Voir [Choisir un binaire CLI](docs/getting-started/binary-selection.md) pour plus de details.
 
 ### Docker
 

--- a/README_HI.md
+++ b/README_HI.md
@@ -111,6 +111,14 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
+**Linux (ARM64, Raspberry Pi 4/5):**
+
+```bash
+curl -L -o piper.tar.gz https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz
+tar xzf piper.tar.gz
+cd piper
+```
+
 **2. मॉडल डाउनलोड करें और ऑडियो जनरेट करें**
 
 ```sh
@@ -124,6 +132,8 @@ cd piper
 > **Windows cmd कोडपेज के बारे में:** `--text` विकल्प आंतरिक रूप से `GetCommandLineW()` (UTF-16) का उपयोग करता है, इसलिए यह कोडपेज से स्वतंत्र रूप से काम करता है। पाइप इनपुट (`echo ... | piper`) का उपयोग करते समय ही, पहले `chcp 65001` से UTF-8 में बदलें।
 >
 > **output.wav का आउटपुट स्थान:** वर्तमान डायरेक्टरी (`cd piper` का स्थान) में जनरेट होता है।
+
+> **कौन सी बाइनरी चुनें?** रिलीज़ में `piper-plus-cli-*` (C# .NET) और `piper-plus-rs-cli-*` (Rust) CLI भी शामिल हैं। ऊपर दिया गया त्वरित प्रारंभ **C++ CLI (`piper-*`)** का उपयोग करता है, जिसका प्लेटफ़ॉर्म समर्थन सबसे व्यापक है और अधिकांश उपयोगकर्ताओं के लिए अनुशंसित है। विवरण के लिए [CLI बाइनरी का चयन](docs/getting-started/binary-selection.md) देखें।
 
 ### Python अनुमान
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -111,6 +111,14 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
+**Linux (ARM64, 라즈베리 파이 4/5):**
+
+```bash
+curl -L -o piper.tar.gz https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz
+tar xzf piper.tar.gz
+cd piper
+```
+
 **2. 모델 다운로드 및 음성 생성**
 
 ```sh
@@ -124,6 +132,8 @@ cd piper
 > **Windows cmd의 코드 페이지에 대해:** `--text` 옵션은 내부적으로 `GetCommandLineW()` (UTF-16)를 사용하므로 코드 페이지에 관계없이 그대로 동작합니다. 파이프 입력(`echo ... | piper`)을 사용하는 경우에만 `chcp 65001`로 UTF-8로 전환해 주세요.
 >
 > **output.wav 출력 위치:** 현재 디렉터리(`cd piper`한 위치)에 생성됩니다.
+
+> **어떤 바이너리를 선택해야 하나요?** 릴리스에는 `piper-plus-cli-*` (C# .NET) 및 `piper-plus-rs-cli-*` (Rust) CLI도 포함되어 있습니다. 위의 빠른 시작은 **C++ CLI (`piper-*`)**를 사용하며, 가장 폭넓은 플랫폼을 지원하므로 대부분의 사용자에게 권장됩니다. 자세한 내용은 [CLI 바이너리 선택하기](docs/getting-started/binary-selection.md)를 참조하세요.
 
 ### Python 추론
 

--- a/README_PT.md
+++ b/README_PT.md
@@ -111,6 +111,14 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
+**Linux (ARM64, Raspberry Pi 4/5):**
+
+```bash
+curl -L -o piper.tar.gz https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz
+tar xzf piper.tar.gz
+cd piper
+```
+
 **2. Baixar o modelo e gerar áudio**
 
 ```sh
@@ -124,6 +132,8 @@ cd piper
 > **Sobre o code page do cmd no Windows:** A opção `--text` utiliza `GetCommandLineW()` (UTF-16) internamente, portanto funciona independentemente do code page. Apenas ao usar entrada por pipe (`echo ... | piper`), mude para UTF-8 previamente com `chcp 65001`.
 >
 > **Destino do output.wav:** O arquivo é gerado no diretório atual (onde foi executado `cd piper`).
+
+> **Qual binário devo escolher?** As releases também incluem as CLIs `piper-plus-cli-*` (C# .NET) e `piper-plus-rs-cli-*` (Rust). O Início Rápido acima utiliza a **CLI C++ (`piper-*`)**, que tem o suporte de plataforma mais amplo e é recomendada para a maioria dos usuários. Consulte [Escolhendo um binário CLI](docs/getting-started/binary-selection.md) para mais detalhes.
 
 ### Inferência Python
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -111,6 +111,14 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
+**Linux (ARM64, Raspberry Pi 4/5):**
+
+```bash
+curl -L -o piper.tar.gz https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz
+tar xzf piper.tar.gz
+cd piper
+```
+
 **2. Скачайте модель и сгенерируйте речь**
 
 ```sh
@@ -124,6 +132,8 @@ cd piper
 > **О кодовой странице Windows cmd:** Опция `--text` внутри использует `GetCommandLineW()` (UTF-16), поэтому работает независимо от кодовой страницы. При использовании ввода через конвейер (`echo ... | piper`) предварительно переключите кодовую страницу на UTF-8 командой `chcp 65001`.
 >
 > **Каталог вывода output.wav:** Файл создаётся в текущем каталоге (куда вы перешли командой `cd piper`).
+
+> **Какой бинарник выбрать?** Релизы также включают CLI `piper-plus-cli-*` (C# .NET) и `piper-plus-rs-cli-*` (Rust). В быстром старте выше используется **C++ CLI (`piper-*`)**, который имеет самую широкую поддержку платформ и рекомендуется для большинства пользователей. Подробнее см. [Выбор CLI-бинарника](docs/getting-started/binary-selection.md).
 
 ### Вывод через Python
 

--- a/README_SV.md
+++ b/README_SV.md
@@ -111,6 +111,14 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
+**Linux (ARM64, Raspberry Pi 4/5):**
+
+```bash
+curl -L -o piper.tar.gz https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz
+tar xzf piper.tar.gz
+cd piper
+```
+
 **2. Ladda ner en modell och generera tal**
 
 ```sh
@@ -124,6 +132,8 @@ cd piper
 > **Om kodsidor i Windows cmd:** Flaggan `--text` använder internt `GetCommandLineW()` (UTF-16) och fungerar därför oberoende av kodsida. Endast vid pipe-inmatning (`echo ... | piper`) behöver du först köra `chcp 65001` för att byta till UTF-8.
 >
 > **Utdatafil för output.wav:** Filen skapas i den aktuella katalogen (där du körde `cd piper`).
+
+> **Vilken binärfil ska jag välja?** Releaserna innehåller även `piper-plus-cli-*` (C# .NET) och `piper-plus-rs-cli-*` (Rust) CLI:er. Snabbstarten ovan använder **C++ CLI (`piper-*`)**, som har bredast plattformsstöd och rekommenderas för de flesta användare. Se [Välja en CLI-binärfil](docs/getting-started/binary-selection.md) för detaljer.
 
 ### Python-inferens
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -114,6 +114,14 @@ tar xzf piper.tar.gz
 cd piper
 ```
 
+**Linux (ARM64，树莓派 4/5):**
+
+```bash
+curl -L -o piper.tar.gz https://github.com/ayutaz/piper-plus/releases/latest/download/piper-linux-arm64.tar.gz
+tar xzf piper.tar.gz
+cd piper
+```
+
 **2. 下载模型并生成语音**
 
 ```sh
@@ -127,6 +135,8 @@ cd piper
 > **关于 Windows cmd 代码页：** `--text` 选项内部使用 `GetCommandLineW()` (UTF-16)，不依赖代码页，可直接使用。仅在使用管道输入（`echo ... | piper`）时，需要先运行 `chcp 65001` 切换到 UTF-8。
 >
 > **output.wav 输出位置：** 生成在当前目录（即 `cd piper` 后的位置）。
+
+> **应该选择哪个二进制文件？** Releases 中还提供 `piper-plus-cli-*`（C# .NET）和 `piper-plus-rs-cli-*`（Rust）CLI。上述快速入门使用的是 **C++ CLI（`piper-*`）**，它支持的平台最广，推荐大多数用户使用。详情请参阅[选择 CLI 二进制文件](docs/getting-started/binary-selection.md)。
 
 ### Python 推理
 

--- a/docs/getting-started/binary-selection.md
+++ b/docs/getting-started/binary-selection.md
@@ -59,7 +59,7 @@ Apple Silicon Mac で `piper-macos-arm64.tar.gz` (C++) と `piper-plus-cli-osx-a
 curl -LO https://github.com/ayutaz/piper-plus/releases/latest/download/piper-macos-arm64.tar.gz
 tar -xzf piper-macos-arm64.tar.gz
 cd piper
-./piper --help
+./bin/piper --help
 ```
 
 ### C# .NET CLI (Linux x64)
@@ -89,18 +89,18 @@ Expand-Archive piper-plus-rs-cli.zip -DestinationPath piper-plus-rs-cli
 Gatekeeper によりブロックされる場合があります。展開後、隔離属性を外してください。
 
 ```bash
-xattr -dr com.apple.quarantine ./piper
+xattr -dr com.apple.quarantine ./bin/piper
 ```
 
 または「システム設定 > プライバシーとセキュリティ」から個別に許可することもできます。
 
 ### Linux: `error while loading shared libraries: libonnxruntime.so`
 
-C++ CLI のアーカイブには ONNX Runtime の共有ライブラリが同梱されています。`piper` バイナリと同じディレクトリから実行するか、`LD_LIBRARY_PATH` を設定してください。
+C++ CLI のアーカイブには ONNX Runtime の共有ライブラリが `lib/` ディレクトリに同梱されています。展開した `piper` ディレクトリ直下で `LD_LIBRARY_PATH` に `lib` を追加してから実行してください。
 
 ```bash
-export LD_LIBRARY_PATH=$(pwd):$LD_LIBRARY_PATH
-./piper --help
+export LD_LIBRARY_PATH=$(pwd)/lib:$LD_LIBRARY_PATH
+./bin/piper --help
 ```
 
 ### Windows: Defender / SmartScreen によるブロック

--- a/docs/getting-started/binary-selection.md
+++ b/docs/getting-started/binary-selection.md
@@ -1,0 +1,116 @@
+# CLI バイナリの選び方
+
+GitHub Releases には 3 種類の CLI バイナリが並んでおり、初めて使うときはどれを選べばよいか迷いがちです。このドキュメントは、用途・OS・アーキテクチャから最適なバイナリを選ぶための判断材料をまとめたものです。
+
+**迷ったら C++ CLI (`piper-*`) を選んでください。** 最も多くのプラットフォームで動作し、Quick Start のサンプルとも整合しています。
+
+## 目次
+
+- [3 つのバリアントの比較](#3-つのバリアントの比較)
+- [OS x アーキテクチャ対応マトリクス](#os-x-アーキテクチャ対応マトリクス)
+- [判断フロー](#判断フロー)
+- [ダウンロード方法](#ダウンロード方法)
+- [トラブルシューティング](#トラブルシューティング)
+
+## 3 つのバリアントの比較
+
+| バリアント | 実装 | プレフィクス | 特徴 | 推奨用途 |
+|---|---|---|---|---|
+| **C++ CLI** | C++ | `piper-*` | 最も成熟・安定。バイナリサイズ最小、起動が軽量。armv7 (32bit ARM) を唯一サポート。OpenJTalk 辞書の自動 DL に対応 | 初めて使う / 組み込み機器 / Raspberry Pi / 本番運用で安定性重視 |
+| **C# .NET CLI** | C# / .NET 9 | `piper-plus-cli-*` | 8 言語マルチリンガル (JA/EN/ZH/KO/ES/FR/PT/SV)、`lid` テンソル対応、ストリーミング文分割、カスタム辞書 (JSON/TSV)、インライン音素 `[[ph]]` 記法、モデル名自動解決。Intel Mac (osx-x64) を唯一サポート | Windows ユーザー / Intel Mac ユーザー / 多言語合成 / .NET 環境との統合 |
+| **Rust CLI** | Rust | `piper-plus-rs-cli-*` | ストリーミング、CUDA / CoreML / DirectML での GPU 推論対応。8 言語対応。`--sentence-silence`, `--phoneme-silence` 等の細かい無音制御。jpreprocess (lindera) と naist-jdic (OpenJTalk) を選択可能 | GPU 推論を使いたい / 最新機能や細かいチューニングを試したい / 開発者 |
+
+各バリアントの実装は `src/cpp/`、`src/csharp/PiperPlus.Cli/`、`src/rust/piper-cli/` にあります。
+
+## OS x アーキテクチャ対応マトリクス
+
+`o` = 配布あり、`-` = 配布なし
+
+| OS / アーキテクチャ | C++ (`piper-*`) | C# (`piper-plus-cli-*`) | Rust (`piper-plus-rs-cli-*`) |
+|---|:---:|:---:|:---:|
+| Linux x64 | o | o | o |
+| Linux arm64 (Raspberry Pi 5 等) | o | o | - |
+| Linux armv7 (Raspberry Pi 4 32bit 等) | o | - | - |
+| macOS arm64 (Apple Silicon) | o | o | o |
+| macOS x64 (Intel Mac) | - | o | - |
+| Windows x64 | o | o | o |
+| Windows arm64 | - | o | - |
+
+Intel Mac、Linux armv7、Windows arm64 のいずれかを使う場合は、選択肢が一意に決まる点に注意してください。
+
+## 判断フロー
+
+1. **Raspberry Pi 4 (32bit) などの armv7 環境** -> **C++ CLI 一択** (`piper-linux-armv7.tar.gz`)
+2. **Intel Mac (macOS x64)** -> **C# .NET CLI 一択** (`piper-plus-cli-osx-x64.tar.gz`)
+3. **Windows on ARM** -> **C# .NET CLI 一択** (`piper-plus-cli-win-arm64.zip`)
+4. **GPU 推論 (CUDA / CoreML / DirectML) を使いたい** -> **Rust CLI**
+5. **Windows / 多言語 (中国語・スペイン語など) を使う / .NET と統合したい** -> **C# .NET CLI**
+6. **上記に当てはまらない / とにかく動かしたい / 何を選んでよいか分からない** -> **C++ CLI**
+
+Apple Silicon Mac で `piper-macos-arm64.tar.gz` (C++) と `piper-plus-cli-osx-arm64.tar.gz` (C#) で迷った場合、まずは C++ を試し、多言語合成や `lid` テンソル対応モデルを使う場面で C# を検討するのがおすすめです。
+
+## ダウンロード方法
+
+最新リリースは <https://github.com/ayutaz/piper-plus/releases/latest> にあります。以下は代表的なコマンド例です (ファイル名のバージョン部分は実際のリリースに合わせてください)。
+
+### C++ CLI (macOS arm64)
+
+```bash
+curl -LO https://github.com/ayutaz/piper-plus/releases/latest/download/piper-macos-arm64.tar.gz
+tar -xzf piper-macos-arm64.tar.gz
+cd piper
+./piper --help
+```
+
+### C# .NET CLI (Linux x64)
+
+```bash
+curl -LO https://github.com/ayutaz/piper-plus/releases/latest/download/piper-plus-cli-linux-x64.tar.gz
+tar -xzf piper-plus-cli-linux-x64.tar.gz
+./PiperPlus.Cli --help
+```
+
+### Rust CLI (Windows x64)
+
+PowerShell:
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/ayutaz/piper-plus/releases/latest/download/piper-plus-rs-cli-win-x64.zip -OutFile piper-plus-rs-cli.zip
+Expand-Archive piper-plus-rs-cli.zip -DestinationPath piper-plus-rs-cli
+.\piper-plus-rs-cli\piper-plus-cli.exe --help
+```
+
+実行例の詳細は README の Quick Start セクションを参照してください。
+
+## トラブルシューティング
+
+### macOS: 「開発元を確認できないため開けません」
+
+Gatekeeper によりブロックされる場合があります。展開後、隔離属性を外してください。
+
+```bash
+xattr -dr com.apple.quarantine ./piper
+```
+
+または「システム設定 > プライバシーとセキュリティ」から個別に許可することもできます。
+
+### Linux: `error while loading shared libraries: libonnxruntime.so`
+
+C++ CLI のアーカイブには ONNX Runtime の共有ライブラリが同梱されています。`piper` バイナリと同じディレクトリから実行するか、`LD_LIBRARY_PATH` を設定してください。
+
+```bash
+export LD_LIBRARY_PATH=$(pwd):$LD_LIBRARY_PATH
+./piper --help
+```
+
+### Windows: Defender / SmartScreen によるブロック
+
+署名されていないバイナリは初回起動時にブロックされることがあります。「詳細情報」 -> 「実行」で許可するか、ファイルのプロパティから「ブロックの解除」にチェックを入れてください。
+
+### C# .NET CLI: ランタイム不要
+
+`piper-plus-cli-*` はセルフコンテインド (self-contained) でビルドされており、別途 .NET ランタイムをインストールする必要はありません。
+
+### より詳しい問題
+
+その他の問題は [troubleshooting.md](./troubleshooting.md) を参照してください。

--- a/docs/guides/building-from-source.md
+++ b/docs/guides/building-from-source.md
@@ -1,0 +1,106 @@
+# Building from Source
+
+If pre-built binaries (see [README](../../README_EN.md)) don't fit your platform or you need to modify piper-plus, build from source. This guide covers C++, C#, and Rust runtimes.
+
+## Building C++ CLI
+
+```bash
+git clone https://github.com/ayutaz/piper-plus.git
+cd piper-plus
+mkdir build && cd build
+cmake ..
+cmake --build . --config Release
+```
+
+Prerequisites: C++17 compiler, CMake 3.15+
+
+- **Linux**: Dependencies (ONNX Runtime, OpenJTalk, etc.) are downloaded automatically by CMake
+- **Windows**: See [Windows Setup Guide](docs/getting-started/windows-setup.md)
+- **macOS**: Dependencies are downloaded automatically
+
+## Building C# CLI (PiperPlus)
+
+```bash
+# C# CLI build
+dotnet build src/csharp/PiperPlus.sln -c Release
+# Test
+dotnet test src/csharp/PiperPlus.Core.Tests/
+```
+
+Prerequisites: .NET 8 SDK or later
+
+#### C# CLI Usage Examples
+
+```bash
+# Inference with model name (auto-download supported, defaults to output.wav)
+piper-plus --model tsukuyomi --text "こんにちは" --language ja
+
+# English
+piper-plus --model model.onnx --text "Hello world" --language en
+
+# Multilingual (automatic language detection)
+piper-plus --model model.onnx --text "こんにちはHello你好" --language ja-en-zh
+
+# Inline phoneme notation
+piper-plus --model model.onnx --text "Hello [[ h ə l oʊ ]] world" --language en
+
+# Streaming (progressive PCM output per sentence)
+piper-plus --model model.onnx --text "First sentence. Second sentence." --language en --streaming | aplay -r 22050 -f S16_LE
+
+# Custom dictionary (JSON v1/v2 or TSV)
+piper-plus --model model.onnx --text "AI technology" --language en --custom-dict my_dict.json
+
+# Model management
+piper-plus --download-model tsukuyomi
+piper-plus --list-models ja
+
+# Test mode (verify phoneme IDs without ONNX inference)
+piper-plus --model model.onnx --test-mode --text "hello" --language en
+```
+
+#### Rust CLI Usage Examples
+
+```bash
+# Inference with model name (auto-download supported)
+piper-plus-cli --model tsukuyomi --text "こんにちは" --language ja
+
+# English
+piper-plus-cli --model model.onnx --text "Hello world" --language en
+
+# Model management
+piper-plus-cli --download-model tsukuyomi
+piper-plus-cli --list-models ja
+
+# Streaming (sentence-by-sentence synthesis)
+piper-plus-cli --model model.onnx --text "First sentence. Second sentence." --stream --output-dir chunks/
+
+# Custom dictionary
+piper-plus-cli --model model.onnx --text "AI technology" --custom-dict my_dict.json
+
+# GPU inference
+piper-plus-cli --model model.onnx --text "Hello" --device cuda
+
+# Test mode / quiet mode
+piper-plus-cli --model model.onnx --test-mode --text "hello" --language en
+piper-plus-cli --model model.onnx --text "hello" --language en --quiet
+
+# Raw PCM output (no WAV header)
+piper-plus-cli --model model.onnx --text "hello" --language en --output-raw | aplay -r 22050 -f S16_LE
+```
+
+> **Note:** Install C# CLI with `dotnet tool install -g PiperPlus.Cli` and Rust CLI with `cargo install piper-plus-cli`. Both support 8 languages, custom dictionaries, and streaming.
+
+## Building Rust CLI
+
+```bash
+# Rust CLI build
+cargo build --release -p piper-plus-cli
+# Test
+cargo test -p piper-plus
+```
+
+Prerequisites: Rust 1.88+, cargo
+
+---
+
+→ Back to [README](../../README_EN.md)

--- a/docs/guides/cli-usage.md
+++ b/docs/guides/cli-usage.md
@@ -1,0 +1,149 @@
+# CLI Usage
+
+This guide covers detailed usage of the C++ CLI (`piper`), including command-line options, JSON input format, model management, environment variables, and Windows helper scripts.
+
+## C++ CLI
+
+### Direct Text Input (Recommended)
+
+The `--text` option allows direct text input without piping:
+
+```sh
+# Simple text-to-speech
+./bin/piper --model model.onnx --text "Hello, how are you?" -f output.wav
+
+# Japanese text (no encoding issues on Windows)
+bin\piper.exe --model models\tsukuyomi.onnx --text "こんにちは、今日は良い天気ですね。" -f output.wav
+
+# With speaker selection
+./bin/piper --model model.onnx --text "Hello" --speaker 3 -f output.wav
+```
+
+### Pipe Input
+
+```sh
+# Basic usage
+echo "Hello world" | ./bin/piper --model en_model.onnx --output_file output.wav
+
+# Streaming (low latency)
+echo "Long text..." | ./bin/piper --model en_model.onnx --output_file output.wav --streaming
+
+# GPU inference
+echo "Hello" | ./bin/piper --model en_model.onnx --use-cuda --output_file output.wav
+
+# Phoneme timing output (for lip-sync, subtitles)
+echo "Hello world" | ./bin/piper --model en_model.onnx -f speech.wav --output-timing timing.json
+
+# Custom dictionary
+echo "DockerとGitHubを使います" | ./bin/piper --model ja_model.onnx --custom-dict my_dict.json -f output.wav
+
+# Inline phoneme input
+echo 'Hello [[ h ə l oʊ ]] world' | ./bin/piper --model en_model.onnx -f output.wav
+
+# Raw phoneme input
+echo 'h ə l oʊ _ w ɜː l d' | ./bin/piper --model en_model.onnx --raw-phonemes -f output.wav
+
+# Streaming raw audio output
+echo 'Long text...' | ./bin/piper --model en_model.onnx --output-raw | \
+  aplay -r 22050 -f S16_LE -t raw -
+```
+
+Key options:
+
+| Option | Description | Default |
+|---|---|---|
+| `--model PATH\|NAME` | Model file path, or model name (auto-resolves downloaded models) | - |
+| `--config/-c PATH` | Model config file path (auto-detected if not specified) | - |
+| `--text TEXT` | Direct text input (no piping required) | - |
+| `--output_file/-f FILE` | Output WAV file path | - |
+| `--output_dir/-d DIR` | Output directory (one WAV per utterance) | - |
+| `--output-raw` | Output raw PCM audio (no WAV header) | off |
+| `--streaming` | Chunk-based streaming mode | off |
+| `--use-cuda` | Enable CUDA GPU inference | off |
+| `--gpu-device-id NUM` | GPU device ID | 0 |
+| `--language/-l LANG` | Language code(s) (e.g. `ja`, `en`, `ja-en-zh`) | - |
+| `--length-scale VAL` | Speech speed (smaller = faster) | 1.0 |
+| `--noise-scale VAL` | Audio variation control | 0.667 |
+| `--noise-w VAL` | Phoneme duration variation | 0.8 |
+| `--sentence-silence SEC` | Silence between sentences | 0.2 |
+| `--speaker NUM` | Speaker number for multi-speaker models | 0 |
+| `--phoneme-silence PHONEME SEC` | Silence duration for specific phonemes | - |
+| `--raw-phonemes` | Interpret input as phonemes | off |
+| `--output-timing FILE` | Phoneme timing output (JSON/TSV) | - |
+| `--timing-format FORMAT` | Timing output format (`json` or `tsv`) | json |
+| `--custom-dict FILE` | Custom dictionary (comma-separated for multiple) | - |
+| `--json-input` | JSON input mode | off |
+| `--list-models [LANG]` | List available models | - |
+| `--download-model NAME` | Download a model | - |
+| `--model-dir DIR` | Model download directory | - |
+| `--test-mode` | Verify phoneme IDs without running ONNX inference | off |
+| `--debug` | Enable debug logging | off |
+| `--quiet/-q` | Suppress non-essential output | off |
+| `--version` | Show version | - |
+
+Run `piper --help` for all options.
+
+## JSON Input
+
+Use `--json-input` flag for JSON input:
+
+```json
+{ "text": "First speaker.", "speaker_id": 0, "output_file": "/tmp/speaker_0.wav" }
+{ "text": "Second speaker.", "speaker_id": 1, "output_file": "/tmp/speaker_1.wav" }
+```
+
+## Model Management
+
+### List Available Models
+
+```bash
+# List all available models
+./bin/piper --list-models
+
+# Filter by language
+./bin/piper --list-models ja
+./bin/piper --list-models en
+```
+
+### Download Models
+
+```bash
+# Download a model by name (aliases also work)
+./bin/piper --download-model tsukuyomi
+./bin/piper --download-model en_US-lessac-medium
+
+# Specify download directory
+./bin/piper --download-model tsukuyomi --model-dir /path/to/models
+
+# After download, use by model name (no full path needed)
+./bin/piper --model tsukuyomi --text "こんにちは"
+```
+
+## Environment Variables (C++ CLI)
+
+| Variable | Description | Example |
+|---|---|---|
+| `PIPER_DEFAULT_MODEL` | Default model path when `--model` is not specified | `/path/to/model.onnx` |
+| `PIPER_DEFAULT_CONFIG` | Default config path when `--config` is not specified | `/path/to/config.json` |
+| `PIPER_MODEL_DIR` | Directory for downloaded models | `~/.local/share/piper/models` |
+| `PIPER_GPU_DEVICE_ID` | GPU device ID for CUDA | `0` |
+
+## Helper Scripts (Windows)
+
+For Windows users, helper scripts are provided in the `scripts/` directory:
+
+**PowerShell:**
+
+```powershell
+.\scripts\speak.ps1 "こんにちは、今日は良い天気ですね。"
+.\scripts\speak.ps1 -Model "models\tsukuyomi.onnx" -Text "テスト"
+```
+
+**Command Prompt:**
+
+```cmd
+scripts\speak.bat "こんにちは、今日は良い天気ですね。"
+scripts\speak.bat --model models\tsukuyomi.onnx "テスト"
+```
+
+→ Back to [README](../../README_EN.md)

--- a/docs/guides/pretrained-models.md
+++ b/docs/guides/pretrained-models.md
@@ -1,0 +1,69 @@
+# Pre-trained Models
+
+Available pre-trained piper-plus models, how to download them, and language-specific model details including Japanese TTS.
+
+## Model Download
+
+Pre-trained models for multilingual TTS and fine-tuning are available on Hugging Face.
+
+**Inference Models (ready to use):**
+
+| Model | Languages | Speakers | Description | Download |
+|---|---|---|---|---|
+| Tsukuyomi-chan 6lang | JA/EN/ZH/ES/FR/PT | 1 | Tsukuyomi-chan voice, 6-language, FP16 | [HuggingFace](https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan) |
+| CSS10 Japanese 6lang | JA/EN/ZH/ES/FR/PT | 1 | CSS10 Japanese voice, 6-language, FP16 | [HuggingFace](https://huggingface.co/ayousanz/piper-plus-css10-ja-6lang) |
+
+**Base Models (for fine-tuning):**
+
+| Model | Languages | Speakers | Description | Download |
+|---|---|---|---|---|
+| 6-Language Base | JA/EN/ZH/ES/FR/PT | 571 | Multilingual pre-trained (508,187 utterances, VITS + Prosody) | [HuggingFace](https://huggingface.co/ayousanz/piper-plus-base) |
+
+**Tsukuyomi-chan model:**
+
+**Windows (PowerShell):**
+
+```powershell
+mkdir models
+Invoke-WebRequest -Uri "https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/tsukuyomi-chan-6lang-fp16.onnx" -OutFile models/tsukuyomi.onnx
+Invoke-WebRequest -Uri "https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/config.json" -OutFile models/config.json
+```
+
+**macOS / Linux:**
+
+```bash
+mkdir -p models
+curl -L -o models/tsukuyomi.onnx https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/tsukuyomi-chan-6lang-fp16.onnx
+curl -L -o models/config.json https://huggingface.co/ayousanz/piper-plus-tsukuyomi-chan/resolve/main/config.json
+```
+
+## 6-Language Base Model Features
+
+- Architecture: VITS + Prosody Features
+- Training data: 508,187 utterances (571 speakers across 6 languages)
+- Languages: Japanese (20 speakers), English (310 speakers), Mandarin Chinese (142 speakers), Spanish (63 speakers), French (28 speakers), Portuguese (8 speakers)
+- Language codes: ja=0, en=1, zh=2, es=3, fr=4, pt=5
+- Sample rate: 22,050 Hz
+- Phonemes: 173 symbols (unified multilingual phoneme inventory)
+- Prosody Features: A1/A2/A3 prosody information (Japanese)
+- Extended phonemes: Question markers, context-dependent "N" variants
+
+> **Note:** piper-plus has custom architecture extensions (multilingual embeddings, Prosody A1/A2/A3, 173 symbols) that make it incompatible with upstream Piper checkpoints/ONNX models. Please use piper-plus specific models.
+
+## Japanese TTS Specifics
+
+High-quality Japanese speech synthesis with OpenJTalk integration. Dictionary and voice files are automatically downloaded on first run.
+
+**Environment Variables (optional):**
+
+| Variable | Description |
+|---|---|
+| `OPENJTALK_DICTIONARY_PATH` | OpenJTalk dictionary path (auto-downloads if not set) |
+| `PIPER_AUTO_DOWNLOAD_DICT` | Set to `0` to disable auto-download |
+| `PIPER_OFFLINE_MODE` | Set to `1` for offline mode |
+
+See the Japanese Usage Guide and [Phoneme Mapping Reference](../api-reference/phoneme-mapping.md).
+
+---
+
+→ Back to [README](../../README_EN.md)

--- a/docs/guides/training.md
+++ b/docs/guides/training.md
@@ -1,0 +1,69 @@
+# Training Guide
+
+Training your own piper-plus model from scratch or fine-tuning an existing checkpoint. Covers basic single-speaker training through multi-GPU multi-speaker workflows.
+
+> For production-grade pretraining and fine-tune command templates (e.g., 6-language multilingual base, Tsukuyomi-chan fine-tune), see [CLAUDE.md](../../CLAUDE.md) for the full set of advanced templates and parameter rationales.
+
+See the [Training Guide](training/training-guide.md) for detailed instructions.
+
+## Basic
+
+```bash
+uv pip install ".[train]"
+
+uv run python -m piper_train \
+  --dataset-dir /path/to/dataset \
+  --accelerator gpu --devices 1 --precision 16-mixed \
+  --max_epochs 200 --batch-size 16 \
+  --quality medium \
+  --prosody-dim 16 \
+  --ema-decay 0.9995
+```
+
+## Multi-speaker / Multi-GPU
+
+```bash
+NCCL_DEBUG=WARN NCCL_P2P_DISABLE=1 NCCL_IB_DISABLE=1 \
+uv run python -m piper_train \
+  --dataset-dir /path/to/dataset \
+  --prosody-dim 16 \
+  --accelerator gpu --devices 4 --precision 16-mixed \
+  --max_epochs 200 --batch-size 12 --samples-per-speaker 2 \
+  --checkpoint-epochs 1 --quality medium \
+  --base_lr 2e-4 --disable_auto_lr_scaling \
+  --ema-decay 0.9995
+```
+
+Multi-GPU automatically configures DDP (Distributed Data Parallel). NCCL environment variables are required. See the Multi-GPU Training Guide for details.
+
+## ONNX Export
+
+FP16 conversion is applied by default, reducing model size by ~50%. Use `--no-fp16` to disable.
+
+```bash
+# Standard model (FP16 by default)
+CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
+  /path/to/checkpoint.ckpt /path/to/output.onnx
+
+# Full precision (FP32)
+CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
+  --no-fp16 /path/to/checkpoint.ckpt /path/to/output.onnx
+
+# WavLM model (--stochastic enabled by default)
+CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
+  --stochastic /path/to/checkpoint.ckpt /path/to/output.onnx
+```
+
+## Checkpoint Management
+
+- `--resume_from_checkpoint` — Resume training from checkpoint
+- `--resume_from_single_speaker_checkpoint` — Convert single-speaker to multi-speaker model
+- `--resume-from-multispeaker-checkpoint` — Convert multi-speaker to single-speaker for fine-tuning (auto-enables `--freeze-dp`)
+
+## Voice Evaluation
+
+`scripts/evaluation/` contains evaluation test texts.
+
+---
+
+→ Back to [README](../../README_EN.md)


### PR DESCRIPTION
## Summary

Closes #359

[Zenn スクラップ (kun432 氏)](https://zenn.dev/kun432/scraps/cddbfcd75b8b34) で指摘されていた以下の README の問題を解消:

- 「30秒で試す」にダウンロードコマンドが無く、Mac で `piper-macos-arm64.tar.gz` (C++) と `piper-plus-cli-osx-arm64.tar.gz` (C#) のどちらを選べばよいか分からない
- `./piper --download-model tsukuyomi` だけ書かれていて、そもそもバイナリをどう取得するかが不明

## Changes

### `README.md` / `README_EN.md`

「30秒で試す」 -> 「方法1: プリビルドバイナリ (推奨)」を以下の4ブロックに置き換え:

- **macOS (Apple Silicon)** — `curl -L .../piper-macos-arm64.tar.gz | tar xz`
- **Linux (x86_64)** — `curl -L .../piper-linux-x64.tar.gz | tar xz`
- **Linux (ARM64, Raspberry Pi 4/5)** — `curl -L .../piper-linux-arm64.tar.gz | tar xz`
- **Windows (PowerShell)** — `Invoke-WebRequest ... .zip` + `Expand-Archive`

Quick Start には全プラットフォーム最広対応の **C++ CLI (`piper-*`)** を採用し、末尾に「どのバイナリを選べばよい？」案内 + バイナリ選択ガイドへのリンクを追加。

### `docs/getting-started/binary-selection.md` (新規)

3つのCLIバリアント (C++ / C# .NET / Rust) の使い分けを詳細解説:

- 比較表 (実装・特徴・推奨用途)
- OS x アーキテクチャ対応マトリクス
- 判断フロー (armv7 -> C++、Intel Mac -> C#、GPU -> Rust など)
- ダウンロード方法のサンプルコマンド
- トラブルシューティング (Gatekeeper、libonnxruntime.so、Defender SmartScreen など)

## Test plan

- [x] README.md / README_EN.md の該当セクションが置き換わっていること
- [x] 新規 docs ファイルが作成されていること
- [x] README -> binary-selection.md のリンクが正しいパスを指していること
- [ ] (CI で markdown lint / link check が通ること)
- [ ] (レビュアーによる文言・コマンド動作確認)

## Out of scope (Issue #359 に書いた C 案)

「README 全体を機能別 docs に分割」の大規模リファクタリングは、リンク切れリスクが高いため本 PR ではスコープアウト。バイナリ選択ガイドの抽出のみ対応。