### PR TITLE
feat(http-server): Flask → FastAPI 移行 + ストリーミング対応 (#358)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -99,6 +99,8 @@ jobs:
     - name: Install runtime package dependencies
       run: |
         pip install pyopenjtalk-plus g2p-en pypinyin
+        # HTTP サーバー (FastAPI) のテストに必要な依存。バージョン制約は src/python_run/setup.py の [http] extras で一元管理。
+        pip install fastapi 'uvicorn[standard]' httpx
         python -c "import nltk; nltk.download('averaged_perceptron_tagger_eng', quiet=True); nltk.download('cmudict', quiet=True)"
       env:
         PYTHONUTF8: '1'

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ __pycache__/
 *.egg-info/
 build
 htmlcov
+.coverage
+.coverage.*
+coverage.xml
 # Python package build artifacts
 src/python_run/build/
 src/python_run/dist/

--- a/src/python_run/README_http.md
+++ b/src/python_run/README_http.md
@@ -5,14 +5,16 @@ FastAPI ベースの HTTP サーバー。`/synthesize` の代わりにルート 
 
 ## インストール
 
-```sh
-uv pip install -r requirements_http.txt
-```
-
-または extras 経由:
+`[http]` extras で `fastapi` + `uvicorn[standard]` を入れます。
 
 ```sh
 uv pip install "piper-plus[http]"
+```
+
+`uv add` を使う場合:
+
+```sh
+uv add "piper-plus[http]"
 ```
 
 ## 起動

--- a/src/python_run/README_http.md
+++ b/src/python_run/README_http.md
@@ -1,52 +1,101 @@
 # Piper HTTP Server
 
-Install the requirements into your virtual environment:
+FastAPI ベースの HTTP サーバー。`/synthesize` の代わりにルート (`/`) で WAV を返し、
+`?streaming=true` で **チャンク転送 (chunked transfer) ストリーミング** にも対応します。
+
+## インストール
 
 ```sh
 uv pip install -r requirements_http.txt
 ```
 
-Run the web server:
+または extras 経由:
+
+```sh
+uv pip install "piper-plus[http]"
+```
+
+## 起動
 
 ```sh
 .venv/bin/python3 -m piper.http_server --model ...
 ```
 
-See `--help` for more options.
+`--help` で全オプション一覧。デフォルトは `--host 0.0.0.0 --port 5000`。
 
-Using a `GET` request:
+## エンドポイント
+
+| メソッド | パス | 用途 |
+|--------|------|-----|
+| GET / POST | `/` | テキストから WAV を合成して返す |
+| GET / POST | `/api/phoneme-timing` | 音素タイミング情報を JSON / TSV で返す |
+| GET | `/docs` | Swagger UI (FastAPI 自動生成) |
+| GET | `/openapi.json` | OpenAPI 仕様 |
+
+### `/` — 音声合成
+
+#### 通常 (一括) リクエスト
+
+`GET`:
 
 ```sh
 curl -G --data-urlencode 'text=This is a test.' -o test.wav 'localhost:5000'
 ```
 
-Using a `POST` request:
+`POST`:
 
 ```sh
-curl -X POST -H 'Content-Type: text/plain' --data 'This is a test.' -o test.wav 'localhost:5000'
+curl -X POST -H 'Content-Type: text/plain' \
+  --data 'This is a test.' -o test.wav 'localhost:5000'
 ```
 
-### Phoneme Timing Endpoint
+#### ストリーミング (`?streaming=true`)
 
-**`GET/POST /api/phoneme-timing`** - 音素タイミング情報を返す
+`Transfer-Encoding: chunked` で WAV を逐次配信します。文単位に音声を生成し、
+ヘッダーは「サイズ未確定」用のプレースホルダー (`0xFFFFFFFF`) を埋め込むため、
+ブラウザ / `ffmpeg` / 多くの音声プレーヤーでそのまま再生できます。
 
-Query Parameters:
-- `text` (required): 合成するテキスト
-- `format`: 出力形式 (`json` または `tsv`、デフォルト: `json`)
-- `language`: 言語コード (`ja`, `en`, `zh`, `ko`, `es`, `fr`, `pt`, `sv`)
-- `language_id`: 数値の言語 ID (language より優先)
+```sh
+# ストリーミングで取得し ffplay で逐次再生
+curl -N -X POST -H 'Content-Type: text/plain' \
+  --data 'これはストリーミング再生のテストです。次の文も続けて流します。' \
+  'http://localhost:5000/?streaming=true' | ffplay -nodisp -autoexit -
+```
 
-Examples:
-```bash
-# JSON で取得
-curl "http://localhost:5000/api/phoneme-timing?text=Hello&format=json"
+`streaming` の有効値: `true` / `1` / `yes` / `on` (大文字小文字無視)。
 
-# TSV で取得
-curl "http://localhost:5000/api/phoneme-timing?text=Hello&format=tsv"
+#### クエリパラメータ (両エンドポイント共通)
+
+| パラメータ | 型 | 説明 |
+|-----------|----|------|
+| `text` | string | 合成対象テキスト (`POST` 時はリクエストボディでも可) |
+| `language` | string | 言語コード (`ja`, `en`, `zh`, `ko`, `es`, `fr`, `pt`, `sv`) |
+| `language_id` | int | 数値の言語 ID (`language` より優先) |
+| `streaming` | bool | `/` のみ。`true` でチャンク転送 (デフォルト: `false`) |
+| `format` | string | `/api/phoneme-timing` のみ。`json` (デフォルト) または `tsv` |
+
+### `/api/phoneme-timing` — 音素タイミング
+
+```sh
+# JSON
+curl 'http://localhost:5000/api/phoneme-timing?text=Hello&format=json'
+
+# TSV
+curl 'http://localhost:5000/api/phoneme-timing?text=Hello&format=tsv'
 
 # POST + 日本語
-curl -X POST "http://localhost:5000/api/phoneme-timing?language=ja&format=json" \
-  -d "こんにちは"
+curl -X POST 'http://localhost:5000/api/phoneme-timing?language=ja&format=json' \
+  -d 'こんにちは'
 ```
 
-レスポンス: 200 OK で JSON または TSV を返す。モデルが durations 出力を持たない場合は 400 を返す。
+`200 OK` で JSON または TSV を返します。モデルが duration 出力を持たない場合は
+`400 Bad Request` (`{"error": "Model does not support duration output"}`) を返します。
+
+## Flask 版からの移行
+
+旧 Flask 版と URL / クエリパラメータは互換です:
+
+- `GET/POST /` で WAV を返す挙動は変更なし
+- `/api/phoneme-timing` のレスポンス形状も同一
+- 追加: `?streaming=true` クエリ
+- 追加: `/docs` (Swagger UI), `/openapi.json`

--- a/src/python_run/piper/http_server.py
+++ b/src/python_run/piper/http_server.py
@@ -1,25 +1,207 @@
 #!/usr/bin/env python3
+"""FastAPI HTTP server for Piper TTS.
+
+Endpoints
+---------
+- ``GET/POST /`` — synthesize text, return ``audio/wav`` (optional streaming).
+- ``GET/POST /api/phoneme-timing`` — return phoneme timing as JSON or TSV.
+
+Streaming
+---------
+Pass ``?streaming=true`` (or ``true|1|yes``) on ``/`` to receive a chunked
+WAV response. The server emits a WAV header with placeholder sizes
+(``0xFFFFFFFF``) followed by raw PCM frames per sentence — compatible with
+browsers, ``ffmpeg`` and most media players.
+"""
+
+from __future__ import annotations
+
 import argparse
 import io
 import logging
+import struct
 import wave
 from pathlib import Path
 from typing import Any
 
-from flask import Flask, jsonify, request
+from fastapi import FastAPI, HTTPException, Query, Request, Response
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
 from . import PiperVoice
 from .download import ensure_voice_exists, find_voice, get_voices
+from .timing import timing_to_json, timing_to_tsv
+
+_LOGGER = logging.getLogger(__name__)
 
 
-_LOGGER = logging.getLogger()
+def _build_streaming_wav_header(
+    sample_rate: int, channels: int = 1, bit_depth: int = 16
+) -> bytes:
+    """Build a WAV header with placeholder sizes for chunked streaming.
+
+    Uses ``0xFFFFFFFF`` for the RIFF and data chunk sizes — the conventional
+    "unknown length" sentinel accepted by browsers and ``ffmpeg``.
+    """
+    byte_rate = sample_rate * channels * bit_depth // 8
+    block_align = channels * bit_depth // 8
+    return (
+        b"RIFF"
+        + struct.pack("<I", 0xFFFFFFFF)
+        + b"WAVE"
+        + b"fmt "
+        + struct.pack("<I", 16)
+        + struct.pack("<H", 1)
+        + struct.pack("<H", channels)
+        + struct.pack("<I", sample_rate)
+        + struct.pack("<I", byte_rate)
+        + struct.pack("<H", block_align)
+        + struct.pack("<H", bit_depth)
+        + b"data"
+        + struct.pack("<I", 0xFFFFFFFF)
+    )
+
+
+def _resolve_language_id(
+    voice: PiperVoice,
+    language_id_raw: str | None,
+    language: str | None,
+) -> int | None:
+    if language_id_raw is not None:
+        try:
+            return int(language_id_raw)
+        except (ValueError, TypeError):
+            return None
+    if language is not None:
+        lmap = voice.config.language_id_map
+        if lmap:
+            return lmap.get(language)
+    return None
+
+
+async def _read_text(request: Request, query_text: str | None) -> str:
+    if request.method == "POST":
+        body = await request.body()
+        text = body.decode("utf-8")
+    else:
+        text = query_text or ""
+    return text.strip()
+
+
+def _parse_bool_flag(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def create_app(voice: Any, synthesize_args: dict[str, Any]) -> FastAPI:
+    """Build a FastAPI app wired to the loaded voice."""
+    app = FastAPI(
+        title="Piper TTS HTTP Server",
+        description="Synthesize speech and return WAV audio.",
+    )
+
+    @app.api_route("/", methods=["GET", "POST"])
+    async def app_synthesize(
+        request: Request,
+        text: str | None = Query(None),
+        language: str | None = Query(None),
+        language_id: str | None = Query(None),
+        streaming: str | None = Query(None),
+    ) -> Response:
+        body_text = await _read_text(request, text)
+        if not body_text:
+            raise HTTPException(status_code=400, detail="No text provided")
+
+        resolved_language_id = _resolve_language_id(voice, language_id, language)
+        is_streaming = _parse_bool_flag(streaming)
+        _LOGGER.debug(
+            "Synthesizing text: %s (language_id=%s, streaming=%s)",
+            body_text,
+            resolved_language_id,
+            is_streaming,
+        )
+
+        if is_streaming:
+            sample_rate = voice.config.sample_rate
+
+            def _iter_wav():
+                yield _build_streaming_wav_header(sample_rate)
+                for audio_bytes in voice.synthesize_stream_raw(
+                    body_text,
+                    **synthesize_args,
+                    language_id=resolved_language_id,
+                ):
+                    yield audio_bytes
+
+            return StreamingResponse(_iter_wav(), media_type="audio/wav")
+
+        with io.BytesIO() as wav_io:
+            with wave.open(wav_io, "wb") as wav_file:
+                voice.synthesize(
+                    body_text,
+                    wav_file,
+                    **synthesize_args,
+                    language_id=resolved_language_id,
+                )
+            return Response(content=wav_io.getvalue(), media_type="audio/wav")
+
+    @app.api_route("/api/phoneme-timing", methods=["GET", "POST"])
+    async def app_phoneme_timing(
+        request: Request,
+        text: str | None = Query(None),
+        format: str = Query("json"),
+        language: str | None = Query(None),
+        language_id: str | None = Query(None),
+    ) -> Response:
+        body_text = await _read_text(request, text)
+        if not body_text:
+            return JSONResponse(
+                status_code=400, content={"error": "No text provided"}
+            )
+
+        fmt = format.lower()
+        if fmt not in ("json", "tsv"):
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": f"Unsupported format: {fmt}. Use 'json' or 'tsv'."
+                },
+            )
+
+        resolved_language_id = _resolve_language_id(voice, language_id, language)
+        _, timing_result = voice.synthesize_with_timing(
+            body_text, **synthesize_args, language_id=resolved_language_id
+        )
+
+        if timing_result is None:
+            return JSONResponse(
+                status_code=400,
+                content={"error": "Model does not support duration output"},
+            )
+
+        if fmt == "tsv":
+            return PlainTextResponse(
+                content=timing_to_tsv(timing_result),
+                media_type="text/tab-separated-values",
+            )
+
+        return Response(
+            content=timing_to_json(timing_result),
+            media_type="application/json",
+        )
+
+    return app
 
 
 def main() -> None:
+    import uvicorn
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="0.0.0.0", help="HTTP server host")
     parser.add_argument("--port", type=int, default=5000, help="HTTP server port")
-    parser.add_argument("-m", "--model", required=True, help="Path to Onnx model file")
+    parser.add_argument(
+        "-m", "--model", required=True, help="Path to Onnx model file"
+    )
     parser.add_argument("-c", "--config", help="Path to model config file")
     parser.add_argument("-s", "--speaker", type=int, help="Id of speaker (default: 0)")
     parser.add_argument(
@@ -64,28 +246,21 @@ def main() -> None:
     _LOGGER.debug(args)
 
     if not args.download_dir:
-        # Download to first data directory by default
         args.download_dir = args.data_dir[0]
 
-    # Download voice if file doesn't exist
     model_path = Path(args.model)
     if not model_path.exists():
-        # Load voice info
         voices_info = get_voices(args.download_dir, update_voices=args.update_voices)
-
-        # Resolve aliases for backwards compatibility with old voice names
         aliases_info: dict[str, Any] = {}
         for voice_info in voices_info.values():
             for voice_alias in voice_info.get("aliases", []):
                 aliases_info[voice_alias] = {"_is_alias": True, **voice_info}
-
         voices_info.update(aliases_info)
         ensure_voice_exists(args.model, args.data_dir, args.download_dir, voices_info)
         args.model, args.config = find_voice(args.model, args.data_dir)
 
-    # Load voice
     voice = PiperVoice.load(args.model, config_path=args.config, use_cuda=args.cuda)
-    synthesize_args = {
+    synthesize_args: dict[str, Any] = {
         "speaker_id": args.speaker,
         "length_scale": args.length_scale,
         "noise_scale": args.noise_scale,
@@ -93,128 +268,8 @@ def main() -> None:
         "sentence_silence": args.sentence_silence,
     }
 
-    # Create web server
-    app = Flask(__name__)
-
-    @app.route("/", methods=["GET", "POST"])
-    def app_synthesize() -> bytes:
-        if request.method == "POST":
-            text = request.data.decode("utf-8")
-        else:
-            text = request.args.get("text", "")
-
-        text = text.strip()
-        if not text:
-            raise ValueError("No text provided")
-
-        # Resolve language_id from query parameters
-        language_id: int | None = None
-        language_id_raw = request.args.get("language_id", None)
-        language = request.args.get("language", None)
-
-        if language_id_raw is not None:
-            try:
-                language_id = int(language_id_raw)
-            except (ValueError, TypeError):
-                language_id = None
-        elif language is not None:
-            language_id_map = voice.config.language_id_map
-            if language_id_map:
-                language_id = language_id_map.get(language)
-
-        _LOGGER.debug("Synthesizing text: %s (language_id=%s)", text, language_id)
-        with io.BytesIO() as wav_io:
-            with wave.open(wav_io, "wb") as wav_file:
-                voice.synthesize(
-                    text, wav_file, **synthesize_args, language_id=language_id
-                )
-
-            return wav_io.getvalue()
-
-    @app.route("/api/phoneme-timing", methods=["GET", "POST"])
-    def app_phoneme_timing():
-        """Phoneme timing endpoint.
-
-        Synthesize text and return per-phoneme timing information.
-
-        Query Parameters
-        ----------------
-        text : str
-            Text to synthesize. Can also be sent as POST body.
-        format : str, optional
-            Output format: ``'json'`` (default) or ``'tsv'``.
-        language : str, optional
-            Language code (``'ja'``, ``'en'``, ``'zh'``, etc.). Resolved via
-            the model's ``language_id_map``.
-        language_id : int, optional
-            Numeric language ID. Takes precedence over ``language``.
-
-        Responses
-        ---------
-        200 OK
-            Body is JSON or TSV timing data based on the ``format`` parameter.
-            Content-Type: ``application/json`` or ``text/tab-separated-values``.
-        400 Bad Request
-            Empty text, unsupported format, or model has no duration output.
-
-        Examples
-        --------
-        ::
-
-            curl 'http://localhost:5000/api/phoneme-timing?text=Hello&format=json'
-            curl 'http://localhost:5000/api/phoneme-timing?text=Hello&format=tsv'
-            curl -X POST 'http://localhost:5000/api/phoneme-timing?language=ja' \\
-                 -d 'こんにちは'
-        """
-        if request.method == "POST":
-            text = request.data.decode("utf-8")
-        else:
-            text = request.args.get("text", "")
-
-        text = text.strip()
-        if not text:
-            return jsonify({"error": "No text provided"}), 400
-
-        fmt = request.args.get("format", "json").lower()
-        if fmt not in ("json", "tsv"):
-            return jsonify(
-                {"error": f"Unsupported format: {fmt}. Use 'json' or 'tsv'."}
-            ), 400
-
-        # Resolve language_id
-        language_id: int | None = None
-        language_id_raw = request.args.get("language_id", None)
-        language = request.args.get("language", None)
-
-        if language_id_raw is not None:
-            try:
-                language_id = int(language_id_raw)
-            except (ValueError, TypeError):
-                language_id = None
-        elif language is not None:
-            language_id_map = voice.config.language_id_map
-            if language_id_map:
-                language_id = language_id_map.get(language)
-
-        from .timing import timing_to_json, timing_to_tsv
-
-        _, timing_result = voice.synthesize_with_timing(
-            text, **synthesize_args, language_id=language_id
-        )
-
-        if timing_result is None:
-            return jsonify({"error": "Model does not support duration output"}), 400
-
-        if fmt == "tsv":
-            return (
-                timing_to_tsv(timing_result),
-                200,
-                {"Content-Type": "text/tab-separated-values"},
-            )
-
-        return timing_to_json(timing_result), 200, {"Content-Type": "application/json"}
-
-    app.run(host=args.host, port=args.port)
+    app = create_app(voice, synthesize_args)
+    uvicorn.run(app, host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/src/python_run/piper/http_server.py
+++ b/src/python_run/piper/http_server.py
@@ -111,9 +111,13 @@ def _resolve_language_id(
 
 
 async def _read_text(request: Request, query_text: str | None) -> str:
-    """Read text from POST body or GET ``?text=`` query, with a size cap."""
+    """Read text from POST body or GET ``?text=`` query, with a size cap.
+
+    POST bodies are read as a stream and aborted once ``MAX_TEXT_BYTES`` is
+    exceeded, so chunked / Content-Length-less uploads cannot blow up memory.
+    The same cap is applied to GET ``?text=`` (UTF-8 byte length).
+    """
     if request.method == "POST":
-        # Reject obviously oversized bodies up front when Content-Length is set
         cl = request.headers.get("content-length")
         if cl is not None:
             try:
@@ -121,12 +125,18 @@ async def _read_text(request: Request, query_text: str | None) -> str:
                     raise _RequestTooLarge()
             except ValueError:
                 pass
-        body = await request.body()
-        if len(body) > MAX_TEXT_BYTES:
-            raise _RequestTooLarge()
-        text = body.decode("utf-8", errors="replace")
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in request.stream():
+            total += len(chunk)
+            if total > MAX_TEXT_BYTES:
+                raise _RequestTooLarge()
+            chunks.append(chunk)
+        text = b"".join(chunks).decode("utf-8", errors="replace")
     else:
         text = query_text or ""
+        if len(text.encode("utf-8", errors="replace")) > MAX_TEXT_BYTES:
+            raise _RequestTooLarge()
     return text.strip()
 
 

--- a/src/python_run/piper/http_server.py
+++ b/src/python_run/piper/http_server.py
@@ -33,6 +33,7 @@ from . import PiperVoice
 from .download import ensure_voice_exists, find_voice, get_voices
 from .timing import timing_to_json, timing_to_tsv
 
+
 _LOGGER = logging.getLogger(__name__)
 
 # Default channel/bit-depth assumptions match `PiperVoice.synthesize` output.
@@ -184,12 +185,11 @@ def create_app(voice: Any, synthesize_args: dict[str, Any]) -> FastAPI:
             def _iter_wav():
                 try:
                     yield _build_streaming_wav_header(sample_rate)
-                    for audio_bytes in voice.synthesize_stream_raw(
+                    yield from voice.synthesize_stream_raw(
                         body_text,
                         **synthesize_args,
                         language_id=resolved_language_id,
-                    ):
-                        yield audio_bytes
+                    )
                 except Exception:
                     # Headers have already been sent — we cannot return 500.
                     # Log so operators can diagnose silent client truncation.

--- a/src/python_run/piper/http_server.py
+++ b/src/python_run/piper/http_server.py
@@ -163,9 +163,7 @@ def create_app(voice: Any, synthesize_args: dict[str, Any]) -> FastAPI:
         try:
             body_text = await _read_text(request, text)
         except _RequestTooLarge:
-            return _error_response(
-                413, f"Request body exceeds {MAX_TEXT_BYTES} bytes"
-            )
+            return _error_response(413, f"Request body exceeds {MAX_TEXT_BYTES} bytes")
 
         if not body_text:
             return _error_response(400, "No text provided")
@@ -223,9 +221,7 @@ def create_app(voice: Any, synthesize_args: dict[str, Any]) -> FastAPI:
         try:
             body_text = await _read_text(request, text)
         except _RequestTooLarge:
-            return _error_response(
-                413, f"Request body exceeds {MAX_TEXT_BYTES} bytes"
-            )
+            return _error_response(413, f"Request body exceeds {MAX_TEXT_BYTES} bytes")
 
         if not body_text:
             return _error_response(400, "No text provided")
@@ -279,9 +275,7 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="0.0.0.0", help="HTTP server host")
     parser.add_argument("--port", type=int, default=5000, help="HTTP server port")
-    parser.add_argument(
-        "-m", "--model", required=True, help="Path to Onnx model file"
-    )
+    parser.add_argument("-m", "--model", required=True, help="Path to Onnx model file")
     parser.add_argument("-c", "--config", help="Path to model config file")
     parser.add_argument("-s", "--speaker", type=int, help="Id of speaker (default: 0)")
     parser.add_argument(

--- a/src/python_run/piper/http_server.py
+++ b/src/python_run/piper/http_server.py
@@ -24,7 +24,9 @@ import wave
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Query, Request, Response
+import uvicorn
+from fastapi import FastAPI, Query, Request, Response
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
 from . import PiperVoice
@@ -33,9 +35,20 @@ from .timing import timing_to_json, timing_to_tsv
 
 _LOGGER = logging.getLogger(__name__)
 
+# Default channel/bit-depth assumptions match `PiperVoice.synthesize` output.
+_WAV_CHANNELS = 1
+_WAV_BIT_DEPTH = 16
+
+# Generous text body cap. Practical Piper utterances are well under 10 KiB;
+# 1 MiB stays out of the way of legitimate batched requests while preventing
+# memory blow-up from a single client.
+MAX_TEXT_BYTES = 1 * 1024 * 1024
+
 
 def _build_streaming_wav_header(
-    sample_rate: int, channels: int = 1, bit_depth: int = 16
+    sample_rate: int,
+    channels: int = _WAV_CHANNELS,
+    bit_depth: int = _WAV_BIT_DEPTH,
 ) -> bytes:
     """Build a WAV header with placeholder sizes for chunked streaming.
 
@@ -62,35 +75,73 @@ def _build_streaming_wav_header(
 
 
 def _resolve_language_id(
-    voice: PiperVoice,
+    voice: Any,
     language_id_raw: str | None,
     language: str | None,
 ) -> int | None:
+    """Resolve query parameters to an integer language id.
+
+    Falls back to ``None`` for unparseable / unknown / out-of-range values to
+    preserve the silent-fallback behavior of the original Flask server. Out-
+    of-range values are logged so operators can spot misconfigured clients.
+    """
+    lmap = getattr(voice.config, "language_id_map", None) or None
+
     if language_id_raw is not None:
         try:
-            return int(language_id_raw)
+            language_id = int(language_id_raw)
         except (ValueError, TypeError):
             return None
-    if language is not None:
-        lmap = voice.config.language_id_map
-        if lmap:
-            return lmap.get(language)
+        if lmap is not None:
+            valid_ids = set(lmap.values())
+            if language_id not in valid_ids:
+                _LOGGER.warning(
+                    "language_id=%s out of range (valid: %s); falling back to None",
+                    language_id,
+                    sorted(valid_ids),
+                )
+                return None
+        return language_id
+
+    if language is not None and lmap is not None:
+        return lmap.get(language)
+
     return None
 
 
 async def _read_text(request: Request, query_text: str | None) -> str:
+    """Read text from POST body or GET ``?text=`` query, with a size cap."""
     if request.method == "POST":
+        # Reject obviously oversized bodies up front when Content-Length is set
+        cl = request.headers.get("content-length")
+        if cl is not None:
+            try:
+                if int(cl) > MAX_TEXT_BYTES:
+                    raise _RequestTooLarge()
+            except ValueError:
+                pass
         body = await request.body()
-        text = body.decode("utf-8")
+        if len(body) > MAX_TEXT_BYTES:
+            raise _RequestTooLarge()
+        text = body.decode("utf-8", errors="replace")
     else:
         text = query_text or ""
     return text.strip()
+
+
+class _RequestTooLarge(Exception):
+    """Internal sentinel for body-size enforcement."""
 
 
 def _parse_bool_flag(value: str | None) -> bool:
     if value is None:
         return False
     return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _error_response(status_code: int, message: str) -> JSONResponse:
+    """Flask-compatible ``{"error": ...}`` JSON error body."""
+    return JSONResponse(status_code=status_code, content={"error": message})
 
 
 def create_app(voice: Any, synthesize_args: dict[str, Any]) -> FastAPI:
@@ -108,9 +159,15 @@ def create_app(voice: Any, synthesize_args: dict[str, Any]) -> FastAPI:
         language_id: str | None = Query(None),
         streaming: str | None = Query(None),
     ) -> Response:
-        body_text = await _read_text(request, text)
+        try:
+            body_text = await _read_text(request, text)
+        except _RequestTooLarge:
+            return _error_response(
+                413, f"Request body exceeds {MAX_TEXT_BYTES} bytes"
+            )
+
         if not body_text:
-            raise HTTPException(status_code=400, detail="No text provided")
+            return _error_response(400, "No text provided")
 
         resolved_language_id = _resolve_language_id(voice, language_id, language)
         is_streaming = _parse_bool_flag(streaming)
@@ -125,61 +182,75 @@ def create_app(voice: Any, synthesize_args: dict[str, Any]) -> FastAPI:
             sample_rate = voice.config.sample_rate
 
             def _iter_wav():
-                yield _build_streaming_wav_header(sample_rate)
-                for audio_bytes in voice.synthesize_stream_raw(
-                    body_text,
-                    **synthesize_args,
-                    language_id=resolved_language_id,
-                ):
-                    yield audio_bytes
+                try:
+                    yield _build_streaming_wav_header(sample_rate)
+                    for audio_bytes in voice.synthesize_stream_raw(
+                        body_text,
+                        **synthesize_args,
+                        language_id=resolved_language_id,
+                    ):
+                        yield audio_bytes
+                except Exception:
+                    # Headers have already been sent — we cannot return 500.
+                    # Log so operators can diagnose silent client truncation.
+                    _LOGGER.exception("Streaming synthesis failed")
+                    raise
 
             return StreamingResponse(_iter_wav(), media_type="audio/wav")
 
-        with io.BytesIO() as wav_io:
-            with wave.open(wav_io, "wb") as wav_file:
-                voice.synthesize(
-                    body_text,
-                    wav_file,
-                    **synthesize_args,
-                    language_id=resolved_language_id,
-                )
-            return Response(content=wav_io.getvalue(), media_type="audio/wav")
+        def _do_synth() -> bytes:
+            with io.BytesIO() as wav_io:
+                with wave.open(wav_io, "wb") as wav_file:
+                    voice.synthesize(
+                        body_text,
+                        wav_file,
+                        **synthesize_args,
+                        language_id=resolved_language_id,
+                    )
+                return wav_io.getvalue()
+
+        wav_bytes = await run_in_threadpool(_do_synth)
+        return Response(content=wav_bytes, media_type="audio/wav")
 
     @app.api_route("/api/phoneme-timing", methods=["GET", "POST"])
     async def app_phoneme_timing(
         request: Request,
         text: str | None = Query(None),
-        format: str = Query("json"),
+        fmt: str = Query("json", alias="format"),
         language: str | None = Query(None),
         language_id: str | None = Query(None),
     ) -> Response:
-        body_text = await _read_text(request, text)
-        if not body_text:
-            return JSONResponse(
-                status_code=400, content={"error": "No text provided"}
+        try:
+            body_text = await _read_text(request, text)
+        except _RequestTooLarge:
+            return _error_response(
+                413, f"Request body exceeds {MAX_TEXT_BYTES} bytes"
             )
 
-        fmt = format.lower()
-        if fmt not in ("json", "tsv"):
-            return JSONResponse(
-                status_code=400,
-                content={
-                    "error": f"Unsupported format: {fmt}. Use 'json' or 'tsv'."
-                },
+        if not body_text:
+            return _error_response(400, "No text provided")
+
+        fmt_lower = fmt.lower()
+        if fmt_lower not in ("json", "tsv"):
+            return _error_response(
+                400, f"Unsupported format: {fmt_lower}. Use 'json' or 'tsv'."
             )
 
         resolved_language_id = _resolve_language_id(voice, language_id, language)
-        _, timing_result = voice.synthesize_with_timing(
-            body_text, **synthesize_args, language_id=resolved_language_id
-        )
 
-        if timing_result is None:
-            return JSONResponse(
-                status_code=400,
-                content={"error": "Model does not support duration output"},
+        def _do_timing():
+            return voice.synthesize_with_timing(
+                body_text,
+                **synthesize_args,
+                language_id=resolved_language_id,
             )
 
-        if fmt == "tsv":
+        _, timing_result = await run_in_threadpool(_do_timing)
+
+        if timing_result is None:
+            return _error_response(400, "Model does not support duration output")
+
+        if fmt_lower == "tsv":
             return PlainTextResponse(
                 content=timing_to_tsv(timing_result),
                 media_type="text/tab-separated-values",
@@ -193,9 +264,18 @@ def create_app(voice: Any, synthesize_args: dict[str, Any]) -> FastAPI:
     return app
 
 
-def main() -> None:
-    import uvicorn
+def _warn_if_public_bind(host: str) -> None:
+    """Log a startup warning when binding to a non-loopback address."""
+    if host in ("0.0.0.0", "::", ""):
+        _LOGGER.warning(
+            "Binding to %s with no authentication. "
+            "Anyone able to reach this port can synthesize audio. "
+            "Pass --host 127.0.0.1 to restrict to localhost.",
+            host or "0.0.0.0",
+        )
 
+
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="0.0.0.0", help="HTTP server host")
     parser.add_argument("--port", type=int, default=5000, help="HTTP server port")
@@ -244,6 +324,8 @@ def main() -> None:
     args = parser.parse_args()
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
     _LOGGER.debug(args)
+
+    _warn_if_public_bind(args.host)
 
     if not args.download_dir:
         args.download_dir = args.data_dir[0]

--- a/src/python_run/requirements_http.txt
+++ b/src/python_run/requirements_http.txt
@@ -1,2 +1,0 @@
-fastapi>=0.110,<1
-uvicorn[standard]>=0.27,<1

--- a/src/python_run/requirements_http.txt
+++ b/src/python_run/requirements_http.txt
@@ -1,1 +1,2 @@
-flask>=3,<4
+fastapi>=0.110,<1
+uvicorn[standard]>=0.27,<1

--- a/src/python_run/setup.py
+++ b/src/python_run/setup.py
@@ -64,7 +64,10 @@ setup(
     python_requires=">=3.11",
     extras_require={
         "gpu": ["onnxruntime-gpu>=1.11.0,<2"],
-        "http": ["flask>=3,<4"],
+        "http": [
+            "fastapi>=0.110,<1",
+            "uvicorn[standard]>=0.27,<1",
+        ],
     },
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/src/python_run/tests/test_http_timing.py
+++ b/src/python_run/tests/test_http_timing.py
@@ -10,8 +10,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-fastapi = pytest.importorskip("fastapi")
-httpx = pytest.importorskip("httpx")
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
 
 from fastapi.testclient import TestClient  # noqa: E402
 
@@ -29,9 +30,7 @@ def mock_timing_result() -> TimingResult:
     """Sample TimingResult covering 3 phonemes."""
     return TimingResult(
         phonemes=[
-            PhonemeTimingInfo(
-                phoneme="^", start_ms=0.0, end_ms=58.0, duration_ms=58.0
-            ),
+            PhonemeTimingInfo(phoneme="^", start_ms=0.0, end_ms=58.0, duration_ms=58.0),
             PhonemeTimingInfo(
                 phoneme="k", start_ms=58.0, end_ms=150.8, duration_ms=92.8
             ),
@@ -215,18 +214,14 @@ class TestTimingEndpointLanguageResolution:
         assert resp.status_code == 200
         assert captured["language_id"] == 3
 
-    def test_numeric_language_id_with_no_map_passes_through(
-        self, mock_timing_result
-    ):
+    def test_numeric_language_id_with_no_map_passes_through(self, mock_timing_result):
         """Without a language_id_map, numeric ids are passed through unchanged."""
         client, captured = self._build(mock_timing_result, None)
         resp = client.get("/api/phoneme-timing?text=hello&language_id=5")
         assert resp.status_code == 200
         assert captured["language_id"] == 5
 
-    def test_out_of_range_language_id_falls_back_to_none(
-        self, mock_timing_result
-    ):
+    def test_out_of_range_language_id_falls_back_to_none(self, mock_timing_result):
         """language_id outside the configured map falls back to None."""
         client, captured = self._build(mock_timing_result, {"ja": 0, "en": 1})
         resp = client.get("/api/phoneme-timing?text=hello&language_id=999")
@@ -240,18 +235,14 @@ class TestTimingEndpointLanguageResolution:
         assert captured["language_id"] is None
 
     def test_language_code_resolved(self, mock_timing_result):
-        client, captured = self._build(
-            mock_timing_result, {"ja": 0, "en": 1, "zh": 2}
-        )
+        client, captured = self._build(mock_timing_result, {"ja": 0, "en": 1, "zh": 2})
         resp = client.get("/api/phoneme-timing?text=hello&language=zh")
         assert resp.status_code == 200
         assert captured["language_id"] == 2
 
     def test_invalid_language_id_falls_back_to_none(self, mock_timing_result):
         client, captured = self._build(mock_timing_result, None)
-        resp = client.get(
-            "/api/phoneme-timing?text=hello&language_id=not-an-int"
-        )
+        resp = client.get("/api/phoneme-timing?text=hello&language_id=not-an-int")
         assert resp.status_code == 200
         assert captured["language_id"] is None
 
@@ -296,9 +287,7 @@ class TestSynthesizeEndpoint:
 class TestStreamingEndpoint:
     """Tests for ``?streaming=true`` chunked WAV streaming on ``/``."""
 
-    def test_streaming_returns_wav_with_placeholder_sizes(
-        self, mock_timing_result
-    ):
+    def test_streaming_returns_wav_with_placeholder_sizes(self, mock_timing_result):
         voice = _make_voice(mock_timing_result, sample_rate=22050)
         client = TestClient(create_app(voice, synthesize_args={}))
 
@@ -351,9 +340,7 @@ class TestStreamingEndpoint:
         assert voice.synthesize.called
         assert not voice.synthesize_stream_raw.called
 
-    def test_streaming_wav_header_uses_voice_sample_rate(
-        self, mock_timing_result
-    ):
+    def test_streaming_wav_header_uses_voice_sample_rate(self, mock_timing_result):
         voice = _make_voice(mock_timing_result, sample_rate=16000)
         client = TestClient(create_app(voice, synthesize_args={}))
         with client.stream("POST", "/?streaming=true", content="hello") as resp:
@@ -419,6 +406,35 @@ class TestRequestBodySizeLimit:
         resp = client.post("/api/phoneme-timing", content=oversized)
         assert resp.status_code == 413
 
+    def test_oversized_get_query_raises(self):
+        """``_read_text`` rejects oversized GET ``?text=`` directly.
+
+        We can't exercise this via ``TestClient`` because httpx refuses to
+        build URLs over its own internal cap (``InvalidURL: query too long``)
+        before the request reaches the server.
+        """
+        import asyncio
+
+        from piper.http_server import MAX_TEXT_BYTES, _read_text, _RequestTooLarge
+
+        request = MagicMock()
+        request.method = "GET"
+        oversized = "a" * (MAX_TEXT_BYTES + 1)
+
+        with pytest.raises(_RequestTooLarge):
+            asyncio.run(_read_text(request, oversized))
+
+    def test_within_get_query_accepted(self):
+        """Sanity check: GET ``?text=`` under the cap passes through."""
+        import asyncio
+
+        from piper.http_server import _read_text
+
+        request = MagicMock()
+        request.method = "GET"
+        result = asyncio.run(_read_text(request, "hello"))
+        assert result == "hello"
+
 
 # ---------------------------------------------------------------------------
 # Error response shape consistency
@@ -465,13 +481,9 @@ class TestStreamingExceptionHandling:
 
         with caplog.at_level(logging.ERROR, logger="piper.http_server"):
             with pytest.raises(RuntimeError):
-                with client.stream(
-                    "POST", "/?streaming=true", content="hello"
-                ) as resp:
+                with client.stream("POST", "/?streaming=true", content="hello") as resp:
                     list(resp.iter_bytes())
-        assert any(
-            "Streaming synthesis failed" in r.message for r in caplog.records
-        )
+        assert any("Streaming synthesis failed" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------
@@ -481,9 +493,7 @@ class TestStreamingExceptionHandling:
 
 class TestStreamingLanguageIdPassthrough:
     def test_streaming_passes_language_id(self, mock_timing_result):
-        voice = _make_voice(
-            mock_timing_result, language_id_map={"ja": 0, "en": 1}
-        )
+        voice = _make_voice(mock_timing_result, language_id_map={"ja": 0, "en": 1})
         captured: dict = {}
 
         def _stream(_text, **kwargs):

--- a/src/python_run/tests/test_http_timing.py
+++ b/src/python_run/tests/test_http_timing.py
@@ -207,10 +207,37 @@ class TestTimingEndpointLanguageResolution:
         return TestClient(create_app(voice, synthesize_args={})), captured
 
     def test_numeric_language_id(self, mock_timing_result):
-        client, captured = self._build(mock_timing_result, {"ja": 0, "en": 1})
+        # Use a map that includes id 3 so range validation accepts it
+        client, captured = self._build(
+            mock_timing_result, {"ja": 0, "en": 1, "zh": 2, "fr": 3}
+        )
         resp = client.get("/api/phoneme-timing?text=hello&language_id=3")
         assert resp.status_code == 200
         assert captured["language_id"] == 3
+
+    def test_numeric_language_id_with_no_map_passes_through(
+        self, mock_timing_result
+    ):
+        """Without a language_id_map, numeric ids are passed through unchanged."""
+        client, captured = self._build(mock_timing_result, None)
+        resp = client.get("/api/phoneme-timing?text=hello&language_id=5")
+        assert resp.status_code == 200
+        assert captured["language_id"] == 5
+
+    def test_out_of_range_language_id_falls_back_to_none(
+        self, mock_timing_result
+    ):
+        """language_id outside the configured map falls back to None."""
+        client, captured = self._build(mock_timing_result, {"ja": 0, "en": 1})
+        resp = client.get("/api/phoneme-timing?text=hello&language_id=999")
+        assert resp.status_code == 200
+        assert captured["language_id"] is None
+
+    def test_negative_language_id_falls_back_to_none(self, mock_timing_result):
+        client, captured = self._build(mock_timing_result, {"ja": 0, "en": 1})
+        resp = client.get("/api/phoneme-timing?text=hello&language_id=-1")
+        assert resp.status_code == 200
+        assert captured["language_id"] is None
 
     def test_language_code_resolved(self, mock_timing_result):
         client, captured = self._build(
@@ -362,3 +389,136 @@ def test_timing_json_body_is_parseable(client):
     parsed = json.loads(resp.text)
     assert isinstance(parsed, dict)
     assert "phonemes" in parsed
+
+
+# ---------------------------------------------------------------------------
+# Body size limit (DoS guard)
+# ---------------------------------------------------------------------------
+
+
+class TestRequestBodySizeLimit:
+    """POST bodies above the configured cap are rejected with 413."""
+
+    def test_oversized_body_rejected(self, mock_timing_result):
+        from piper.http_server import MAX_TEXT_BYTES
+
+        voice = _make_voice(mock_timing_result)
+        client = TestClient(create_app(voice, synthesize_args={}))
+        oversized = b"a" * (MAX_TEXT_BYTES + 1)
+        resp = client.post("/", content=oversized)
+        assert resp.status_code == 413
+        body = resp.json()
+        assert "error" in body
+
+    def test_oversized_body_rejected_for_timing(self, mock_timing_result):
+        from piper.http_server import MAX_TEXT_BYTES
+
+        voice = _make_voice(mock_timing_result)
+        client = TestClient(create_app(voice, synthesize_args={}))
+        oversized = b"a" * (MAX_TEXT_BYTES + 1)
+        resp = client.post("/api/phoneme-timing", content=oversized)
+        assert resp.status_code == 413
+
+
+# ---------------------------------------------------------------------------
+# Error response shape consistency
+# ---------------------------------------------------------------------------
+
+
+class TestErrorResponseShape:
+    """All 4xx responses share the ``{"error": ...}`` body shape."""
+
+    def test_synthesize_empty_text_uses_error_key(self, client):
+        resp = client.post("/", content="")
+        assert resp.status_code == 400
+        body = resp.json()
+        assert "error" in body
+        assert "detail" not in body  # Not FastAPI default shape
+
+    def test_timing_empty_text_uses_error_key(self, client):
+        resp = client.post("/api/phoneme-timing", content="")
+        assert resp.status_code == 400
+        body = resp.json()
+        assert "error" in body
+        assert "detail" not in body
+
+
+# ---------------------------------------------------------------------------
+# Streaming exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingExceptionHandling:
+    """Generators that raise mid-stream are logged (no silent failures)."""
+
+    def test_streaming_exception_is_logged(self, mock_timing_result, caplog):
+        import logging
+
+        voice = _make_voice(mock_timing_result)
+
+        def _broken_stream(_text, **_kwargs):
+            yield b"\x00\x00" * 50
+            raise RuntimeError("boom")
+
+        voice.synthesize_stream_raw.side_effect = _broken_stream
+        client = TestClient(create_app(voice, synthesize_args={}))
+
+        with caplog.at_level(logging.ERROR, logger="piper.http_server"):
+            with pytest.raises(RuntimeError):
+                with client.stream(
+                    "POST", "/?streaming=true", content="hello"
+                ) as resp:
+                    list(resp.iter_bytes())
+        assert any(
+            "Streaming synthesis failed" in r.message for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# Streaming additional contract: passes language_id through to voice
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingLanguageIdPassthrough:
+    def test_streaming_passes_language_id(self, mock_timing_result):
+        voice = _make_voice(
+            mock_timing_result, language_id_map={"ja": 0, "en": 1}
+        )
+        captured: dict = {}
+
+        def _stream(_text, **kwargs):
+            captured["language_id"] = kwargs.get("language_id")
+            yield b"\x00\x00" * 100
+
+        voice.synthesize_stream_raw.side_effect = _stream
+        client = TestClient(create_app(voice, synthesize_args={}))
+        with client.stream(
+            "POST", "/?streaming=true&language=en", content="hello"
+        ) as resp:
+            list(resp.iter_bytes())
+        assert captured["language_id"] == 1
+
+
+# ---------------------------------------------------------------------------
+# _warn_if_public_bind helper
+# ---------------------------------------------------------------------------
+
+
+class TestPublicBindWarning:
+    def test_warns_for_wildcard_address(self, caplog):
+        import logging
+
+        from piper.http_server import _warn_if_public_bind
+
+        with caplog.at_level(logging.WARNING, logger="piper.http_server"):
+            _warn_if_public_bind("0.0.0.0")
+        assert any("authentication" in r.message for r in caplog.records)
+
+    def test_no_warning_for_loopback(self, caplog):
+        import logging
+
+        from piper.http_server import _warn_if_public_bind
+
+        with caplog.at_level(logging.WARNING, logger="piper.http_server"):
+            _warn_if_public_bind("127.0.0.1")
+        assert not any("authentication" in r.message for r in caplog.records)

--- a/src/python_run/tests/test_http_timing.py
+++ b/src/python_run/tests/test_http_timing.py
@@ -1,27 +1,32 @@
-"""Tests for HTTP phoneme timing endpoint."""
+"""Tests for the FastAPI HTTP server (synthesis + phoneme timing endpoints)."""
 
 from __future__ import annotations
 
+import io
 import json
+import struct
+import wave
 from unittest.mock import MagicMock
 
 import pytest
 
-flask = pytest.importorskip("flask")
+fastapi = pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
 
-from flask import Flask, jsonify, request  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
-from piper.timing import (  # noqa: E402
-    PhonemeTimingInfo,
-    TimingResult,
-    timing_to_json,
-    timing_to_tsv,
-)
+from piper.http_server import create_app  # noqa: E402
+from piper.timing import PhonemeTimingInfo, TimingResult  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-def mock_timing_result():
-    """Sample TimingResult for testing."""
+def mock_timing_result() -> TimingResult:
+    """Sample TimingResult covering 3 phonemes."""
     return TimingResult(
         phonemes=[
             PhonemeTimingInfo(
@@ -39,97 +44,55 @@ def mock_timing_result():
     )
 
 
-def _create_app(mock_voice: MagicMock) -> Flask:
-    """Build a Flask app wired to *mock_voice*."""
-    app = Flask(__name__)
-
-    @app.route("/api/phoneme-timing", methods=["GET", "POST"])
-    def app_phoneme_timing():
-        if request.method == "POST":
-            text = request.data.decode("utf-8")
-        else:
-            text = request.args.get("text", "")
-
-        text = text.strip()
-        if not text:
-            return jsonify({"error": "No text provided"}), 400
-
-        fmt = request.args.get("format", "json")
-
-        if fmt not in ("json", "tsv"):
-            return jsonify({"error": f"Unsupported format: {fmt}"}), 400
-
-        # Resolve language_id (mirrors http_server.py logic)
-        language_id: int | None = None
-        language_id_raw = request.args.get("language_id", None)
-        language = request.args.get("language", None)
-
-        if language_id_raw is not None:
-            try:
-                language_id = int(language_id_raw)
-            except (ValueError, TypeError):
-                language_id = None
-        elif language is not None:
-            language_id_map = mock_voice.config.language_id_map
-            if language_id_map:
-                language_id = language_id_map.get(language)
-
-        _, timing_result = mock_voice.synthesize_with_timing(
-            text, language_id=language_id
-        )
-
-        if timing_result is None:
-            return (
-                jsonify({"error": "Model does not support duration output"}),
-                400,
-            )
-
-        if fmt == "tsv":
-            return (
-                timing_to_tsv(timing_result),
-                200,
-                {"Content-Type": "text/tab-separated-values"},
-            )
-
-        return (
-            timing_to_json(timing_result),
-            200,
-            {"Content-Type": "application/json"},
-        )
-
-    return app
-
-
-@pytest.fixture
-def app(mock_timing_result):
-    """Create Flask test app with mocked voice that returns timing."""
+def _make_voice(
+    timing_result: TimingResult | None,
+    language_id_map: dict[str, int] | None = None,
+    sample_rate: int = 22050,
+) -> MagicMock:
+    """Build a mock voice that mimics PiperVoice's relevant attributes."""
     mock_voice = MagicMock()
-    mock_voice.synthesize_with_timing.return_value = (
-        b"fake-wav",
-        mock_timing_result,
-    )
-    mock_voice.config.language_id_map = None
-    return _create_app(mock_voice)
+    mock_voice.config.language_id_map = language_id_map
+    mock_voice.config.sample_rate = sample_rate
+    mock_voice.synthesize_with_timing.return_value = (b"fake-wav", timing_result)
+
+    def _fake_synth(text, wav_file, **_kwargs):
+        wav_file.setframerate(sample_rate)
+        wav_file.setsampwidth(2)
+        wav_file.setnchannels(1)
+        wav_file.writeframes(b"\x00\x00" * 100)
+
+    mock_voice.synthesize.side_effect = _fake_synth
+
+    def _fake_stream_raw(_text, **_kwargs):
+        # Two PCM "sentences" of 100 samples (200 bytes) each.
+        yield b"\x01\x00" * 100
+        yield b"\x02\x00" * 100
+
+    mock_voice.synthesize_stream_raw.side_effect = _fake_stream_raw
+    return mock_voice
 
 
 @pytest.fixture
-def client(app):
-    """Flask test client."""
-    return app.test_client()
+def client(mock_timing_result) -> TestClient:
+    voice = _make_voice(mock_timing_result)
+    app = create_app(voice, synthesize_args={})
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# /api/phoneme-timing — JSON / TSV happy paths
+# ---------------------------------------------------------------------------
 
 
 class TestTimingEndpointJSON:
-    """POST text -> JSON response with phonemes array."""
+    """POST text → JSON response with phonemes array."""
 
     def test_timing_endpoint_json(self, client, mock_timing_result):
-        resp = client.post(
-            "/api/phoneme-timing",
-            data="konnichiwa",
-        )
+        resp = client.post("/api/phoneme-timing", content="konnichiwa")
         assert resp.status_code == 200
-        assert resp.content_type == "application/json"
+        assert resp.headers["content-type"].startswith("application/json")
 
-        body = json.loads(resp.data)
+        body = resp.json()
         assert "phonemes" in body
         assert len(body["phonemes"]) == 3
         assert body["phonemes"][0]["phoneme"] == "^"
@@ -139,9 +102,8 @@ class TestTimingEndpointJSON:
         assert body["sample_rate"] == 22050
 
     def test_phoneme_timing_fields(self, client):
-        """Each phoneme entry has start_ms, end_ms, duration_ms, phoneme."""
-        resp = client.post("/api/phoneme-timing", data="hello")
-        body = json.loads(resp.data)
+        resp = client.post("/api/phoneme-timing", content="hello")
+        body = resp.json()
         for entry in body["phonemes"]:
             assert "phoneme" in entry
             assert "start_ms" in entry
@@ -150,317 +112,253 @@ class TestTimingEndpointJSON:
 
 
 class TestTimingEndpointTSV:
-    """POST text with format=tsv -> TSV response."""
+    """POST text with format=tsv → TSV response."""
 
     def test_timing_endpoint_tsv(self, client):
-        resp = client.post(
-            "/api/phoneme-timing?format=tsv",
-            data="konnichiwa",
-        )
+        resp = client.post("/api/phoneme-timing?format=tsv", content="konnichiwa")
         assert resp.status_code == 200
-        assert resp.content_type == "text/tab-separated-values"
+        assert resp.headers["content-type"].startswith("text/tab-separated-values")
 
-        text = resp.data.decode("utf-8")
+        text = resp.text
         lines = text.strip().split("\n")
-        # Header + 3 data lines
-        assert len(lines) == 4
+        assert len(lines) == 4  # header + 3 data lines
+        assert lines[0] == "start_ms\tend_ms\tduration_ms\tphoneme"
 
-        header = lines[0]
-        assert header == "start_ms\tend_ms\tduration_ms\tphoneme"
-
-        # First data line should be the "^" phoneme
         cols = lines[1].split("\t")
         assert len(cols) == 4
         assert cols[3] == "^"
         assert cols[0] == "0.000"
 
 
+# ---------------------------------------------------------------------------
+# /api/phoneme-timing — error cases
+# ---------------------------------------------------------------------------
+
+
 class TestTimingEndpointErrors:
-    """Error cases for the phoneme-timing endpoint."""
-
-    def test_timing_endpoint_no_text_post(self, client):
-        """POST with empty body returns 400."""
-        resp = client.post("/api/phoneme-timing", data="")
+    def test_no_text_post(self, client):
+        resp = client.post("/api/phoneme-timing", content="")
         assert resp.status_code == 400
-        body = json.loads(resp.data)
-        assert "error" in body
+        assert "error" in resp.json()
 
-    def test_timing_endpoint_no_text_get(self, client):
-        """GET without text param returns 400."""
+    def test_no_text_get(self, client):
         resp = client.get("/api/phoneme-timing")
         assert resp.status_code == 400
-        body = json.loads(resp.data)
-        assert "error" in body
+        assert "error" in resp.json()
 
-    def test_timing_endpoint_whitespace_only(self, client):
-        """POST with whitespace-only body returns 400."""
-        resp = client.post("/api/phoneme-timing", data="   \n  ")
+    def test_whitespace_only(self, client):
+        resp = client.post("/api/phoneme-timing", content="   \n  ")
         assert resp.status_code == 400
 
-    def test_timing_endpoint_no_duration_support(self):
-        """When synthesize_with_timing returns None timing, respond 400."""
-        mock_voice = MagicMock()
-        mock_voice.synthesize_with_timing.return_value = (b"fake-wav", None)
-        mock_voice.config.language_id_map = None
-
-        none_app = _create_app(mock_voice)
-        client = none_app.test_client()
-        resp = client.post("/api/phoneme-timing", data="hello")
+    def test_no_duration_support(self):
+        voice = _make_voice(timing_result=None)
+        client = TestClient(create_app(voice, synthesize_args={}))
+        resp = client.post("/api/phoneme-timing", content="hello")
         assert resp.status_code == 400
-        body = json.loads(resp.data)
+        body = resp.json()
         assert "duration" in body["error"].lower() or "support" in body["error"].lower()
 
 
 class TestTimingEndpointGET:
-    """GET requests with text query parameter."""
-
-    def test_timing_endpoint_get(self, client):
+    def test_get_json(self, client):
         resp = client.get("/api/phoneme-timing?text=hello")
         assert resp.status_code == 200
-        body = json.loads(resp.data)
+        body = resp.json()
         assert "phonemes" in body
         assert len(body["phonemes"]) == 3
 
-    def test_timing_endpoint_get_tsv(self, client):
+    def test_get_tsv(self, client):
         resp = client.get("/api/phoneme-timing?text=hello&format=tsv")
         assert resp.status_code == 200
-        assert resp.content_type == "text/tab-separated-values"
+        assert resp.headers["content-type"].startswith("text/tab-separated-values")
 
 
 class TestTimingEndpointFormatValidation:
-    """Tests for format parameter validation."""
-
     def test_invalid_format_returns_400(self, client):
-        """Unsupported format (e.g., xml) should return 400."""
         resp = client.get("/api/phoneme-timing?text=hello&format=xml")
         assert resp.status_code == 400
-        data = json.loads(resp.data)
-        assert "error" in data
-        assert "xml" in data["error"].lower() or "unsupported" in data["error"].lower()
+        body = resp.json()
+        assert "error" in body
+        assert "xml" in body["error"].lower() or "unsupported" in body["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# /api/phoneme-timing — language_id resolution
+# ---------------------------------------------------------------------------
 
 
 class TestTimingEndpointLanguageResolution:
-    """Tests for language_id / language query parameter resolution.
+    """Language resolution rules:
 
-    The endpoint supports two forms:
-    - `?language_id=N` — use integer directly
-    - `?language=<code>` — look up in voice.config.language_id_map
+    - ``?language_id=N`` — use integer directly
+    - ``?language=<code>`` — look up in ``voice.config.language_id_map``
+    - Unparseable / unknown values fall back to ``None``
     """
 
-    def test_language_id_numeric_parameter_accepted(self, mock_timing_result):
-        """GET with ?language_id=3 succeeds and returns timing JSON."""
-        from flask import Flask, jsonify, request
-
-        from piper.timing import timing_to_json, timing_to_tsv
-
-        captured = {}
-        mock_voice = MagicMock()
-        mock_voice.config.language_id_map = {"ja": 0, "en": 1}
+    def _build(self, mock_timing_result, language_id_map):
+        voice = _make_voice(mock_timing_result, language_id_map=language_id_map)
+        captured: dict = {}
 
         def _synth(text, **kwargs):
             captured["language_id"] = kwargs.get("language_id")
             return (b"fake-wav", mock_timing_result)
 
-        mock_voice.synthesize_with_timing.side_effect = _synth
+        voice.synthesize_with_timing.side_effect = _synth
+        return TestClient(create_app(voice, synthesize_args={})), captured
 
-        app = Flask(__name__)
-
-        @app.route("/api/phoneme-timing", methods=["GET", "POST"])
-        def handler():
-            text = (
-                request.data.decode("utf-8")
-                if request.method == "POST"
-                else request.args.get("text", "")
-            )
-            text = text.strip()
-            if not text:
-                return jsonify({"error": "No text provided"}), 400
-
-            fmt = request.args.get("format", "json").lower()
-            if fmt not in ("json", "tsv"):
-                return jsonify({"error": f"Unsupported format: {fmt}"}), 400
-
-            language_id = None
-            language_id_raw = request.args.get("language_id", None)
-            language = request.args.get("language", None)
-            if language_id_raw is not None:
-                try:
-                    language_id = int(language_id_raw)
-                except (ValueError, TypeError):
-                    language_id = None
-            elif language is not None:
-                lmap = mock_voice.config.language_id_map
-                if lmap:
-                    language_id = lmap.get(language)
-
-            _, timing = mock_voice.synthesize_with_timing(
-                text, language_id=language_id
-            )
-            if timing is None:
-                return jsonify({"error": "Model does not support duration output"}), 400
-            if fmt == "tsv":
-                return (
-                    timing_to_tsv(timing),
-                    200,
-                    {"Content-Type": "text/tab-separated-values"},
-                )
-            return (
-                timing_to_json(timing),
-                200,
-                {"Content-Type": "application/json"},
-            )
-
-        client = app.test_client()
+    def test_numeric_language_id(self, mock_timing_result):
+        client, captured = self._build(mock_timing_result, {"ja": 0, "en": 1})
         resp = client.get("/api/phoneme-timing?text=hello&language_id=3")
         assert resp.status_code == 200
         assert captured["language_id"] == 3
 
-    def test_language_code_resolved_via_language_id_map(self, mock_timing_result):
-        """GET with ?language=ja looks up language_id_map and passes 0."""
-        from flask import Flask, jsonify, request
-
-        from piper.timing import timing_to_json, timing_to_tsv
-
-        captured = {}
-        mock_voice = MagicMock()
-        mock_voice.config.language_id_map = {"ja": 0, "en": 1, "zh": 2}
-
-        def _synth(text, **kwargs):
-            captured["language_id"] = kwargs.get("language_id")
-            return (b"fake-wav", mock_timing_result)
-
-        mock_voice.synthesize_with_timing.side_effect = _synth
-
-        app = Flask(__name__)
-
-        @app.route("/api/phoneme-timing", methods=["GET", "POST"])
-        def handler():
-            text = request.args.get("text", "").strip()
-            if not text:
-                return jsonify({"error": "No text provided"}), 400
-            fmt = request.args.get("format", "json").lower()
-            if fmt not in ("json", "tsv"):
-                return jsonify({"error": f"Unsupported format: {fmt}"}), 400
-
-            language_id = None
-            language = request.args.get("language", None)
-            language_id_raw = request.args.get("language_id", None)
-            if language_id_raw is not None:
-                try:
-                    language_id = int(language_id_raw)
-                except (ValueError, TypeError):
-                    language_id = None
-            elif language is not None:
-                lmap = mock_voice.config.language_id_map
-                if lmap:
-                    language_id = lmap.get(language)
-
-            _, timing = mock_voice.synthesize_with_timing(
-                text, language_id=language_id
-            )
-            if timing is None:
-                return jsonify({"error": "no duration support"}), 400
-            if fmt == "tsv":
-                return timing_to_tsv(timing), 200, {"Content-Type": "text/tab-separated-values"}
-            return timing_to_json(timing), 200, {"Content-Type": "application/json"}
-
-        client = app.test_client()
+    def test_language_code_resolved(self, mock_timing_result):
+        client, captured = self._build(
+            mock_timing_result, {"ja": 0, "en": 1, "zh": 2}
+        )
         resp = client.get("/api/phoneme-timing?text=hello&language=zh")
         assert resp.status_code == 200
         assert captured["language_id"] == 2
 
     def test_invalid_language_id_falls_back_to_none(self, mock_timing_result):
-        """Non-integer language_id falls back to None (gracefully)."""
-        from flask import Flask, jsonify, request
-
-        from piper.timing import timing_to_json
-
-        captured = {}
-        mock_voice = MagicMock()
-        mock_voice.config.language_id_map = None
-
-        def _synth(text, **kwargs):
-            captured["language_id"] = kwargs.get("language_id")
-            return (b"fake-wav", mock_timing_result)
-
-        mock_voice.synthesize_with_timing.side_effect = _synth
-
-        app = Flask(__name__)
-
-        @app.route("/api/phoneme-timing", methods=["GET", "POST"])
-        def handler():
-            text = request.args.get("text", "").strip()
-            if not text:
-                return jsonify({"error": "No text provided"}), 400
-            fmt = request.args.get("format", "json").lower()
-            if fmt not in ("json", "tsv"):
-                return jsonify({"error": f"Unsupported format: {fmt}"}), 400
-
-            language_id = None
-            language_id_raw = request.args.get("language_id", None)
-            if language_id_raw is not None:
-                try:
-                    language_id = int(language_id_raw)
-                except (ValueError, TypeError):
-                    language_id = None
-
-            _, timing = mock_voice.synthesize_with_timing(
-                text, language_id=language_id
-            )
-            return timing_to_json(timing), 200, {"Content-Type": "application/json"}
-
-        client = app.test_client()
-        resp = client.get("/api/phoneme-timing?text=hello&language_id=not-an-int")
+        client, captured = self._build(mock_timing_result, None)
+        resp = client.get(
+            "/api/phoneme-timing?text=hello&language_id=not-an-int"
+        )
         assert resp.status_code == 200
         assert captured["language_id"] is None
 
     def test_unknown_language_code_returns_none(self, mock_timing_result):
-        """Unknown language code (not in language_id_map) resolves to None."""
-        from flask import Flask, jsonify, request
-
-        from piper.timing import timing_to_json
-
-        captured = {}
-        mock_voice = MagicMock()
-        mock_voice.config.language_id_map = {"ja": 0, "en": 1}
-
-        def _synth(text, **kwargs):
-            captured["language_id"] = kwargs.get("language_id")
-            return (b"fake-wav", mock_timing_result)
-
-        mock_voice.synthesize_with_timing.side_effect = _synth
-
-        app = Flask(__name__)
-
-        @app.route("/api/phoneme-timing", methods=["GET", "POST"])
-        def handler():
-            text = request.args.get("text", "").strip()
-            if not text:
-                return jsonify({"error": "No text provided"}), 400
-            fmt = request.args.get("format", "json").lower()
-            if fmt not in ("json", "tsv"):
-                return jsonify({"error": f"Unsupported format: {fmt}"}), 400
-
-            language_id = None
-            language_id_raw = request.args.get("language_id", None)
-            language = request.args.get("language", None)
-            if language_id_raw is not None:
-                try:
-                    language_id = int(language_id_raw)
-                except (ValueError, TypeError):
-                    language_id = None
-            elif language is not None:
-                lmap = mock_voice.config.language_id_map
-                if lmap:
-                    language_id = lmap.get(language)
-
-            _, timing = mock_voice.synthesize_with_timing(
-                text, language_id=language_id
-            )
-            return timing_to_json(timing), 200, {"Content-Type": "application/json"}
-
-        client = app.test_client()
+        client, captured = self._build(mock_timing_result, {"ja": 0, "en": 1})
         resp = client.get("/api/phoneme-timing?text=hello&language=fr")
-        # Unknown language returns None (lmap.get returns None for missing keys)
         assert resp.status_code == 200
         assert captured["language_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# / synthesis endpoint — non-streaming + streaming
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeEndpoint:
+    """Tests for the root ``/`` synthesis endpoint."""
+
+    def test_post_returns_wav(self, client):
+        resp = client.post("/", content="hello")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("audio/wav")
+        # Valid WAV header starts with "RIFF...WAVE"
+        assert resp.content[:4] == b"RIFF"
+        assert resp.content[8:12] == b"WAVE"
+
+    def test_get_with_text_query(self, client):
+        resp = client.get("/?text=hello")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("audio/wav")
+        assert resp.content[:4] == b"RIFF"
+
+    def test_empty_text_returns_400(self, client):
+        resp = client.post("/", content="")
+        assert resp.status_code == 400
+
+    def test_whitespace_text_returns_400(self, client):
+        resp = client.post("/", content="   \n  ")
+        assert resp.status_code == 400
+
+
+class TestStreamingEndpoint:
+    """Tests for ``?streaming=true`` chunked WAV streaming on ``/``."""
+
+    def test_streaming_returns_wav_with_placeholder_sizes(
+        self, mock_timing_result
+    ):
+        voice = _make_voice(mock_timing_result, sample_rate=22050)
+        client = TestClient(create_app(voice, synthesize_args={}))
+
+        with client.stream("POST", "/?streaming=true", content="hello") as resp:
+            assert resp.status_code == 200
+            assert resp.headers["content-type"].startswith("audio/wav")
+            chunks = list(resp.iter_bytes())
+
+        body = b"".join(chunks)
+        # WAV header (44 bytes) + raw PCM
+        assert body[:4] == b"RIFF"
+        assert body[8:12] == b"WAVE"
+        # Streaming uses placeholder sizes (0xFFFFFFFF) for RIFF + data
+        riff_size = struct.unpack("<I", body[4:8])[0]
+        data_size = struct.unpack("<I", body[40:44])[0]
+        assert riff_size == 0xFFFFFFFF
+        assert data_size == 0xFFFFFFFF
+        # Should contain PCM payload from both yielded sentences (200B + 200B)
+        assert len(body) >= 44 + 200 + 200
+
+    def test_streaming_invokes_synthesize_stream_raw(self, mock_timing_result):
+        voice = _make_voice(mock_timing_result)
+        client = TestClient(create_app(voice, synthesize_args={}))
+        client.post("/?streaming=true", content="hello")
+        assert voice.synthesize_stream_raw.called
+        # synthesize() (the non-streaming path) should NOT have been called
+        assert not voice.synthesize.called
+
+    def test_non_streaming_uses_synthesize(self, mock_timing_result):
+        voice = _make_voice(mock_timing_result)
+        client = TestClient(create_app(voice, synthesize_args={}))
+        client.post("/", content="hello")
+        assert voice.synthesize.called
+        assert not voice.synthesize_stream_raw.called
+
+    def test_streaming_flag_accepts_truthy_values(self, mock_timing_result):
+        for flag in ("true", "1", "yes", "on", "TRUE"):
+            voice = _make_voice(mock_timing_result)
+            client = TestClient(create_app(voice, synthesize_args={}))
+            client.post(f"/?streaming={flag}", content="hello")
+            assert voice.synthesize_stream_raw.called, (
+                f"streaming={flag} should enable streaming"
+            )
+
+    def test_streaming_flag_off_by_default(self, mock_timing_result):
+        voice = _make_voice(mock_timing_result)
+        client = TestClient(create_app(voice, synthesize_args={}))
+        # No streaming param at all
+        client.post("/", content="hello")
+        assert voice.synthesize.called
+        assert not voice.synthesize_stream_raw.called
+
+    def test_streaming_wav_header_uses_voice_sample_rate(
+        self, mock_timing_result
+    ):
+        voice = _make_voice(mock_timing_result, sample_rate=16000)
+        client = TestClient(create_app(voice, synthesize_args={}))
+        with client.stream("POST", "/?streaming=true", content="hello") as resp:
+            chunks = list(resp.iter_bytes())
+        header = b"".join(chunks)[:44]
+        # Sample rate is at offset 24 (4 bytes, little endian)
+        assert struct.unpack("<I", header[24:28])[0] == 16000
+
+
+# ---------------------------------------------------------------------------
+# Smoke check: produced non-streaming WAV is parseable by `wave`
+# ---------------------------------------------------------------------------
+
+
+class TestNonStreamingWavValidity:
+    def test_wav_response_is_valid_wave_file(self, client):
+        resp = client.post("/", content="hello")
+        assert resp.status_code == 200
+        with wave.open(io.BytesIO(resp.content), "rb") as wav_in:
+            assert wav_in.getnchannels() == 1
+            assert wav_in.getsampwidth() == 2
+            assert wav_in.getframerate() == 22050
+
+
+# ---------------------------------------------------------------------------
+# JSON content-type smoke (FastAPI returns JSON via Response/JSONResponse)
+# ---------------------------------------------------------------------------
+
+
+def test_timing_json_body_is_parseable(client):
+    resp = client.get("/api/phoneme-timing?text=hello")
+    assert resp.status_code == 200
+    parsed = json.loads(resp.text)
+    assert isinstance(parsed, dict)
+    assert "phonemes" in parsed


### PR DESCRIPTION
## Summary

[Issue #358](https://github.com/ayutaz/piper-plus/issues/358) 対応。`piper.http_server` を Flask から FastAPI に書き換え、`/` エンドポイントに **チャンク転送 (Transfer-Encoding: chunked) ストリーミング** を追加します。

エージェントチームによる 4 観点 (コード品質 / セキュリティ / ストリーミング正当性 / 後方互換) のレビュー指摘を反映済み。

## 主な変更

### 新機能
- `?streaming=true` で WAV ヘッダ (placeholder size `0xFFFFFFFF`) + `synthesize_stream_raw()` を `StreamingResponse` で逐次配信
- `/docs` (Swagger UI) と `/openapi.json` 自動提供 (FastAPI 副次効果)

### 技術的改善
- `create_app(voice, synthesize_args)` 関数化でテスト容易性向上 (本番コードを直接駆動)
- 同期 ONNX 推論を `run_in_threadpool` で逃がし、event loop ブロッキングを解消
- 入力サイズ上限 1 MiB を導入 (超過時 413)
- `--host 0.0.0.0` / `::` 起動時に認証なし公開を WARNING ログで警告
- ストリーミング generator を `try/except` + `_LOGGER.exception` で囲み silent failure 解消
- `language_id` の範囲チェック追加 (マップ外は None fallback + WARNING ログ)

### 後方互換
- URL/クエリパラメータは旧 Flask 版と互換 (破壊的変更なし)
- CLI オプション 14 個すべて維持
- エラーレスポンス形状を `{"error": ...}` で統一 (Flask `jsonify` と同形)

### 依存
- `flask>=3,<4` → `fastapi>=0.110,<1` + `uvicorn[standard]>=0.27,<1`
- `requirements_http.txt` / `setup.py [http]` extras を更新

### テスト
- 既存 12 件 → **37 件** (FastAPI `TestClient` 移行 + 防御層テスト追加)
- カバレッジ `http_server.py`: 68% → 75%
- 新規カバレッジ: サイズ制限 / ストリーミング例外 / language_id 範囲 / 起動時警告 / エラー形状統一

## Test plan

- [x] 既存テスト 25 → 37 件、全て pass
- [x] FastAPI `TestClient` で実本番 `create_app()` を駆動
- [x] WAV header の RIFF/fmt/data 構造を `struct.unpack` で検証
- [x] ストリーミング `0xFFFFFFFF` placeholder と payload 配信を確認
- [x] `wave` ライブラリで非ストリーミング WAV がパース可能
- [x] エージェントチーム 4 観点レビュー指摘を反映 (Must/Should fix)
- [ ] 実機での `?streaming=true` 再生検証 (Safari / Chrome / Firefox / ffmpeg / VLC) — 手動

## Related

- Closes #358
- Zenn スクラップでの指摘元: https://zenn.dev/kun432/scraps/cddbfcd75b8b34
- 既存 FastAPI 実装 (OpenAI 互換): \`docker/python-inference/inference.py\`