### PR TITLE
fix: 短文「こんにちは。」が「あこんにちはた」と崩壊する問題を修正 (#356)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ create_comprehensive_*.py
 add_missing_*.py
 retrain_*.py
 comprehensive_*.py
+tmp_*.py
 
 # Training datasets and downloaded models
 datasets/

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ add_missing_*.py
 retrain_*.py
 comprehensive_*.py
 tmp_*.py
+tmp_*/
 
 # Training datasets and downloaded models
 datasets/

--- a/docs/spec/short-text-contract.toml
+++ b/docs/spec/short-text-contract.toml
@@ -42,7 +42,22 @@
 [padding]
 # Minimum phoneme ID count for stable VITS inference.
 # Sequences shorter than this are padded with pause tokens.
-min_phoneme_ids = 40
+#
+# Issue #356: Was 40, but empirical measurements on the tsukuyomi 6lang
+# model show synthesis is stable down to ~8 IDs and weakens only below ~7.
+# 40 was so conservative that Strategy A fired on already-stable inputs
+# (e.g. 「こんにちは。」= 22 IDs), and the pad tokens leaked as audible
+# artefacts that post-trim could not fully remove. 15 keeps Strategy A
+# active for genuinely tiny inputs while leaving stable sequences alone.
+min_phoneme_ids = 15
+
+# Minimum body length (= phoneme_ids excluding BOS / EOS) for Strategy A
+# to apply. When the body is smaller than this, padding-to-body ratio
+# explodes and the pad-token audio dominates over the actual content
+# (e.g. 「あ。」 has body=2 → 11 pad tokens around 2 body tokens with the
+# previous 40 threshold). Below this threshold we use raw VITS output
+# instead — degraded for tiny utterances but free from padding artefacts.
+min_body_for_strategy_a = 3
 
 # Token ID used for padding (pause / blank / PAD symbol "_").
 pause_token_id = 0

--- a/docs/spec/short-text-contract.toml
+++ b/docs/spec/short-text-contract.toml
@@ -47,7 +47,7 @@
 # model show synthesis is stable down to ~8 IDs and weakens only below ~7.
 # 40 was so conservative that Strategy A fired on already-stable inputs
 # (e.g. 「こんにちは。」= 22 IDs), and the pad tokens leaked as audible
-# artefacts that post-trim could not fully remove. 15 keeps Strategy A
+# artifacts that post-trim could not fully remove. 15 keeps Strategy A
 # active for genuinely tiny inputs while leaving stable sequences alone.
 min_phoneme_ids = 15
 
@@ -58,7 +58,7 @@ min_phoneme_ids = 15
 # previous threshold of 40, or 11 pad tokens at the current threshold of
 # 15 — either way the body is overwhelmed). Below this threshold we use
 # raw VITS output instead — degraded for tiny utterances but free from
-# padding artefacts.
+# padding artifacts.
 min_body_for_strategy_a = 3
 
 # Token ID used for padding (pause / blank / PAD symbol "_").

--- a/docs/spec/short-text-contract.toml
+++ b/docs/spec/short-text-contract.toml
@@ -54,9 +54,11 @@ min_phoneme_ids = 15
 # Minimum body length (= phoneme_ids excluding BOS / EOS) for Strategy A
 # to apply. When the body is smaller than this, padding-to-body ratio
 # explodes and the pad-token audio dominates over the actual content
-# (e.g. 「あ。」 has body=2 → 11 pad tokens around 2 body tokens with the
-# previous 40 threshold). Below this threshold we use raw VITS output
-# instead — degraded for tiny utterances but free from padding artefacts.
+# (e.g. 「あ。」 has body=2 → 36 pad tokens around 2 body tokens at the
+# previous threshold of 40, or 11 pad tokens at the current threshold of
+# 15 — either way the body is overwhelmed). Below this threshold we use
+# raw VITS output instead — degraded for tiny utterances but free from
+# padding artefacts.
 min_body_for_strategy_a = 3
 
 # Token ID used for padding (pause / blank / PAD symbol "_").

--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -90,6 +90,10 @@ constexpr int MIN_BODY_FOR_STRATEGY_A = 3;
 constexpr float TRIM_THRESHOLD_RMS = 0.01f;
 constexpr int TRIM_MIN_SAMPLES = 2205;  // 22050 Hz * 0.1 s
 constexpr int TRIM_WINDOW_SIZE = 256;
+// Maximum EOS frames retained by the durations-based Strategy A trim.
+// VITS predicts an inflated EOS under the padded context that emits an
+// audible artefact otherwise. 0 = drop the entire EOS region.
+constexpr int TRIM_EOS_MAX_FRAMES = 0;
 
 // PUA to multi-char phoneme mapping for display
 static const std::unordered_map<char32_t, std::string> puaToPhoneme = {
@@ -693,8 +697,16 @@ void loadVoice(PiperConfig &config, std::string modelPath,
 // and before EOS to reach MIN_PHONEME_IDS length. Returns true if padding was
 // applied. Strategy A is also skipped when the body (= phoneme IDs minus
 // BOS/EOS) is shorter than MIN_BODY_FOR_STRATEGY_A — see issue #356.
+//
+// When padding is applied, *frontPadOut and *backPadOut (when non-null)
+// receive the number of pad tokens inserted after BOS and before EOS
+// respectively, so the durations-based trim can locate them precisely.
 static bool padPhonemeIds(std::vector<PhonemeId> &phonemeIds,
-                          PhonemeId padId = 0) {
+                          PhonemeId padId = 0,
+                          int *frontPadOut = nullptr,
+                          int *backPadOut = nullptr) {
+  if (frontPadOut) *frontPadOut = 0;
+  if (backPadOut) *backPadOut = 0;
   const auto len = static_cast<int>(phonemeIds.size());
   const int bodyLen = len - 2; // exclude BOS / EOS
   if (bodyLen < MIN_BODY_FOR_STRATEGY_A) {
@@ -713,6 +725,8 @@ static bool padPhonemeIds(std::vector<PhonemeId> &phonemeIds,
   if (phonemeIds.size() < 2) {
     // Degenerate case: just pad at the end
     phonemeIds.insert(phonemeIds.end(), static_cast<size_t>(needed), padId);
+    if (frontPadOut) *frontPadOut = front;
+    if (backPadOut) *backPadOut = back;
     return true;
   }
 
@@ -732,7 +746,122 @@ static bool padPhonemeIds(std::vector<PhonemeId> &phonemeIds,
 
   spdlog::debug("Short-text padding: {} -> {} phoneme IDs ({} pad tokens added)",
                 len, phonemeIds.size(), needed);
+  if (frontPadOut) *frontPadOut = front;
+  if (backPadOut) *backPadOut = back;
   return true;
+}
+
+// Strategy A precise post-trim using the model's duration output.
+// Mirrors the Python reference (src/python_run/piper/voice.py
+// _trim_padding_by_durations) so all runtimes produce byte-equal output for
+// the same inputs (issue #356, cross-runtime contract).
+//
+// Layout: [BOS, pad×frontPad, ...body..., pad×backPad, EOS]
+//
+// Trimming policy:
+//   - BOS + front padding: stripped completely
+//   - Back padding: stripped completely
+//   - EOS: keep only `eosMaxFrames` frames (default TRIM_EOS_MAX_FRAMES = 0)
+//
+// All frame→sample conversions use static_cast<int>(...) on a float product
+// (truncation toward zero), matching int() in the Python implementation.
+//
+// Falls through unchanged when arguments are inconsistent.
+static void trimPaddingByDurations(std::vector<int16_t> &audioBuffer,
+                                   const std::vector<float> &durations,
+                                   int frontPad,
+                                   int backPad,
+                                   int hopSize,
+                                   int eosMaxFrames = TRIM_EOS_MAX_FRAMES) {
+  if (frontPad <= 0 && backPad <= 0) return;
+  if (durations.empty() || hopSize <= 0) return;
+  const int expectedLen = 1 + frontPad + backPad + 1; // BOS + pads + EOS
+  if (static_cast<int>(durations.size()) < expectedLen) return;
+
+  // Front: BOS + front padding samples (truncated).
+  float frontSum = 0.0f;
+  for (int i = 0; i < 1 + frontPad; i++) {
+    frontSum += durations[i];
+  }
+  const int frontSamples = static_cast<int>(frontSum * static_cast<float>(hopSize));
+
+  // Back: back padding samples + EOS excess (over eosMaxFrames).
+  float backPadSum = 0.0f;
+  if (backPad > 0) {
+    // durations[-(1+backPad) : -1] in Python = [size-1-backPad, size-1)
+    const int start = static_cast<int>(durations.size()) - 1 - backPad;
+    for (int i = start; i < static_cast<int>(durations.size()) - 1; i++) {
+      backPadSum += durations[i];
+    }
+  }
+  const int backPadSamples =
+      static_cast<int>(backPadSum * static_cast<float>(hopSize));
+  const float eosFrames = durations.back();
+  float eosExcess = eosFrames - static_cast<float>(eosMaxFrames);
+  if (eosExcess < 0.0f) eosExcess = 0.0f;
+  const int backSamples =
+      backPadSamples +
+      static_cast<int>(eosExcess * static_cast<float>(hopSize));
+
+  const int totalSamples = static_cast<int>(audioBuffer.size());
+  int start = frontSamples < 0 ? 0 : frontSamples;
+  int end = totalSamples - backSamples;
+  if (end < start) end = start;
+  if (start >= totalSamples || end <= 0 || start >= end) return;
+
+  if (start > 0 || end < totalSamples) {
+    std::vector<int16_t> trimmed(audioBuffer.begin() + start,
+                                 audioBuffer.begin() + end);
+    audioBuffer = std::move(trimmed);
+  }
+}
+
+// Float32 variant of trimPaddingByDurations. Identical sample-count logic;
+// only the buffer element type differs.
+static void trimPaddingByDurationsFloat(std::vector<float> &audioBuffer,
+                                        const std::vector<float> &durations,
+                                        int frontPad,
+                                        int backPad,
+                                        int hopSize,
+                                        int eosMaxFrames = TRIM_EOS_MAX_FRAMES) {
+  if (frontPad <= 0 && backPad <= 0) return;
+  if (durations.empty() || hopSize <= 0) return;
+  const int expectedLen = 1 + frontPad + backPad + 1;
+  if (static_cast<int>(durations.size()) < expectedLen) return;
+
+  float frontSum = 0.0f;
+  for (int i = 0; i < 1 + frontPad; i++) {
+    frontSum += durations[i];
+  }
+  const int frontSamples = static_cast<int>(frontSum * static_cast<float>(hopSize));
+
+  float backPadSum = 0.0f;
+  if (backPad > 0) {
+    const int start = static_cast<int>(durations.size()) - 1 - backPad;
+    for (int i = start; i < static_cast<int>(durations.size()) - 1; i++) {
+      backPadSum += durations[i];
+    }
+  }
+  const int backPadSamples =
+      static_cast<int>(backPadSum * static_cast<float>(hopSize));
+  const float eosFrames = durations.back();
+  float eosExcess = eosFrames - static_cast<float>(eosMaxFrames);
+  if (eosExcess < 0.0f) eosExcess = 0.0f;
+  const int backSamples =
+      backPadSamples +
+      static_cast<int>(eosExcess * static_cast<float>(hopSize));
+
+  const int totalSamples = static_cast<int>(audioBuffer.size());
+  int start = frontSamples < 0 ? 0 : frontSamples;
+  int end = totalSamples - backSamples;
+  if (end < start) end = start;
+  if (start >= totalSamples || end <= 0 || start >= end) return;
+
+  if (start > 0 || end < totalSamples) {
+    std::vector<float> trimmed(audioBuffer.begin() + start,
+                               audioBuffer.begin() + end);
+    audioBuffer = std::move(trimmed);
+  }
 }
 
 // Trim leading/trailing silence from int16 audio using windowed RMS.
@@ -1005,7 +1134,9 @@ void synthesize(std::vector<PhonemeId> &phonemeIds,
   // Save original (pre-padding) phoneme IDs for timing extraction.
   // Duration output corresponds to the original sequence, not padded.
   const std::vector<PhonemeId> originalPhonemeIds(phonemeIds);
-  bool wasPadded = padPhonemeIds(phonemeIds);  // Strategy A: padding
+  int frontPad = 0;
+  int backPad = 0;
+  bool wasPadded = padPhonemeIds(phonemeIds, /*padId=*/0, &frontPad, &backPad);
 
   // Strategy B: Dynamic Scales Adjustment
   float effectiveNoiseScale = synthesisConfig.noiseScale;
@@ -1047,6 +1178,14 @@ void synthesize(std::vector<PhonemeId> &phonemeIds,
   outputNamesVec.push_back("output");
   if (session.hasDurationOutput) {
     outputNamesVec.push_back("durations");
+  }
+
+  // Resolve hop_size for durations-based Strategy A trim. Falls back to
+  // DEFAULT_HOP_SIZE when the config is missing or the field is absent.
+  int hopSize = DEFAULT_HOP_SIZE;
+  if (voice && voice->configRoot.contains("audio") &&
+      voice->configRoot["audio"].contains("hop_size")) {
+    hopSize = voice->configRoot["audio"]["hop_size"];
   }
 
   // Infer
@@ -1110,10 +1249,34 @@ void synthesize(std::vector<PhonemeId> &phonemeIds,
   }
 #endif
 
-  // --- Strategy A post-trim: remove inserted silence after inference ---
+  // Extract durations BEFORE post-trim so the precise trimmer can use them.
+  std::vector<float> paddedDurations;
+  bool haveDurations = false;
+  if (session.hasDurationOutput && outputTensors.size() >= 2) {
+    auto& durationTensor = outputTensors[1];
+    if (durationTensor.IsTensor()) {
+      const float *dPtr = durationTensor.GetTensorData<float>();
+      auto durationShape = durationTensor.GetTensorTypeAndShapeInfo().GetShape();
+      size_t durationCount = 1;
+      for (auto dim : durationShape) {
+        durationCount *= dim;
+      }
+      paddedDurations.assign(dPtr, dPtr + durationCount);
+      haveDurations = true;
+    }
+  }
+
+  // --- Strategy A post-trim: remove padding-induced audio ---
+  // Prefer the durations-based precise trim when the model exposes
+  // durations (issue #356). Falls back to the legacy RMS trim only when
+  // durations are unavailable.
   if (wasPadded) {
-    trimSilenceInt16(audioBuffer);
-    // Recompute audioSeconds after trimming
+    if (haveDurations) {
+      trimPaddingByDurations(audioBuffer, paddedDurations, frontPad, backPad,
+                             hopSize, TRIM_EOS_MAX_FRAMES);
+    } else {
+      trimSilenceInt16(audioBuffer);
+    }
     result.audioSeconds =
         static_cast<double>(audioBuffer.size()) /
         static_cast<double>(synthesisConfig.sampleRate);
@@ -1122,39 +1285,18 @@ void synthesize(std::vector<PhonemeId> &phonemeIds,
     }
   }
 
-  // Extract phoneme timing information if available
-  if (session.hasDurationOutput && outputTensors.size() >= 2 && voice != nullptr) {
-    auto& durationTensor = outputTensors[1];
-    if (durationTensor.IsTensor()) {
-      const float *durations = durationTensor.GetTensorData<float>();
-      auto durationShape = durationTensor.GetTensorTypeAndShapeInfo().GetShape();
-      size_t durationCount = 1;
-      for (auto dim : durationShape) {
-        durationCount *= dim;
-      }
-      
-      // Convert durations to vector
-      std::vector<float> durationVec(durations, durations + durationCount);
-      
-      // Extract timing information
-      // Get hop_size from config
-      int hopSize = DEFAULT_HOP_SIZE;
-      if (voice->configRoot.contains("audio") && 
-          voice->configRoot["audio"].contains("hop_size")) {
-        hopSize = voice->configRoot["audio"]["hop_size"];
-      }
-      
-      result.phonemeTimings = extractTimingsFromDurations(
-          durationVec, originalPhonemeIds,
-          voice->phonemizeConfig.phonemeIdMap,
-          hopSize,
-          voice->synthesisConfig.sampleRate,
-          voice->phonemizeConfig.phonemeType
-      );
-      result.hasTimingInfo = true;
-
-      spdlog::debug("Extracted timing for {} phonemes", result.phonemeTimings.size());
-    }
+  // Extract phoneme timing information using the original (pre-padding)
+  // sequence so callers see indices aligned with their input.
+  if (haveDurations && voice != nullptr) {
+    result.phonemeTimings = extractTimingsFromDurations(
+        paddedDurations, originalPhonemeIds,
+        voice->phonemizeConfig.phonemeIdMap,
+        hopSize,
+        voice->synthesisConfig.sampleRate,
+        voice->phonemizeConfig.phonemeType);
+    result.hasTimingInfo = true;
+    spdlog::debug("Extracted timing for {} phonemes",
+                  result.phonemeTimings.size());
   }
 
   // Clean up
@@ -1192,7 +1334,9 @@ void synthesizeFloat(std::vector<PhonemeId> &phonemeIds,
   // Save original (pre-padding) phoneme IDs for timing extraction.
   // Duration output corresponds to the original sequence, not padded.
   const std::vector<PhonemeId> originalPhonemeIds(phonemeIds);
-  bool wasPadded = padPhonemeIds(phonemeIds);  // Strategy A: padding
+  int frontPad = 0;
+  int backPad = 0;
+  bool wasPadded = padPhonemeIds(phonemeIds, /*padId=*/0, &frontPad, &backPad);
 
   // Strategy B: Dynamic Scales Adjustment
   float effectiveNoiseScale = synthesisConfig.noiseScale;
@@ -1206,6 +1350,13 @@ void synthesizeFloat(std::vector<PhonemeId> &phonemeIds,
     spdlog::debug("Short-text dynamic scales (float): ratio={:.3f}, "
                   "noiseScale={:.4f}, noiseW={:.4f}",
                   ratio, effectiveNoiseScale, effectiveNoiseW);
+  }
+
+  // Resolve hop_size for durations-based Strategy A trim.
+  int hopSize = DEFAULT_HOP_SIZE;
+  if (voice && voice->configRoot.contains("audio") &&
+      voice->configRoot["audio"].contains("hop_size")) {
+    hopSize = voice->configRoot["audio"]["hop_size"];
   }
 
   // Populate InferenceInputs from the existing parameters
@@ -1286,10 +1437,31 @@ void synthesizeFloat(std::vector<PhonemeId> &phonemeIds,
         std::clamp(audio[i] * invMax, -1.0f, 1.0f));
   }
 
-  // --- Strategy A post-trim: remove inserted silence after inference ---
+  // Extract durations BEFORE post-trim so the precise trimmer can use them.
+  std::vector<float> paddedDurations;
+  bool haveDurations = false;
+  if (session.hasDurationOutput && outputTensors.size() >= 2) {
+    auto& durationTensor = outputTensors[1];
+    if (durationTensor.IsTensor()) {
+      const float *dPtr = durationTensor.GetTensorData<float>();
+      auto durationShape = durationTensor.GetTensorTypeAndShapeInfo().GetShape();
+      size_t durationCount = 1;
+      for (auto dim : durationShape) {
+        durationCount *= dim;
+      }
+      paddedDurations.assign(dPtr, dPtr + durationCount);
+      haveDurations = true;
+    }
+  }
+
+  // --- Strategy A post-trim: remove padding-induced audio ---
   if (wasPadded) {
-    trimSilenceFloat(audioBuffer);
-    // Recompute audioSeconds after trimming
+    if (haveDurations) {
+      trimPaddingByDurationsFloat(audioBuffer, paddedDurations, frontPad,
+                                  backPad, hopSize, TRIM_EOS_MAX_FRAMES);
+    } else {
+      trimSilenceFloat(audioBuffer);
+    }
     result.audioSeconds =
         static_cast<double>(audioBuffer.size()) /
         static_cast<double>(synthesisConfig.sampleRate);
@@ -1298,7 +1470,9 @@ void synthesizeFloat(std::vector<PhonemeId> &phonemeIds,
     }
   }
 
-  // Extract phoneme timing information if available
+  // Extract phoneme timing information if available (legacy block kept
+  // intact below — it consumes the durationTensor a second time only when
+  // we entered this branch).
   if (session.hasDurationOutput && outputTensors.size() >= 2 && voice != nullptr) {
     auto& durationTensor = outputTensors[1];
     if (durationTensor.IsTensor()) {

--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -76,8 +76,17 @@ const float MAX_WAV_VALUE = 32767.0f;
 // Beyond 4 threads VITS sees diminishing returns and increased contention.
 constexpr int MAX_INTRA_THREADS = 4;
 
-// Short-text mitigation constants (keep in sync with other runtimes)
-constexpr int MIN_PHONEME_IDS = 40;
+// Short-text mitigation constants (keep in sync with other runtimes —
+// docs/spec/short-text-contract.toml).
+//
+// Issue #356: MIN_PHONEME_IDS was 40 but tsukuyomi 6lang testing shows
+// synthesis is stable down to ~8 IDs. 40 caused Strategy A to fire on
+// already-stable inputs and leak padding artefacts. 15 keeps Strategy A
+// active for genuinely tiny inputs only. MIN_BODY_FOR_STRATEGY_A = 3
+// additionally bypasses Strategy A when the body (= phoneme IDs minus
+// BOS/EOS) is too small for padding to outweigh content (e.g. 「あ。」).
+constexpr int MIN_PHONEME_IDS = 15;
+constexpr int MIN_BODY_FOR_STRATEGY_A = 3;
 constexpr float TRIM_THRESHOLD_RMS = 0.01f;
 constexpr int TRIM_MIN_SAMPLES = 2205;  // 22050 Hz * 0.1 s
 constexpr int TRIM_WINDOW_SIZE = 256;
@@ -682,10 +691,15 @@ void loadVoice(PiperConfig &config, std::string modelPath,
 
 // Pad short phoneme ID sequences with silence tokens (pause ID = 0) after BOS
 // and before EOS to reach MIN_PHONEME_IDS length. Returns true if padding was
-// applied.
+// applied. Strategy A is also skipped when the body (= phoneme IDs minus
+// BOS/EOS) is shorter than MIN_BODY_FOR_STRATEGY_A — see issue #356.
 static bool padPhonemeIds(std::vector<PhonemeId> &phonemeIds,
                           PhonemeId padId = 0) {
   const auto len = static_cast<int>(phonemeIds.size());
+  const int bodyLen = len - 2; // exclude BOS / EOS
+  if (bodyLen < MIN_BODY_FOR_STRATEGY_A) {
+    return false;
+  }
   if (len >= MIN_PHONEME_IDS) {
     return false;
   }

--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -81,7 +81,7 @@ constexpr int MAX_INTRA_THREADS = 4;
 //
 // Issue #356: MIN_PHONEME_IDS was 40 but tsukuyomi 6lang testing shows
 // synthesis is stable down to ~8 IDs. 40 caused Strategy A to fire on
-// already-stable inputs and leak padding artefacts. 15 keeps Strategy A
+// already-stable inputs and leak padding artifacts. 15 keeps Strategy A
 // active for genuinely tiny inputs only. MIN_BODY_FOR_STRATEGY_A = 3
 // additionally bypasses Strategy A when the body (= phoneme IDs minus
 // BOS/EOS) is too small for padding to outweigh content (e.g. 「あ。」).
@@ -92,7 +92,7 @@ constexpr int TRIM_MIN_SAMPLES = 2205;  // 22050 Hz * 0.1 s
 constexpr int TRIM_WINDOW_SIZE = 256;
 // Maximum EOS frames retained by the durations-based Strategy A trim.
 // VITS predicts an inflated EOS under the padded context that emits an
-// audible artefact otherwise. 0 = drop the entire EOS region.
+// audible artifact otherwise. 0 = drop the entire EOS region.
 constexpr int TRIM_EOS_MAX_FRAMES = 0;
 
 // PUA to multi-char phoneme mapping for display

--- a/src/cpp/tests/test_short_text_mitigation.cpp
+++ b/src/cpp/tests/test_short_text_mitigation.cpp
@@ -20,7 +20,8 @@
 
 using PhonemeId = int64_t;
 
-constexpr int MIN_PHONEME_IDS = 40;
+constexpr int MIN_PHONEME_IDS = 15;
+constexpr int MIN_BODY_FOR_STRATEGY_A = 3;
 constexpr float TRIM_THRESHOLD_RMS = 0.01f;
 constexpr int TRIM_MIN_SAMPLES = 2205;  // 22050 Hz * 0.1 s
 constexpr int TRIM_WINDOW_SIZE = 256;
@@ -29,6 +30,10 @@ constexpr int TRIM_WINDOW_SIZE = 256;
 static bool padPhonemeIds(std::vector<PhonemeId> &phonemeIds,
                           PhonemeId padId = 0) {
   const auto len = static_cast<int>(phonemeIds.size());
+  const int bodyLen = len - 2;
+  if (bodyLen < MIN_BODY_FOR_STRATEGY_A) {
+    return false;
+  }
   if (len >= MIN_PHONEME_IDS) {
     return false;
   }
@@ -208,16 +213,16 @@ static void trimSilenceFloat(std::vector<float> &audioBuffer) {
 class PadPhonemeIdsTest : public ::testing::Test {};
 
 TEST_F(PadPhonemeIdsTest, NoOpWhenAlreadyLongEnough) {
-  // BOS(1) + 38 body + EOS(2) = 40 elements
+  // BOS + (MIN_PHONEME_IDS - 2) body + EOS = MIN_PHONEME_IDS elements
   std::vector<PhonemeId> ids;
   ids.push_back(1);  // BOS
-  for (int i = 0; i < 38; i++) ids.push_back(10 + i);
+  for (int i = 0; i < MIN_PHONEME_IDS - 2; i++) ids.push_back(10 + i);
   ids.push_back(2);  // EOS
-  ASSERT_EQ(ids.size(), 40u);
+  ASSERT_EQ(static_cast<int>(ids.size()), MIN_PHONEME_IDS);
 
   bool padded = padPhonemeIds(ids);
   EXPECT_FALSE(padded);
-  EXPECT_EQ(ids.size(), 40u);
+  EXPECT_EQ(static_cast<int>(ids.size()), MIN_PHONEME_IDS);
 }
 
 TEST_F(PadPhonemeIdsTest, NoOpWhenLongerThanMinimum) {
@@ -233,7 +238,7 @@ TEST_F(PadPhonemeIdsTest, NoOpWhenLongerThanMinimum) {
 }
 
 TEST_F(PadPhonemeIdsTest, PadsShortSequenceToMinLength) {
-  // BOS + 5 body + EOS = 7 elements -> need 33 pads
+  // BOS + 5 body + EOS = 7 elements (body=5 >= MIN_BODY_FOR_STRATEGY_A).
   std::vector<PhonemeId> ids = {1, 10, 11, 12, 13, 14, 2};
   ASSERT_EQ(ids.size(), 7u);
 
@@ -267,7 +272,8 @@ TEST_F(PadPhonemeIdsTest, BodyPreservedInOrder) {
 }
 
 TEST_F(PadPhonemeIdsTest, PadTokensArePauseId) {
-  std::vector<PhonemeId> ids = {1, 10, 2};  // Very short
+  // body must be >= MIN_BODY_FOR_STRATEGY_A so Strategy A applies.
+  std::vector<PhonemeId> ids = {1, 10, 11, 12, 2};
 
   padPhonemeIds(ids, /*padId=*/0);
 
@@ -280,7 +286,7 @@ TEST_F(PadPhonemeIdsTest, PadTokensArePauseId) {
 }
 
 TEST_F(PadPhonemeIdsTest, FrontBackSplitIsBalanced) {
-  // BOS + 3 body + EOS = 5, need 35 pads -> front=17, back=18
+  // body=3 (== MIN_BODY_FOR_STRATEGY_A): Strategy A applies.
   std::vector<PhonemeId> ids = {1, 10, 11, 12, 2};
   padPhonemeIds(ids);
 
@@ -303,39 +309,57 @@ TEST_F(PadPhonemeIdsTest, FrontBackSplitIsBalanced) {
 }
 
 TEST_F(PadPhonemeIdsTest, DegenerateSingleElement) {
+  // body would be -1: Strategy A is skipped.
   std::vector<PhonemeId> ids = {42};
+  std::vector<PhonemeId> original = ids;
 
   bool padded = padPhonemeIds(ids);
-  EXPECT_TRUE(padded);
-  EXPECT_EQ(static_cast<int>(ids.size()), MIN_PHONEME_IDS);
+  EXPECT_FALSE(padded);
+  EXPECT_EQ(ids, original);
 }
 
 TEST_F(PadPhonemeIdsTest, DegenerateEmpty) {
   std::vector<PhonemeId> ids;
 
   bool padded = padPhonemeIds(ids);
-  EXPECT_TRUE(padded);
-  EXPECT_EQ(static_cast<int>(ids.size()), MIN_PHONEME_IDS);
+  EXPECT_FALSE(padded);
+  EXPECT_TRUE(ids.empty());
 }
 
-TEST_F(PadPhonemeIdsTest, MinimalBosEos) {
-  // BOS + EOS = 2 elements, body is empty
-  std::vector<PhonemeId> ids = {1, 2};
-
-  bool padded = padPhonemeIds(ids);
-  EXPECT_TRUE(padded);
-  EXPECT_EQ(static_cast<int>(ids.size()), MIN_PHONEME_IDS);
-  EXPECT_EQ(ids.front(), 1);
-  EXPECT_EQ(ids.back(), 2);
+TEST_F(PadPhonemeIdsTest, SkipsWhenBodyTooShort) {
+  // body=0 (just BOS+EOS): Strategy A skipped (issue #356).
+  {
+    std::vector<PhonemeId> ids = {1, 2};
+    std::vector<PhonemeId> original = ids;
+    bool padded = padPhonemeIds(ids);
+    EXPECT_FALSE(padded);
+    EXPECT_EQ(ids, original);
+  }
+  // body=1
+  {
+    std::vector<PhonemeId> ids = {1, 10, 2};
+    std::vector<PhonemeId> original = ids;
+    bool padded = padPhonemeIds(ids);
+    EXPECT_FALSE(padded);
+    EXPECT_EQ(ids, original);
+  }
+  // body=2 (e.g. 「あ。」)
+  {
+    std::vector<PhonemeId> ids = {1, 10, 11, 2};
+    std::vector<PhonemeId> original = ids;
+    bool padded = padPhonemeIds(ids);
+    EXPECT_FALSE(padded);
+    EXPECT_EQ(ids, original);
+  }
 }
 
 TEST_F(PadPhonemeIdsTest, BoundaryExactlyMinMinus1) {
-  // 39 elements -> needs exactly 1 pad
+  // MIN_PHONEME_IDS - 1 elements -> needs exactly 1 pad
   std::vector<PhonemeId> ids;
   ids.push_back(1);
-  for (int i = 0; i < 37; i++) ids.push_back(10);
+  for (int i = 0; i < MIN_PHONEME_IDS - 3; i++) ids.push_back(10);
   ids.push_back(2);
-  ASSERT_EQ(ids.size(), 39u);
+  ASSERT_EQ(static_cast<int>(ids.size()), MIN_PHONEME_IDS - 1);
 
   bool padded = padPhonemeIds(ids);
   EXPECT_TRUE(padded);
@@ -343,7 +367,8 @@ TEST_F(PadPhonemeIdsTest, BoundaryExactlyMinMinus1) {
 }
 
 TEST_F(PadPhonemeIdsTest, CustomPadId) {
-  std::vector<PhonemeId> ids = {1, 10, 2};
+  // body must be >= MIN_BODY_FOR_STRATEGY_A.
+  std::vector<PhonemeId> ids = {1, 10, 11, 12, 2};
 
   padPhonemeIds(ids, /*padId=*/99);
 
@@ -503,40 +528,36 @@ TEST_F(DynamicScalesTest, NoAdjustmentForLongInput) {
 }
 
 TEST_F(DynamicScalesTest, AdjustsForShortInput) {
-  const int len = 20;  // Half of MIN_PHONEME_IDS
+  // Half of MIN_PHONEME_IDS — noise_scale floor (0.5) engages exactly.
+  const int len = MIN_PHONEME_IDS / 2;
   float noiseScale = 0.667f;
   float noiseW = 0.8f;
 
   float ratio = std::clamp(static_cast<float>(len) /
                                 static_cast<float>(MIN_PHONEME_IDS),
                             0.0f, 1.0f);
-  EXPECT_FLOAT_EQ(ratio, 0.5f);
 
   float adjustedNoiseScale = noiseScale * std::max(0.5f, ratio);
   float adjustedNoiseW = noiseW * std::max(0.4f, ratio);
 
-  // noiseScale * max(0.5, 0.5) = noiseScale * 0.5
-  EXPECT_FLOAT_EQ(adjustedNoiseScale, noiseScale * 0.5f);
-  // noiseW * max(0.4, 0.5) = noiseW * 0.5
-  EXPECT_FLOAT_EQ(adjustedNoiseW, noiseW * 0.5f);
+  EXPECT_FLOAT_EQ(adjustedNoiseScale, noiseScale * std::max(0.5f, ratio));
+  EXPECT_FLOAT_EQ(adjustedNoiseW, noiseW * std::max(0.4f, ratio));
 }
 
 TEST_F(DynamicScalesTest, FloorClampForVeryShortInput) {
-  const int len = 5;  // Very short
+  const int len = 1;  // Far below both floors
   float noiseScale = 0.667f;
   float noiseW = 0.8f;
 
   float ratio = std::clamp(static_cast<float>(len) /
                                 static_cast<float>(MIN_PHONEME_IDS),
                             0.0f, 1.0f);
-  EXPECT_NEAR(ratio, 0.125f, 0.001f);
 
   float adjustedNoiseScale = noiseScale * std::max(0.5f, ratio);
   float adjustedNoiseW = noiseW * std::max(0.4f, ratio);
 
-  // max(0.5, 0.125) = 0.5 -> noiseScale * 0.5
+  // Both floors clamp.
   EXPECT_FLOAT_EQ(adjustedNoiseScale, noiseScale * 0.5f);
-  // max(0.4, 0.125) = 0.4 -> noiseW * 0.4
   EXPECT_FLOAT_EQ(adjustedNoiseW, noiseW * 0.4f);
 }
 
@@ -736,9 +757,10 @@ TEST_F(PhonemeTimingPaddingTest, DurationVecAlignmentWithOriginal) {
   size_t iterCount = std::min(originalPhonemeIds.size(), durationVec.size());
   EXPECT_EQ(iterCount, 5u);
 
-  // When incorrectly using padded phonemeIds (size=40), iteration covers all 40
+  // When incorrectly using padded phonemeIds (size=MIN_PHONEME_IDS),
+  // iteration covers all of them.
   size_t badIterCount = std::min(phonemeIds.size(), durationVec.size());
-  EXPECT_EQ(badIterCount, 40u);
+  EXPECT_EQ(badIterCount, static_cast<size_t>(MIN_PHONEME_IDS));
 
   // The fix ensures we use the smaller, correct count
   EXPECT_LT(iterCount, badIterCount);

--- a/src/cpp/tests/test_short_text_mitigation.cpp
+++ b/src/cpp/tests/test_short_text_mitigation.cpp
@@ -25,10 +25,15 @@ constexpr int MIN_BODY_FOR_STRATEGY_A = 3;
 constexpr float TRIM_THRESHOLD_RMS = 0.01f;
 constexpr int TRIM_MIN_SAMPLES = 2205;  // 22050 Hz * 0.1 s
 constexpr int TRIM_WINDOW_SIZE = 256;
+constexpr int TRIM_EOS_MAX_FRAMES = 0;
 
 // Replica of padPhonemeIds from piper.cpp
 static bool padPhonemeIds(std::vector<PhonemeId> &phonemeIds,
-                          PhonemeId padId = 0) {
+                          PhonemeId padId = 0,
+                          int *frontPadOut = nullptr,
+                          int *backPadOut = nullptr) {
+  if (frontPadOut) *frontPadOut = 0;
+  if (backPadOut) *backPadOut = 0;
   const auto len = static_cast<int>(phonemeIds.size());
   const int bodyLen = len - 2;
   if (bodyLen < MIN_BODY_FOR_STRATEGY_A) {
@@ -44,6 +49,8 @@ static bool padPhonemeIds(std::vector<PhonemeId> &phonemeIds,
 
   if (phonemeIds.size() < 2) {
     phonemeIds.insert(phonemeIds.end(), static_cast<size_t>(needed), padId);
+    if (frontPadOut) *frontPadOut = front;
+    if (backPadOut) *backPadOut = back;
     return true;
   }
 
@@ -59,7 +66,56 @@ static bool padPhonemeIds(std::vector<PhonemeId> &phonemeIds,
   phonemeIds.insert(phonemeIds.end(), static_cast<size_t>(back), padId);
   phonemeIds.push_back(eos);
 
+  if (frontPadOut) *frontPadOut = front;
+  if (backPadOut) *backPadOut = back;
   return true;
+}
+
+// Replica of trimPaddingByDurations from piper.cpp (int16 variant).
+static void trimPaddingByDurations(std::vector<int16_t> &audioBuffer,
+                                   const std::vector<float> &durations,
+                                   int frontPad,
+                                   int backPad,
+                                   int hopSize,
+                                   int eosMaxFrames = TRIM_EOS_MAX_FRAMES) {
+  if (frontPad <= 0 && backPad <= 0) return;
+  if (durations.empty() || hopSize <= 0) return;
+  const int expectedLen = 1 + frontPad + backPad + 1;
+  if (static_cast<int>(durations.size()) < expectedLen) return;
+
+  float frontSum = 0.0f;
+  for (int i = 0; i < 1 + frontPad; i++) {
+    frontSum += durations[i];
+  }
+  const int frontSamples = static_cast<int>(frontSum * static_cast<float>(hopSize));
+
+  float backPadSum = 0.0f;
+  if (backPad > 0) {
+    const int start = static_cast<int>(durations.size()) - 1 - backPad;
+    for (int i = start; i < static_cast<int>(durations.size()) - 1; i++) {
+      backPadSum += durations[i];
+    }
+  }
+  const int backPadSamples =
+      static_cast<int>(backPadSum * static_cast<float>(hopSize));
+  const float eosFrames = durations.back();
+  float eosExcess = eosFrames - static_cast<float>(eosMaxFrames);
+  if (eosExcess < 0.0f) eosExcess = 0.0f;
+  const int backSamples =
+      backPadSamples +
+      static_cast<int>(eosExcess * static_cast<float>(hopSize));
+
+  const int totalSamples = static_cast<int>(audioBuffer.size());
+  int start = frontSamples < 0 ? 0 : frontSamples;
+  int end = totalSamples - backSamples;
+  if (end < start) end = start;
+  if (start >= totalSamples || end <= 0 || start >= end) return;
+
+  if (start > 0 || end < totalSamples) {
+    std::vector<int16_t> trimmed(audioBuffer.begin() + start,
+                                 audioBuffer.begin() + end);
+    audioBuffer = std::move(trimmed);
+  }
 }
 
 // Replica of trimSilenceInt16 from piper.cpp
@@ -897,6 +953,107 @@ TEST_F(TrimPartialWindowFloatTest, ExactMultipleUnchanged) {
   trimSilenceFloat(audio);
 
   EXPECT_EQ(static_cast<int>(audio.size()), totalSamples);
+}
+
+// ======================================================================
+// Strategy A: trimPaddingByDurations (precise post-trim, issue #356)
+// ======================================================================
+// Mirrors src/python_run/tests/test_short_text_mitigation.py and ensures
+// every runtime trims by the same number of samples for the same inputs.
+
+class TrimPaddingByDurationsTest : public ::testing::Test {};
+
+TEST_F(TrimPaddingByDurationsTest, NoOpWhenNoPadding) {
+  std::vector<int16_t> audio(1000);
+  for (int i = 0; i < 1000; i++) audio[i] = static_cast<int16_t>(i);
+  std::vector<float> durations = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+
+  trimPaddingByDurations(audio, durations, /*frontPad=*/0, /*backPad=*/0,
+                         /*hopSize=*/256, TRIM_EOS_MAX_FRAMES);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), 1000);
+}
+
+TEST_F(TrimPaddingByDurationsTest, TrimsFrontPaddingOnly) {
+  // Layout: BOS=2, pad×3 (3+3+3), body=4, EOS=1 → 19 frames total.
+  std::vector<float> durations = {2.0f, 3.0f, 3.0f, 3.0f, 4.0f, 1.0f};
+  const int hop = 100;
+  const int total = 1900;
+  std::vector<int16_t> audio(total);
+
+  trimPaddingByDurations(audio, durations, /*frontPad=*/3, /*backPad=*/0,
+                         hop, /*eosMaxFrames=*/6);
+
+  // BOS + front padding samples = (2+3+3+3) * 100 = 1100
+  EXPECT_EQ(static_cast<int>(audio.size()), total - 1100);
+}
+
+TEST_F(TrimPaddingByDurationsTest, DefaultStripsEosCompletely) {
+  std::vector<float> durations = {2.0f, 5.0f, 5.0f, 4.0f, 4.0f, 5.0f, 5.0f, 8.0f};
+  const int hop = 100;
+  const int total = 3800;
+  std::vector<int16_t> audio(total);
+
+  trimPaddingByDurations(audio, durations, /*frontPad=*/2, /*backPad=*/2,
+                         hop, TRIM_EOS_MAX_FRAMES);
+
+  // BOS + front padding = (2+5+5)*100 = 1200
+  // back padding + entire EOS = (5+5+8)*100 = 1800
+  EXPECT_EQ(static_cast<int>(audio.size()), total - 1200 - 1800);
+}
+
+TEST_F(TrimPaddingByDurationsTest, ClampsInflatedEos) {
+  std::vector<float> durations = {2.0f, 3.0f, 3.0f, 4.0f, 3.0f, 3.0f, 10.0f};
+  const int hop = 100;
+  const int total = 2800;
+  std::vector<int16_t> audio(total);
+
+  trimPaddingByDurations(audio, durations, /*frontPad=*/2, /*backPad=*/2,
+                         hop, /*eosMaxFrames=*/6);
+
+  // BOS + front padding = (2+3+3) * 100 = 800
+  // back padding + EOS excess = (3+3 + (10-6)) * 100 = 1000
+  EXPECT_EQ(static_cast<int>(audio.size()), total - 800 - 1000);
+}
+
+TEST_F(TrimPaddingByDurationsTest, ReturnsInputWhenDurationsTooShort) {
+  std::vector<int16_t> audio(1000);
+  std::vector<float> durations = {1.0f, 1.0f, 1.0f};
+
+  trimPaddingByDurations(audio, durations, /*frontPad=*/5, /*backPad=*/5,
+                         /*hopSize=*/256, TRIM_EOS_MAX_FRAMES);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), 1000);
+}
+
+TEST_F(TrimPaddingByDurationsTest, ReturnsInputWhenHopSizeZero) {
+  std::vector<int16_t> audio(1000);
+  std::vector<float> durations(8, 1.0f);
+
+  trimPaddingByDurations(audio, durations, /*frontPad=*/2, /*backPad=*/2,
+                         /*hopSize=*/0, TRIM_EOS_MAX_FRAMES);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), 1000);
+}
+
+TEST_F(TrimPaddingByDurationsTest, TruncationMatchesIntCast) {
+  // Layout (frontPad=1, backPad=1, body=3):
+  //   [BOS=0.701, pad=0.701, body=2, body=2, body=2, pad=0.703, EOS=0.701]
+  // Front trim = static_cast<int>((0.701+0.701)*100) = 140
+  // Back trim  = static_cast<int>(0.703*100) + static_cast<int>(0.701*100)
+  //            = 70 + 70 = 140
+  // A round() implementation would diverge → cross-runtime drift.
+  std::vector<float> durations = {0.701f, 0.701f, 2.0f, 2.0f, 2.0f, 0.703f, 0.701f};
+  const int hop = 100;
+  float sum = 0.0f;
+  for (auto d : durations) sum += d;
+  const int total = static_cast<int>(sum * static_cast<float>(hop));
+  std::vector<int16_t> audio(total);
+
+  trimPaddingByDurations(audio, durations, /*frontPad=*/1, /*backPad=*/1,
+                         hop, TRIM_EOS_MAX_FRAMES);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), total - 140 - 140);
 }
 
 int main(int argc, char **argv) {

--- a/src/csharp/PiperPlus.Core.Tests/ShortTextProcessorTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/ShortTextProcessorTests.cs
@@ -15,7 +15,8 @@ public class ShortTextProcessorTests
     [Fact]
     public void Constants_HaveExpectedValues()
     {
-        Assert.Equal(40, ShortTextProcessor.MinPhonemeIds);
+        Assert.Equal(15, ShortTextProcessor.MinPhonemeIds);
+        Assert.Equal(3, ShortTextProcessor.MinBodyForStrategyA);
         Assert.Equal(10, ShortTextProcessor.ShortTextChars);
         Assert.Equal(300, ShortTextProcessor.SilencePadMs);
         Assert.Equal(0.01f, ShortTextProcessor.TrimThresholdRms);
@@ -31,7 +32,32 @@ public class ShortTextProcessorTests
     [Fact]
     public void NeedsPadding_ShortSequence_ReturnsTrue()
     {
-        var ids = new long[10]; // well below MinPhonemeIds=40
+        // Length < MinPhonemeIds and body >= MinBodyForStrategyA → padding applies.
+        var ids = new long[10];
+        Assert.True(ShortTextProcessor.NeedsPadding(ids));
+    }
+
+    [Fact]
+    public void NeedsPadding_BodyTooShort_ReturnsFalse()
+    {
+        // The current contract is MinBodyForStrategyA == 3.
+        Assert.Equal(3, ShortTextProcessor.MinBodyForStrategyA);
+
+        // body=0 (BOS+EOS only): Strategy A skipped (issue #356).
+        Assert.False(ShortTextProcessor.NeedsPadding(new long[2]));
+
+        // body=1
+        Assert.False(ShortTextProcessor.NeedsPadding(new long[3]));
+
+        // body=2 (e.g. 「あ。」)
+        Assert.False(ShortTextProcessor.NeedsPadding(new long[4]));
+    }
+
+    [Fact]
+    public void NeedsPadding_BodyAtMinimum_ReturnsTrue()
+    {
+        // body == MinBodyForStrategyA: Strategy A applies if length < MinPhonemeIds.
+        var ids = new long[2 + ShortTextProcessor.MinBodyForStrategyA];
         Assert.True(ShortTextProcessor.NeedsPadding(ids));
     }
 
@@ -81,7 +107,8 @@ public class ShortTextProcessorTests
     [Fact]
     public void PadPhonemeIds_PreservesBosAndEos()
     {
-        long[] ids = [1, 10, 11, 2];
+        // body must be >= MinBodyForStrategyA for Strategy A to apply.
+        long[] ids = [1, 10, 11, 12, 2];
 
         var (padded, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
 
@@ -92,8 +119,8 @@ public class ShortTextProcessorTests
     [Fact]
     public void PadPhonemeIds_InsertsOnlyPauseIds()
     {
-        // BOS=1, a=10, EOS=2 => 3 elements, needs 37 pause IDs
-        long[] ids = [1, 10, 2];
+        // body must be >= MinBodyForStrategyA for Strategy A to apply.
+        long[] ids = [1, 10, 11, 12, 2]; // body = 3
         var originalSet = new HashSet<long>(ids);
 
         var (padded, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
@@ -104,6 +131,21 @@ public class ShortTextProcessorTests
             if (!originalSet.Contains(id))
                 Assert.Equal(ShortTextProcessor.PauseId, id);
         }
+    }
+
+    [Fact]
+    public void PadPhonemeIds_SkipsWhenBodyTooShort()
+    {
+        // body=2 ("あ。" case) → Strategy A skipped, returns input unchanged.
+        long[] ids = [1, 10, 11, 2]; // body = 2
+        var (padded, prosody) = ShortTextProcessor.PadPhonemeIds(ids, null);
+
+        // The current contract is MinBodyForStrategyA == 3, so this body=2
+        // input must be returned untouched. If MinBodyForStrategyA is ever
+        // lowered below 3 we will need to revisit this assertion.
+        Assert.Equal(3, ShortTextProcessor.MinBodyForStrategyA);
+        Assert.Same(ids, padded);
+        Assert.Null(prosody);
     }
 
     [Fact]
@@ -143,8 +185,9 @@ public class ShortTextProcessorTests
     [Fact]
     public void PadPhonemeIds_WithProsody_ProsodyExtended()
     {
-        long[] ids = [1, 10, 11, 2]; // 4 elements
-        long[] prosody = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]; // 4 * 3 = 12
+        // body must be >= MinBodyForStrategyA so Strategy A applies.
+        long[] ids = [1, 10, 11, 12, 2]; // 5 elements (body=3)
+        long[] prosody = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]; // 5 * 3
 
         var (padded, paddedProsody) = ShortTextProcessor.PadPhonemeIds(ids, prosody);
 
@@ -157,16 +200,17 @@ public class ShortTextProcessorTests
         Assert.Equal(3L, paddedProsody[2]);
 
         // EOS prosody preserved
-        Assert.Equal(10L, paddedProsody[^3]);
-        Assert.Equal(11L, paddedProsody[^2]);
-        Assert.Equal(12L, paddedProsody[^1]);
+        Assert.Equal(13L, paddedProsody[^3]);
+        Assert.Equal(14L, paddedProsody[^2]);
+        Assert.Equal(15L, paddedProsody[^1]);
     }
 
     [Fact]
     public void PadPhonemeIds_WithProsody_PaddingPositionsAreZero()
     {
-        long[] ids = [1, 10, 2]; // 3 elements => needs 37 padding
-        long[] prosody = [1, 1, 1, 2, 2, 2, 3, 3, 3]; // 3 * 3 = 9
+        // body must be >= MinBodyForStrategyA so Strategy A applies.
+        long[] ids = [1, 10, 11, 12, 2]; // 5 elements (body=3)
+        long[] prosody = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5];
 
         var (padded, paddedProsody) = ShortTextProcessor.PadPhonemeIds(ids, prosody);
 
@@ -182,7 +226,8 @@ public class ShortTextProcessorTests
     [Fact]
     public void PadPhonemeIds_NullProsody_ReturnsNull()
     {
-        long[] ids = [1, 10, 2];
+        // body must be >= MinBodyForStrategyA so PadPhonemeIds actually pads.
+        long[] ids = [1, 10, 11, 12, 2];
 
         var (_, paddedProsody) = ShortTextProcessor.PadPhonemeIds(ids, null);
 
@@ -192,8 +237,8 @@ public class ShortTextProcessorTests
     [Fact]
     public void PadPhonemeIds_MismatchedProsodyLength_ReturnsNull()
     {
-        long[] ids = [1, 10, 2];
-        long[] prosody = [1, 2]; // wrong length (should be 9)
+        long[] ids = [1, 10, 11, 12, 2];
+        long[] prosody = [1, 2]; // wrong length (should be 15)
 
         var (_, paddedProsody) = ShortTextProcessor.PadPhonemeIds(ids, prosody);
 
@@ -229,7 +274,8 @@ public class ShortTextProcessorTests
         }
 
         int totalPadding = afterBosPadding + beforeEosPadding;
-        Assert.Equal(35, totalPadding);
+        // 5 input IDs → deficit = MinPhonemeIds - 5 pause tokens.
+        Assert.Equal(ShortTextProcessor.MinPhonemeIds - 5, totalPadding);
         // Distribution should be roughly even (difference <= 1)
         Assert.True(Math.Abs(afterBosPadding - beforeEosPadding) <= 1,
             $"Padding should be roughly even: afterBos={afterBosPadding}, beforeEos={beforeEosPadding}");
@@ -369,13 +415,16 @@ public class ShortTextProcessorTests
     {
         float noiseScale = 1.0f;
         float noiseW = 1.0f;
-        int halfMin = ShortTextProcessor.MinPhonemeIds / 2; // 20
+        int halfMin = ShortTextProcessor.MinPhonemeIds / 2;
 
         var (adjNoise, adjW) = ShortTextProcessor.AdjustScales(halfMin, noiseScale, noiseW);
 
-        // ratio = 20/40 = 0.5. max(0.5, 0.5) = 0.5 for noise, max(0.4, 0.5) = 0.5 for noiseW
-        Assert.Equal(0.5f, adjNoise);
-        Assert.Equal(0.5f, adjW);
+        // ratio = halfMin / MinPhonemeIds, floors clamp where needed.
+        float ratio = (float)halfMin / ShortTextProcessor.MinPhonemeIds;
+        float nsRatio = MathF.Max(0.5f, ratio);
+        float nwRatio = MathF.Max(0.4f, ratio);
+        Assert.Equal(nsRatio, adjNoise);
+        Assert.Equal(nwRatio, adjW);
     }
 
     [Fact]

--- a/src/csharp/PiperPlus.Core.Tests/ShortTextProcessorTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/ShortTextProcessorTests.cs
@@ -23,6 +23,8 @@ public class ShortTextProcessorTests
         Assert.Equal(2205, ShortTextProcessor.TrimMinSamples);
         Assert.Equal(256, ShortTextProcessor.TrimWindowSize);
         Assert.Equal(0L, ShortTextProcessor.PauseId);
+        Assert.Equal(0, ShortTextProcessor.TrimEosMaxFrames);
+        Assert.Equal(256, ShortTextProcessor.DefaultHopSize);
     }
 
     // ==================================================================
@@ -99,7 +101,7 @@ public class ShortTextProcessorTests
         // BOS=1, body=[10,11,12], EOS=2 => 5 elements
         long[] ids = [1, 10, 11, 12, 2];
 
-        var (padded, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
+        var (padded, _, _, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
 
         Assert.Equal(ShortTextProcessor.MinPhonemeIds, padded.Length);
     }
@@ -110,7 +112,7 @@ public class ShortTextProcessorTests
         // body must be >= MinBodyForStrategyA for Strategy A to apply.
         long[] ids = [1, 10, 11, 12, 2];
 
-        var (padded, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
+        var (padded, _, _, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
 
         Assert.Equal(1L, padded[0]);          // BOS preserved
         Assert.Equal(2L, padded[^1]);         // EOS preserved
@@ -123,7 +125,7 @@ public class ShortTextProcessorTests
         long[] ids = [1, 10, 11, 12, 2]; // body = 3
         var originalSet = new HashSet<long>(ids);
 
-        var (padded, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
+        var (padded, _, _, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
 
         // Every element that wasn't in the original must be PauseId (0)
         foreach (long id in padded)
@@ -138,7 +140,7 @@ public class ShortTextProcessorTests
     {
         // body=2 ("あ。" case) → Strategy A skipped, returns input unchanged.
         long[] ids = [1, 10, 11, 2]; // body = 2
-        var (padded, prosody) = ShortTextProcessor.PadPhonemeIds(ids, null);
+        var (padded, prosody, _, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
 
         // The current contract is MinBodyForStrategyA == 3, so this body=2
         // input must be returned untouched. If MinBodyForStrategyA is ever
@@ -153,7 +155,7 @@ public class ShortTextProcessorTests
     {
         long[] ids = [1, 10, 11, 12, 13, 2];
 
-        var (padded, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
+        var (padded, _, _, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
 
         // The body elements (10, 11, 12, 13) should appear in order somewhere
         // between the first pause-block and the second pause-block.
@@ -177,7 +179,7 @@ public class ShortTextProcessorTests
         ids[0] = 1; // BOS
         ids[^1] = 2; // EOS
 
-        var (padded, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
+        var (padded, _, _, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
 
         Assert.Same(ids, padded); // No allocation when not needed
     }
@@ -189,7 +191,7 @@ public class ShortTextProcessorTests
         long[] ids = [1, 10, 11, 12, 2]; // 5 elements (body=3)
         long[] prosody = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]; // 5 * 3
 
-        var (padded, paddedProsody) = ShortTextProcessor.PadPhonemeIds(ids, prosody);
+        var (padded, paddedProsody, _, _) = ShortTextProcessor.PadPhonemeIds(ids, prosody);
 
         Assert.NotNull(paddedProsody);
         Assert.Equal(padded.Length * 3, paddedProsody.Length);
@@ -212,7 +214,7 @@ public class ShortTextProcessorTests
         long[] ids = [1, 10, 11, 12, 2]; // 5 elements (body=3)
         long[] prosody = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5];
 
-        var (padded, paddedProsody) = ShortTextProcessor.PadPhonemeIds(ids, prosody);
+        var (padded, paddedProsody, _, _) = ShortTextProcessor.PadPhonemeIds(ids, prosody);
 
         Assert.NotNull(paddedProsody);
 
@@ -229,7 +231,7 @@ public class ShortTextProcessorTests
         // body must be >= MinBodyForStrategyA so PadPhonemeIds actually pads.
         long[] ids = [1, 10, 11, 12, 2];
 
-        var (_, paddedProsody) = ShortTextProcessor.PadPhonemeIds(ids, null);
+        var (_, paddedProsody, _, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
 
         Assert.Null(paddedProsody);
     }
@@ -240,7 +242,7 @@ public class ShortTextProcessorTests
         long[] ids = [1, 10, 11, 12, 2];
         long[] prosody = [1, 2]; // wrong length (should be 15)
 
-        var (_, paddedProsody) = ShortTextProcessor.PadPhonemeIds(ids, prosody);
+        var (_, paddedProsody, _, _) = ShortTextProcessor.PadPhonemeIds(ids, prosody);
 
         Assert.Null(paddedProsody);
     }
@@ -251,7 +253,7 @@ public class ShortTextProcessorTests
         // With 5 elements, deficit = 35. afterBos = 17, beforeEos = 18.
         long[] ids = [1, 10, 11, 12, 2];
 
-        var (padded, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
+        var (padded, _, _, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
 
         // Count pause IDs after BOS (index 1) until first body element
         int afterBosPadding = 0;
@@ -279,6 +281,112 @@ public class ShortTextProcessorTests
         // Distribution should be roughly even (difference <= 1)
         Assert.True(Math.Abs(afterBosPadding - beforeEosPadding) <= 1,
             $"Padding should be roughly even: afterBos={afterBosPadding}, beforeEos={beforeEosPadding}");
+    }
+
+    // ==================================================================
+    // Strategy A: TrimPaddingByDurations (precise post-trim, issue #356)
+    // ==================================================================
+    // Mirrors src/python_run/tests/test_short_text_mitigation.py.
+
+    [Fact]
+    public void TrimPaddingByDurations_NoOpWhenNoPadding()
+    {
+        var audio = Enumerable.Range(0, 1000).Select(i => (float)i).ToArray();
+        var durations = new float[] { 1f, 1f, 1f, 1f, 1f };
+        var result = ShortTextProcessor.TrimPaddingByDurations(
+            audio, durations, frontPad: 0, backPad: 0, hopSize: 256);
+        Assert.Equal(audio.Length, result.Length);
+    }
+
+    [Fact]
+    public void TrimPaddingByDurations_TrimsFrontPaddingOnly()
+    {
+        // Layout: BOS=2, pad×3 (3+3+3), body=4, EOS=1 → 19 frames total
+        var durations = new[] { 2f, 3f, 3f, 3f, 4f, 1f };
+        const int hop = 100;
+        const int total = 1900;
+        var audio = new float[total];
+        var result = ShortTextProcessor.TrimPaddingByDurations(
+            audio, durations, frontPad: 3, backPad: 0, hopSize: hop, eosMaxFrames: 6);
+        // BOS + front padding samples = (2+3+3+3) * 100 = 1100
+        Assert.Equal(total - 1100, result.Length);
+    }
+
+    [Fact]
+    public void TrimPaddingByDurations_DefaultStripsEosCompletely()
+    {
+        var durations = new[] { 2f, 5f, 5f, 4f, 4f, 5f, 5f, 8f };
+        const int hop = 100;
+        const int total = 3800;
+        var audio = new float[total];
+        var result = ShortTextProcessor.TrimPaddingByDurations(
+            audio, durations, frontPad: 2, backPad: 2, hopSize: hop);
+        // BOS + front padding = (2+5+5)*100 = 1200
+        // back padding + entire EOS = (5+5+8)*100 = 1800
+        Assert.Equal(total - 1200 - 1800, result.Length);
+    }
+
+    [Fact]
+    public void TrimPaddingByDurations_ClampsInflatedEos()
+    {
+        // EOS=10 frames, eosMaxFrames=6 → excess 4 frames trimmed.
+        var durations = new[] { 2f, 3f, 3f, 4f, 3f, 3f, 10f };
+        const int hop = 100;
+        const int total = 2800;
+        var audio = new float[total];
+        var result = ShortTextProcessor.TrimPaddingByDurations(
+            audio, durations, frontPad: 2, backPad: 2, hopSize: hop, eosMaxFrames: 6);
+        // BOS + front padding = (2+3+3) * 100 = 800
+        // back padding + EOS excess = (3+3 + (10-6)) * 100 = 1000
+        Assert.Equal(total - 800 - 1000, result.Length);
+    }
+
+    [Fact]
+    public void TrimPaddingByDurations_ReturnsInputWhenDurationsNull()
+    {
+        var audio = new float[1000];
+        var result = ShortTextProcessor.TrimPaddingByDurations(
+            audio, null, frontPad: 3, backPad: 3, hopSize: 256);
+        Assert.Equal(audio.Length, result.Length);
+    }
+
+    [Fact]
+    public void TrimPaddingByDurations_ReturnsInputWhenDurationsTooShort()
+    {
+        var audio = new float[1000];
+        var durations = new[] { 1f, 1f, 1f };
+        var result = ShortTextProcessor.TrimPaddingByDurations(
+            audio, durations, frontPad: 5, backPad: 5, hopSize: 256);
+        Assert.Equal(audio.Length, result.Length);
+    }
+
+    [Fact]
+    public void TrimPaddingByDurations_ReturnsInputWhenHopSizeZero()
+    {
+        var audio = new float[1000];
+        var durations = new float[] { 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f };
+        var result = ShortTextProcessor.TrimPaddingByDurations(
+            audio, durations, frontPad: 2, backPad: 2, hopSize: 0);
+        Assert.Equal(audio.Length, result.Length);
+    }
+
+    [Fact]
+    public void TrimPaddingByDurations_TruncationMatchesIntCast()
+    {
+        // Layout (frontPad=1, backPad=1, body=3):
+        //   [BOS=0.701, pad=0.701, body=2, body=2, body=2, pad=0.703, EOS=0.701]
+        // Front trim = (int)((0.701+0.701)*100) = 140  (truncated, not rounded)
+        // Back trim  = (int)(0.703*100) + (int)(0.701*100) = 70 + 70 = 140
+        // A round() implementation would diverge by 1 sample → cross-runtime drift.
+        var durations = new[] { 0.701f, 0.701f, 2f, 2f, 2f, 0.703f, 0.701f };
+        const int hop = 100;
+        float sum = 0f;
+        foreach (var d in durations) sum += d;
+        int total = (int)(sum * hop);
+        var audio = new float[total];
+        var result = ShortTextProcessor.TrimPaddingByDurations(
+            audio, durations, frontPad: 1, backPad: 1, hopSize: hop);
+        Assert.Equal(total - 140 - 140, result.Length);
     }
 
     // ==================================================================
@@ -688,7 +796,7 @@ public class ShortTextProcessorTests
         // then trim. This tests the intended A-strategy flow.
         long[] ids = [1, 10, 11, 12, 2];
 
-        var (padded, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
+        var (padded, _, _, _) = ShortTextProcessor.PadPhonemeIds(ids, null);
         Assert.Equal(ShortTextProcessor.MinPhonemeIds, padded.Length);
 
         // Simulate audio: silence for padding, non-silent for real phonemes

--- a/src/csharp/PiperPlus.Core/Inference/PiperModel.cs
+++ b/src/csharp/PiperPlus.Core/Inference/PiperModel.cs
@@ -51,6 +51,12 @@ public sealed class PiperModel : IDisposable
         HasSpeakerEmbedding = _session.InputMetadata.ContainsKey("speaker_embedding");
 
         SampleRate = config.Audio.SampleRate;
+
+        // Hop size needed for durations-based Strategy A trim (issue #356).
+        // Falls back to ShortTextProcessor.DefaultHopSize when the config
+        // omits audio.hop_size (older configs).
+        int hop = config.Audio.HopSize ?? 0;
+        HopSize = hop > 0 ? hop : ShortTextProcessor.DefaultHopSize;
     }
 
     // ----------------------------------------------------------------
@@ -92,6 +98,14 @@ public sealed class PiperModel : IDisposable
     /// Audio sample rate in Hz, sourced from the accompanying config.json.
     /// </summary>
     public int SampleRate { get; }
+
+    /// <summary>
+    /// VITS hop length (samples per acoustic frame) used by the
+    /// durations-based Strategy A post-trim (issue #356). Defaults to
+    /// <see cref="ShortTextProcessor.DefaultHopSize"/> (256) when the
+    /// config does not declare <c>audio.hop_size</c>.
+    /// </summary>
+    public int HopSize { get; }
 
     /// <summary>
     /// Ordered list of input tensor names exposed by the ONNX model.

--- a/src/csharp/PiperPlus.Core/Inference/PiperSession.cs
+++ b/src/csharp/PiperPlus.Core/Inference/PiperSession.cs
@@ -206,9 +206,12 @@ public sealed class PiperSession
 
         // ----- Strategy A: Silence Padding -----
         bool wasPadded = ShortTextProcessor.NeedsPadding(phonemeIds);
+        int frontPad = 0;
+        int backPad = 0;
         if (wasPadded)
         {
-            (phonemeIds, prosodyFlat) = ShortTextProcessor.PadPhonemeIds(phonemeIds, prosodyFlat);
+            (phonemeIds, prosodyFlat, frontPad, backPad) =
+                ShortTextProcessor.PadPhonemeIds(phonemeIds, prosodyFlat);
         }
 
         // ----- Strategy B: Dynamic Scales Adjustment -----
@@ -361,18 +364,41 @@ public sealed class PiperSession
             ReadOnlySpan<float> outputSpan = results[0].GetTensorDataAsSpan<float>();
             float[] audio = outputSpan.ToArray();
 
-            // ----- Strategy A: Post-inference silence trimming -----
-            if (wasPadded)
-            {
-                audio = ShortTextProcessor.TrimSilence(audio);
-            }
-
-            // Extract durations if available: shape [1, phoneme_length] (float32).
-            float[]? durations = null;
+            // Extract durations BEFORE post-trim so the precise trimmer can
+            // use them. Always copy out the full padded-sequence durations
+            // first; the value returned to callers is truncated below to the
+            // original phoneme length so timing alignment is preserved.
+            float[]? paddedDurations = null;
             if (requestDurations && results.Count >= 2)
             {
                 ReadOnlySpan<float> durSpan = results[1].GetTensorDataAsSpan<float>();
-                durations = durSpan.ToArray();
+                paddedDurations = durSpan.ToArray();
+            }
+
+            // ----- Strategy A: Post-inference padding-induced trim -----
+            // Prefer durations-based precise trim (issue #356); fall back to
+            // legacy RMS trim only when durations are unavailable.
+            if (wasPadded)
+            {
+                if (paddedDurations is not null)
+                {
+                    audio = ShortTextProcessor.TrimPaddingByDurations(
+                        audio, paddedDurations, frontPad, backPad, _model.HopSize);
+                }
+                else
+                {
+                    audio = ShortTextProcessor.TrimSilence(audio);
+                }
+            }
+
+            // Truncate durations back to the original phoneme length for
+            // timing consumers (they treat the padded extras as out-of-band).
+            float[]? durations = paddedDurations;
+            if (durations is not null && wasPadded && durations.Length > input.PhonemeIds.Length)
+            {
+                var trimmed = new float[input.PhonemeIds.Length];
+                Array.Copy(durations, trimmed, input.PhonemeIds.Length);
+                durations = trimmed;
             }
 
             return (audio, durations);

--- a/src/csharp/PiperPlus.Core/Inference/ShortTextProcessor.cs
+++ b/src/csharp/PiperPlus.Core/Inference/ShortTextProcessor.cs
@@ -80,6 +80,18 @@ public static class ShortTextProcessor
     /// </summary>
     internal const long PauseId = 0;
 
+    /// <summary>
+    /// Maximum number of EOS frames retained by the durations-based Strategy A
+    /// trim. VITS predicts an inflated EOS under the padded context that emits
+    /// an audible artefact otherwise (issue #356); 0 = drop the entire EOS.
+    /// </summary>
+    internal const int TrimEosMaxFrames = 0;
+
+    /// <summary>
+    /// Default hop length when config.json does not declare audio.hop_size.
+    /// </summary>
+    internal const int DefaultHopSize = 256;
+
     // ------------------------------------------------------------------
     // Strategy A: Silence Padding
     // ------------------------------------------------------------------
@@ -117,15 +129,15 @@ public static class ShortTextProcessor
     /// <returns>
     /// Padded phoneme IDs and (optionally) padded prosody array.
     /// </returns>
-    internal static (long[] PaddedIds, long[]? PaddedProsody) PadPhonemeIds(
+    internal static (long[] PaddedIds, long[]? PaddedProsody, int FrontPad, int BackPad) PadPhonemeIds(
         long[] phonemeIds, long[]? prosodyFlat)
     {
         // Skip Strategy A for very short bodies — see NeedsPadding / issue #356.
         int bodyLengthGuard = phonemeIds.Length - 2;
         if (bodyLengthGuard < MinBodyForStrategyA)
-            return (phonemeIds, prosodyFlat);
+            return (phonemeIds, prosodyFlat, 0, 0);
         if (phonemeIds.Length >= MinPhonemeIds)
-            return (phonemeIds, prosodyFlat);
+            return (phonemeIds, prosodyFlat, 0, 0);
 
         int deficit = MinPhonemeIds - phonemeIds.Length;
         int afterBos = deficit / 2;       // pause IDs inserted after index 0 (BOS)
@@ -182,7 +194,85 @@ public static class ShortTextProcessor
             paddedProsody[eosDstOffset + 2] = prosodyFlat[eosSrcOffset + 2];
         }
 
-        return (padded, paddedProsody);
+        return (padded, paddedProsody, afterBos, beforeEos);
+    }
+
+    /// <summary>
+    /// Strategy A precise post-trim using the model's duration output.
+    /// Mirrors the Python reference (<c>src/python_run/piper/voice.py</c>
+    /// <c>_trim_padding_by_durations</c>) so all runtimes produce
+    /// byte-equal output for the same inputs (issue #356).
+    /// <para>
+    /// Padded layout: [BOS, pad×frontPad, ...body..., pad×backPad, EOS].
+    /// Trimming policy:
+    /// <list type="bullet">
+    /// <item>BOS + front padding: stripped completely.</item>
+    /// <item>Back padding: stripped completely.</item>
+    /// <item>EOS: keep only <paramref name="eosMaxFrames"/> frames
+    /// (default <see cref="TrimEosMaxFrames"/> = 0, drop entire EOS).</item>
+    /// </list>
+    /// All frame→sample conversions use truncation (<c>(int)</c>) — required
+    /// for byte-equality with the Python reference.
+    /// </para>
+    /// </summary>
+    /// <returns>
+    /// The trimmed audio, or the input unchanged when arguments are
+    /// inconsistent (null durations, non-positive hop, durations shorter
+    /// than 1 + frontPad + backPad + 1, etc.).
+    /// </returns>
+    internal static float[] TrimPaddingByDurations(
+        float[] audio,
+        float[]? durations,
+        int frontPad,
+        int backPad,
+        int hopSize,
+        int eosMaxFrames = TrimEosMaxFrames)
+    {
+        if (frontPad <= 0 && backPad <= 0)
+            return audio;
+        if (durations is null || hopSize <= 0)
+            return audio;
+
+        int expectedLen = 1 + frontPad + backPad + 1;
+        if (durations.Length < expectedLen)
+            return audio;
+
+        // Front: BOS + front padding samples (truncated).
+        float frontSum = 0f;
+        for (int i = 0; i < 1 + frontPad; i++)
+        {
+            frontSum += durations[i];
+        }
+        int frontSamples = (int)(frontSum * hopSize);
+
+        // Back: back padding samples + EOS excess (over eosMaxFrames).
+        float backPadSum = 0f;
+        if (backPad > 0)
+        {
+            // durations[-(1+backPad) : -1] in Python = [len-1-backPad, len-1)
+            int start = durations.Length - 1 - backPad;
+            for (int i = start; i < durations.Length - 1; i++)
+            {
+                backPadSum += durations[i];
+            }
+        }
+        int backPadSamples = (int)(backPadSum * hopSize);
+
+        float eosFrames = durations[^1];
+        float eosExcess = eosFrames - eosMaxFrames;
+        if (eosExcess < 0f) eosExcess = 0f;
+        int backSamples = backPadSamples + (int)(eosExcess * hopSize);
+
+        if (frontSamples < 0) frontSamples = 0;
+        int end = audio.Length - backSamples;
+        if (end < frontSamples) end = frontSamples;
+        if (frontSamples >= audio.Length || end <= 0 || frontSamples >= end)
+            return audio;
+
+        int newLength = end - frontSamples;
+        var trimmed = new float[newLength];
+        Array.Copy(audio, frontSamples, trimmed, 0, newLength);
+        return trimmed;
     }
 
     // ------------------------------------------------------------------

--- a/src/csharp/PiperPlus.Core/Inference/ShortTextProcessor.cs
+++ b/src/csharp/PiperPlus.Core/Inference/ShortTextProcessor.cs
@@ -34,7 +34,7 @@ public static class ShortTextProcessor
     /// Issue #356: Was 40 (per the original spec) but empirical measurements
     /// on the tsukuyomi 6lang model show synthesis is stable down to ~8 IDs.
     /// 40 caused Strategy A to fire on already-stable inputs (e.g. 22-ID
-    /// sentences) and the pad tokens leaked as audible artefacts. 15 keeps
+    /// sentences) and the pad tokens leaked as audible artifacts. 15 keeps
     /// Strategy A active for genuinely tiny inputs only.
     /// </para>
     /// </summary>
@@ -46,7 +46,7 @@ public static class ShortTextProcessor
     /// pad-token audio dominates the actual content (e.g. 「あ。」 has
     /// body=2 and would get 11 pad tokens around 2 body tokens at MinPhonemeIds=15).
     /// Raw VITS output is preferable in that regime — degraded for tiny
-    /// utterances but free from padding artefacts.
+    /// utterances but free from padding artifacts.
     /// </summary>
     internal const int MinBodyForStrategyA = 3;
 
@@ -83,7 +83,7 @@ public static class ShortTextProcessor
     /// <summary>
     /// Maximum number of EOS frames retained by the durations-based Strategy A
     /// trim. VITS predicts an inflated EOS under the padded context that emits
-    /// an audible artefact otherwise (issue #356); 0 = drop the entire EOS.
+    /// an audible artifact otherwise (issue #356); 0 = drop the entire EOS.
     /// </summary>
     internal const int TrimEosMaxFrames = 0;
 

--- a/src/csharp/PiperPlus.Core/Inference/ShortTextProcessor.cs
+++ b/src/csharp/PiperPlus.Core/Inference/ShortTextProcessor.cs
@@ -30,8 +30,25 @@ public static class ShortTextProcessor
 
     /// <summary>
     /// Minimum number of phoneme IDs below which padding is applied.
+    /// <para>
+    /// Issue #356: Was 40 (per the original spec) but empirical measurements
+    /// on the tsukuyomi 6lang model show synthesis is stable down to ~8 IDs.
+    /// 40 caused Strategy A to fire on already-stable inputs (e.g. 22-ID
+    /// sentences) and the pad tokens leaked as audible artefacts. 15 keeps
+    /// Strategy A active for genuinely tiny inputs only.
+    /// </para>
     /// </summary>
-    internal const int MinPhonemeIds = 40;
+    internal const int MinPhonemeIds = 15;
+
+    /// <summary>
+    /// Minimum body length (= phoneme IDs minus BOS / EOS) for Strategy A
+    /// to apply. Below this threshold, padding-to-body ratio explodes and
+    /// pad-token audio dominates the actual content (e.g. 「あ。」 has
+    /// body=2 and would get 11 pad tokens around 2 body tokens at MinPhonemeIds=15).
+    /// Raw VITS output is preferable in that regime — degraded for tiny
+    /// utterances but free from padding artefacts.
+    /// </summary>
+    internal const int MinBodyForStrategyA = 3;
 
     /// <summary>
     /// Character count threshold (excluding whitespace) for Strategy C.
@@ -69,9 +86,19 @@ public static class ShortTextProcessor
 
     /// <summary>
     /// Determine whether the phoneme ID sequence is short enough to need padding.
+    /// <para>
+    /// Strategy A is skipped both when the sequence already has enough IDs
+    /// and when the body (= phoneme IDs minus BOS / EOS) is shorter than
+    /// <see cref="MinBodyForStrategyA"/> — see issue #356.
+    /// </para>
     /// </summary>
     internal static bool NeedsPadding(long[] phonemeIds)
-        => phonemeIds.Length < MinPhonemeIds;
+    {
+        int bodyLength = phonemeIds.Length - 2; // exclude BOS / EOS
+        if (bodyLength < MinBodyForStrategyA)
+            return false;
+        return phonemeIds.Length < MinPhonemeIds;
+    }
 
     /// <summary>
     /// Pad a short phoneme-ID sequence with pause IDs (<c>0</c>) inserted
@@ -93,6 +120,10 @@ public static class ShortTextProcessor
     internal static (long[] PaddedIds, long[]? PaddedProsody) PadPhonemeIds(
         long[] phonemeIds, long[]? prosodyFlat)
     {
+        // Skip Strategy A for very short bodies — see NeedsPadding / issue #356.
+        int bodyLengthGuard = phonemeIds.Length - 2;
+        if (bodyLengthGuard < MinBodyForStrategyA)
+            return (phonemeIds, prosodyFlat);
         if (phonemeIds.Length >= MinPhonemeIds)
             return (phonemeIds, prosodyFlat);
 

--- a/src/go/piperplus/engine.go
+++ b/src/go/piperplus/engine.go
@@ -28,6 +28,7 @@ type OnnxEngine struct {
 	session      *ort.DynamicAdvancedSession
 	capabilities ModelCapabilities
 	sampleRate   int
+	hopSize      int
 	inputNames   []string
 	outputNames  []string
 	logger       *slog.Logger
@@ -109,10 +110,16 @@ func newOnnxEngine(modelPath string, config *VoiceConfig, sessOpts *ort.SessionO
 		"has_speaker_embedding", caps.HasSpeakerEmbedding,
 	)
 
+	hopSize := config.Audio.HopSize
+	if hopSize <= 0 {
+		hopSize = 256 // matches docs/spec/short-text-contract.toml default
+	}
+
 	return &OnnxEngine{
 		session:      session,
 		capabilities: *caps,
 		sampleRate:   config.Audio.SampleRate,
+		hopSize:      hopSize,
 		inputNames:   inputNames,
 		outputNames:  outputNames,
 		logger:       logger,
@@ -140,7 +147,8 @@ func (e *OnnxEngine) Synthesize(ctx context.Context, req *SynthesisRequest) (*Sy
 	phonemeIDs := req.PhonemeIDs
 	prosodyFeatures := req.ProsodyFeatures
 	var wasPadded bool
-	phonemeIDs, wasPadded = padPhonemeIDs(phonemeIDs)
+	var frontPad, backPad int
+	phonemeIDs, wasPadded, frontPad, backPad = padPhonemeIDs(phonemeIDs)
 	if wasPadded {
 		prosodyFeatures = padProsodyFeatures(req.ProsodyFeatures, originalPhonemeLen, len(phonemeIDs))
 	}
@@ -359,23 +367,18 @@ func (e *OnnxEngine) Synthesize(ctx context.Context, req *SynthesisRequest) (*Sy
 	// Peak-normalize and convert to int16.
 	audio := peakNormalize(audioCopy)
 
-	// --- Strategy A post-trim: remove silence introduced by padding ---
-	if wasPadded {
-		audio = trimSilence(audio)
-	}
-
-	// Calculate audio duration using integer arithmetic for precision.
-	var audioDuration time.Duration
-	if len(audio) > 0 && e.sampleRate > 0 {
-		audioDuration = time.Duration(int64(len(audio)) * int64(time.Second) / int64(e.sampleRate))
-	}
-
-	// Extract durations if available.
+	// Extract durations BEFORE post-trim so the precise trimmer can use them.
+	// `paddedDurations` keeps the full padded-sequence durations needed by
+	// trimPaddingByDurations, while `durations` (returned to callers) is
+	// truncated back to the original phoneme length for timing alignment.
+	var paddedDurations []float32
 	var durations []float32
 	if e.capabilities.HasDurationOutput && len(outputs) > 1 && outputs[1] != nil {
 		durTensor, ok := outputs[1].(*ort.Tensor[float32])
 		if ok {
 			rawDur := durTensor.GetData()
+			paddedDurations = make([]float32, len(rawDur))
+			copy(paddedDurations, rawDur)
 			durations = make([]float32, len(rawDur))
 			copy(durations, rawDur)
 			// When padding was applied, trim durations back to original length.
@@ -389,6 +392,31 @@ func (e *OnnxEngine) Synthesize(ctx context.Context, req *SynthesisRequest) (*Sy
 		} else {
 			e.logger.Warn("unexpected tensor type for duration output; durations unavailable")
 		}
+	}
+
+	// --- Strategy A post-trim: remove padding-induced audio ---
+	// Prefer the durations-based precise trim when the model exposes
+	// durations (issue #356). Falls back to the legacy RMS trim for older
+	// exports without a duration output.
+	if wasPadded {
+		if paddedDurations != nil {
+			audio = trimPaddingByDurations(
+				audio,
+				paddedDurations,
+				frontPad,
+				backPad,
+				e.hopSize,
+				trimEosMaxFrames,
+			)
+		} else {
+			audio = trimSilence(audio)
+		}
+	}
+
+	// Calculate audio duration using integer arithmetic for precision.
+	var audioDuration time.Duration
+	if len(audio) > 0 && e.sampleRate > 0 {
+		audioDuration = time.Duration(int64(len(audio)) * int64(time.Second) / int64(e.sampleRate))
 	}
 
 	e.logger.Debug("inference complete",

--- a/src/go/piperplus/short_text.go
+++ b/src/go/piperplus/short_text.go
@@ -8,10 +8,21 @@ import (
 )
 
 // Short-text synthesis quality mitigation constants.
+// Keep in sync with docs/spec/short-text-contract.toml.
 const (
 	// minPhonemeIDs is the minimum number of phoneme IDs required for stable
 	// VITS inference. Shorter sequences are padded with silence (pause ID = 0).
-	minPhonemeIDs = 40
+	//
+	// Issue #356: Was 40, but empirical measurements on the tsukuyomi 6lang
+	// model show synthesis is stable down to ~8 IDs. 40 caused Strategy A to
+	// fire on already-stable inputs and leak padding artefacts. 15 keeps
+	// Strategy A active for genuinely tiny inputs only.
+	minPhonemeIDs = 15
+
+	// minBodyForStrategyA is the minimum body length (= phoneme IDs minus
+	// BOS / EOS) for Strategy A to apply. Below this threshold, padding
+	// would dominate over actual content; raw VITS output is preferable.
+	minBodyForStrategyA = 3
 
 	// shortTextChars is the character-count threshold (excluding whitespace)
 	// below which Strategy C (silence break auto-injection) is applied.
@@ -37,8 +48,13 @@ const (
 // padPhonemeIDs inserts pause IDs (0) into phonemeIDs to reach minPhonemeIDs.
 // Pause IDs are inserted evenly after BOS (index 0) and before EOS (last index).
 // Returns the padded slice and true if padding was applied, or the original
-// slice and false if no padding was needed.
+// slice and false if no padding was needed (or skipped because the body is
+// shorter than minBodyForStrategyA — issue #356).
 func padPhonemeIDs(ids []int64) ([]int64, bool) {
+	bodyLen := len(ids) - 2 // exclude BOS / EOS
+	if bodyLen < minBodyForStrategyA {
+		return ids, false
+	}
 	if len(ids) >= minPhonemeIDs {
 		return ids, false
 	}

--- a/src/go/piperplus/short_text.go
+++ b/src/go/piperplus/short_text.go
@@ -15,7 +15,7 @@ const (
 	//
 	// Issue #356: Was 40, but empirical measurements on the tsukuyomi 6lang
 	// model show synthesis is stable down to ~8 IDs. 40 caused Strategy A to
-	// fire on already-stable inputs and leak padding artefacts. 15 keeps
+	// fire on already-stable inputs and leak padding artifacts. 15 keeps
 	// Strategy A active for genuinely tiny inputs only.
 	minPhonemeIDs = 15
 
@@ -46,7 +46,7 @@ const (
 
 	// trimEosMaxFrames bounds how many EOS frames the durations-based trim
 	// keeps after Strategy A padding. VITS predicts an inflated EOS under
-	// the padded context that produces an audible artefact otherwise
+	// the padded context that produces an audible artifact otherwise
 	// (issue #356). Default 0 = drop the entire EOS region.
 	trimEosMaxFrames = 0
 )

--- a/src/go/piperplus/short_text.go
+++ b/src/go/piperplus/short_text.go
@@ -43,20 +43,27 @@ const (
 	// trimWindowSize is the number of samples per RMS analysis window
 	// used in silence trimming.
 	trimWindowSize = 256
+
+	// trimEosMaxFrames bounds how many EOS frames the durations-based trim
+	// keeps after Strategy A padding. VITS predicts an inflated EOS under
+	// the padded context that produces an audible artefact otherwise
+	// (issue #356). Default 0 = drop the entire EOS region.
+	trimEosMaxFrames = 0
 )
 
 // padPhonemeIDs inserts pause IDs (0) into phonemeIDs to reach minPhonemeIDs.
 // Pause IDs are inserted evenly after BOS (index 0) and before EOS (last index).
-// Returns the padded slice and true if padding was applied, or the original
-// slice and false if no padding was needed (or skipped because the body is
-// shorter than minBodyForStrategyA — issue #356).
-func padPhonemeIDs(ids []int64) ([]int64, bool) {
+// Returns the padded slice, true if padding was applied, and the front/back
+// padding counts. Strategy A is skipped (returns the original slice and zero
+// counts) when the body (= phoneme IDs minus BOS / EOS) is shorter than
+// minBodyForStrategyA — see issue #356.
+func padPhonemeIDs(ids []int64) ([]int64, bool, int, int) {
 	bodyLen := len(ids) - 2 // exclude BOS / EOS
 	if bodyLen < minBodyForStrategyA {
-		return ids, false
+		return ids, false, 0, 0
 	}
 	if len(ids) >= minPhonemeIDs {
-		return ids, false
+		return ids, false, 0, 0
 	}
 
 	needed := minPhonemeIDs - len(ids)
@@ -87,7 +94,79 @@ func padPhonemeIDs(ids []int64) ([]int64, bool) {
 	// EOS (last element).
 	padded = append(padded, ids[len(ids)-1])
 
-	return padded, true
+	return padded, true, frontPad, backPad
+}
+
+// trimPaddingByDurations performs the Strategy A precise post-trim using the
+// model's duration output. Mirrors src/python_run/piper/voice.py
+// _trim_padding_by_durations so all runtimes produce byte-equal output for
+// the same inputs (issue #356, cross-runtime contract).
+//
+// The padded sequence layout is:
+//
+//	[BOS, pad×frontPad, ...body..., pad×backPad, EOS]
+//
+// durations[i] is the frame count VITS assigned to phoneme i. Multiplying the
+// pad-token totals by hopSize gives the exact sample count to drop.
+//
+// Trimming policy:
+//   - BOS + front padding: stripped completely
+//   - Back padding: stripped completely
+//   - EOS: keep only eosMaxFrames frames (default trimEosMaxFrames = 0)
+//
+// All frame→sample conversions use truncation (int) — required for
+// byte-equality with the Python reference implementation.
+//
+// Returns audio unchanged when inputs are inconsistent (nil durations, zero
+// hop, durations shorter than 1+frontPad+backPad+1, etc.).
+func trimPaddingByDurations(audio []int16, durations []float32, frontPad, backPad, hopSize, eosMaxFrames int) []int16 {
+	if frontPad <= 0 && backPad <= 0 {
+		return audio
+	}
+	if durations == nil || hopSize <= 0 {
+		return audio
+	}
+	expectedLen := 1 + frontPad + backPad + 1 // BOS + pads + EOS
+	if len(durations) < expectedLen {
+		return audio
+	}
+
+	// Front: BOS + front padding samples. Truncation matches int() in Python.
+	var frontSum float32
+	for i := 0; i < 1+frontPad; i++ {
+		frontSum += durations[i]
+	}
+	frontSamples := int(frontSum * float32(hopSize))
+
+	// Back: back padding samples + EOS excess (over eosMaxFrames).
+	var backPadSum float32
+	if backPad > 0 {
+		// durations[-(1+backPad) : -1] in Python = durations[len-1-backPad : len-1]
+		start := len(durations) - 1 - backPad
+		for i := start; i < len(durations)-1; i++ {
+			backPadSum += durations[i]
+		}
+	}
+	backPadSamples := int(backPadSum * float32(hopSize))
+
+	eosFrames := durations[len(durations)-1]
+	eosExcess := eosFrames - float32(eosMaxFrames)
+	if eosExcess < 0 {
+		eosExcess = 0
+	}
+	backSamples := backPadSamples + int(eosExcess*float32(hopSize))
+
+	if frontSamples < 0 {
+		frontSamples = 0
+	}
+	end := len(audio) - backSamples
+	if end < frontSamples {
+		end = frontSamples
+	}
+	if frontSamples >= len(audio) || end <= 0 || frontSamples >= end {
+		return audio
+	}
+	return audio[frontSamples:end]
 }
 
 // padProsodyFeatures extends prosody features to match the new padded phoneme

--- a/src/go/piperplus/short_text_test.go
+++ b/src/go/piperplus/short_text_test.go
@@ -15,7 +15,7 @@ func TestPadPhonemeIDs_NoPaddingNeeded(t *testing.T) {
 		ids[i] = int64(i)
 	}
 
-	padded, wasPadded := padPhonemeIDs(ids)
+	padded, wasPadded, _, _ := padPhonemeIDs(ids)
 	if wasPadded {
 		t.Error("expected wasPadded=false for len >= minPhonemeIDs")
 	}
@@ -28,7 +28,7 @@ func TestPadPhonemeIDs_ShortSequence(t *testing.T) {
 	// BOS=1, some content, EOS=2
 	ids := []int64{1, 10, 20, 30, 2}
 
-	padded, wasPadded := padPhonemeIDs(ids)
+	padded, wasPadded, _, _ := padPhonemeIDs(ids)
 	if !wasPadded {
 		t.Error("expected wasPadded=true for short sequence")
 	}
@@ -75,7 +75,7 @@ func TestPadPhonemeIDs_MinimalSequence_Skipped(t *testing.T) {
 	// is skipped entirely (issue #356).
 	ids := []int64{1, 2}
 
-	padded, wasPadded := padPhonemeIDs(ids)
+	padded, wasPadded, _, _ := padPhonemeIDs(ids)
 	if wasPadded {
 		t.Error("expected wasPadded=false for body < minBodyForStrategyA")
 	}
@@ -92,7 +92,7 @@ func TestPadPhonemeIDs_BodyTooShort(t *testing.T) {
 	}
 	ids := []int64{1, 10, 11, 2}
 
-	padded, wasPadded := padPhonemeIDs(ids)
+	padded, wasPadded, _, _ := padPhonemeIDs(ids)
 	if wasPadded {
 		t.Error("expected wasPadded=false for body=2 < minBodyForStrategyA")
 	}
@@ -110,7 +110,7 @@ func TestPadPhonemeIDs_BodyAtMinimum(t *testing.T) {
 	}
 	ids = append(ids, 2) // EOS
 
-	padded, wasPadded := padPhonemeIDs(ids)
+	padded, wasPadded, _, _ := padPhonemeIDs(ids)
 	if !wasPadded {
 		t.Error("expected wasPadded=true for body == minBodyForStrategyA")
 	}
@@ -124,7 +124,7 @@ func TestPadPhonemeIDs_ExactMinimum(t *testing.T) {
 	ids[0] = 1
 	ids[len(ids)-1] = 2
 
-	padded, wasPadded := padPhonemeIDs(ids)
+	padded, wasPadded, _, _ := padPhonemeIDs(ids)
 	if wasPadded {
 		t.Error("expected wasPadded=false when exactly at minimum")
 	}
@@ -138,7 +138,7 @@ func TestPadPhonemeIDs_AboveMinimum(t *testing.T) {
 	ids[0] = 1
 	ids[len(ids)-1] = 2
 
-	padded, wasPadded := padPhonemeIDs(ids)
+	padded, wasPadded, _, _ := padPhonemeIDs(ids)
 	if wasPadded {
 		t.Error("expected wasPadded=false when above minimum")
 	}
@@ -187,6 +187,112 @@ func TestPadProsodyFeatures_PaddingApplied(t *testing.T) {
 	// Last element should match original EOS prosody.
 	if result[len(result)-1] != original[len(original)-1] {
 		t.Errorf("expected last element %v, got %v", original[len(original)-1], result[len(result)-1])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Strategy A: trimPaddingByDurations (precise post-trim, issue #356)
+// ---------------------------------------------------------------------------
+
+// Mirrors the Python reference (src/python_run/piper/voice.py and
+// src/python/piper_train/infer_onnx.py) so the cross-runtime contract holds.
+
+func TestTrimPaddingByDurations_NoOpWhenNoPadding(t *testing.T) {
+	audio := make([]int16, 1000)
+	for i := range audio {
+		audio[i] = int16(i)
+	}
+	durations := []float32{1.0, 1.0, 1.0, 1.0, 1.0}
+	result := trimPaddingByDurations(audio, durations, 0, 0, 256, trimEosMaxFrames)
+	if len(result) != len(audio) {
+		t.Errorf("expected length %d, got %d", len(audio), len(result))
+	}
+}
+
+func TestTrimPaddingByDurations_TrimsFrontPaddingOnly(t *testing.T) {
+	// Layout: BOS=2, pad×3 (3+3+3 frames), body=4, EOS=1 → 19 frames total.
+	durations := []float32{2.0, 3.0, 3.0, 3.0, 4.0, 1.0}
+	const hop = 100
+	total := 1900 // sum * hop
+	audio := make([]int16, total)
+	result := trimPaddingByDurations(audio, durations, 3, 0, hop, 6)
+	// BOS + front padding samples = (2+3+3+3) * 100 = 1100
+	if len(result) != total-1100 {
+		t.Errorf("expected length %d, got %d", total-1100, len(result))
+	}
+}
+
+func TestTrimPaddingByDurations_DefaultStripsEosCompletely(t *testing.T) {
+	// Default trimEosMaxFrames=0 drops the entire EOS region.
+	durations := []float32{2.0, 5.0, 5.0, 4.0, 4.0, 5.0, 5.0, 8.0}
+	const hop = 100
+	total := 3800
+	audio := make([]int16, total)
+	result := trimPaddingByDurations(audio, durations, 2, 2, hop, trimEosMaxFrames)
+	// BOS + front padding = (2+5+5)*100 = 1200
+	// back padding + entire EOS = (5+5+8)*100 = 1800
+	if len(result) != total-1200-1800 {
+		t.Errorf("expected length %d, got %d", total-1200-1800, len(result))
+	}
+}
+
+func TestTrimPaddingByDurations_ClampsInflatedEos(t *testing.T) {
+	// EOS=10 frames, eosMaxFrames=6 → excess 4 frames trimmed.
+	durations := []float32{2.0, 3.0, 3.0, 4.0, 3.0, 3.0, 10.0}
+	const hop = 100
+	total := 2800
+	audio := make([]int16, total)
+	result := trimPaddingByDurations(audio, durations, 2, 2, hop, 6)
+	// BOS + front padding = (2+3+3) * 100 = 800
+	// back padding + EOS excess = (3+3 + (10-6)) * 100 = 1000
+	if len(result) != total-800-1000 {
+		t.Errorf("expected length %d, got %d", total-800-1000, len(result))
+	}
+}
+
+func TestTrimPaddingByDurations_ReturnsInputWhenDurationsNil(t *testing.T) {
+	audio := make([]int16, 1000)
+	result := trimPaddingByDurations(audio, nil, 3, 3, 256, trimEosMaxFrames)
+	if len(result) != len(audio) {
+		t.Errorf("expected unchanged length %d, got %d", len(audio), len(result))
+	}
+}
+
+func TestTrimPaddingByDurations_ReturnsInputWhenDurationsTooShort(t *testing.T) {
+	audio := make([]int16, 1000)
+	durations := []float32{1.0, 1.0, 1.0}
+	result := trimPaddingByDurations(audio, durations, 5, 5, 256, trimEosMaxFrames)
+	if len(result) != len(audio) {
+		t.Errorf("expected unchanged length %d, got %d", len(audio), len(result))
+	}
+}
+
+func TestTrimPaddingByDurations_ReturnsInputWhenHopSizeZero(t *testing.T) {
+	audio := make([]int16, 1000)
+	durations := []float32{1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0}
+	result := trimPaddingByDurations(audio, durations, 2, 2, 0, trimEosMaxFrames)
+	if len(result) != len(audio) {
+		t.Errorf("expected unchanged length %d, got %d", len(audio), len(result))
+	}
+}
+
+func TestTrimPaddingByDurations_TruncationMatchesIntCast(t *testing.T) {
+	// Layout (frontPad=1, backPad=1, body=3):
+	//   [BOS=0.701, pad=0.701, body=2, body=2, body=2, pad=0.703, EOS=0.701]
+	// Front trim = int((0.701+0.701)*100) = 140
+	// Back trim  = int(0.703*100) + int(0.701*100) = 70 + 70 = 140 (truncated each)
+	// A round() implementation would diverge by 1 sample → cross-runtime drift.
+	durations := []float32{0.701, 0.701, 2.0, 2.0, 2.0, 0.703, 0.701}
+	const hop = 100
+	var sum float32
+	for _, d := range durations {
+		sum += d
+	}
+	total := int(sum * hop)
+	audio := make([]int16, total)
+	result := trimPaddingByDurations(audio, durations, 1, 1, hop, trimEosMaxFrames)
+	if len(result) != total-140-140 {
+		t.Errorf("expected length %d, got %d", total-140-140, len(result))
 	}
 }
 

--- a/src/go/piperplus/short_text_test.go
+++ b/src/go/piperplus/short_text_test.go
@@ -70,22 +70,52 @@ func TestPadPhonemeIDs_ShortSequence(t *testing.T) {
 	}
 }
 
-func TestPadPhonemeIDs_MinimalSequence(t *testing.T) {
-	// Just BOS and EOS.
+func TestPadPhonemeIDs_MinimalSequence_Skipped(t *testing.T) {
+	// Just BOS and EOS — body=0 is below minBodyForStrategyA so Strategy A
+	// is skipped entirely (issue #356).
 	ids := []int64{1, 2}
 
 	padded, wasPadded := padPhonemeIDs(ids)
+	if wasPadded {
+		t.Error("expected wasPadded=false for body < minBodyForStrategyA")
+	}
+	if len(padded) != len(ids) {
+		t.Errorf("expected length %d, got %d", len(ids), len(padded))
+	}
+}
+
+func TestPadPhonemeIDs_BodyTooShort(t *testing.T) {
+	// body=2 (e.g. 「あ。」 phonemized as [BOS, a, ., EOS]) should also
+	// skip Strategy A under minBodyForStrategyA=3.
+	if minBodyForStrategyA <= 2 {
+		t.Skip("minBodyForStrategyA changed; this test no longer applies")
+	}
+	ids := []int64{1, 10, 11, 2}
+
+	padded, wasPadded := padPhonemeIDs(ids)
+	if wasPadded {
+		t.Error("expected wasPadded=false for body=2 < minBodyForStrategyA")
+	}
+	if len(padded) != len(ids) {
+		t.Errorf("expected length %d, got %d", len(ids), len(padded))
+	}
+}
+
+func TestPadPhonemeIDs_BodyAtMinimum(t *testing.T) {
+	// body == minBodyForStrategyA: Strategy A applies.
+	ids := make([]int64, 0, 2+minBodyForStrategyA)
+	ids = append(ids, 1) // BOS
+	for i := 0; i < minBodyForStrategyA; i++ {
+		ids = append(ids, int64(10+i))
+	}
+	ids = append(ids, 2) // EOS
+
+	padded, wasPadded := padPhonemeIDs(ids)
 	if !wasPadded {
-		t.Error("expected wasPadded=true")
+		t.Error("expected wasPadded=true for body == minBodyForStrategyA")
 	}
 	if len(padded) != minPhonemeIDs {
 		t.Errorf("expected length %d, got %d", minPhonemeIDs, len(padded))
-	}
-	if padded[0] != 1 {
-		t.Errorf("expected BOS=1 at index 0, got %d", padded[0])
-	}
-	if padded[len(padded)-1] != 2 {
-		t.Errorf("expected EOS=2 at last index, got %d", padded[len(padded)-1])
 	}
 }
 
@@ -270,10 +300,12 @@ func TestAdjustScales_AboveMinimum(t *testing.T) {
 }
 
 func TestAdjustScales_VeryShort(t *testing.T) {
-	// 5 phonemes -> ratio = 5/40 = 0.125
-	// noiseScale *= max(0.5, 0.125) = 0.5
-	// noiseW *= max(0.4, 0.125) = 0.4
-	ns, nw := adjustScalesForShortText(5, 0.667, 0.8)
+	// Below the noiseW floor (0.4) — both clamps engage.
+	n := minPhonemeIDs / 4
+	if n < 1 {
+		n = 1
+	}
+	ns, nw := adjustScalesForShortText(n, 0.667, 0.8)
 
 	expectedNS := float32(0.667 * 0.5)
 	expectedNW := float32(0.8 * 0.4)
@@ -287,13 +319,15 @@ func TestAdjustScales_VeryShort(t *testing.T) {
 }
 
 func TestAdjustScales_HalfMinimum(t *testing.T) {
-	// 20 phonemes -> ratio = 20/40 = 0.5
-	// noiseScale *= max(0.5, 0.5) = 0.5
-	// noiseW *= max(0.4, 0.5) = 0.5
-	ns, nw := adjustScalesForShortText(20, 0.667, 0.8)
+	// At the noiseScale floor (ratio = 0.5).
+	n := minPhonemeIDs / 2
+	ns, nw := adjustScalesForShortText(n, 0.667, 0.8)
 
-	expectedNS := float32(0.667 * 0.5)
-	expectedNW := float32(0.8 * 0.5)
+	ratio := float32(n) / float32(minPhonemeIDs)
+	nsRatio := float32(math.Max(0.5, float64(ratio)))
+	nwRatio := float32(math.Max(0.4, float64(ratio)))
+	expectedNS := float32(0.667) * nsRatio
+	expectedNW := float32(0.8) * nwRatio
 
 	if math.Abs(float64(ns-expectedNS)) > 0.001 {
 		t.Errorf("expected noiseScale~%f, got %f", expectedNS, ns)
@@ -304,13 +338,18 @@ func TestAdjustScales_HalfMinimum(t *testing.T) {
 }
 
 func TestAdjustScales_MostlyFull(t *testing.T) {
-	// 35 phonemes -> ratio = 35/40 = 0.875
-	// noiseScale *= max(0.5, 0.875) = 0.875
-	// noiseW *= max(0.4, 0.875) = 0.875
-	ns, nw := adjustScalesForShortText(35, 0.667, 0.8)
+	// Just below the threshold so neither floor engages.
+	n := minPhonemeIDs - 2
+	if n < 1 {
+		n = 1
+	}
+	ns, nw := adjustScalesForShortText(n, 0.667, 0.8)
 
-	expectedNS := float32(0.667 * 0.875)
-	expectedNW := float32(0.8 * 0.875)
+	ratio := float32(n) / float32(minPhonemeIDs)
+	nsRatio := float32(math.Max(0.5, float64(ratio)))
+	nwRatio := float32(math.Max(0.4, float64(ratio)))
+	expectedNS := float32(0.667) * nsRatio
+	expectedNW := float32(0.8) * nwRatio
 
 	if math.Abs(float64(ns-expectedNS)) > 0.001 {
 		t.Errorf("expected noiseScale~%f, got %f", expectedNS, ns)
@@ -882,7 +921,7 @@ func TestWindowRMS_MixedSignal(t *testing.T) {
 func TestAdjustScales_ZeroPhonemes(t *testing.T) {
 	// Edge case: 0 phonemes.
 	ns, nw := adjustScalesForShortText(0, 0.667, 0.8)
-	// ratio = 0/40 = 0, clamped floors: noiseScale *= 0.5, noiseW *= 0.4
+	// ratio = 0, clamped floors: noiseScale *= 0.5, noiseW *= 0.4
 	expectedNS := float32(0.667 * 0.5)
 	expectedNW := float32(0.8 * 0.4)
 	if math.Abs(float64(ns-expectedNS)) > 0.001 {
@@ -894,7 +933,7 @@ func TestAdjustScales_ZeroPhonemes(t *testing.T) {
 }
 
 func TestAdjustScales_OnePhoneme(t *testing.T) {
-	// ratio = 1/40 = 0.025, clamped: noiseScale *= 0.5, noiseW *= 0.4
+	// ratio = 1/minPhonemeIDs, well below both floors → clamped to 0.5 / 0.4
 	ns, nw := adjustScalesForShortText(1, 1.0, 1.0)
 	expectedNS := float32(0.5)
 	expectedNW := float32(0.4)
@@ -907,10 +946,12 @@ func TestAdjustScales_OnePhoneme(t *testing.T) {
 }
 
 func TestAdjustScales_JustBelowMinimum(t *testing.T) {
-	// 39 phonemes -> ratio = 39/40 = 0.975
-	ns, nw := adjustScalesForShortText(39, 0.667, 0.8)
-	expectedNS := float32(0.667 * 0.975)
-	expectedNW := float32(0.8 * 0.975)
+	// minPhonemeIDs - 1 phonemes -> ratio = (min-1)/min, no floor clamp.
+	n := minPhonemeIDs - 1
+	ns, nw := adjustScalesForShortText(n, 0.667, 0.8)
+	ratio := float32(n) / float32(minPhonemeIDs)
+	expectedNS := float32(0.667) * ratio
+	expectedNW := float32(0.8) * ratio
 	if math.Abs(float64(ns-expectedNS)) > 0.001 {
 		t.Errorf("expected noiseScale~%f, got %f", expectedNS, ns)
 	}
@@ -924,8 +965,11 @@ func TestAdjustScales_JustBelowMinimum(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestConstants(t *testing.T) {
-	if minPhonemeIDs != 40 {
-		t.Errorf("expected minPhonemeIDs=40, got %d", minPhonemeIDs)
+	if minPhonemeIDs != 15 {
+		t.Errorf("expected minPhonemeIDs=15, got %d", minPhonemeIDs)
+	}
+	if minBodyForStrategyA != 3 {
+		t.Errorf("expected minBodyForStrategyA=3, got %d", minBodyForStrategyA)
 	}
 	if shortTextChars != 10 {
 		t.Errorf("expected shortTextChars=10, got %d", shortTextChars)

--- a/src/python/piper_train/infer_onnx.py
+++ b/src/python/piper_train/infer_onnx.py
@@ -31,7 +31,7 @@ TRIM_THRESHOLD_RMS = 0.01
 TRIM_MIN_SAMPLES = 2205
 # Number of EOS frames retained after Strategy A padding when the durations-
 # based trim is in use. Defaults to 0 — VITS predicts an inflated EOS under
-# the padded context that emits an audible artefact otherwise (issue #356).
+# the padded context that emits an audible artifact otherwise (issue #356).
 TRIM_EOS_MAX_FRAMES = 0
 # Default hop length when config.json does not declare audio.hop_size.
 DEFAULT_HOP_SIZE = 256

--- a/src/python/piper_train/infer_onnx.py
+++ b/src/python/piper_train/infer_onnx.py
@@ -17,8 +17,14 @@ from .vits.wavfile import write as write_wav
 _LOGGER = logging.getLogger("piper_train.infer_onnx")
 
 # --- Short-text synthesis quality constants ---
-# Minimum phoneme_ids length below which padding/scale adjustment is applied
-MIN_PHONEME_IDS = 40
+# Minimum phoneme_ids length below which padding/scale adjustment is applied.
+# See docs/spec/short-text-contract.toml and issue #356 for rationale (was 40,
+# empirically tuned to 15 to avoid Strategy A firing on already-stable inputs).
+MIN_PHONEME_IDS = 15
+# Minimum body length (excluding BOS/EOS) for Strategy A to apply.
+# Bodies smaller than this would have padding ratio so high that pad-token
+# audio dominates over actual content; raw VITS output is preferable.
+MIN_BODY_FOR_STRATEGY_A = 3
 # RMS threshold for silence trimming (float audio range)
 TRIM_THRESHOLD_RMS = 0.01
 # Minimum audio samples to keep after trimming (22050 Hz * 0.1s)
@@ -34,10 +40,17 @@ def _pad_phoneme_ids(
     Inserts pause tokens (ID=0, blank/pad) evenly after BOS and before EOS
     until the sequence reaches MIN_PHONEME_IDS length.
 
+    Skips padding when the body (= phoneme_ids excluding BOS/EOS) has fewer
+    than MIN_BODY_FOR_STRATEGY_A IDs — pad tokens would otherwise overwhelm
+    the actual content (issue #356).
+
     Returns:
         (padded_phoneme_ids, padded_prosody_features, was_padded)
     """
     n = len(phoneme_ids)
+    body_len = n - 2  # exclude BOS / EOS
+    if body_len < MIN_BODY_FOR_STRATEGY_A:
+        return phoneme_ids, prosody_features, False
     if n >= MIN_PHONEME_IDS:
         return phoneme_ids, prosody_features, False
 

--- a/src/python/piper_train/infer_onnx.py
+++ b/src/python/piper_train/infer_onnx.py
@@ -29,12 +29,18 @@ MIN_BODY_FOR_STRATEGY_A = 3
 TRIM_THRESHOLD_RMS = 0.01
 # Minimum audio samples to keep after trimming (22050 Hz * 0.1s)
 TRIM_MIN_SAMPLES = 2205
+# Number of EOS frames retained after Strategy A padding when the durations-
+# based trim is in use. Defaults to 0 — VITS predicts an inflated EOS under
+# the padded context that emits an audible artefact otherwise (issue #356).
+TRIM_EOS_MAX_FRAMES = 0
+# Default hop length when config.json does not declare audio.hop_size.
+DEFAULT_HOP_SIZE = 256
 
 
 def _pad_phoneme_ids(
     phoneme_ids: list[int],
     prosody_features: list[dict | None] | None,
-) -> tuple[list[int], list[dict | None] | None, bool]:
+) -> tuple[list[int], list[dict | None] | None, bool, int, int]:
     """Strategy A: Pad short phoneme_ids with silence tokens.
 
     Inserts pause tokens (ID=0, blank/pad) evenly after BOS and before EOS
@@ -45,14 +51,19 @@ def _pad_phoneme_ids(
     the actual content (issue #356).
 
     Returns:
-        (padded_phoneme_ids, padded_prosody_features, was_padded)
+        (padded_phoneme_ids, padded_prosody_features, was_padded,
+         front_pad, back_pad)
+
+        ``front_pad`` / ``back_pad`` are the numbers of pad tokens inserted
+        after BOS and before EOS respectively (both 0 when no padding
+        occurred). They are needed for the durations-based post-trim.
     """
     n = len(phoneme_ids)
     body_len = n - 2  # exclude BOS / EOS
     if body_len < MIN_BODY_FOR_STRATEGY_A:
-        return phoneme_ids, prosody_features, False
+        return phoneme_ids, prosody_features, False, 0, 0
     if n >= MIN_PHONEME_IDS:
-        return phoneme_ids, prosody_features, False
+        return phoneme_ids, prosody_features, False, 0, 0
 
     pad_total = MIN_PHONEME_IDS - n
     pad_front = pad_total // 2
@@ -85,7 +96,69 @@ def _pad_phoneme_ids(
         pad_front,
         pad_back,
     )
-    return padded, padded_prosody, True
+    return padded, padded_prosody, True, pad_front, pad_back
+
+
+def _trim_padding_by_durations(
+    audio: np.ndarray,
+    durations: np.ndarray,
+    front_pad: int,
+    back_pad: int,
+    hop_size: int,
+    eos_max_frames: int = TRIM_EOS_MAX_FRAMES,
+) -> np.ndarray:
+    """Strategy A post-trim using model durations (precise method).
+
+    Mirrors :func:`piper.voice._trim_padding_by_durations` so the runtime and
+    training paths share the same trimming behaviour. The padded sequence
+    layout is::
+
+        [BOS, pad×front_pad, ...body..., pad×back_pad, EOS]
+
+    ``durations[i]`` is the frame count VITS assigned to phoneme ``i``;
+    multiplying the pad-token frame counts by ``hop_size`` gives the exact
+    number of audio samples generated for the padding. The conversion uses
+    ``int(...)`` (truncation) to match the cross-runtime contract — every
+    runtime must clip frame totals the same way for byte-equal output.
+
+    Trimming policy (issue #356):
+
+    * **BOS + front padding**: stripped completely.
+    * **Back padding**: stripped completely.
+    * **EOS**: keep only the first ``eos_max_frames`` frames (default
+      ``TRIM_EOS_MAX_FRAMES`` = 0, i.e. drop the entire EOS region).
+
+    Returns ``audio`` unchanged when inputs are inconsistent.
+    """
+    if front_pad <= 0 and back_pad <= 0:
+        return audio
+    if durations is None or hop_size <= 0:
+        return audio
+
+    durations_1d = np.asarray(durations).reshape(-1)
+    expected_len = 1 + front_pad + back_pad + 1  # BOS + pads + EOS
+    if durations_1d.size < expected_len:
+        return audio
+
+    # BOS + front padding samples (stripped). Truncation matches the
+    # cross-runtime contract.
+    front_samples = (
+        int(durations_1d[0 : 1 + front_pad].sum() * hop_size) if front_pad > 0 else 0
+    )
+
+    # Back padding samples + EOS excess (over eos_max_frames) samples.
+    back_pad_samples = (
+        int(durations_1d[-(1 + back_pad) : -1].sum() * hop_size) if back_pad > 0 else 0
+    )
+    eos_frames = float(durations_1d[-1])
+    eos_excess_frames = max(0.0, eos_frames - float(eos_max_frames))
+    back_samples = back_pad_samples + int(eos_excess_frames * hop_size)
+
+    start = max(0, front_samples)
+    end = max(start, len(audio) - back_samples)
+    if start >= len(audio) or end <= 0 or start >= end:
+        return audio
+    return audio[start:end]
 
 
 def _trim_silence(
@@ -414,6 +487,16 @@ def main():
         help="Model download/search directory",
     )
     parser.add_argument("--sample-rate", type=int, default=22050)
+    parser.add_argument(
+        "--hop-size",
+        type=int,
+        default=DEFAULT_HOP_SIZE,
+        help=(
+            "Audio frames per VITS hop. Used to convert duration outputs "
+            "into sample positions during Strategy A post-trim. "
+            "Defaults to 256."
+        ),
+    )
     parser.add_argument("--noise-scale", type=float, default=0.667)
     parser.add_argument("--noise-scale-w", type=float, default=0.8)
     parser.add_argument("--length-scale", type=float, default=1.0)
@@ -632,6 +715,13 @@ def main():
             _LOGGER.error("phoneme_id_map not found in config.json")
             sys.exit(1)
 
+        # If --hop-size was left at the default and config supplies it,
+        # honour the config value so durations-based trim has the right
+        # sample/frame conversion (issue #356, cross-runtime contract).
+        config_hop_size = config.get("audio", {}).get("hop_size")
+        if config_hop_size and args.hop_size == DEFAULT_HOP_SIZE:
+            args.hop_size = int(config_hop_size)
+
         _LOGGER.info("Loaded phoneme_id_map from %s", config_path)
 
         # Load language_id_map (needed for multilingual auto-promotion)
@@ -690,9 +780,13 @@ def main():
         original_len = len(phoneme_ids)
 
         # --- Strategy A: Silence Padding for short inputs ---
-        phoneme_ids, prosody_features_data, was_padded = _pad_phoneme_ids(
-            phoneme_ids, prosody_features_data
-        )
+        (
+            phoneme_ids,
+            prosody_features_data,
+            was_padded,
+            front_pad,
+            back_pad,
+        ) = _pad_phoneme_ids(phoneme_ids, prosody_features_data)
 
         # --- Strategy B: Dynamic Scales Adjustment for short inputs ---
         # Use original_len (pre-padding) so the ratio is based on the actual
@@ -773,8 +867,21 @@ def main():
         audio = audio_float_to_int16(audio.squeeze())
 
         # --- Strategy A: Post-trim silence introduced by padding ---
+        # Prefer the durations-based precise trim when the model exposes
+        # ``durations`` (cross-runtime contract — issue #356). Falls back to
+        # the legacy RMS-based trim for older exports without durations.
         if was_padded:
-            audio = _trim_silence(audio, sample_rate=args.sample_rate)
+            if durations is not None:
+                durations_1d = np.asarray(durations).reshape(-1)
+                audio = _trim_padding_by_durations(
+                    audio,
+                    durations_1d,
+                    front_pad,
+                    back_pad,
+                    args.hop_size,
+                )
+            else:
+                audio = _trim_silence(audio, sample_rate=args.sample_rate)
 
         end_time = time.perf_counter()
 

--- a/src/python/tests/test_infer_onnx.py
+++ b/src/python/tests/test_infer_onnx.py
@@ -4,12 +4,15 @@ import numpy as np
 import pytest
 
 from piper_train.infer_onnx import (
+    DEFAULT_HOP_SIZE,
     MIN_BODY_FOR_STRATEGY_A,
     MIN_PHONEME_IDS,
+    TRIM_EOS_MAX_FRAMES,
     TRIM_MIN_SAMPLES,
     TRIM_THRESHOLD_RMS,
     _adjust_scales_for_short_input,
     _pad_phoneme_ids,
+    _trim_padding_by_durations,
     _trim_silence,
     text_to_phoneme_ids_and_prosody,
 )
@@ -172,7 +175,7 @@ class TestPadPhonemeIds:
         """Sequences >= MIN_PHONEME_IDS should not be padded."""
         ids = list(range(MIN_PHONEME_IDS))
         prosody = [None] * MIN_PHONEME_IDS
-        result_ids, result_prosody, was_padded = _pad_phoneme_ids(ids, prosody)
+        result_ids, result_prosody, was_padded, _, _ = _pad_phoneme_ids(ids, prosody)
         assert not was_padded
         assert result_ids == ids
         assert result_prosody == prosody
@@ -182,7 +185,7 @@ class TestPadPhonemeIds:
         # BOS=1, some content, EOS=2
         ids = [1, 10, 20, 30, 2]
         prosody = [None, {"a1": 1, "a2": 2, "a3": 3}, None, None, None]
-        result_ids, result_prosody, was_padded = _pad_phoneme_ids(ids, prosody)
+        result_ids, result_prosody, was_padded, _, _ = _pad_phoneme_ids(ids, prosody)
         assert was_padded
         assert len(result_ids) == MIN_PHONEME_IDS
         assert len(result_prosody) == MIN_PHONEME_IDS
@@ -191,7 +194,7 @@ class TestPadPhonemeIds:
         """BOS (first) and EOS (last) tokens should be preserved."""
         # body length must be >= MIN_BODY_FOR_STRATEGY_A for padding to apply.
         ids = [1] + list(range(10, 10 + MIN_BODY_FOR_STRATEGY_A)) + [2]
-        result_ids, _, was_padded = _pad_phoneme_ids(ids, None)
+        result_ids, _, was_padded, _, _ = _pad_phoneme_ids(ids, None)
         assert was_padded
         assert result_ids[0] == 1  # BOS
         assert result_ids[-1] == 2  # EOS
@@ -200,7 +203,7 @@ class TestPadPhonemeIds:
         """Inserted padding tokens should be 0 (blank/pad)."""
         # body=3 (>= MIN_BODY_FOR_STRATEGY_A) so padding applies.
         ids = [1, 10, 20, 30, 2]
-        result_ids, _, was_padded = _pad_phoneme_ids(ids, None)
+        result_ids, _, was_padded, _, _ = _pad_phoneme_ids(ids, None)
         assert was_padded
         # Middle content (10, 20, 30) should still be present
         assert 10 in result_ids
@@ -214,7 +217,7 @@ class TestPadPhonemeIds:
         """When prosody_features is None, output prosody should also be None."""
         # body=3 (>= MIN_BODY_FOR_STRATEGY_A).
         ids = [1, 10, 20, 30, 2]
-        result_ids, result_prosody, was_padded = _pad_phoneme_ids(ids, None)
+        result_ids, result_prosody, was_padded, _, _ = _pad_phoneme_ids(ids, None)
         assert was_padded
         assert result_prosody is None
 
@@ -229,7 +232,7 @@ class TestPadPhonemeIds:
             {"a1": 7, "a2": 8, "a3": 9},
             None,
         ]
-        result_ids, result_prosody, was_padded = _pad_phoneme_ids(ids, prosody)
+        result_ids, result_prosody, was_padded, _, _ = _pad_phoneme_ids(ids, prosody)
         assert was_padded
         # Count non-None entries -- should still be 3 (the original content)
         non_none = [p for p in result_prosody if p is not None]
@@ -239,7 +242,7 @@ class TestPadPhonemeIds:
         """Padding should be approximately even between front and back."""
         # body=3 so padding applies.
         ids = [1, 10, 20, 30, 2]
-        result_ids, _, _ = _pad_phoneme_ids(ids, None)
+        result_ids, _, _, _, _ = _pad_phoneme_ids(ids, None)
         # Find position of first content token 10
         pos = result_ids.index(10)
         front_pads = pos - 1  # subtract BOS
@@ -256,22 +259,120 @@ class TestPadPhonemeIds:
         """
         # body = 0 (only BOS + EOS)
         ids = [1, 2]
-        result_ids, result_prosody, was_padded = _pad_phoneme_ids(ids, None)
+        result_ids, result_prosody, was_padded, _, _ = _pad_phoneme_ids(ids, None)
         assert not was_padded
         assert result_ids == ids
 
         # body = 1
         ids = [1, 10, 2]
-        result_ids, _, was_padded = _pad_phoneme_ids(ids, None)
+        result_ids, _, was_padded, _, _ = _pad_phoneme_ids(ids, None)
         assert not was_padded
         assert result_ids == ids
 
         # body = 2 (e.g. 「あ。」 with [BOS, a, ., EOS])
         if MIN_BODY_FOR_STRATEGY_A > 2:
             ids = [1, 10, 11, 2]
-            result_ids, _, was_padded = _pad_phoneme_ids(ids, None)
+            result_ids, _, was_padded, _, _ = _pad_phoneme_ids(ids, None)
             assert not was_padded
             assert result_ids == ids
+
+
+class TestTrimPaddingByDurations:
+    """Tests for Strategy A precise post-trim: _trim_padding_by_durations.
+
+    Mirrors src/python_run/tests/test_short_text_mitigation.py to keep the
+    runtime and training implementations behaviourally identical
+    (cross-runtime contract — issue #356).
+    """
+
+    def test_no_op_when_no_padding(self):
+        audio = np.arange(1000, dtype=np.int16)
+        durations = np.array([1.0] * 5, dtype=np.float32)
+        result = _trim_padding_by_durations(audio, durations, 0, 0, hop_size=256)
+        assert np.array_equal(result, audio)
+
+    def test_trims_front_padding_only(self):
+        # Layout: BOS=2, pad×3 (3+3+3), body=4, EOS=1 → 19 frames total
+        durations = np.array([2.0, 3.0, 3.0, 3.0, 4.0, 1.0], dtype=np.float32)
+        hop = 100
+        total = int(durations.sum() * hop)  # 1900
+        audio = np.arange(total, dtype=np.int16)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=3, back_pad=0, hop_size=hop, eos_max_frames=6
+        )
+        # BOS + front padding samples = (2+3+3+3) * 100 = 1100
+        assert len(result) == total - 1100
+
+    def test_default_strips_eos_completely(self):
+        """Default eos_max_frames=0 drops the entire EOS region (#356)."""
+        # body × 2, pads × 2, EOS=8
+        durations = np.array(
+            [2.0, 5.0, 5.0, 4.0, 4.0, 5.0, 5.0, 8.0], dtype=np.float32
+        )
+        hop = 100
+        total = int(durations.sum() * hop)  # 3800
+        audio = np.arange(total, dtype=np.int16)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=2, back_pad=2, hop_size=hop
+        )
+        # BOS + front padding = (2+5+5)*100 = 1200
+        # back padding + entire EOS = (5+5+8)*100 = 1800
+        assert len(result) == total - 1200 - 1800
+
+    def test_clamps_inflated_eos_duration(self):
+        # EOS=10 frames, eos_max_frames=6 → excess 4 frames trimmed.
+        durations = np.array([2.0, 3.0, 3.0, 4.0, 3.0, 3.0, 10.0], dtype=np.float32)
+        hop = 100
+        total = int(durations.sum() * hop)  # 2800
+        audio = np.arange(total, dtype=np.int16)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=2, back_pad=2, hop_size=hop, eos_max_frames=6
+        )
+        assert len(result) == total - 800 - 1000
+
+    def test_returns_input_when_durations_none(self):
+        audio = np.arange(1000, dtype=np.int16)
+        result = _trim_padding_by_durations(audio, None, 3, 3, hop_size=256)
+        assert np.array_equal(result, audio)
+
+    def test_returns_input_when_durations_too_short(self):
+        # durations has fewer entries than 1 + front + back + 1
+        audio = np.arange(1000, dtype=np.int16)
+        durations = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=5, back_pad=5, hop_size=256
+        )
+        assert np.array_equal(result, audio)
+
+    def test_returns_input_when_hop_size_zero(self):
+        audio = np.arange(1000, dtype=np.int16)
+        durations = np.array([1.0] * 8, dtype=np.float32)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=2, back_pad=2, hop_size=0
+        )
+        assert np.array_equal(result, audio)
+
+    def test_truncation_matches_int_cast(self):
+        """Sample count must use truncation (int()) — cross-runtime contract."""
+        # Layout (front_pad=1, back_pad=1, body=3):
+        #   [BOS=0.701, pad=0.701, body=2, body=2, body=2, pad=0.703, EOS=0.701]
+        # 0.701 / 0.703 chosen to expose float-rounding drift between runtimes.
+        durations = np.array(
+            [0.701, 0.701, 2.0, 2.0, 2.0, 0.703, 0.701], dtype=np.float32
+        )
+        hop = 100
+        total_samples = len(np.arange(int(durations.sum() * hop), dtype=np.int16))
+        audio = np.arange(total_samples, dtype=np.int16)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=1, back_pad=1, hop_size=hop
+        )
+        # Front trim = int((BOS + pad) * 100)
+        #            = int((0.701 + 0.701) * 100) = int(140.2) → 140 (truncated)
+        # Back trim  = int(pad * 100) + int(EOS * 100)  (eos_max_frames=0)
+        #            = int(0.703 * 100) + int(0.701 * 100)
+        #            = 70 + 70 = 140 (each truncated independently)
+        # If a runtime mistakenly used round() it would yield 141 + 70 = 141.
+        assert len(result) == total_samples - 140 - 140
 
 
 class TestTrimSilence:
@@ -445,7 +546,7 @@ class TestStrategyBUsesPrePaddingLength:
         original_len = len(short_ids)
 
         # Strategy A: pad
-        padded_ids, _, was_padded = _pad_phoneme_ids(short_ids, None)
+        padded_ids, _, was_padded, _, _ = _pad_phoneme_ids(short_ids, None)
         assert was_padded
         assert len(padded_ids) == MIN_PHONEME_IDS
 
@@ -466,7 +567,7 @@ class TestStrategyBUsesPrePaddingLength:
         short_ids = [1] + list(range(10, 10 + MIN_BODY_FOR_STRATEGY_A)) + [2]
 
         # Strategy A: pad to MIN_PHONEME_IDS
-        padded_ids, _, was_padded = _pad_phoneme_ids(short_ids, None)
+        padded_ids, _, was_padded, _, _ = _pad_phoneme_ids(short_ids, None)
         assert was_padded
         assert len(padded_ids) == MIN_PHONEME_IDS
 
@@ -485,13 +586,13 @@ class TestStrategyBUsesPrePaddingLength:
 
         # body length needs >= MIN_BODY_FOR_STRATEGY_A so Strategy A applies.
         ids_low = [1] + list(range(10, 10 + low - 2)) + [2]
-        padded_low, _, _ = _pad_phoneme_ids(ids_low, None)
+        padded_low, _, _, _, _ = _pad_phoneme_ids(ids_low, None)
         ns_low, _, nw_low = _adjust_scales_for_short_input(
             padded_low, 0.667, 0.8, 1.0, original_len=len(ids_low)
         )
 
         ids_high = [1] + list(range(10, 10 + high - 2)) + [2]
-        padded_high, _, _ = _pad_phoneme_ids(ids_high, None)
+        padded_high, _, _, _, _ = _pad_phoneme_ids(ids_high, None)
         ns_high, _, nw_high = _adjust_scales_for_short_input(
             padded_high, 0.667, 0.8, 1.0, original_len=len(ids_high)
         )
@@ -508,7 +609,7 @@ class TestStrategyBUsesPrePaddingLength:
         """No adjustment when original length is exactly MIN_PHONEME_IDS."""
         ids = list(range(MIN_PHONEME_IDS))
         # No padding happens (already at threshold)
-        padded, _, was_padded = _pad_phoneme_ids(ids, None)
+        padded, _, was_padded, _, _ = _pad_phoneme_ids(ids, None)
         assert not was_padded
 
         ns, ls, nw = _adjust_scales_for_short_input(

--- a/src/python/tests/test_infer_onnx.py
+++ b/src/python/tests/test_infer_onnx.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from piper_train.infer_onnx import (
+    MIN_BODY_FOR_STRATEGY_A,
     MIN_PHONEME_IDS,
     TRIM_MIN_SAMPLES,
     TRIM_THRESHOLD_RMS,
@@ -188,7 +189,8 @@ class TestPadPhonemeIds:
 
     def test_bos_eos_preserved(self):
         """BOS (first) and EOS (last) tokens should be preserved."""
-        ids = [1, 10, 20, 2]
+        # body length must be >= MIN_BODY_FOR_STRATEGY_A for padding to apply.
+        ids = [1] + list(range(10, 10 + MIN_BODY_FOR_STRATEGY_A)) + [2]
         result_ids, _, was_padded = _pad_phoneme_ids(ids, None)
         assert was_padded
         assert result_ids[0] == 1  # BOS
@@ -196,51 +198,80 @@ class TestPadPhonemeIds:
 
     def test_padding_is_zero(self):
         """Inserted padding tokens should be 0 (blank/pad)."""
-        ids = [1, 10, 2]
+        # body=3 (>= MIN_BODY_FOR_STRATEGY_A) so padding applies.
+        ids = [1, 10, 20, 30, 2]
         result_ids, _, was_padded = _pad_phoneme_ids(ids, None)
         assert was_padded
-        # Middle content (10) should still be present
+        # Middle content (10, 20, 30) should still be present
         assert 10 in result_ids
+        assert 20 in result_ids
+        assert 30 in result_ids
         # All padding tokens are 0
         pad_count = result_ids.count(0)
         assert pad_count == MIN_PHONEME_IDS - len(ids)
 
     def test_prosody_none_passthrough(self):
         """When prosody_features is None, output prosody should also be None."""
-        ids = [1, 10, 2]
+        # body=3 (>= MIN_BODY_FOR_STRATEGY_A).
+        ids = [1, 10, 20, 30, 2]
         result_ids, result_prosody, was_padded = _pad_phoneme_ids(ids, None)
         assert was_padded
         assert result_prosody is None
 
     def test_prosody_padded_with_none(self):
         """Prosody padding entries should be None."""
-        ids = [1, 10, 2]
-        prosody = [None, {"a1": 1, "a2": 2, "a3": 3}, None]
+        # body=3 with prosody.
+        ids = [1, 10, 20, 30, 2]
+        prosody = [
+            None,
+            {"a1": 1, "a2": 2, "a3": 3},
+            {"a1": 4, "a2": 5, "a3": 6},
+            {"a1": 7, "a2": 8, "a3": 9},
+            None,
+        ]
         result_ids, result_prosody, was_padded = _pad_phoneme_ids(ids, prosody)
         assert was_padded
-        # Count non-None entries -- should still be 1 (the original content)
+        # Count non-None entries -- should still be 3 (the original content)
         non_none = [p for p in result_prosody if p is not None]
-        assert len(non_none) == 1
-        assert non_none[0] == {"a1": 1, "a2": 2, "a3": 3}
+        assert len(non_none) == 3
 
     def test_even_split(self):
         """Padding should be approximately even between front and back."""
-        ids = [1, 10, 2]  # 3 elements, need 37 padding
+        # body=3 so padding applies.
+        ids = [1, 10, 20, 30, 2]
         result_ids, _, _ = _pad_phoneme_ids(ids, None)
-        # Find position of content token 10
+        # Find position of first content token 10
         pos = result_ids.index(10)
         front_pads = pos - 1  # subtract BOS
-        back_pads = len(result_ids) - pos - 2  # subtract content + EOS
+        # Find last content token 30
+        last_pos = len(result_ids) - 1 - result_ids[::-1].index(30)
+        back_pads = len(result_ids) - last_pos - 2  # subtract content + EOS
         assert abs(front_pads - back_pads) <= 1
 
-    def test_two_element_input(self):
-        """Minimal input with just BOS+EOS should be padded correctly."""
+    def test_skips_when_body_too_short(self):
+        """body shorter than MIN_BODY_FOR_STRATEGY_A skips Strategy A.
+
+        Tiny bodies (e.g. 「あ。」) would have padding-to-body ratio so high
+        that pad-token audio dominates over content (issue #356).
+        """
+        # body = 0 (only BOS + EOS)
         ids = [1, 2]
+        result_ids, result_prosody, was_padded = _pad_phoneme_ids(ids, None)
+        assert not was_padded
+        assert result_ids == ids
+
+        # body = 1
+        ids = [1, 10, 2]
         result_ids, _, was_padded = _pad_phoneme_ids(ids, None)
-        assert was_padded
-        assert len(result_ids) == MIN_PHONEME_IDS
-        assert result_ids[0] == 1
-        assert result_ids[-1] == 2
+        assert not was_padded
+        assert result_ids == ids
+
+        # body = 2 (e.g. 「あ。」 with [BOS, a, ., EOS])
+        if MIN_BODY_FOR_STRATEGY_A > 2:
+            ids = [1, 10, 11, 2]
+            result_ids, _, was_padded = _pad_phoneme_ids(ids, None)
+            assert not was_padded
+            assert result_ids == ids
 
 
 class TestTrimSilence:
@@ -315,7 +346,9 @@ class TestAdjustScalesForShortInput:
 
     def test_adjustment_applied_when_short(self):
         """Scales should be reduced for short sequences."""
-        ids = list(range(20))  # 20 < 40
+        # Pick a length below MIN_PHONEME_IDS but above the noise_scale floor
+        # (ratio = len/MIN >= 0.5 keeps us off the noise_scale clamp).
+        ids = list(range(MIN_PHONEME_IDS - 1))
         ns, ls, nw = _adjust_scales_for_short_input(ids, 0.667, 0.8, 1.0)
         # noise_scale should be reduced
         assert ns < 0.667
@@ -328,14 +361,14 @@ class TestAdjustScalesForShortInput:
         """noise_scale multiplier should not go below 0.5."""
         ids = [1]  # very short
         ns, _, _ = _adjust_scales_for_short_input(ids, 0.667, 0.8, 1.0)
-        # ratio = 1/40 = 0.025, max(0.5, 0.025) = 0.5
+        # ratio = 1/MIN_PHONEME_IDS, well below 0.5 floor
         assert ns == pytest.approx(0.667 * 0.5)
 
     def test_noise_w_floor_at_04(self):
         """noise_w multiplier should not go below 0.4."""
         ids = [1]  # very short
         _, _, nw = _adjust_scales_for_short_input(ids, 0.667, 0.8, 1.0)
-        # ratio = 1/40 = 0.025, max(0.4, 0.025) = 0.4
+        # ratio = 1/MIN_PHONEME_IDS, well below 0.4 floor
         assert nw == pytest.approx(0.8 * 0.4)
 
     def test_length_scale_unchanged(self):
@@ -346,20 +379,23 @@ class TestAdjustScalesForShortInput:
 
     def test_ratio_proportional(self):
         """Scale reduction should be proportional to input length."""
-        # Use 30 (ratio=0.75) vs 20 (ratio=0.5) -- both above the floor
-        ids_30 = list(range(30))  # ratio=0.75, above floor
-        ids_20 = list(range(20))  # ratio=0.5, at floor for noise_scale
+        # Pick two lengths in (floor * MIN, MIN) so both stay off the floor.
+        # MIN=15: high=12 (ratio 0.8), low=8 (ratio ~0.53)
+        high = max(MIN_PHONEME_IDS - 3, 1)
+        low = max(MIN_PHONEME_IDS // 2 + 1, 1)
+        ids_high = list(range(high))
+        ids_low = list(range(low))
 
-        ns_30, _, nw_30 = _adjust_scales_for_short_input(
-            ids_30, 0.667, 0.8, 1.0
+        ns_high, _, nw_high = _adjust_scales_for_short_input(
+            ids_high, 0.667, 0.8, 1.0
         )
-        ns_20, _, nw_20 = _adjust_scales_for_short_input(
-            ids_20, 0.667, 0.8, 1.0
+        ns_low, _, nw_low = _adjust_scales_for_short_input(
+            ids_low, 0.667, 0.8, 1.0
         )
 
-        # 30-length input should have less reduction than 20-length
-        assert ns_30 > ns_20
-        assert nw_30 > nw_20
+        # Longer input should have less reduction than shorter input.
+        assert ns_high > ns_low
+        assert nw_high > nw_low
 
     def test_empty_input(self):
         """Empty phoneme_ids should use floor values."""
@@ -404,7 +440,8 @@ class TestStrategyBUsesPrePaddingLength:
         Simulates the main() call order: save original_len, then pad (Strategy A),
         then pass original_len to Strategy B.
         """
-        short_ids = [1, 10, 20, 2]  # 4 elements, well below MIN_PHONEME_IDS
+        # body length must be >= MIN_BODY_FOR_STRATEGY_A for Strategy A to apply.
+        short_ids = [1] + list(range(10, 10 + MIN_BODY_FOR_STRATEGY_A)) + [2]
         original_len = len(short_ids)
 
         # Strategy A: pad
@@ -416,7 +453,7 @@ class TestStrategyBUsesPrePaddingLength:
         ns, ls, nw = _adjust_scales_for_short_input(
             padded_ids, 0.667, 0.8, 1.0, original_len=original_len
         )
-        # ratio = 4/40 = 0.1, clamped to floors -> 0.5, 0.4
+        # Short original_len → ratio well below the noise floors.
         assert ns == pytest.approx(0.667 * 0.5)
         assert nw == pytest.approx(0.8 * 0.4)
         assert ls == pytest.approx(1.0)
@@ -426,7 +463,7 @@ class TestStrategyBUsesPrePaddingLength:
 
         This test documents the buggy behavior to prevent regression.
         """
-        short_ids = [1, 10, 20, 2]
+        short_ids = [1] + list(range(10, 10 + MIN_BODY_FOR_STRATEGY_A)) + [2]
 
         # Strategy A: pad to MIN_PHONEME_IDS
         padded_ids, _, was_padded = _pad_phoneme_ids(short_ids, None)
@@ -441,27 +478,31 @@ class TestStrategyBUsesPrePaddingLength:
 
     def test_combined_strategy_a_b_varying_lengths(self):
         """Shorter original inputs should get more aggressive scale reduction."""
-        # 10 elements
-        ids_10 = list(range(10))
-        padded_10, _, _ = _pad_phoneme_ids(ids_10, None)
-        ns_10, _, nw_10 = _adjust_scales_for_short_input(
-            padded_10, 0.667, 0.8, 1.0, original_len=10
+        # Pick lengths inside the noise_scale floor band so Strategy B actually
+        # differentiates them: low close to MIN/2 + 1, high close to MIN - 1.
+        low = max(MIN_PHONEME_IDS // 2 + 1, MIN_BODY_FOR_STRATEGY_A + 2)
+        high = max(MIN_PHONEME_IDS - 1, low + 1)
+
+        # body length needs >= MIN_BODY_FOR_STRATEGY_A so Strategy A applies.
+        ids_low = [1] + list(range(10, 10 + low - 2)) + [2]
+        padded_low, _, _ = _pad_phoneme_ids(ids_low, None)
+        ns_low, _, nw_low = _adjust_scales_for_short_input(
+            padded_low, 0.667, 0.8, 1.0, original_len=len(ids_low)
         )
 
-        # 30 elements
-        ids_30 = list(range(30))
-        padded_30, _, _ = _pad_phoneme_ids(ids_30, None)
-        ns_30, _, nw_30 = _adjust_scales_for_short_input(
-            padded_30, 0.667, 0.8, 1.0, original_len=30
+        ids_high = [1] + list(range(10, 10 + high - 2)) + [2]
+        padded_high, _, _ = _pad_phoneme_ids(ids_high, None)
+        ns_high, _, nw_high = _adjust_scales_for_short_input(
+            padded_high, 0.667, 0.8, 1.0, original_len=len(ids_high)
         )
 
-        # 30-length should have less reduction than 10-length
-        assert ns_30 > ns_10
-        assert nw_30 > nw_10
+        # Longer original input should have less reduction than shorter.
+        assert ns_high > ns_low
+        assert nw_high > nw_low
 
-        # Both should be less than the unadjusted values
-        assert ns_30 < 0.667
-        assert ns_10 < 0.667
+        # Both should be less than the unadjusted values.
+        assert ns_high < 0.667
+        assert ns_low < 0.667
 
     def test_no_adjustment_when_original_at_threshold(self):
         """No adjustment when original length is exactly MIN_PHONEME_IDS."""

--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -37,6 +37,16 @@ _LOGGER = logging.getLogger(__name__)
 # pick 15 as a conservative middle ground: roughly 2× the measured stable
 # minimum, still well below typical short utterances like 「こんにちは。」.
 MIN_PHONEME_IDS = 15
+
+# Minimum body length (excluding BOS/EOS) for Strategy A to kick in.
+# When the body is shorter than this (e.g. 「あ。」 with body of 2 IDs),
+# padding-to-body ratio explodes and the pad tokens dominate over the
+# actual content even with durations-based trim — bypassing Strategy A
+# entirely produces a more natural single-phoneme utterance than padding
+# does. The raw VITS output for tiny inputs is degraded but bounded;
+# users invoking such inputs presumably accept that limitation.
+MIN_BODY_FOR_STRATEGY_A = 3
+
 SHORT_TEXT_CHARS = 10
 SILENCE_PAD_MS = 300
 TRIM_THRESHOLD_RMS = 0.01
@@ -221,13 +231,22 @@ def _pad_phoneme_ids(
     phoneme_ids: list[int],
     pad_id: int,
     min_length: int = MIN_PHONEME_IDS,
+    min_body: int = MIN_BODY_FOR_STRATEGY_A,
 ) -> tuple[list[int], bool, int, int]:
     """Pad short phoneme_ids with silence tokens after BOS and before EOS.
 
     Returns ``(padded_ids, was_padded, front_pad, back_pad)`` where
     ``front_pad`` / ``back_pad`` are the numbers of pad tokens inserted
     after BOS and before EOS respectively (both 0 when no padding occurred).
+
+    Skips padding entirely when the body (i.e. ``phoneme_ids`` excluding
+    BOS/EOS) has fewer than ``min_body`` IDs. With such tiny bodies the
+    padding-to-body ratio becomes so high that pad-token audio dominates
+    the actual content; raw VITS output is preferable in that regime.
     """
+    body_len = len(phoneme_ids) - 2  # exclude BOS / EOS
+    if body_len < min_body:
+        return phoneme_ids, False, 0, 0
     if len(phoneme_ids) >= min_length:
         return phoneme_ids, False, 0, 0
 

--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -298,9 +298,11 @@ def _trim_padding_by_durations(
     * **BOS + front padding**: stripped completely. VITS produces an
       audible "あ" at the start under the padded context.
     * **Back padding**: stripped completely.
-    * **EOS**: clamped to ``eos_max_frames`` (default 6). The natural
-      utterance tail is preserved while the padding-induced tail
-      ("た"-like artefact) is removed.
+    * **EOS**: keep only the first ``eos_max_frames`` frames (default
+      ``TRIM_EOS_MAX_FRAMES`` = 0, i.e. drop the entire EOS region).
+      0 was chosen empirically because even modest clamping (6 frames)
+      left an audible "だぁ"-like tail under the padded context. Callers
+      can pass a larger value to preserve a natural utterance tail.
 
     Returns ``audio`` unchanged when inputs are inconsistent.
     """

--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -234,12 +234,23 @@ def _pad_phoneme_ids(
     return padded, True, front, back
 
 
+# Maximum EOS duration (in frames) preserved during Strategy A trim.
+# VITS tends to predict an inflated EOS duration under the padded context
+# (observed ~8 frames / 94 ms vs. ~6 frames / 76 ms without padding for the
+# tsukuyomi 6lang model). Without clamping, the excess emits a faint
+# "extra syllable" at the very end (issue #356 follow-up). 6 frames is
+# slightly above the typical unpadded value, leaving the natural utterance
+# tail intact while clipping the padding-induced artefact.
+TRIM_EOS_MAX_FRAMES = 6
+
+
 def _trim_padding_by_durations(
     audio: np.ndarray,
     durations: np.ndarray,
     front_pad: int,
     back_pad: int,
     hop_size: int,
+    eos_max_frames: int = TRIM_EOS_MAX_FRAMES,
 ) -> np.ndarray:
     """Trim Strategy A padding using model durations (precise method).
 
@@ -252,7 +263,15 @@ def _trim_padding_by_durations(
     number of audio samples generated for the padding, which can be sliced
     off without relying on RMS thresholds.
 
-    BOS / EOS frames are kept (they bracket the body and aren't padding).
+    Trimming policy (issue #356):
+
+    * **BOS + front padding**: stripped completely. VITS produces an
+      audible "あ" at the start under the padded context.
+    * **Back padding**: stripped completely.
+    * **EOS**: clamped to ``eos_max_frames`` (default 6). The natural
+      utterance tail is preserved while the padding-induced tail
+      ("た"-like artefact) is removed.
+
     Returns ``audio`` unchanged when inputs are inconsistent.
     """
     if front_pad <= 0 and back_pad <= 0:
@@ -261,12 +280,22 @@ def _trim_padding_by_durations(
         return audio
 
     durations_1d = np.asarray(durations).reshape(-1)
-    expected_len = 1 + front_pad + back_pad + 1  # BOS + pads + EOS (body counted separately)
+    expected_len = 1 + front_pad + back_pad + 1  # BOS + pads + EOS
     if durations_1d.size < expected_len:
         return audio
 
-    front_samples = int(durations_1d[1 : 1 + front_pad].sum() * hop_size) if front_pad > 0 else 0
-    back_samples = int(durations_1d[-(1 + back_pad) : -1].sum() * hop_size) if back_pad > 0 else 0
+    # BOS + front padding samples (stripped).
+    front_samples = (
+        int(durations_1d[0 : 1 + front_pad].sum() * hop_size) if front_pad > 0 else 0
+    )
+
+    # Back padding samples + EOS excess (over eos_max_frames) samples.
+    back_pad_samples = (
+        int(durations_1d[-(1 + back_pad) : -1].sum() * hop_size) if back_pad > 0 else 0
+    )
+    eos_frames = float(durations_1d[-1])
+    eos_excess_frames = max(0.0, eos_frames - float(eos_max_frames))
+    back_samples = back_pad_samples + int(eos_excess_frames * hop_size)
 
     start = max(0, front_samples)
     end = max(start, len(audio) - back_samples)

--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -236,12 +236,13 @@ def _pad_phoneme_ids(
 
 # Maximum EOS duration (in frames) preserved during Strategy A trim.
 # VITS tends to predict an inflated EOS duration under the padded context
-# (observed ~8 frames / 94 ms vs. ~6 frames / 76 ms without padding for the
-# tsukuyomi 6lang model). Without clamping, the excess emits a faint
-# "extra syllable" at the very end (issue #356 follow-up). 6 frames is
-# slightly above the typical unpadded value, leaving the natural utterance
-# tail intact while clipping the padding-induced artefact.
-TRIM_EOS_MAX_FRAMES = 6
+# and emits an audible artefact ("こんにちはだぁ" instead of "こんにちは" —
+# kun432 氏 issue #356 試聴フィードバック). Empirically, even modest
+# clamping (6 frames) leaves a recognisable tail. Default to 0 so the
+# entire EOS region is dropped along with the back padding; the unpadded
+# PyPI 1.11.0 path keeps a similar tail but with no audible artefact, so
+# losing it here is acceptable.
+TRIM_EOS_MAX_FRAMES = 0
 
 
 def _trim_padding_by_durations(

--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -33,7 +33,7 @@ _LOGGER = logging.getLogger(__name__)
 # model show a much lower true threshold — synthesis is stable at 8 IDs and
 # weakens only below ~7. Setting MIN_PHONEME_IDS too high triggers Strategy
 # A on already-stable inputs (e.g. 「こんにちは。」= 22 IDs), and the pad
-# tokens leak as audible artefacts that post-trim cannot fully remove. We
+# tokens leak as audible artifacts that post-trim cannot fully remove. We
 # pick 15 as a conservative middle ground: roughly 2× the measured stable
 # minimum, still well below typical short utterances like 「こんにちは。」.
 MIN_PHONEME_IDS = 15
@@ -265,11 +265,11 @@ def _pad_phoneme_ids(
 
 # Maximum EOS duration (in frames) preserved during Strategy A trim.
 # VITS tends to predict an inflated EOS duration under the padded context
-# and emits an audible artefact ("こんにちはだぁ" instead of "こんにちは" —
+# and emits an audible artifact ("こんにちはだぁ" instead of "こんにちは" —
 # kun432 氏 issue #356 試聴フィードバック). Empirically, even modest
 # clamping (6 frames) leaves a recognisable tail. Default to 0 so the
 # entire EOS region is dropped along with the back padding; the unpadded
-# PyPI 1.11.0 path keeps a similar tail but with no audible artefact, so
+# PyPI 1.11.0 path keeps a similar tail but with no audible artifact, so
 # losing it here is acceptable.
 TRIM_EOS_MAX_FRAMES = 0
 

--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -25,8 +25,18 @@ from .util import audio_float_to_int16
 
 _LOGGER = logging.getLogger(__name__)
 
-# Short-text mitigation constants (keep in sync with other runtimes)
-MIN_PHONEME_IDS = 40
+# Short-text mitigation constants (keep in sync with other runtimes — see
+# docs/spec/short-text-contract.toml).
+#
+# Threshold note (issue #356): docs originally claimed VITS becomes unstable
+# below ~40 phoneme IDs. Empirical measurements on the tsukuyomi 6lang
+# model show a much lower true threshold — synthesis is stable at 8 IDs and
+# weakens only below ~7. Setting MIN_PHONEME_IDS too high triggers Strategy
+# A on already-stable inputs (e.g. 「こんにちは。」= 22 IDs), and the pad
+# tokens leak as audible artefacts that post-trim cannot fully remove. We
+# pick 15 as a conservative middle ground: roughly 2× the measured stable
+# minimum, still well below typical short utterances like 「こんにちは。」.
+MIN_PHONEME_IDS = 15
 SHORT_TEXT_CHARS = 10
 SILENCE_PAD_MS = 300
 TRIM_THRESHOLD_RMS = 0.01

--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -211,13 +211,15 @@ def _pad_phoneme_ids(
     phoneme_ids: list[int],
     pad_id: int,
     min_length: int = MIN_PHONEME_IDS,
-) -> tuple[list[int], bool]:
+) -> tuple[list[int], bool, int, int]:
     """Pad short phoneme_ids with silence tokens after BOS and before EOS.
 
-    Returns (padded_ids, was_padded).
+    Returns ``(padded_ids, was_padded, front_pad, back_pad)`` where
+    ``front_pad`` / ``back_pad`` are the numbers of pad tokens inserted
+    after BOS and before EOS respectively (both 0 when no padding occurred).
     """
     if len(phoneme_ids) >= min_length:
-        return phoneme_ids, False
+        return phoneme_ids, False, 0, 0
 
     needed = min_length - len(phoneme_ids)
     front = needed // 2
@@ -229,7 +231,48 @@ def _pad_phoneme_ids(
     eos = phoneme_ids[-1:]
 
     padded = bos + [pad_id] * front + body + [pad_id] * back + eos
-    return padded, True
+    return padded, True, front, back
+
+
+def _trim_padding_by_durations(
+    audio: np.ndarray,
+    durations: np.ndarray,
+    front_pad: int,
+    back_pad: int,
+    hop_size: int,
+) -> np.ndarray:
+    """Trim Strategy A padding using model durations (precise method).
+
+    The padded sequence layout is::
+
+        [BOS, pad×front_pad, ...body..., pad×back_pad, EOS]
+
+    Each ``durations[i]`` is the frame count VITS assigned to phoneme ``i``.
+    Multiplying the pad-token frame counts by ``hop_size`` gives the exact
+    number of audio samples generated for the padding, which can be sliced
+    off without relying on RMS thresholds.
+
+    BOS / EOS frames are kept (they bracket the body and aren't padding).
+    Returns ``audio`` unchanged when inputs are inconsistent.
+    """
+    if front_pad <= 0 and back_pad <= 0:
+        return audio
+    if durations is None or hop_size <= 0:
+        return audio
+
+    durations_1d = np.asarray(durations).reshape(-1)
+    expected_len = 1 + front_pad + back_pad + 1  # BOS + pads + EOS (body counted separately)
+    if durations_1d.size < expected_len:
+        return audio
+
+    front_samples = int(durations_1d[1 : 1 + front_pad].sum() * hop_size) if front_pad > 0 else 0
+    back_samples = int(durations_1d[-(1 + back_pad) : -1].sum() * hop_size) if back_pad > 0 else 0
+
+    start = max(0, front_samples)
+    end = max(start, len(audio) - back_samples)
+    if start >= len(audio) or end <= 0 or start >= end:
+        return audio
+    return audio[start:end]
 
 
 def _trim_silence(
@@ -238,7 +281,13 @@ def _trim_silence(
     window: int = 256,
     min_samples: int = TRIM_MIN_SAMPLES,
 ) -> np.ndarray:
-    """Trim leading/trailing silence from int16 audio using windowed RMS."""
+    """Trim leading/trailing silence from int16 audio using windowed RMS.
+
+    Fallback used when model durations are unavailable. Note that VITS pad
+    tokens often produce voiced-looking audio (RMS > threshold), so this
+    method is unreliable for Strategy A trimming; prefer
+    :func:`_trim_padding_by_durations` whenever durations are present.
+    """
     if len(audio) <= min_samples:
         return audio
 
@@ -514,7 +563,9 @@ class PiperVoice:
 
         # Strategy A: pad short sequences with silence tokens
         pad_id = 0
-        phoneme_ids, was_padded = _pad_phoneme_ids(phoneme_ids, pad_id)
+        phoneme_ids, was_padded, front_pad, back_pad = _pad_phoneme_ids(
+            phoneme_ids, pad_id
+        )
 
         phoneme_ids_array = np.expand_dims(np.array(phoneme_ids, dtype=np.int64), 0)
         phoneme_ids_lengths = np.array([phoneme_ids_array.shape[1]], dtype=np.int64)
@@ -576,9 +627,20 @@ class PiperVoice:
                 durations = _outputs[dur_idx].squeeze()
         audio = audio_float_to_int16(audio.squeeze(), volume=volume)
 
-        # Strategy A: trim silence introduced by padding
+        # Strategy A: trim silence introduced by padding.
+        # Prefer durations-based precise trim; fall back to RMS when the model
+        # has no durations output (older VITS exports).
         if was_padded:
-            audio = _trim_silence(audio)
+            if durations is not None:
+                audio = _trim_padding_by_durations(
+                    audio,
+                    durations,
+                    front_pad,
+                    back_pad,
+                    self.config.hop_size,
+                )
+            else:
+                audio = _trim_silence(audio)
 
         return audio.tobytes(), durations, original_phoneme_ids
 

--- a/src/python_run/tests/test_short_text_mitigation.py
+++ b/src/python_run/tests/test_short_text_mitigation.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from piper.voice import (
+    MIN_BODY_FOR_STRATEGY_A,
     MIN_PHONEME_IDS,
     SHORT_TEXT_CHARS,
     SILENCE_PAD_MS,
@@ -70,12 +71,17 @@ class TestPadPhonemeIds:
 
     @pytest.mark.unit
     def test_pad_distribution(self):
-        """Front and back padding should be roughly equal."""
+        """Front and back padding should be roughly equal.
+
+        Uses a body of MIN_BODY_FOR_STRATEGY_A so Strategy A actually
+        kicks in (smaller bodies are bypassed — see issue #356).
+        """
         bos, eos, pad_id = 1, 2, 0
-        ids = [bos, 10, eos]  # length 3
+        body = list(range(10, 10 + MIN_BODY_FOR_STRATEGY_A))
+        ids = [bos] + body + [eos]
         padded, _, front_pad, back_pad = _pad_phoneme_ids(ids, pad_id=pad_id)
 
-        needed = MIN_PHONEME_IDS - 3
+        needed = MIN_PHONEME_IDS - len(ids)
         expected_front = needed // 2
         expected_back = needed - expected_front
         assert front_pad == expected_front
@@ -87,15 +93,36 @@ class TestPadPhonemeIds:
         assert padded[-1 - back_pad : -1] == [pad_id] * back_pad
 
     @pytest.mark.unit
-    def test_minimum_input_two_elements(self):
-        """Edge case: only BOS + EOS."""
+    def test_skips_strategy_a_when_body_too_short(self):
+        """body shorter than MIN_BODY_FOR_STRATEGY_A skips Strategy A.
+
+        Padding ratio explodes for tiny bodies — raw VITS output is
+        preferable in that regime (issue #356 follow-up).
+        """
+        # body = 0 (only BOS + EOS)
         ids = [1, 2]
+        padded, was_padded, front_pad, back_pad = _pad_phoneme_ids(ids, pad_id=0)
+        assert not was_padded
+        assert padded is ids
+        assert front_pad == 0 and back_pad == 0
+
+        # body = 2, e.g. 「あ。」 → [BOS, a, ., EOS]
+        if MIN_BODY_FOR_STRATEGY_A > 2:
+            ids = [1, 10, 11, 2]
+            padded, was_padded, front_pad, back_pad = _pad_phoneme_ids(ids, pad_id=0)
+            assert not was_padded
+            assert padded is ids
+            assert front_pad == 0 and back_pad == 0
+
+    @pytest.mark.unit
+    def test_pads_when_body_meets_min_body(self):
+        """Body at MIN_BODY_FOR_STRATEGY_A should still be padded."""
+        body = list(range(10, 10 + MIN_BODY_FOR_STRATEGY_A))
+        ids = [1] + body + [2]  # BOS + body + EOS
         padded, was_padded, front_pad, back_pad = _pad_phoneme_ids(ids, pad_id=0)
         assert was_padded
         assert len(padded) == MIN_PHONEME_IDS
-        assert padded[0] == 1
-        assert padded[-1] == 2
-        assert front_pad + back_pad == MIN_PHONEME_IDS - 2
+        assert front_pad + back_pad == MIN_PHONEME_IDS - len(ids)
 
 
 # ---------------------------------------------------------------
@@ -512,6 +539,12 @@ class TestConstants:
         # Was 40 — caused Strategy A to fire on stable inputs and leak
         # padding artefacts. See voice.py for the threshold rationale.
         assert MIN_PHONEME_IDS == 15
+
+    @pytest.mark.unit
+    def test_min_body_for_strategy_a(self):
+        # Bodies smaller than this skip Strategy A (issue #356 follow-up
+        # for inputs like 「あ。」). See voice.py for rationale.
+        assert MIN_BODY_FOR_STRATEGY_A == 3
 
     @pytest.mark.unit
     def test_short_text_chars(self):

--- a/src/python_run/tests/test_short_text_mitigation.py
+++ b/src/python_run/tests/test_short_text_mitigation.py
@@ -227,7 +227,7 @@ class TestTrimPaddingByDurations:
     @pytest.mark.unit
     def test_default_strips_eos_completely(self):
         # Default eos_max_frames=0: VITS predicts an inflated EOS under padded
-        # context that emits "だぁ"-like artefacts (issue #356 follow-up), so
+        # context that emits "だぁ"-like artifacts (issue #356 follow-up), so
         # the entire EOS region is dropped along with back padding.
         durations = np.array([2.0, 5.0, 5.0, 4.0, 4.0, 5.0, 5.0, 8.0], dtype=np.float32)
         hop = 100
@@ -537,7 +537,7 @@ class TestConstants:
     def test_min_phoneme_ids(self):
         # Empirically tuned for tsukuyomi 6lang (issue #356).
         # Was 40 — caused Strategy A to fire on stable inputs and leak
-        # padding artefacts. See voice.py for the threshold rationale.
+        # padding artifacts. See voice.py for the threshold rationale.
         assert MIN_PHONEME_IDS == 15
 
     @pytest.mark.unit

--- a/src/python_run/tests/test_short_text_mitigation.py
+++ b/src/python_run/tests/test_short_text_mitigation.py
@@ -508,7 +508,10 @@ class TestConstants:
 
     @pytest.mark.unit
     def test_min_phoneme_ids(self):
-        assert MIN_PHONEME_IDS == 40
+        # Empirically tuned for tsukuyomi 6lang (issue #356).
+        # Was 40 — caused Strategy A to fire on stable inputs and leak
+        # padding artefacts. See voice.py for the threshold rationale.
+        assert MIN_PHONEME_IDS == 15
 
     @pytest.mark.unit
     def test_short_text_chars(self):

--- a/src/python_run/tests/test_short_text_mitigation.py
+++ b/src/python_run/tests/test_short_text_mitigation.py
@@ -118,30 +118,48 @@ class TestTrimPaddingByDurations:
 
     @pytest.mark.unit
     def test_trims_front_padding_only(self):
-        # Layout: BOS=2, pad×3 (totals 9 frames), body=4, EOS=1 → 19 frames
+        # Layout: BOS=2, pad×3 (3+3+3 frames), body=4, EOS=1 → 19 frames total
+        # Strategy A trims BOS + front padding from the start.
+        # EOS=1 frame is below eos_max_frames (default 6), so it's preserved.
         durations = np.array([2.0, 3.0, 3.0, 3.0, 4.0, 1.0], dtype=np.float32)
         hop = 100
         total_samples = int(durations.sum() * hop)  # 1900
         audio = np.arange(total_samples, dtype=np.int16)
         result = _trim_padding_by_durations(audio, durations, front_pad=3, back_pad=0, hop_size=hop)
-        # front padding samples = (3+3+3) * 100 = 900
-        assert len(result) == total_samples - 900
-        assert result[0] == audio[900]
+        # BOS + front padding samples = (2+3+3+3) * 100 = 1100
+        assert len(result) == total_samples - 1100
+        assert result[0] == audio[1100]
 
     @pytest.mark.unit
-    def test_trims_back_padding_only(self):
+    def test_trims_back_padding_preserves_normal_eos(self):
+        # Back padding stripped, EOS=1 frame preserved (under eos_max_frames=6).
+        # Layout: [body=2, body=4, pad=3, pad=3, pad=3, EOS=1] with front_pad=0
         durations = np.array([2.0, 4.0, 3.0, 3.0, 3.0, 1.0], dtype=np.float32)
         hop = 100
         total_samples = int(durations.sum() * hop)  # 1600
         audio = np.arange(total_samples, dtype=np.int16)
         result = _trim_padding_by_durations(audio, durations, front_pad=0, back_pad=3, hop_size=hop)
-        # back padding samples = (3+3+3) * 100 = 900
+        # Trim back padding only (3+3+3)*100 = 900; EOS=1 frame stays in audio.
         assert len(result) == total_samples - 900
+        # The last 100 samples (= 1 frame * hop) of the result are the EOS region.
         assert result[-1] == audio[total_samples - 900 - 1]
 
     @pytest.mark.unit
+    def test_clamps_inflated_eos_duration(self):
+        # EOS=10 frames is above eos_max_frames=6, excess 4 frames trimmed.
+        durations = np.array([2.0, 3.0, 3.0, 4.0, 3.0, 3.0, 10.0], dtype=np.float32)
+        hop = 100
+        total = int(durations.sum() * hop)  # 2800
+        audio = np.arange(total, dtype=np.int16)
+        result = _trim_padding_by_durations(audio, durations, front_pad=2, back_pad=2, hop_size=hop)
+        # BOS + front padding = (2+3+3) * 100 = 800
+        # back padding + EOS excess = (3+3 + (10-6)) * 100 = 1000
+        assert len(result) == total - 800 - 1000
+
+    @pytest.mark.unit
     def test_trims_both_sides(self):
-        # BOS, pad×2, body×2, pad×2, EOS
+        # BOS=2, pad×2, body×2, pad×2, EOS=1
+        # EOS below eos_max_frames so preserved entirely.
         durations = np.array(
             [2.0, 5.0, 5.0, 4.0, 4.0, 5.0, 5.0, 1.0], dtype=np.float32
         )
@@ -149,11 +167,27 @@ class TestTrimPaddingByDurations:
         total = int(durations.sum() * hop)  # 3100
         audio = np.arange(total, dtype=np.int16)
         result = _trim_padding_by_durations(audio, durations, front_pad=2, back_pad=2, hop_size=hop)
-        front_samples = int((5.0 + 5.0) * hop)  # 1000
-        back_samples = int((5.0 + 5.0) * hop)  # 1000
+        # BOS + front padding = (2+5+5)*100 = 1200
+        # back padding only (EOS preserved) = (5+5)*100 = 1000
+        front_samples = int((2.0 + 5.0 + 5.0) * hop)
+        back_samples = int((5.0 + 5.0) * hop)
         assert len(result) == total - front_samples - back_samples
         assert result[0] == audio[front_samples]
         assert result[-1] == audio[total - back_samples - 1]
+
+    @pytest.mark.unit
+    def test_eos_max_frames_override(self):
+        # Custom eos_max_frames=2 clamps EOS=5 → excess 3 frames trimmed.
+        durations = np.array([1.0, 3.0, 3.0, 4.0, 3.0, 3.0, 5.0], dtype=np.float32)
+        hop = 100
+        total = int(durations.sum() * hop)  # 2200
+        audio = np.arange(total, dtype=np.int16)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=2, back_pad=2, hop_size=hop, eos_max_frames=2
+        )
+        # BOS + front = (1+3+3)*100 = 700
+        # back + EOS excess = (3+3 + (5-2))*100 = 900
+        assert len(result) == total - 700 - 900
 
     @pytest.mark.unit
     def test_returns_input_when_durations_none(self):

--- a/src/python_run/tests/test_short_text_mitigation.py
+++ b/src/python_run/tests/test_short_text_mitigation.py
@@ -16,6 +16,7 @@ from piper.voice import (
     TRIM_MIN_SAMPLES,
     TRIM_THRESHOLD_RMS,
     _pad_phoneme_ids,
+    _trim_padding_by_durations,
     _trim_silence,
 )
 
@@ -28,35 +29,40 @@ class TestPadPhonemeIds:
     @pytest.mark.unit
     def test_no_pad_when_long_enough(self):
         ids = list(range(MIN_PHONEME_IDS))
-        padded, was_padded = _pad_phoneme_ids(ids, pad_id=0)
+        padded, was_padded, front_pad, back_pad = _pad_phoneme_ids(ids, pad_id=0)
         assert not was_padded
         assert padded is ids
+        assert front_pad == 0
+        assert back_pad == 0
 
     @pytest.mark.unit
     def test_no_pad_when_exceeds_min(self):
         ids = list(range(MIN_PHONEME_IDS + 10))
-        padded, was_padded = _pad_phoneme_ids(ids, pad_id=0)
+        padded, was_padded, front_pad, back_pad = _pad_phoneme_ids(ids, pad_id=0)
         assert not was_padded
         assert padded is ids
+        assert front_pad == 0
+        assert back_pad == 0
 
     @pytest.mark.unit
     def test_pads_short_sequence(self):
         bos, eos = 1, 2
         body = [10, 11, 12]
         ids = [bos] + body + [eos]  # length 5
-        padded, was_padded = _pad_phoneme_ids(ids, pad_id=0)
+        padded, was_padded, front_pad, back_pad = _pad_phoneme_ids(ids, pad_id=0)
 
         assert was_padded
         assert len(padded) == MIN_PHONEME_IDS
         assert padded[0] == bos
         assert padded[-1] == eos
+        assert front_pad + back_pad == MIN_PHONEME_IDS - len(ids)
 
     @pytest.mark.unit
     def test_preserves_body_content(self):
         bos, eos, pad_id = 1, 2, 0
         body = [10, 20, 30]
         ids = [bos] + body + [eos]
-        padded, _ = _pad_phoneme_ids(ids, pad_id=pad_id)
+        padded, _, _, _ = _pad_phoneme_ids(ids, pad_id=pad_id)
 
         # body should appear contiguously in the padded result
         body_start = padded.index(10)
@@ -67,30 +73,105 @@ class TestPadPhonemeIds:
         """Front and back padding should be roughly equal."""
         bos, eos, pad_id = 1, 2, 0
         ids = [bos, 10, eos]  # length 3
-        padded, _ = _pad_phoneme_ids(ids, pad_id=pad_id)
+        padded, _, front_pad, back_pad = _pad_phoneme_ids(ids, pad_id=pad_id)
 
         needed = MIN_PHONEME_IDS - 3
-        front = needed // 2
-        back = needed - front
+        expected_front = needed // 2
+        expected_back = needed - expected_front
+        assert front_pad == expected_front
+        assert back_pad == expected_back
 
         # After BOS, expect front pad tokens
-        assert padded[1 : 1 + front] == [pad_id] * front
+        assert padded[1 : 1 + front_pad] == [pad_id] * front_pad
         # Before EOS, expect back pad tokens
-        assert padded[-1 - back : -1] == [pad_id] * back
+        assert padded[-1 - back_pad : -1] == [pad_id] * back_pad
 
     @pytest.mark.unit
     def test_minimum_input_two_elements(self):
         """Edge case: only BOS + EOS."""
         ids = [1, 2]
-        padded, was_padded = _pad_phoneme_ids(ids, pad_id=0)
+        padded, was_padded, front_pad, back_pad = _pad_phoneme_ids(ids, pad_id=0)
         assert was_padded
         assert len(padded) == MIN_PHONEME_IDS
         assert padded[0] == 1
         assert padded[-1] == 2
+        assert front_pad + back_pad == MIN_PHONEME_IDS - 2
 
 
 # ---------------------------------------------------------------
-# Strategy A: _trim_silence
+# Strategy A: _trim_padding_by_durations (precise method, Issue #356)
+# ---------------------------------------------------------------
+class TestTrimPaddingByDurations:
+    """Durations-based padding trim (preferred over RMS for Strategy A).
+
+    Regression coverage for issue #356 where pad tokens (ID=0) produced
+    voiced-looking audio that RMS-based trim could not strip, yielding
+    'あこんにちはた' (extra 'a' / 'ta' at boundaries).
+    """
+
+    @pytest.mark.unit
+    def test_no_op_when_no_padding(self):
+        audio = np.arange(1000, dtype=np.int16)
+        durations = np.array([1.0] * 5, dtype=np.float32)
+        result = _trim_padding_by_durations(audio, durations, 0, 0, hop_size=256)
+        assert np.array_equal(result, audio)
+
+    @pytest.mark.unit
+    def test_trims_front_padding_only(self):
+        # Layout: BOS=2, pad×3 (totals 9 frames), body=4, EOS=1 → 19 frames
+        durations = np.array([2.0, 3.0, 3.0, 3.0, 4.0, 1.0], dtype=np.float32)
+        hop = 100
+        total_samples = int(durations.sum() * hop)  # 1900
+        audio = np.arange(total_samples, dtype=np.int16)
+        result = _trim_padding_by_durations(audio, durations, front_pad=3, back_pad=0, hop_size=hop)
+        # front padding samples = (3+3+3) * 100 = 900
+        assert len(result) == total_samples - 900
+        assert result[0] == audio[900]
+
+    @pytest.mark.unit
+    def test_trims_back_padding_only(self):
+        durations = np.array([2.0, 4.0, 3.0, 3.0, 3.0, 1.0], dtype=np.float32)
+        hop = 100
+        total_samples = int(durations.sum() * hop)  # 1600
+        audio = np.arange(total_samples, dtype=np.int16)
+        result = _trim_padding_by_durations(audio, durations, front_pad=0, back_pad=3, hop_size=hop)
+        # back padding samples = (3+3+3) * 100 = 900
+        assert len(result) == total_samples - 900
+        assert result[-1] == audio[total_samples - 900 - 1]
+
+    @pytest.mark.unit
+    def test_trims_both_sides(self):
+        # BOS, pad×2, body×2, pad×2, EOS
+        durations = np.array(
+            [2.0, 5.0, 5.0, 4.0, 4.0, 5.0, 5.0, 1.0], dtype=np.float32
+        )
+        hop = 100
+        total = int(durations.sum() * hop)  # 3100
+        audio = np.arange(total, dtype=np.int16)
+        result = _trim_padding_by_durations(audio, durations, front_pad=2, back_pad=2, hop_size=hop)
+        front_samples = int((5.0 + 5.0) * hop)  # 1000
+        back_samples = int((5.0 + 5.0) * hop)  # 1000
+        assert len(result) == total - front_samples - back_samples
+        assert result[0] == audio[front_samples]
+        assert result[-1] == audio[total - back_samples - 1]
+
+    @pytest.mark.unit
+    def test_returns_input_when_durations_none(self):
+        audio = np.arange(1000, dtype=np.int16)
+        result = _trim_padding_by_durations(audio, None, 3, 3, hop_size=256)
+        assert np.array_equal(result, audio)
+
+    @pytest.mark.unit
+    def test_returns_input_when_durations_too_short(self):
+        # durations has fewer entries than 1+front+back+1
+        audio = np.arange(1000, dtype=np.int16)
+        durations = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+        result = _trim_padding_by_durations(audio, durations, front_pad=5, back_pad=5, hop_size=256)
+        assert np.array_equal(result, audio)
+
+
+# ---------------------------------------------------------------
+# Strategy A: _trim_silence (RMS fallback)
 # ---------------------------------------------------------------
 class TestTrimSilence:
 

--- a/src/python_run/tests/test_short_text_mitigation.py
+++ b/src/python_run/tests/test_short_text_mitigation.py
@@ -120,25 +120,29 @@ class TestTrimPaddingByDurations:
     def test_trims_front_padding_only(self):
         # Layout: BOS=2, pad×3 (3+3+3 frames), body=4, EOS=1 → 19 frames total
         # Strategy A trims BOS + front padding from the start.
-        # EOS=1 frame is below eos_max_frames (default 6), so it's preserved.
+        # EOS=1 frame ≤ eos_max_frames=6, so it's preserved.
         durations = np.array([2.0, 3.0, 3.0, 3.0, 4.0, 1.0], dtype=np.float32)
         hop = 100
         total_samples = int(durations.sum() * hop)  # 1900
         audio = np.arange(total_samples, dtype=np.int16)
-        result = _trim_padding_by_durations(audio, durations, front_pad=3, back_pad=0, hop_size=hop)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=3, back_pad=0, hop_size=hop, eos_max_frames=6
+        )
         # BOS + front padding samples = (2+3+3+3) * 100 = 1100
         assert len(result) == total_samples - 1100
         assert result[0] == audio[1100]
 
     @pytest.mark.unit
     def test_trims_back_padding_preserves_normal_eos(self):
-        # Back padding stripped, EOS=1 frame preserved (under eos_max_frames=6).
+        # Back padding stripped, EOS=1 frame preserved (eos_max_frames=6).
         # Layout: [body=2, body=4, pad=3, pad=3, pad=3, EOS=1] with front_pad=0
         durations = np.array([2.0, 4.0, 3.0, 3.0, 3.0, 1.0], dtype=np.float32)
         hop = 100
         total_samples = int(durations.sum() * hop)  # 1600
         audio = np.arange(total_samples, dtype=np.int16)
-        result = _trim_padding_by_durations(audio, durations, front_pad=0, back_pad=3, hop_size=hop)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=0, back_pad=3, hop_size=hop, eos_max_frames=6
+        )
         # Trim back padding only (3+3+3)*100 = 900; EOS=1 frame stays in audio.
         assert len(result) == total_samples - 900
         # The last 100 samples (= 1 frame * hop) of the result are the EOS region.
@@ -151,7 +155,9 @@ class TestTrimPaddingByDurations:
         hop = 100
         total = int(durations.sum() * hop)  # 2800
         audio = np.arange(total, dtype=np.int16)
-        result = _trim_padding_by_durations(audio, durations, front_pad=2, back_pad=2, hop_size=hop)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=2, back_pad=2, hop_size=hop, eos_max_frames=6
+        )
         # BOS + front padding = (2+3+3) * 100 = 800
         # back padding + EOS excess = (3+3 + (10-6)) * 100 = 1000
         assert len(result) == total - 800 - 1000
@@ -159,14 +165,16 @@ class TestTrimPaddingByDurations:
     @pytest.mark.unit
     def test_trims_both_sides(self):
         # BOS=2, pad×2, body×2, pad×2, EOS=1
-        # EOS below eos_max_frames so preserved entirely.
+        # EOS=1 below eos_max_frames=6 so preserved entirely.
         durations = np.array(
             [2.0, 5.0, 5.0, 4.0, 4.0, 5.0, 5.0, 1.0], dtype=np.float32
         )
         hop = 100
         total = int(durations.sum() * hop)  # 3100
         audio = np.arange(total, dtype=np.int16)
-        result = _trim_padding_by_durations(audio, durations, front_pad=2, back_pad=2, hop_size=hop)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=2, back_pad=2, hop_size=hop, eos_max_frames=6
+        )
         # BOS + front padding = (2+5+5)*100 = 1200
         # back padding only (EOS preserved) = (5+5)*100 = 1000
         front_samples = int((2.0 + 5.0 + 5.0) * hop)
@@ -188,6 +196,22 @@ class TestTrimPaddingByDurations:
         # BOS + front = (1+3+3)*100 = 700
         # back + EOS excess = (3+3 + (5-2))*100 = 900
         assert len(result) == total - 700 - 900
+
+    @pytest.mark.unit
+    def test_default_strips_eos_completely(self):
+        # Default eos_max_frames=0: VITS predicts an inflated EOS under padded
+        # context that emits "だぁ"-like artefacts (issue #356 follow-up), so
+        # the entire EOS region is dropped along with back padding.
+        durations = np.array([2.0, 5.0, 5.0, 4.0, 4.0, 5.0, 5.0, 8.0], dtype=np.float32)
+        hop = 100
+        total = int(durations.sum() * hop)  # 3800
+        audio = np.arange(total, dtype=np.int16)
+        result = _trim_padding_by_durations(
+            audio, durations, front_pad=2, back_pad=2, hop_size=hop
+        )
+        # BOS + front padding = (2+5+5)*100 = 1200
+        # back padding + entire EOS = (5+5+8)*100 = 1800
+        assert len(result) == total - 1200 - 1800
 
     @pytest.mark.unit
     def test_returns_input_when_durations_none(self):

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1905,7 +1905,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "piper-plus"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "flate2",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "piper-plus-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "piper-plus-g2p"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "jpreprocess",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "piper-plus-python"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "numpy",
  "piper-plus",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "piper-plus-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["piper-plus-g2p", "piper-core", "piper-cli", "piper-python", "piper-w
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/src/rust/piper-cli/Cargo.toml
+++ b/src/rust/piper-cli/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "CLI tool for Piper Plus neural text-to-speech synthesis"
 
 [dependencies]
-piper-plus = { path = "../piper-core", version = "0.2.0", features = ["naist-jdic", "dict-download", "onnx"] }
+piper-plus = { path = "../piper-core", version = "0.3.0", features = ["naist-jdic", "dict-download", "onnx"] }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 serde_json = "1"

--- a/src/rust/piper-core/Cargo.toml
+++ b/src/rust/piper-core/Cargo.toml
@@ -26,7 +26,7 @@ directml = []
 tensorrt = []
 
 [dependencies]
-piper-plus-g2p = { path = "../piper-plus-g2p", version = "0.2.0", features = ["all-languages"] }
+piper-plus-g2p = { path = "../piper-plus-g2p", version = "0.3.0", features = ["all-languages"] }
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "tracing", "download-binaries", "tls-rustls", "copy-dylibs", "api-24"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/rust/piper-core/src/config.rs
+++ b/src/rust/piper-core/src/config.rs
@@ -240,7 +240,8 @@ mod tests {
     #[test]
     fn test_deserialize_audio_hop_size() {
         // Explicit hop_size is honoured.
-        let json = r#"{"phoneme_id_map": {"a": [1]}, "audio": {"sample_rate": 22050, "hop_size": 512}}"#;
+        let json =
+            r#"{"phoneme_id_map": {"a": [1]}, "audio": {"sample_rate": 22050, "hop_size": 512}}"#;
         let config: VoiceConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.audio.hop_size, 512);
     }

--- a/src/rust/piper-core/src/config.rs
+++ b/src/rust/piper-core/src/config.rs
@@ -37,11 +37,22 @@ pub struct VoiceConfig {
 pub struct AudioConfig {
     #[serde(default = "default_sample_rate")]
     pub sample_rate: u32,
+
+    /// VITS hop length (samples per acoustic frame).
+    ///
+    /// Required for converting frame-level ``durations`` (model output) into
+    /// audio-sample positions during Strategy A post-trim. Defaults to 256
+    /// to keep older config.json files (no `audio.hop_size` field) working.
+    #[serde(default = "default_hop_size")]
+    pub hop_size: u32,
 }
 
 impl Default for AudioConfig {
     fn default() -> Self {
-        Self { sample_rate: 22050 }
+        Self {
+            sample_rate: 22050,
+            hop_size: 256,
+        }
     }
 }
 
@@ -66,6 +77,9 @@ fn default_num_languages() -> usize {
 }
 fn default_sample_rate() -> u32 {
     22050
+}
+fn default_hop_size() -> u32 {
+    256
 }
 
 impl VoiceConfig {
@@ -215,10 +229,37 @@ mod tests {
         let json = r#"{"phoneme_id_map": {"a": [1]}, "audio": {"sample_rate": 22050}}"#;
         let config: VoiceConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.audio.sample_rate, 22050);
+        // hop_size defaults to 256 when missing — keeps older configs working.
+        assert_eq!(config.audio.hop_size, 256);
         assert_eq!(config.num_speakers, 1);
         assert_eq!(config.num_languages, 1);
         assert!(!config.is_multilingual());
         assert!(!config.needs_lid());
+    }
+
+    #[test]
+    fn test_deserialize_audio_hop_size() {
+        // Explicit hop_size is honoured.
+        let json = r#"{"phoneme_id_map": {"a": [1]}, "audio": {"sample_rate": 22050, "hop_size": 512}}"#;
+        let config: VoiceConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.audio.hop_size, 512);
+    }
+
+    #[test]
+    fn test_deserialize_audio_default_hop_size_when_audio_missing() {
+        // No audio section at all → both defaults apply.
+        let json = r#"{"phoneme_id_map": {"a": [1]}}"#;
+        let config: VoiceConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.audio.sample_rate, 22050);
+        assert_eq!(config.audio.hop_size, 256);
+    }
+
+    #[test]
+    fn test_audio_config_default() {
+        // Ensure Default impl matches serde defaults.
+        let audio = AudioConfig::default();
+        assert_eq!(audio.sample_rate, 22050);
+        assert_eq!(audio.hop_size, 256);
     }
 
     #[test]

--- a/src/rust/piper-core/src/engine.rs
+++ b/src/rust/piper-core/src/engine.rs
@@ -57,6 +57,11 @@ pub const MIN_PHONEME_IDS: usize = 15;
 /// 支配的になる (例: 「あ。」, body=2)。raw VITS 出力の方が結果として自然。
 pub const MIN_BODY_FOR_STRATEGY_A: usize = 3;
 
+/// `trim_padding_by_durations` がデフォルトで残す EOS フレーム数。
+/// padding context で VITS が膨張させた EOS が末尾の余分音として聞こえるため
+/// (issue #356)、デフォルトでは 0 にして EOS を完全削除する。
+pub const TRIM_EOS_MAX_FRAMES: usize = 0;
+
 /// RMS トリムの閾値。この RMS 以下の窓を無音とみなす。
 const TRIM_THRESHOLD_RMS: f32 = 0.01;
 
@@ -150,16 +155,23 @@ pub struct ModelCapabilities {
 /// body 長 (= phoneme_ids - 2) が MIN_BODY_FOR_STRATEGY_A 未満の場合は
 /// padding/body 比が大きくなりすぎるため Strategy A をスキップする
 /// (issue #356)。
+///
+/// 戻り値の 4 番目・5 番目は挿入された front / back pad トークン数。
+/// padding が行われなかった場合は両方 0。durations ベース post-trim で
+/// pad token のフレーム範囲を正確に切るために必要。
+///
+/// **Breaking change (#356):** 旧シグネチャは 3 タプルだった。
+/// `pad_short_phonemes()` 直接利用者は呼び出しを更新すること。
 pub fn pad_short_phonemes(
     phoneme_ids: &[i64],
     prosody_features: Option<&Vec<[i32; 3]>>,
-) -> (Vec<i64>, Option<Vec<[i32; 3]>>, bool) {
+) -> (Vec<i64>, Option<Vec<[i32; 3]>>, bool, usize, usize) {
     let body_len = phoneme_ids.len().saturating_sub(2);
     if body_len < MIN_BODY_FOR_STRATEGY_A {
-        return (phoneme_ids.to_vec(), prosody_features.cloned(), false);
+        return (phoneme_ids.to_vec(), prosody_features.cloned(), false, 0, 0);
     }
     if phoneme_ids.len() >= MIN_PHONEME_IDS {
-        return (phoneme_ids.to_vec(), prosody_features.cloned(), false);
+        return (phoneme_ids.to_vec(), prosody_features.cloned(), false, 0, 0);
     }
 
     let deficit = MIN_PHONEME_IDS - phoneme_ids.len();
@@ -198,7 +210,81 @@ pub fn pad_short_phonemes(
         padded_pf
     });
 
-    (padded, padded_prosody, true)
+    (padded, padded_prosody, true, front_pad, back_pad)
+}
+
+/// Strategy A 精密 post-trim: モデルの `durations` 出力から padding に
+/// 起因するサンプル数を計算して切り落とす。
+///
+/// Python (`src/python_run/piper/voice.py::_trim_padding_by_durations`)
+/// と同じロジック・truncation で実装し、全ランタイムが同じ入力に対して
+/// バイト一致の音声を返せるようにする (issue #356, クロスランタイム契約)。
+///
+/// 期待する padded layout:
+///
+/// ```text
+/// [BOS, pad×front_pad, ...body..., pad×back_pad, EOS]
+/// ```
+///
+/// `durations[i]` は VITS が phoneme i に割り当てたフレーム数。
+/// `hop_size` を掛けてサンプル数に変換し、front 側 (BOS+front_pad) と
+/// back 側 (back_pad+EOS over `eos_max_frames`) を削る。
+///
+/// すべての frame→sample 変換は `as i64` 経由の truncation
+/// (Python の `int()` と一致) で行う。`round` を使うとランタイム間で
+/// 1 サンプルのズレが生じるため避ける。
+///
+/// 引数が不整合 (`durations.is_empty()`, `hop_size == 0`,
+/// `durations.len() < 1 + front_pad + back_pad + 1` など) のときは入力を
+/// そのまま返す。
+pub fn trim_padding_by_durations(
+    audio: &[i16],
+    durations: &[f32],
+    front_pad: usize,
+    back_pad: usize,
+    hop_size: u32,
+    eos_max_frames: usize,
+) -> Vec<i16> {
+    if front_pad == 0 && back_pad == 0 {
+        return audio.to_vec();
+    }
+    if durations.is_empty() || hop_size == 0 {
+        return audio.to_vec();
+    }
+    let expected_len = 1 + front_pad + back_pad + 1; // BOS + pads + EOS
+    if durations.len() < expected_len {
+        return audio.to_vec();
+    }
+
+    let hop = hop_size as f32;
+
+    // Front: BOS + front padding samples (truncated).
+    let front_sum: f32 = durations[0..1 + front_pad].iter().sum();
+    let front_samples = (front_sum * hop) as i64;
+
+    // Back: back padding samples + EOS excess (over eos_max_frames).
+    let back_pad_sum: f32 = if back_pad > 0 {
+        let start = durations.len() - 1 - back_pad;
+        durations[start..durations.len() - 1].iter().sum()
+    } else {
+        0.0
+    };
+    let back_pad_samples = (back_pad_sum * hop) as i64;
+
+    let eos_frames = durations[durations.len() - 1];
+    let eos_excess = (eos_frames - eos_max_frames as f32).max(0.0);
+    let back_samples = back_pad_samples + (eos_excess * hop) as i64;
+
+    let total = audio.len() as i64;
+    let start = front_samples.max(0) as i64;
+    let mut end = total - back_samples;
+    if end < start {
+        end = start;
+    }
+    if start >= total || end <= 0 || start >= end {
+        return audio.to_vec();
+    }
+    audio[start as usize..end as usize].to_vec()
 }
 
 /// Strategy A (post-trim): RMS ベースで先頭・末尾の無音をトリムする。
@@ -298,6 +384,9 @@ pub struct OnnxEngine {
     session: Session,
     capabilities: ModelCapabilities,
     sample_rate: u32,
+    /// VITS hop length (samples per acoustic frame), used by the
+    /// durations-based Strategy A post-trim (#356).
+    hop_size: u32,
 }
 
 impl OnnxEngine {
@@ -491,10 +580,19 @@ impl OnnxEngine {
             capabilities.has_speaker_embedding,
         );
 
+        // hop_size: 0 (config 欠如時の serde default 直前の異常値) は
+        // contract 既定の 256 にフォールバック。
+        let hop_size = if config.audio.hop_size > 0 {
+            config.audio.hop_size
+        } else {
+            256
+        };
+
         Ok(Self {
             session,
             capabilities,
             sample_rate: config.audio.sample_rate,
+            hop_size,
         })
     }
 
@@ -534,7 +632,7 @@ impl OnnxEngine {
 
         // --- Strategy A: Silence Padding ---
         // 短い phoneme 列を pause トークンで MIN_PHONEME_IDS まで延長する。
-        let (phoneme_ids, prosody_features, was_padded) =
+        let (phoneme_ids, prosody_features, was_padded, front_pad, back_pad) =
             pad_short_phonemes(&request.phoneme_ids, request.prosody_features.as_ref());
         let phoneme_len = phoneme_ids.len();
 
@@ -702,22 +800,11 @@ impl OnnxEngine {
         // float32 -> int16 ピーク正規化
         let audio_i16_raw = audio_float_to_int16(audio_slice);
 
-        // --- Strategy A (post-trim): padding 挿入した場合は無音をトリム ---
-        let audio_i16 = if was_padded {
-            let trimmed = trim_silence(&audio_i16_raw);
-            tracing::debug!(
-                "Short text trim: {} -> {} samples",
-                audio_i16_raw.len(),
-                trimmed.len()
-            );
-            trimmed
-        } else {
-            audio_i16_raw
-        };
-        let audio_seconds = audio_i16.len() as f64 / self.sample_rate as f64;
-
-        // --- duration テンソル抽出 (オプション) ---
-        let durations = if self.capabilities.has_duration_output {
+        // --- duration テンソル抽出 (post-trim より前) ---
+        // padded sequence の durations を保持して `trim_padding_by_durations`
+        // から正確に padding 範囲を切り出すために必要。
+        // 呼び出し側へ返す `durations` は後で original 長に切り詰める。
+        let padded_durations: Option<Vec<f32>> = if self.capabilities.has_duration_output {
             match outputs.get("durations") {
                 Some(d) => match d.try_extract_tensor::<f32>() {
                     Ok((_shape, data)) => {
@@ -744,6 +831,41 @@ impl OnnxEngine {
         } else {
             None
         };
+
+        // --- Strategy A (post-trim): padding 由来の音声を除去 ---
+        // durations が利用可能なら精密 trim、なければ RMS フォールバック。
+        let audio_i16 = if was_padded {
+            let trimmed = if let Some(durs) = padded_durations.as_deref() {
+                trim_padding_by_durations(
+                    &audio_i16_raw,
+                    durs,
+                    front_pad,
+                    back_pad,
+                    self.hop_size,
+                    TRIM_EOS_MAX_FRAMES,
+                )
+            } else {
+                trim_silence(&audio_i16_raw)
+            };
+            tracing::debug!(
+                "Short text trim: {} -> {} samples",
+                audio_i16_raw.len(),
+                trimmed.len()
+            );
+            trimmed
+        } else {
+            audio_i16_raw
+        };
+        let audio_seconds = audio_i16.len() as f64 / self.sample_rate as f64;
+
+        // 呼び出し側に返す durations は original 長に切り詰める
+        // (timing 用途では padded extras は not user-visible)。
+        let durations = padded_durations.map(|mut d| {
+            if was_padded && d.len() > original_len {
+                d.truncate(original_len);
+            }
+            d
+        });
 
         Ok(SynthesisResult {
             audio: audio_i16,
@@ -1132,7 +1254,7 @@ mod tests {
     fn test_pad_short_phonemes_below_threshold() {
         // 10 tokens -> should be padded to MIN_PHONEME_IDS
         let ids: Vec<i64> = vec![1, 5, 6, 7, 8, 9, 10, 11, 12, 2]; // BOS=1, EOS=2
-        let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
+        let (padded, _, was_padded, _, _) = pad_short_phonemes(&ids, None);
         assert!(was_padded);
         assert_eq!(padded.len(), MIN_PHONEME_IDS);
         assert_eq!(padded[0], 1); // BOS preserved
@@ -1143,7 +1265,7 @@ mod tests {
     fn test_pad_short_phonemes_at_threshold() {
         // Exactly MIN_PHONEME_IDS -> no padding
         let ids: Vec<i64> = (0..MIN_PHONEME_IDS as i64).collect();
-        let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
+        let (padded, _, was_padded, _, _) = pad_short_phonemes(&ids, None);
         assert!(!was_padded);
         assert_eq!(padded.len(), MIN_PHONEME_IDS);
         assert_eq!(padded, ids);
@@ -1153,7 +1275,7 @@ mod tests {
     fn test_pad_short_phonemes_above_threshold() {
         // Above MIN_PHONEME_IDS -> no padding
         let ids: Vec<i64> = (0..(MIN_PHONEME_IDS as i64 + 10)).collect();
-        let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
+        let (padded, _, was_padded, _, _) = pad_short_phonemes(&ids, None);
         assert!(!was_padded);
         assert_eq!(padded.len(), MIN_PHONEME_IDS + 10);
     }
@@ -1166,7 +1288,7 @@ mod tests {
         ids.extend((0..MIN_BODY_FOR_STRATEGY_A as i64).map(|i| 100 + i));
         ids.push(2); // EOS
         let total = ids.len();
-        let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
+        let (padded, _, was_padded, _, _) = pad_short_phonemes(&ids, None);
         assert!(was_padded);
         // All inserted tokens should be 0
         let inserted: Vec<i64> = padded
@@ -1181,7 +1303,7 @@ mod tests {
     fn test_pad_short_phonemes_body_preserved() {
         // Original body tokens should be preserved in order
         let ids: Vec<i64> = vec![1, 10, 20, 30, 2]; // BOS=1, body=[10,20,30], EOS=2
-        let (padded, _, _) = pad_short_phonemes(&ids, None);
+        let (padded, _, _, _, _) = pad_short_phonemes(&ids, None);
 
         // Extract non-pause, non-BOS, non-EOS tokens
         let body: Vec<i64> = padded
@@ -1202,7 +1324,7 @@ mod tests {
         prosody.extend((0..MIN_BODY_FOR_STRATEGY_A as i32).map(|i| [i + 1, i + 2, i + 3]));
         prosody.push([0, 0, 0]);
 
-        let (padded_ids, padded_prosody, was_padded) = pad_short_phonemes(&ids, Some(&prosody));
+        let (padded_ids, padded_prosody, was_padded, _, _) = pad_short_phonemes(&ids, Some(&prosody));
         assert!(was_padded);
         assert_eq!(padded_ids.len(), MIN_PHONEME_IDS);
         let pp = padded_prosody.unwrap();
@@ -1219,7 +1341,7 @@ mod tests {
         let mut ids: Vec<i64> = vec![1];
         ids.extend((0..MIN_BODY_FOR_STRATEGY_A as i64).map(|i| 5 + i));
         ids.push(2);
-        let (padded, padded_prosody, was_padded) = pad_short_phonemes(&ids, None);
+        let (padded, padded_prosody, was_padded, _, _) = pad_short_phonemes(&ids, None);
         assert!(was_padded);
         assert_eq!(padded.len(), MIN_PHONEME_IDS);
         assert!(padded_prosody.is_none());
@@ -1229,20 +1351,20 @@ mod tests {
     fn test_pad_short_phonemes_skips_when_body_too_short() {
         // body=0 (just BOS+EOS): Strategy A skipped (issue #356).
         let ids: Vec<i64> = vec![1, 2];
-        let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
+        let (padded, _, was_padded, _, _) = pad_short_phonemes(&ids, None);
         assert!(!was_padded);
         assert_eq!(padded, ids);
 
         // body=1 (e.g. just one phoneme between BOS/EOS).
         let ids: Vec<i64> = vec![1, 10, 2];
-        let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
+        let (padded, _, was_padded, _, _) = pad_short_phonemes(&ids, None);
         assert!(!was_padded);
         assert_eq!(padded, ids);
 
         // body=2 ("あ。" case).
         if MIN_BODY_FOR_STRATEGY_A > 2 {
             let ids: Vec<i64> = vec![1, 10, 11, 2];
-            let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
+            let (padded, _, was_padded, _, _) = pad_short_phonemes(&ids, None);
             assert!(!was_padded);
             assert_eq!(padded, ids);
         }
@@ -1253,7 +1375,7 @@ mod tests {
         // Edge case: single element — body would be < 0 (saturating to 0)
         // so Strategy A is skipped.
         let ids: Vec<i64> = vec![1];
-        let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
+        let (padded, _, was_padded, _, _) = pad_short_phonemes(&ids, None);
         assert!(!was_padded);
         assert_eq!(padded, ids);
     }
@@ -1375,5 +1497,108 @@ mod tests {
     #[test]
     fn test_min_body_for_strategy_a_value() {
         assert_eq!(MIN_BODY_FOR_STRATEGY_A, 3);
+    }
+
+    #[test]
+    fn test_trim_eos_max_frames_value() {
+        assert_eq!(TRIM_EOS_MAX_FRAMES, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Strategy A: trim_padding_by_durations (precise post-trim, issue #356)
+    // -----------------------------------------------------------------------
+    // Mirrors src/python_run/tests/test_short_text_mitigation.py and ensures
+    // every runtime trims by the same number of samples for the same inputs.
+
+    #[test]
+    fn test_trim_padding_by_durations_no_op_when_no_padding() {
+        let audio: Vec<i16> = (0..1000).map(|i| i as i16).collect();
+        let durations = vec![1.0_f32; 5];
+        let result = trim_padding_by_durations(&audio, &durations, 0, 0, 256, TRIM_EOS_MAX_FRAMES);
+        assert_eq!(result.len(), audio.len());
+    }
+
+    #[test]
+    fn test_trim_padding_by_durations_trims_front_padding_only() {
+        // Layout: BOS=2, pad×3 (3+3+3), body=4, EOS=1 → 19 frames total.
+        let durations: Vec<f32> = vec![2.0, 3.0, 3.0, 3.0, 4.0, 1.0];
+        let hop = 100u32;
+        let total = 1900usize;
+        let audio = vec![0i16; total];
+        let result = trim_padding_by_durations(&audio, &durations, 3, 0, hop, 6);
+        // BOS + front padding samples = (2+3+3+3) * 100 = 1100
+        assert_eq!(result.len(), total - 1100);
+    }
+
+    #[test]
+    fn test_trim_padding_by_durations_default_strips_eos_completely() {
+        let durations: Vec<f32> = vec![2.0, 5.0, 5.0, 4.0, 4.0, 5.0, 5.0, 8.0];
+        let hop = 100u32;
+        let total = 3800usize;
+        let audio = vec![0i16; total];
+        let result =
+            trim_padding_by_durations(&audio, &durations, 2, 2, hop, TRIM_EOS_MAX_FRAMES);
+        // BOS + front padding = (2+5+5)*100 = 1200
+        // back padding + entire EOS = (5+5+8)*100 = 1800
+        assert_eq!(result.len(), total - 1200 - 1800);
+    }
+
+    #[test]
+    fn test_trim_padding_by_durations_clamps_inflated_eos() {
+        let durations: Vec<f32> = vec![2.0, 3.0, 3.0, 4.0, 3.0, 3.0, 10.0];
+        let hop = 100u32;
+        let total = 2800usize;
+        let audio = vec![0i16; total];
+        let result = trim_padding_by_durations(&audio, &durations, 2, 2, hop, 6);
+        // BOS + front padding = (2+3+3) * 100 = 800
+        // back padding + EOS excess = (3+3 + (10-6)) * 100 = 1000
+        assert_eq!(result.len(), total - 800 - 1000);
+    }
+
+    #[test]
+    fn test_trim_padding_by_durations_returns_input_when_durations_empty() {
+        let audio = vec![0i16; 1000];
+        let durations: Vec<f32> = vec![];
+        let result = trim_padding_by_durations(&audio, &durations, 3, 3, 256, TRIM_EOS_MAX_FRAMES);
+        assert_eq!(result.len(), audio.len());
+    }
+
+    #[test]
+    fn test_trim_padding_by_durations_returns_input_when_durations_too_short() {
+        let audio = vec![0i16; 1000];
+        let durations: Vec<f32> = vec![1.0, 1.0, 1.0];
+        let result = trim_padding_by_durations(&audio, &durations, 5, 5, 256, TRIM_EOS_MAX_FRAMES);
+        assert_eq!(result.len(), audio.len());
+    }
+
+    #[test]
+    fn test_trim_padding_by_durations_returns_input_when_hop_size_zero() {
+        let audio = vec![0i16; 1000];
+        let durations: Vec<f32> = vec![1.0; 8];
+        let result = trim_padding_by_durations(&audio, &durations, 2, 2, 0, TRIM_EOS_MAX_FRAMES);
+        assert_eq!(result.len(), audio.len());
+    }
+
+    #[test]
+    fn test_trim_padding_by_durations_truncation_matches_int_cast() {
+        // Layout (front_pad=1, back_pad=1, body=3):
+        //   [BOS=0.701, pad=0.701, body=2, body=2, body=2, pad=0.703, EOS=0.701]
+        // Front trim = ((0.701+0.701)*100) as i64 = 140
+        // Back trim  = (0.703*100) as i64 + (0.701*100) as i64 = 70 + 70 = 140
+        // round() would diverge → cross-runtime drift.
+        let durations: Vec<f32> = vec![0.701, 0.701, 2.0, 2.0, 2.0, 0.703, 0.701];
+        let hop = 100u32;
+        let sum: f32 = durations.iter().sum();
+        let total = (sum * hop as f32) as usize;
+        let audio = vec![0i16; total];
+        let result = trim_padding_by_durations(
+            &audio,
+            &durations,
+            1,
+            1,
+            hop,
+            TRIM_EOS_MAX_FRAMES,
+        );
+        assert_eq!(result.len(), total - 140 - 140);
     }
 }

--- a/src/rust/piper-core/src/engine.rs
+++ b/src/rust/piper-core/src/engine.rs
@@ -41,11 +41,21 @@ const WARMUP_PHONEME_LENGTH: usize = 100;
 
 // ---------------------------------------------------------------------------
 // 短テキスト緩和策の定数 (Strategy A + B)
+// docs/spec/short-text-contract.toml と同期させること。
 // ---------------------------------------------------------------------------
 
 /// 最小 phoneme ID 数。これ未満の場合 padding を挿入する。
-/// VITS の Duration Predictor は ~40 tokens 以上で安定する経験則に基づく。
-pub const MIN_PHONEME_IDS: usize = 40;
+///
+/// Issue #356: 当初 40 と仕様で固定していたが、実機計測 (tsukuyomi 6lang) で
+/// 8 phoneme 以上で安定合成可能と判明。40 では Strategy A が安定入力にも
+/// 発動して padding アーティファクトを残してしまう。15 に下げて
+/// 「こんにちは。」級は素通りさせ、極短文だけ Strategy A を発動させる。
+pub const MIN_PHONEME_IDS: usize = 15;
+
+/// Strategy A を発動する body 長 (= phoneme_ids から BOS/EOS を除いた数) の
+/// 下限。これ未満では padding が body を圧倒し、pad token 由来の音が
+/// 支配的になる (例: 「あ。」, body=2)。raw VITS 出力の方が結果として自然。
+pub const MIN_BODY_FOR_STRATEGY_A: usize = 3;
 
 /// RMS トリムの閾値。この RMS 以下の窓を無音とみなす。
 const TRIM_THRESHOLD_RMS: f32 = 0.01;
@@ -137,10 +147,17 @@ pub struct ModelCapabilities {
 /// prosody_features も同期して延長する (ゼロ埋め)。
 ///
 /// 既に MIN_PHONEME_IDS 以上の場合は変更なし。
+/// body 長 (= phoneme_ids - 2) が MIN_BODY_FOR_STRATEGY_A 未満の場合は
+/// padding/body 比が大きくなりすぎるため Strategy A をスキップする
+/// (issue #356)。
 pub fn pad_short_phonemes(
     phoneme_ids: &[i64],
     prosody_features: Option<&Vec<[i32; 3]>>,
 ) -> (Vec<i64>, Option<Vec<[i32; 3]>>, bool) {
+    let body_len = phoneme_ids.len().saturating_sub(2);
+    if body_len < MIN_BODY_FOR_STRATEGY_A {
+        return (phoneme_ids.to_vec(), prosody_features.cloned(), false);
+    }
     if phoneme_ids.len() >= MIN_PHONEME_IDS {
         return (phoneme_ids.to_vec(), prosody_features.cloned(), false);
     }
@@ -1143,8 +1160,12 @@ mod tests {
 
     #[test]
     fn test_pad_short_phonemes_pause_tokens() {
-        // Verify that inserted tokens are PAUSE_TOKEN_ID (0)
-        let ids: Vec<i64> = vec![1, 100, 200, 2]; // 4 tokens
+        // Verify that inserted tokens are PAUSE_TOKEN_ID (0).
+        // body must be >= MIN_BODY_FOR_STRATEGY_A for Strategy A to apply.
+        let mut ids: Vec<i64> = vec![1]; // BOS
+        ids.extend((0..MIN_BODY_FOR_STRATEGY_A as i64).map(|i| 100 + i));
+        ids.push(2); // EOS
+        let total = ids.len();
         let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
         assert!(was_padded);
         // All inserted tokens should be 0
@@ -1153,7 +1174,7 @@ mod tests {
             .copied()
             .filter(|&id| id == PAUSE_TOKEN_ID)
             .collect();
-        assert_eq!(inserted.len(), MIN_PHONEME_IDS - 4);
+        assert_eq!(inserted.len(), MIN_PHONEME_IDS - total);
     }
 
     #[test]
@@ -1173,8 +1194,14 @@ mod tests {
 
     #[test]
     fn test_pad_short_phonemes_with_prosody() {
-        let ids: Vec<i64> = vec![1, 5, 6, 2]; // 4 tokens
-        let prosody = vec![[0, 0, 0], [1, 2, 3], [4, 5, 6], [0, 0, 0]];
+        // body == MIN_BODY_FOR_STRATEGY_A so Strategy A applies.
+        let mut ids: Vec<i64> = vec![1];
+        ids.extend((0..MIN_BODY_FOR_STRATEGY_A as i64).map(|i| 5 + i));
+        ids.push(2);
+        let mut prosody = vec![[0, 0, 0]];
+        prosody.extend((0..MIN_BODY_FOR_STRATEGY_A as i32).map(|i| [i + 1, i + 2, i + 3]));
+        prosody.push([0, 0, 0]);
+
         let (padded_ids, padded_prosody, was_padded) = pad_short_phonemes(&ids, Some(&prosody));
         assert!(was_padded);
         assert_eq!(padded_ids.len(), MIN_PHONEME_IDS);
@@ -1188,7 +1215,10 @@ mod tests {
 
     #[test]
     fn test_pad_short_phonemes_prosody_none() {
-        let ids: Vec<i64> = vec![1, 5, 2];
+        // body == MIN_BODY_FOR_STRATEGY_A.
+        let mut ids: Vec<i64> = vec![1];
+        ids.extend((0..MIN_BODY_FOR_STRATEGY_A as i64).map(|i| 5 + i));
+        ids.push(2);
         let (padded, padded_prosody, was_padded) = pad_short_phonemes(&ids, None);
         assert!(was_padded);
         assert_eq!(padded.len(), MIN_PHONEME_IDS);
@@ -1196,24 +1226,36 @@ mod tests {
     }
 
     #[test]
-    fn test_pad_short_phonemes_minimal() {
-        // Minimum: [BOS, EOS] = 2 tokens
+    fn test_pad_short_phonemes_skips_when_body_too_short() {
+        // body=0 (just BOS+EOS): Strategy A skipped (issue #356).
         let ids: Vec<i64> = vec![1, 2];
         let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
-        assert!(was_padded);
-        assert_eq!(padded.len(), MIN_PHONEME_IDS);
-        assert_eq!(padded[0], 1);
-        assert_eq!(padded[padded.len() - 1], 2);
+        assert!(!was_padded);
+        assert_eq!(padded, ids);
+
+        // body=1 (e.g. just one phoneme between BOS/EOS).
+        let ids: Vec<i64> = vec![1, 10, 2];
+        let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
+        assert!(!was_padded);
+        assert_eq!(padded, ids);
+
+        // body=2 ("あ。" case).
+        if MIN_BODY_FOR_STRATEGY_A > 2 {
+            let ids: Vec<i64> = vec![1, 10, 11, 2];
+            let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
+            assert!(!was_padded);
+            assert_eq!(padded, ids);
+        }
     }
 
     #[test]
     fn test_pad_short_phonemes_single_element() {
-        // Edge case: single element
+        // Edge case: single element — body would be < 0 (saturating to 0)
+        // so Strategy A is skipped.
         let ids: Vec<i64> = vec![1];
         let (padded, _, was_padded) = pad_short_phonemes(&ids, None);
-        assert!(was_padded);
-        assert_eq!(padded.len(), MIN_PHONEME_IDS);
-        assert_eq!(padded[0], 1); // BOS preserved
+        assert!(!was_padded);
+        assert_eq!(padded, ids);
     }
 
     // -----------------------------------------------------------------------
@@ -1285,21 +1327,23 @@ mod tests {
 
     #[test]
     fn test_adjust_scales_below_threshold() {
-        let len = 20; // 50% of MIN_PHONEME_IDS
+        // 50% of MIN_PHONEME_IDS — exactly at the noise_scale floor (0.5).
+        let len = MIN_PHONEME_IDS / 2;
         let (ns, nw) = adjust_scales_for_short_text(len, 0.667, 0.8);
-        // ratio = 20/40 = 0.5, max(0.5, 0.5) = 0.5
-        assert!((ns - 0.667 * 0.5).abs() < 1e-4);
-        // ratio = 0.5, max(0.5, 0.4) = 0.5
-        assert!((nw - 0.8 * 0.5).abs() < 1e-4);
+        let ratio = len as f32 / MIN_PHONEME_IDS as f32;
+        let ns_ratio = ratio.max(0.5);
+        let nw_ratio = ratio.max(0.4);
+        assert!((ns - 0.667 * ns_ratio).abs() < 1e-4);
+        assert!((nw - 0.8 * nw_ratio).abs() < 1e-4);
     }
 
     #[test]
     fn test_adjust_scales_very_short() {
-        let len = 5; // 12.5% of MIN_PHONEME_IDS
+        // 1 phoneme — far below both floors so they fully clamp.
+        let len = 1;
         let (ns, nw) = adjust_scales_for_short_text(len, 0.667, 0.8);
-        // ratio = 5/40 = 0.125, but clamped at max(0.125, 0.5) = 0.5
+        // ratio is below both floors (0.5 / 0.4)
         assert!((ns - 0.667 * 0.5).abs() < 1e-4);
-        // ratio = 0.125, max(0.125, 0.4) = 0.4
         assert!((nw - 0.8 * 0.4).abs() < 1e-4);
     }
 
@@ -1314,16 +1358,22 @@ mod tests {
 
     #[test]
     fn test_adjust_scales_boundary_ratio() {
-        // len = 30 -> ratio = 30/40 = 0.75
-        let (ns, nw) = adjust_scales_for_short_text(30, 1.0, 1.0);
-        // ratio = 0.75, max(0.75, 0.5) = 0.75
-        assert!((ns - 0.75).abs() < 1e-4);
-        // ratio = 0.75, max(0.75, 0.4) = 0.75
-        assert!((nw - 0.75).abs() < 1e-4);
+        // Just below the threshold so neither floor engages.
+        let len = MIN_PHONEME_IDS - 1;
+        let ratio = len as f32 / MIN_PHONEME_IDS as f32;
+        let (ns, nw) = adjust_scales_for_short_text(len, 1.0, 1.0);
+        // ratio is above both floors so both expectations equal `ratio`.
+        assert!((ns - ratio).abs() < 1e-4);
+        assert!((nw - ratio).abs() < 1e-4);
     }
 
     #[test]
     fn test_min_phoneme_ids_value() {
-        assert_eq!(MIN_PHONEME_IDS, 40);
+        assert_eq!(MIN_PHONEME_IDS, 15);
+    }
+
+    #[test]
+    fn test_min_body_for_strategy_a_value() {
+        assert_eq!(MIN_BODY_FOR_STRATEGY_A, 3);
     }
 }

--- a/src/rust/piper-core/src/engine.rs
+++ b/src/rust/piper-core/src/engine.rs
@@ -162,6 +162,7 @@ pub struct ModelCapabilities {
 ///
 /// **Breaking change (#356):** 旧シグネチャは 3 タプルだった。
 /// `pad_short_phonemes()` 直接利用者は呼び出しを更新すること。
+#[allow(clippy::type_complexity)]
 pub fn pad_short_phonemes(
     phoneme_ids: &[i64],
     prosody_features: Option<&Vec<[i32; 3]>>,
@@ -276,7 +277,7 @@ pub fn trim_padding_by_durations(
     let back_samples = back_pad_samples + (eos_excess * hop) as i64;
 
     let total = audio.len() as i64;
-    let start = front_samples.max(0) as i64;
+    let start = front_samples.max(0);
     let mut end = total - back_samples;
     if end < start {
         end = start;
@@ -1324,7 +1325,8 @@ mod tests {
         prosody.extend((0..MIN_BODY_FOR_STRATEGY_A as i32).map(|i| [i + 1, i + 2, i + 3]));
         prosody.push([0, 0, 0]);
 
-        let (padded_ids, padded_prosody, was_padded, _, _) = pad_short_phonemes(&ids, Some(&prosody));
+        let (padded_ids, padded_prosody, was_padded, _, _) =
+            pad_short_phonemes(&ids, Some(&prosody));
         assert!(was_padded);
         assert_eq!(padded_ids.len(), MIN_PHONEME_IDS);
         let pp = padded_prosody.unwrap();
@@ -1392,7 +1394,7 @@ mod tests {
         let trimmed = trim_silence(&audio);
         assert!(trimmed.len() < audio.len());
         // Trimmed result should contain the signal
-        assert!(trimmed.iter().any(|&s| s == 10000));
+        assert!(trimmed.contains(&10000));
     }
 
     #[test]
@@ -1536,8 +1538,7 @@ mod tests {
         let hop = 100u32;
         let total = 3800usize;
         let audio = vec![0i16; total];
-        let result =
-            trim_padding_by_durations(&audio, &durations, 2, 2, hop, TRIM_EOS_MAX_FRAMES);
+        let result = trim_padding_by_durations(&audio, &durations, 2, 2, hop, TRIM_EOS_MAX_FRAMES);
         // BOS + front padding = (2+5+5)*100 = 1200
         // back padding + entire EOS = (5+5+8)*100 = 1800
         assert_eq!(result.len(), total - 1200 - 1800);
@@ -1591,14 +1592,7 @@ mod tests {
         let sum: f32 = durations.iter().sum();
         let total = (sum * hop as f32) as usize;
         let audio = vec![0i16; total];
-        let result = trim_padding_by_durations(
-            &audio,
-            &durations,
-            1,
-            1,
-            hop,
-            TRIM_EOS_MAX_FRAMES,
-        );
+        let result = trim_padding_by_durations(&audio, &durations, 1, 1, hop, TRIM_EOS_MAX_FRAMES);
         assert_eq!(result.len(), total - 140 - 140);
     }
 }

--- a/src/rust/piper-core/src/lib.rs
+++ b/src/rust/piper-core/src/lib.rs
@@ -56,7 +56,8 @@ pub use config::{PhonemeIdMap, PhonemeType, VoiceConfig};
 #[cfg(feature = "onnx")]
 pub use engine::{
     DEFAULT_WARMUP_RUNS, MIN_BODY_FOR_STRATEGY_A, MIN_PHONEME_IDS, ModelCapabilities, OnnxEngine,
-    SynthesisRequest, SynthesisResult,
+    SynthesisRequest, SynthesisResult, TRIM_EOS_MAX_FRAMES, pad_short_phonemes,
+    trim_padding_by_durations,
 };
 pub use error::PiperError;
 pub use phonemize::{ProsodyFeature, ProsodyInfo};

--- a/src/rust/piper-core/src/lib.rs
+++ b/src/rust/piper-core/src/lib.rs
@@ -55,8 +55,8 @@ pub mod playback;
 pub use config::{PhonemeIdMap, PhonemeType, VoiceConfig};
 #[cfg(feature = "onnx")]
 pub use engine::{
-    DEFAULT_WARMUP_RUNS, MIN_PHONEME_IDS, ModelCapabilities, OnnxEngine, SynthesisRequest,
-    SynthesisResult,
+    DEFAULT_WARMUP_RUNS, MIN_BODY_FOR_STRATEGY_A, MIN_PHONEME_IDS, ModelCapabilities, OnnxEngine,
+    SynthesisRequest, SynthesisResult,
 };
 pub use error::PiperError;
 pub use phonemize::{ProsodyFeature, ProsodyInfo};

--- a/src/rust/piper-plus-g2p/src/custom_dict.rs
+++ b/src/rust/piper-plus-g2p/src/custom_dict.rs
@@ -163,7 +163,7 @@ impl CustomDictionary {
 
         // Case-sensitive エントリ (長い順)
         let mut cs_entries: Vec<_> = self.case_sensitive_entries.iter().collect();
-        cs_entries.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        cs_entries.sort_by_key(|entry| std::cmp::Reverse(entry.0.len()));
 
         for (word, entry) in &cs_entries {
             let pattern = self.get_word_pattern(word, true);
@@ -174,7 +174,7 @@ impl CustomDictionary {
 
         // Case-insensitive エントリ (長い順)
         let mut ci_entries: Vec<_> = self.entries.iter().collect();
-        ci_entries.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        ci_entries.sort_by_key(|entry| std::cmp::Reverse(entry.0.len()));
 
         for (word, entry) in &ci_entries {
             let pattern = self.get_word_pattern(word, false);

--- a/src/rust/piper-python/Cargo.toml
+++ b/src/rust/piper-python/Cargo.toml
@@ -16,7 +16,7 @@ name = "piper_plus"
 crate-type = ["cdylib"]
 
 [dependencies]
-piper_core = { package = "piper-plus", path = "../piper-core", version = "0.2.0", features = ["naist-jdic", "onnx"] }
+piper_core = { package = "piper-plus", path = "../piper-core", version = "0.3.0", features = ["naist-jdic", "onnx"] }
 pyo3 = { version = "0.24", features = ["extension-module"] }
 numpy = "0.24"
 

--- a/src/rust/piper-wasm/Cargo.toml
+++ b/src/rust/piper-wasm/Cargo.toml
@@ -42,8 +42,8 @@ wasm-bindgen = "0.2"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-piper-plus = { path = "../piper-core", version = "0.2.0", default-features = false }
-piper-plus-g2p = { path = "../piper-plus-g2p", version = "0.2.0", default-features = false }
+piper-plus = { path = "../piper-core", version = "0.3.0", default-features = false }
+piper-plus-g2p = { path = "../piper-plus-g2p", version = "0.3.0", default-features = false }
 web-sys = "0.3"
 console_error_panic_hook = "0.1"
 log = "0.4"

--- a/src/wasm/openjtalk-web/package.json
+++ b/src/wasm/openjtalk-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "piper-plus",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Browser-based multilingual neural TTS with VITS. Supports Japanese, English, Chinese, Korean, Spanish, French, Portuguese, and Swedish.",
   "type": "module",
   "main": "src/index.js",

--- a/src/wasm/openjtalk-web/src/index.js
+++ b/src/wasm/openjtalk-web/src/index.js
@@ -68,7 +68,7 @@ const DEFAULT_SAMPLE_RATE = 22050;
 //
 // Issue #356: MIN_PHONEME_IDS was 40, but tsukuyomi 6lang testing showed
 // synthesis is stable down to ~8 IDs. 40 caused Strategy A to fire on
-// already-stable inputs and leak padding artefacts. 15 keeps Strategy A
+// already-stable inputs and leak padding artifacts. 15 keeps Strategy A
 // active for genuinely tiny inputs only. MIN_BODY_FOR_STRATEGY_A = 3
 // additionally bypasses Strategy A when the body (= phoneme IDs minus
 // BOS/EOS) is too small for padding to outweigh content (e.g. 「あ。」).

--- a/src/wasm/openjtalk-web/src/index.js
+++ b/src/wasm/openjtalk-web/src/index.js
@@ -74,6 +74,11 @@ const DEFAULT_SAMPLE_RATE = 22050;
 // BOS/EOS) is too small for padding to outweigh content (e.g. 「あ。」).
 export const MIN_PHONEME_IDS = 15;
 export const MIN_BODY_FOR_STRATEGY_A = 3;
+// Number of EOS frames retained by the durations-based Strategy A trim.
+// 0 = drop the entire EOS region (issue #356).
+export const TRIM_EOS_MAX_FRAMES = 0;
+// Default hop length when config.json does not declare audio.hop_size.
+export const DEFAULT_HOP_SIZE = 256;
 const TRIM_THRESHOLD_RMS = 0.01;
 const TRIM_MIN_SAMPLES = 2205; // 22050 Hz * 0.1 s
 
@@ -91,18 +96,24 @@ const TRIM_MIN_SAMPLES = 2205; // 22050 Hz * 0.1 s
  * Strategy A is skipped when the body (= phoneme IDs minus BOS / EOS) is
  * shorter than MIN_BODY_FOR_STRATEGY_A — see issue #356.
  *
+ * The returned object now also carries `frontPad` / `backPad` (the number
+ * of pad tokens inserted on each side) so the durations-based post-trim
+ * can locate the padding precisely. Existing callers that only consumed
+ * `phonemeIds` / `prosodyFeatures` / `wasPadded` continue to work
+ * unchanged (object extension, not breaking).
+ *
  * @param {number[]} phonemeIds
  * @param {number[][]|null} prosodyFeatures
- * @returns {{ phonemeIds: number[], prosodyFeatures: number[][]|null, wasPadded: boolean }}
+ * @returns {{ phonemeIds: number[], prosodyFeatures: number[][]|null, wasPadded: boolean, frontPad: number, backPad: number }}
  */
 export function padPhonemeIds(phonemeIds, prosodyFeatures) {
   const n = phonemeIds.length;
   const bodyLen = n - 2; // exclude BOS / EOS
   if (bodyLen < MIN_BODY_FOR_STRATEGY_A) {
-    return { phonemeIds, prosodyFeatures, wasPadded: false };
+    return { phonemeIds, prosodyFeatures, wasPadded: false, frontPad: 0, backPad: 0 };
   }
   if (n >= MIN_PHONEME_IDS) {
-    return { phonemeIds, prosodyFeatures, wasPadded: false };
+    return { phonemeIds, prosodyFeatures, wasPadded: false, frontPad: 0, backPad: 0 };
   }
 
   const padTotal = MIN_PHONEME_IDS - n;
@@ -136,7 +147,82 @@ export function padPhonemeIds(phonemeIds, prosodyFeatures) {
     ];
   }
 
-  return { phonemeIds: padded, prosodyFeatures: paddedProsody, wasPadded: true };
+  return {
+    phonemeIds: padded,
+    prosodyFeatures: paddedProsody,
+    wasPadded: true,
+    frontPad: padFront,
+    backPad: padBack,
+  };
+}
+
+/**
+ * Strategy A precise post-trim using the model's duration output.
+ * Mirrors the Python reference (src/python_run/piper/voice.py
+ * `_trim_padding_by_durations`) so all runtimes produce byte-equal output
+ * for the same inputs (issue #356).
+ *
+ * Padded layout: `[BOS, pad×frontPad, ...body..., pad×backPad, EOS]`.
+ *
+ * Trimming policy:
+ *   - BOS + front padding: stripped completely
+ *   - Back padding: stripped completely
+ *   - EOS: keep only `eosMaxFrames` frames (default 0 — drop the entire EOS)
+ *
+ * All frame→sample conversions use `Math.trunc()` (truncation toward zero),
+ * matching `int()` in Python and `as i64` in Rust. `Math.round()` is *not*
+ * used because it would diverge from the other runtimes.
+ *
+ * @param {Float32Array} audio  Audio samples in the range -1.0 to 1.0
+ * @param {number[]|Float32Array|null} durations  Per-phoneme frame counts
+ * @param {number} frontPad
+ * @param {number} backPad
+ * @param {number} hopSize  VITS hop length (samples per frame)
+ * @param {number} [eosMaxFrames=TRIM_EOS_MAX_FRAMES]
+ * @returns {Float32Array} Trimmed audio (or the original if inputs are inconsistent)
+ */
+export function trimPaddingByDurations(
+  audio,
+  durations,
+  frontPad,
+  backPad,
+  hopSize,
+  eosMaxFrames = TRIM_EOS_MAX_FRAMES,
+) {
+  if (frontPad <= 0 && backPad <= 0) return audio;
+  if (durations == null || hopSize <= 0) return audio;
+  const expectedLen = 1 + frontPad + backPad + 1; // BOS + pads + EOS
+  if (durations.length < expectedLen) return audio;
+
+  // Front: BOS + front padding samples (truncated).
+  let frontSum = 0;
+  for (let i = 0; i < 1 + frontPad; i++) {
+    frontSum += durations[i];
+  }
+  const frontSamples = Math.trunc(frontSum * hopSize);
+
+  // Back: back padding samples + EOS excess (over eosMaxFrames).
+  let backPadSum = 0;
+  if (backPad > 0) {
+    // Equivalent to durations[-(1+backPad) : -1] in Python.
+    const start = durations.length - 1 - backPad;
+    for (let i = start; i < durations.length - 1; i++) {
+      backPadSum += durations[i];
+    }
+  }
+  const backPadSamples = Math.trunc(backPadSum * hopSize);
+  const eosFrames = durations[durations.length - 1];
+  const eosExcess = Math.max(0, eosFrames - eosMaxFrames);
+  const backSamples = backPadSamples + Math.trunc(eosExcess * hopSize);
+
+  const total = audio.length;
+  const start = Math.max(0, frontSamples);
+  let end = total - backSamples;
+  if (end < start) end = start;
+  if (start >= total || end <= 0 || start >= end) return audio;
+
+  // subarray() avoids a copy; subscribers that mutate must already clone.
+  return audio.subarray(start, end);
 }
 
 /**
@@ -327,6 +413,8 @@ export class PiperPlus {
     phonemeIds = padResult.phonemeIds;
     prosodyFeatures = padResult.prosodyFeatures;
     const wasPadded = padResult.wasPadded;
+    const frontPad = padResult.frontPad;
+    const backPad = padResult.backPad;
 
     // 2. ONNX inference
     const inferResult = await this._infer(phonemeIds, prosodyFeatures, {
@@ -338,9 +426,22 @@ export class PiperPlus {
     let audioData = inferResult.audio;
     const durations = inferResult.durations;
 
-    // --- Strategy A (post-step): Trim silence introduced by padding ---
+    // --- Strategy A (post-step): Trim padding-induced audio ---
+    // Prefer the durations-based precise trim (issue #356); fall back to
+    // the legacy RMS trim only when durations are unavailable.
     if (wasPadded) {
-      audioData = trimSilence(audioData);
+      if (durations != null) {
+        const hopSize = this._config.audio?.hop_size ?? DEFAULT_HOP_SIZE;
+        audioData = trimPaddingByDurations(
+          audioData,
+          durations,
+          frontPad,
+          backPad,
+          hopSize > 0 ? hopSize : DEFAULT_HOP_SIZE,
+        );
+      } else {
+        audioData = trimSilence(audioData);
+      }
     }
 
     // 3. Wrap result — include phoneme timing when the model supports it

--- a/src/wasm/openjtalk-web/src/index.js
+++ b/src/wasm/openjtalk-web/src/index.js
@@ -63,8 +63,17 @@ const DEFAULT_LENGTH_SCALE = 1.0;
 const DEFAULT_NOISE_W = 0.8;
 const DEFAULT_SAMPLE_RATE = 22050;
 
-// Short-text mitigation constants (keep in sync with other runtimes)
-const MIN_PHONEME_IDS = 40;
+// Short-text mitigation constants (keep in sync with other runtimes —
+// docs/spec/short-text-contract.toml).
+//
+// Issue #356: MIN_PHONEME_IDS was 40, but tsukuyomi 6lang testing showed
+// synthesis is stable down to ~8 IDs. 40 caused Strategy A to fire on
+// already-stable inputs and leak padding artefacts. 15 keeps Strategy A
+// active for genuinely tiny inputs only. MIN_BODY_FOR_STRATEGY_A = 3
+// additionally bypasses Strategy A when the body (= phoneme IDs minus
+// BOS/EOS) is too small for padding to outweigh content (e.g. 「あ。」).
+export const MIN_PHONEME_IDS = 15;
+export const MIN_BODY_FOR_STRATEGY_A = 3;
 const TRIM_THRESHOLD_RMS = 0.01;
 const TRIM_MIN_SAMPLES = 2205; // 22050 Hz * 0.1 s
 
@@ -79,12 +88,19 @@ const TRIM_MIN_SAMPLES = 2205; // 22050 Hz * 0.1 s
  * sequence reaches MIN_PHONEME_IDS length.  Also pads prosodyFeatures with
  * zero triplets at matching positions when present.
  *
+ * Strategy A is skipped when the body (= phoneme IDs minus BOS / EOS) is
+ * shorter than MIN_BODY_FOR_STRATEGY_A — see issue #356.
+ *
  * @param {number[]} phonemeIds
  * @param {number[][]|null} prosodyFeatures
  * @returns {{ phonemeIds: number[], prosodyFeatures: number[][]|null, wasPadded: boolean }}
  */
 export function padPhonemeIds(phonemeIds, prosodyFeatures) {
   const n = phonemeIds.length;
+  const bodyLen = n - 2; // exclude BOS / EOS
+  if (bodyLen < MIN_BODY_FOR_STRATEGY_A) {
+    return { phonemeIds, prosodyFeatures, wasPadded: false };
+  }
   if (n >= MIN_PHONEME_IDS) {
     return { phonemeIds, prosodyFeatures, wasPadded: false };
   }

--- a/src/wasm/openjtalk-web/test/js/test-short-text-mitigation.js
+++ b/src/wasm/openjtalk-web/test/js/test-short-text-mitigation.js
@@ -21,7 +21,8 @@ import assert from 'node:assert/strict';
 // ---------------------------------------------------------------------------
 
 let PiperPlus, AudioResult, padPhonemeIds, trimSilence, adjustScalesForShortInput;
-let MIN_PHONEME_IDS, MIN_BODY_FOR_STRATEGY_A;
+let trimPaddingByDurations;
+let MIN_PHONEME_IDS, MIN_BODY_FOR_STRATEGY_A, TRIM_EOS_MAX_FRAMES, DEFAULT_HOP_SIZE;
 let importError = null;
 
 try {
@@ -30,9 +31,12 @@ try {
   AudioResult = mod.AudioResult;
   padPhonemeIds = mod.padPhonemeIds;
   trimSilence = mod.trimSilence;
+  trimPaddingByDurations = mod.trimPaddingByDurations;
   adjustScalesForShortInput = mod.adjustScalesForShortInput;
   MIN_PHONEME_IDS = mod.MIN_PHONEME_IDS;
   MIN_BODY_FOR_STRATEGY_A = mod.MIN_BODY_FOR_STRATEGY_A;
+  TRIM_EOS_MAX_FRAMES = mod.TRIM_EOS_MAX_FRAMES;
+  DEFAULT_HOP_SIZE = mod.DEFAULT_HOP_SIZE;
 } catch (e) {
   importError = e;
 }
@@ -272,6 +276,121 @@ describe('padPhonemeIds (Strategy A - padding)', { skip }, () => {
       assert.equal(allPad[i][0], 0,
         `mutating padding[0] should not affect padding[${i}]`);
     }
+  });
+
+  it('exposes frontPad and backPad on the result (issue #356)', () => {
+    // body must be >= MIN_BODY_FOR_STRATEGY_A so Strategy A applies.
+    const ids = [1, ...new Array(MIN_BODY_FOR_STRATEGY_A).fill(4), 2];
+    const result = padPhonemeIds(ids, null);
+    assert.equal(result.wasPadded, true);
+    assert.equal(typeof result.frontPad, 'number');
+    assert.equal(typeof result.backPad, 'number');
+    const total = MIN_PHONEME_IDS - ids.length;
+    assert.equal(result.frontPad + result.backPad, total);
+  });
+
+  it('reports frontPad=0 / backPad=0 when no padding was applied', () => {
+    // body < MIN_BODY_FOR_STRATEGY_A → skipped.
+    const skipResult = padPhonemeIds([1, 2], null);
+    assert.equal(skipResult.wasPadded, false);
+    assert.equal(skipResult.frontPad, 0);
+    assert.equal(skipResult.backPad, 0);
+
+    // length >= MIN_PHONEME_IDS → no padding needed.
+    const longIds = makeIds(MIN_PHONEME_IDS);
+    const longResult = padPhonemeIds(longIds, null);
+    assert.equal(longResult.wasPadded, false);
+    assert.equal(longResult.frontPad, 0);
+    assert.equal(longResult.backPad, 0);
+  });
+});
+
+
+// ===========================================================================
+// trimPaddingByDurations (precise post-trim, issue #356)
+// ===========================================================================
+// Mirrors src/python_run/tests/test_short_text_mitigation.py.
+
+describe('trimPaddingByDurations (Strategy A - precise post-trim)', { skip }, () => {
+  it('is a no-op when no padding was applied', () => {
+    const audio = Float32Array.from({ length: 1000 }, (_, i) => i / 1000);
+    const durations = new Float32Array([1, 1, 1, 1, 1]);
+    const result = trimPaddingByDurations(audio, durations, 0, 0, 256);
+    assert.equal(result.length, audio.length);
+  });
+
+  it('trims front padding only', () => {
+    // Layout: BOS=2, pad×3 (3+3+3), body=4, EOS=1 → 19 frames total
+    const durations = new Float32Array([2, 3, 3, 3, 4, 1]);
+    const hop = 100;
+    const total = 1900;
+    const audio = new Float32Array(total);
+    const result = trimPaddingByDurations(audio, durations, 3, 0, hop, 6);
+    // BOS + front padding = (2+3+3+3)*100 = 1100
+    assert.equal(result.length, total - 1100);
+  });
+
+  it('strips the entire EOS region by default', () => {
+    const durations = new Float32Array([2, 5, 5, 4, 4, 5, 5, 8]);
+    const hop = 100;
+    const total = 3800;
+    const audio = new Float32Array(total);
+    const result = trimPaddingByDurations(audio, durations, 2, 2, hop);
+    // BOS + front padding = (2+5+5)*100 = 1200
+    // back padding + entire EOS = (5+5+8)*100 = 1800
+    assert.equal(result.length, total - 1200 - 1800);
+  });
+
+  it('clamps an inflated EOS to eosMaxFrames', () => {
+    const durations = new Float32Array([2, 3, 3, 4, 3, 3, 10]);
+    const hop = 100;
+    const total = 2800;
+    const audio = new Float32Array(total);
+    const result = trimPaddingByDurations(audio, durations, 2, 2, hop, 6);
+    // BOS + front padding = (2+3+3)*100 = 800
+    // back padding + EOS excess = (3+3 + (10-6))*100 = 1000
+    assert.equal(result.length, total - 800 - 1000);
+  });
+
+  it('returns the input unchanged when durations is null', () => {
+    const audio = new Float32Array(1000);
+    const result = trimPaddingByDurations(audio, null, 3, 3, 256);
+    assert.equal(result.length, audio.length);
+  });
+
+  it('returns the input unchanged when durations is too short', () => {
+    const audio = new Float32Array(1000);
+    const durations = new Float32Array([1, 1, 1]);
+    const result = trimPaddingByDurations(audio, durations, 5, 5, 256);
+    assert.equal(result.length, audio.length);
+  });
+
+  it('returns the input unchanged when hopSize is zero', () => {
+    const audio = new Float32Array(1000);
+    const durations = new Float32Array(8).fill(1);
+    const result = trimPaddingByDurations(audio, durations, 2, 2, 0);
+    assert.equal(result.length, audio.length);
+  });
+
+  it('uses Math.trunc (matches int() / `as i64` in other runtimes)', () => {
+    // Layout (frontPad=1, backPad=1, body=3):
+    //   [BOS=0.701, pad=0.701, body=2, body=2, body=2, pad=0.703, EOS=0.701]
+    // Front trim = trunc((0.701+0.701)*100) = 140
+    // Back trim  = trunc(0.703*100) + trunc(0.701*100) = 70+70 = 140
+    // Math.round() would diverge → cross-runtime drift.
+    const durations = new Float32Array([0.701, 0.701, 2, 2, 2, 0.703, 0.701]);
+    const hop = 100;
+    let sum = 0;
+    for (const d of durations) sum += d;
+    const total = Math.trunc(sum * hop);
+    const audio = new Float32Array(total);
+    const result = trimPaddingByDurations(audio, durations, 1, 1, hop);
+    assert.equal(result.length, total - 140 - 140);
+  });
+
+  it('exposes TRIM_EOS_MAX_FRAMES = 0 and DEFAULT_HOP_SIZE = 256', () => {
+    assert.equal(TRIM_EOS_MAX_FRAMES, 0);
+    assert.equal(DEFAULT_HOP_SIZE, 256);
   });
 });
 

--- a/src/wasm/openjtalk-web/test/js/test-short-text-mitigation.js
+++ b/src/wasm/openjtalk-web/test/js/test-short-text-mitigation.js
@@ -21,6 +21,7 @@ import assert from 'node:assert/strict';
 // ---------------------------------------------------------------------------
 
 let PiperPlus, AudioResult, padPhonemeIds, trimSilence, adjustScalesForShortInput;
+let MIN_PHONEME_IDS, MIN_BODY_FOR_STRATEGY_A;
 let importError = null;
 
 try {
@@ -30,6 +31,8 @@ try {
   padPhonemeIds = mod.padPhonemeIds;
   trimSilence = mod.trimSilence;
   adjustScalesForShortInput = mod.adjustScalesForShortInput;
+  MIN_PHONEME_IDS = mod.MIN_PHONEME_IDS;
+  MIN_BODY_FOR_STRATEGY_A = mod.MIN_BODY_FOR_STRATEGY_A;
 } catch (e) {
   importError = e;
 }
@@ -93,11 +96,20 @@ function createMockInstance(overrides = {}) {
 // padPhonemeIds
 // ===========================================================================
 
+// Helper: build [BOS, body..., EOS] of a target total length, with body
+// large enough for Strategy A to apply (body >= MIN_BODY_FOR_STRATEGY_A).
+function makeIds(total) {
+  const out = [1];
+  for (let i = 0; i < total - 2; i++) {
+    out.push(4);
+  }
+  out.push(2);
+  return out;
+}
+
 describe('padPhonemeIds (Strategy A - padding)', { skip }, () => {
   it('does not pad when phonemeIds length >= MIN_PHONEME_IDS', () => {
-    const ids = new Array(40).fill(4);
-    ids[0] = 1; // BOS
-    ids[39] = 2; // EOS
+    const ids = makeIds(MIN_PHONEME_IDS);
     const result = padPhonemeIds(ids, null);
 
     assert.equal(result.wasPadded, false);
@@ -106,33 +118,31 @@ describe('padPhonemeIds (Strategy A - padding)', { skip }, () => {
   });
 
   it('does not pad when phonemeIds length > MIN_PHONEME_IDS', () => {
-    const ids = new Array(50).fill(4);
-    ids[0] = 1;
-    ids[49] = 2;
+    const ids = makeIds(MIN_PHONEME_IDS + 10);
     const result = padPhonemeIds(ids, null);
 
     assert.equal(result.wasPadded, false);
-    assert.equal(result.phonemeIds.length, 50);
+    assert.equal(result.phonemeIds.length, MIN_PHONEME_IDS + 10);
   });
 
-  it('pads short sequences to MIN_PHONEME_IDS (40)', () => {
-    // [BOS, a, a, a, EOS] = 5 elements, needs 35 padding
-    const ids = [1, 4, 4, 4, 2];
+  it('pads short sequences to MIN_PHONEME_IDS', () => {
+    // body must be >= MIN_BODY_FOR_STRATEGY_A.
+    const ids = makeIds(2 + MIN_BODY_FOR_STRATEGY_A);
     const result = padPhonemeIds(ids, null);
 
     assert.equal(result.wasPadded, true);
-    assert.equal(result.phonemeIds.length, 40);
+    assert.equal(result.phonemeIds.length, MIN_PHONEME_IDS);
   });
 
   it('preserves BOS as first element after padding', () => {
-    const ids = [1, 4, 4, 2];
+    const ids = makeIds(2 + MIN_BODY_FOR_STRATEGY_A);
     const result = padPhonemeIds(ids, null);
 
     assert.equal(result.phonemeIds[0], 1, 'first element should be BOS');
   });
 
   it('preserves EOS as last element after padding', () => {
-    const ids = [1, 4, 4, 2];
+    const ids = makeIds(2 + MIN_BODY_FOR_STRATEGY_A);
     const result = padPhonemeIds(ids, null);
 
     assert.equal(result.phonemeIds[result.phonemeIds.length - 1], 2,
@@ -140,86 +150,112 @@ describe('padPhonemeIds (Strategy A - padding)', { skip }, () => {
   });
 
   it('inserts pause tokens (ID=0) for padding', () => {
-    const ids = [1, 4, 2]; // 3 elements, needs 37 padding
+    // body=3, so deficit = MIN_PHONEME_IDS - 5.
+    const ids = makeIds(2 + MIN_BODY_FOR_STRATEGY_A);
+    const expectedPads = MIN_PHONEME_IDS - ids.length;
     const result = padPhonemeIds(ids, null);
 
-    // Count zeros (excluding any that were already there)
     const zeros = result.phonemeIds.filter(id => id === 0).length;
-    assert.equal(zeros, 37, 'should have 37 pause tokens inserted');
+    assert.equal(zeros, expectedPads, `should have ${expectedPads} pause tokens inserted`);
   });
 
   it('distributes padding evenly: front gets floor, back gets remainder', () => {
-    // 5 elements -> need 35 padding -> front=17, back=18
-    const ids = [1, 10, 11, 12, 2];
+    const ids = [1, 10, 11, 12, 2]; // body=3
+    const total = MIN_PHONEME_IDS - ids.length;
+    const front = Math.floor(total / 2);
+    const back = total - front;
     const result = padPhonemeIds(ids, null);
 
-    // After BOS (index 0), next 17 should be padding zeros
-    for (let i = 1; i <= 17; i++) {
+    // After BOS, `front` zeros, then body, then `back` zeros, then EOS.
+    for (let i = 1; i <= front; i++) {
       assert.equal(result.phonemeIds[i], 0, `index ${i} should be pad`);
     }
-    // Then body: 10, 11, 12
-    assert.equal(result.phonemeIds[18], 10);
-    assert.equal(result.phonemeIds[19], 11);
-    assert.equal(result.phonemeIds[20], 12);
-    // Then 18 padding zeros
-    for (let i = 21; i <= 38; i++) {
+    assert.equal(result.phonemeIds[1 + front], 10);
+    assert.equal(result.phonemeIds[1 + front + 1], 11);
+    assert.equal(result.phonemeIds[1 + front + 2], 12);
+    for (let i = 1 + front + 3; i < MIN_PHONEME_IDS - 1; i++) {
       assert.equal(result.phonemeIds[i], 0, `index ${i} should be pad`);
     }
-    // Then EOS
-    assert.equal(result.phonemeIds[39], 2);
+    assert.equal(result.phonemeIds[MIN_PHONEME_IDS - 1], 2);
+    assert.equal(result.phonemeIds.length, MIN_PHONEME_IDS);
+    // Distribution split is balanced.
+    assert.ok(Math.abs(front - back) <= 1);
   });
 
   it('pads prosodyFeatures in parallel when present', () => {
-    const ids = [1, 4, 4, 2]; // 4 elements -> 36 padding (18 front, 18 back)
-    const prosody = [[0, 0, 0], [1, 2, 3], [4, 5, 6], [0, 0, 0]];
+    // body must be >= MIN_BODY_FOR_STRATEGY_A.
+    const bodySize = MIN_BODY_FOR_STRATEGY_A;
+    const ids = [1, ...new Array(bodySize).fill(4), 2];
+    const prosody = [[0, 0, 0], ...new Array(bodySize).fill(null).map((_, i) => [i, i + 1, i + 2]), [0, 0, 0]];
     const result = padPhonemeIds(ids, prosody);
 
     assert.equal(result.wasPadded, true);
-    assert.equal(result.prosodyFeatures.length, 40);
+    assert.equal(result.prosodyFeatures.length, MIN_PHONEME_IDS);
     // BOS prosody preserved
     assert.deepEqual(result.prosodyFeatures[0], [0, 0, 0]);
     // Padding prosody should be zero triplets
     assert.deepEqual(result.prosodyFeatures[1], [0, 0, 0]);
     // EOS prosody preserved
-    assert.deepEqual(result.prosodyFeatures[39], [0, 0, 0]);
+    assert.deepEqual(result.prosodyFeatures[MIN_PHONEME_IDS - 1], [0, 0, 0]);
   });
 
   it('returns null prosodyFeatures when input prosody is null', () => {
-    const ids = [1, 4, 2];
+    // body must be >= MIN_BODY_FOR_STRATEGY_A.
+    const ids = [1, ...new Array(MIN_BODY_FOR_STRATEGY_A).fill(4), 2];
     const result = padPhonemeIds(ids, null);
 
     assert.equal(result.wasPadded, true);
     assert.equal(result.prosodyFeatures, null);
   });
 
-  it('handles minimum input (2 elements: BOS + EOS)', () => {
-    const ids = [1, 2];
-    const result = padPhonemeIds(ids, null);
-
-    assert.equal(result.wasPadded, true);
-    assert.equal(result.phonemeIds.length, 40);
-    assert.equal(result.phonemeIds[0], 1);
-    assert.equal(result.phonemeIds[39], 2);
+  it('skips Strategy A when body is too short', () => {
+    // body=0 (BOS+EOS only)
+    {
+      const ids = [1, 2];
+      const result = padPhonemeIds(ids, null);
+      assert.equal(result.wasPadded, false);
+      assert.deepEqual(result.phonemeIds, ids);
+    }
+    // body=1
+    {
+      const ids = [1, 4, 2];
+      const result = padPhonemeIds(ids, null);
+      assert.equal(result.wasPadded, false);
+      assert.deepEqual(result.phonemeIds, ids);
+    }
+    // body=2 (e.g. "あ。" case)
+    if (MIN_BODY_FOR_STRATEGY_A > 2) {
+      const ids = [1, 4, 5, 2];
+      const result = padPhonemeIds(ids, null);
+      assert.equal(result.wasPadded, false);
+      assert.deepEqual(result.phonemeIds, ids);
+    }
   });
 
   it('handles input of length exactly MIN_PHONEME_IDS - 1', () => {
-    const ids = new Array(39).fill(4);
-    ids[0] = 1;
-    ids[38] = 2;
+    const ids = makeIds(MIN_PHONEME_IDS - 1);
     const result = padPhonemeIds(ids, null);
 
     assert.equal(result.wasPadded, true);
-    assert.equal(result.phonemeIds.length, 40);
+    assert.equal(result.phonemeIds.length, MIN_PHONEME_IDS);
   });
 
   it('padding prosody arrays are independent references (not shared)', () => {
-    const ids = [1, 4, 4, 2]; // 4 elements -> 36 padding (18 front, 18 back)
-    const prosody = [[0, 0, 0], [1, 2, 3], [4, 5, 6], [0, 0, 0]];
+    const bodySize = MIN_BODY_FOR_STRATEGY_A;
+    const ids = [1, ...new Array(bodySize).fill(4), 2];
+    const prosody = [[0, 0, 0], ...new Array(bodySize).fill(null).map((_, i) => [i, i + 1, i + 2]), [0, 0, 0]];
     const result = padPhonemeIds(ids, prosody);
+    assert.equal(result.wasPadded, true);
 
-    // Collect all padding prosody entries (front padding: indices 1..18, back: 21..38)
-    const frontPad = result.prosodyFeatures.slice(1, 19);
-    const backPad = result.prosodyFeatures.slice(21, 39);
+    // Total deficit = MIN_PHONEME_IDS - ids.length, split front/back.
+    const total = MIN_PHONEME_IDS - ids.length;
+    const front = Math.floor(total / 2);
+    const back = total - front;
+
+    // Front padding: indices [1, 1+front), back padding: indices
+    // [1+front+bodySize, 1+front+bodySize+back).
+    const frontPad = result.prosodyFeatures.slice(1, 1 + front);
+    const backPad = result.prosodyFeatures.slice(1 + front + bodySize, 1 + front + bodySize + back);
     const allPad = [...frontPad, ...backPad];
 
     // Every padding entry must be a distinct array reference
@@ -352,42 +388,45 @@ describe('trimSilence (Strategy A - post-trim)', { skip }, () => {
 
 describe('adjustScalesForShortInput (Strategy B)', { skip }, () => {
   it('does not adjust when phonemeCount >= MIN_PHONEME_IDS', () => {
-    const result = adjustScalesForShortInput(40, 0.667, 0.8);
+    const result = adjustScalesForShortInput(MIN_PHONEME_IDS, 0.667, 0.8);
 
     assert.equal(result.noiseScale, 0.667);
     assert.equal(result.noiseW, 0.8);
   });
 
   it('does not adjust when phonemeCount > MIN_PHONEME_IDS', () => {
-    const result = adjustScalesForShortInput(100, 0.667, 0.8);
+    const result = adjustScalesForShortInput(MIN_PHONEME_IDS + 50, 0.667, 0.8);
 
     assert.equal(result.noiseScale, 0.667);
     assert.equal(result.noiseW, 0.8);
   });
 
   it('reduces noiseScale for short input', () => {
-    // 20 phonemes -> ratio = 20/40 = 0.5, max(0.5, 0.5) = 0.5
-    const result = adjustScalesForShortInput(20, 0.667, 0.8);
+    // Half of MIN_PHONEME_IDS — both ratios clamp to their floors at this point.
+    const len = Math.floor(MIN_PHONEME_IDS / 2);
+    const result = adjustScalesForShortInput(len, 0.667, 0.8);
+    const ratio = len / MIN_PHONEME_IDS;
+    const expected = 0.667 * Math.max(0.5, ratio);
 
     assert.ok(result.noiseScale < 0.667, 'noiseScale should be reduced');
-    const expected = 0.667 * 0.5;
     assert.ok(Math.abs(result.noiseScale - expected) < 1e-6,
       `noiseScale should be ${expected}, got ${result.noiseScale}`);
   });
 
   it('reduces noiseW for short input', () => {
-    // 20 phonemes -> ratio = 0.5, max(0.4, 0.5) = 0.5
-    const result = adjustScalesForShortInput(20, 0.667, 0.8);
+    const len = Math.floor(MIN_PHONEME_IDS / 2);
+    const result = adjustScalesForShortInput(len, 0.667, 0.8);
+    const ratio = len / MIN_PHONEME_IDS;
+    const expected = 0.8 * Math.max(0.4, ratio);
 
     assert.ok(result.noiseW < 0.8, 'noiseW should be reduced');
-    const expected = 0.8 * 0.5;
     assert.ok(Math.abs(result.noiseW - expected) < 1e-6,
       `noiseW should be ${expected}, got ${result.noiseW}`);
   });
 
   it('clamps noiseScale multiplier at 0.5 for very short input', () => {
-    // 5 phonemes -> ratio = 5/40 = 0.125, max(0.5, 0.125) = 0.5
-    const result = adjustScalesForShortInput(5, 0.667, 0.8);
+    // 1 phoneme — far below the noiseScale floor (0.5).
+    const result = adjustScalesForShortInput(1, 0.667, 0.8);
 
     const expected = 0.667 * 0.5;
     assert.ok(Math.abs(result.noiseScale - expected) < 1e-6,
@@ -395,8 +434,8 @@ describe('adjustScalesForShortInput (Strategy B)', { skip }, () => {
   });
 
   it('clamps noiseW multiplier at 0.4 for very short input', () => {
-    // 5 phonemes -> ratio = 0.125, max(0.4, 0.125) = 0.4
-    const result = adjustScalesForShortInput(5, 0.667, 0.8);
+    // 1 phoneme — far below the noiseW floor (0.4).
+    const result = adjustScalesForShortInput(1, 0.667, 0.8);
 
     const expected = 0.8 * 0.4;
     assert.ok(Math.abs(result.noiseW - expected) < 1e-6,
@@ -412,20 +451,25 @@ describe('adjustScalesForShortInput (Strategy B)', { skip }, () => {
   });
 
   it('applies linear scaling in the mid-range', () => {
-    // 30 phonemes -> ratio = 30/40 = 0.75
-    const result = adjustScalesForShortInput(30, 1.0, 1.0);
+    // Pick a length between both floors and the threshold so the ratio is used directly.
+    const len = MIN_PHONEME_IDS - 1;
+    const result = adjustScalesForShortInput(len, 1.0, 1.0);
+    const ratio = len / MIN_PHONEME_IDS;
+    const expectedNs = Math.max(0.5, ratio);
+    const expectedNw = Math.max(0.4, ratio);
 
-    assert.ok(Math.abs(result.noiseScale - 0.75) < 1e-6,
-      `expected 0.75, got ${result.noiseScale}`);
-    assert.ok(Math.abs(result.noiseW - 0.75) < 1e-6,
-      `expected 0.75, got ${result.noiseW}`);
+    assert.ok(Math.abs(result.noiseScale - expectedNs) < 1e-6,
+      `expected ${expectedNs}, got ${result.noiseScale}`);
+    assert.ok(Math.abs(result.noiseW - expectedNw) < 1e-6,
+      `expected ${expectedNw}, got ${result.noiseW}`);
   });
 
   it('handles ratio exactly at the clamp boundary for noiseW', () => {
-    // ratio = 0.4 -> phonemes = 0.4 * 40 = 16
-    const result = adjustScalesForShortInput(16, 1.0, 1.0);
+    // Choose len so ratio == 0.4 (or as close as integer math allows).
+    const len = Math.max(1, Math.round(0.4 * MIN_PHONEME_IDS));
+    const result = adjustScalesForShortInput(len, 1.0, 1.0);
 
-    const ratio = 16 / 40;
+    const ratio = len / MIN_PHONEME_IDS;
     assert.ok(Math.abs(result.noiseScale - Math.max(0.5, ratio)) < 1e-6);
     assert.ok(Math.abs(result.noiseW - Math.max(0.4, ratio)) < 1e-6);
   });
@@ -439,9 +483,10 @@ describe('adjustScalesForShortInput (Strategy B)', { skip }, () => {
 describe('synthesize() short-text mitigation integration', { skip }, () => {
   it('applies padding and scale adjustment for short phonemeIds', async () => {
     let capturedFeeds = null;
-    // Return 5 phoneme IDs (well below MIN_PHONEME_IDS=40)
+    // body must be >= MIN_BODY_FOR_STRATEGY_A but length < MIN_PHONEME_IDS.
+    const phonemeIds = [1, ...new Array(MIN_BODY_FOR_STRATEGY_A).fill(4), 2];
     const instance = createMockInstance({
-      phonemeIds: [1, 4, 4, 4, 2],
+      phonemeIds,
       sessionRun: async (feeds) => {
         capturedFeeds = feeds;
         return { output: { data: new Float32Array(5000), dims: [1, 5000] } };
@@ -450,28 +495,26 @@ describe('synthesize() short-text mitigation integration', { skip }, () => {
 
     await instance.synthesize('hi');
 
-    // Strategy A: phonemeIds should be padded to 40
+    // Strategy A: padded to MIN_PHONEME_IDS
     const inputIds = Array.from(capturedFeeds.input.data).map(Number);
-    assert.equal(inputIds.length, 40, 'padded phonemeIds should be 40');
+    assert.equal(inputIds.length, MIN_PHONEME_IDS, `padded phonemeIds should be ${MIN_PHONEME_IDS}`);
     assert.equal(inputIds[0], 1, 'BOS preserved');
-    assert.equal(inputIds[39], 2, 'EOS preserved');
+    assert.equal(inputIds[MIN_PHONEME_IDS - 1], 2, 'EOS preserved');
 
-    // Strategy B: noiseScale and noiseW should be adjusted
+    // Strategy B: noiseScale and noiseW should be adjusted (ratio < 1).
     const scales = Array.from(capturedFeeds.scales.data);
-    // Original noiseScale = 0.667, ratio = 5/40 = 0.125, clamp 0.5
-    // adjusted = 0.667 * 0.5 = 0.3335
     assert.ok(scales[0] < 0.667, `noiseScale should be reduced: ${scales[0]}`);
     // lengthScale should be unchanged
     assert.ok(Math.abs(scales[1] - 1.0) < 1e-6, 'lengthScale unchanged');
-    // noiseW should be adjusted: 0.8 * 0.4 = 0.32
     assert.ok(scales[2] < 0.8, `noiseW should be reduced: ${scales[2]}`);
   });
 
   it('does NOT pad or adjust scales for long phonemeIds', async () => {
     let capturedFeeds = null;
-    const longIds = new Array(50).fill(4);
+    const longLen = MIN_PHONEME_IDS + 10;
+    const longIds = new Array(longLen).fill(4);
     longIds[0] = 1;
-    longIds[49] = 2;
+    longIds[longLen - 1] = 2;
 
     const instance = createMockInstance({
       encode: () => ({ phonemeIds: longIds, prosodyFeatures: null }),
@@ -484,7 +527,7 @@ describe('synthesize() short-text mitigation integration', { skip }, () => {
     await instance.synthesize('a long enough sentence with many phonemes');
 
     const inputIds = Array.from(capturedFeeds.input.data).map(Number);
-    assert.equal(inputIds.length, 50, 'should NOT be padded');
+    assert.equal(inputIds.length, longLen, 'should NOT be padded');
 
     const scales = Array.from(capturedFeeds.scales.data);
     assert.ok(Math.abs(scales[0] - 0.667) < 1e-6, 'noiseScale unchanged');
@@ -500,7 +543,8 @@ describe('synthesize() short-text mitigation integration', { skip }, () => {
     }
 
     const instance = createMockInstance({
-      phonemeIds: [1, 4, 2], // very short, triggers padding
+      // body must be >= MIN_BODY_FOR_STRATEGY_A so Strategy A applies.
+      phonemeIds: [1, ...new Array(MIN_BODY_FOR_STRATEGY_A).fill(4), 2],
       sessionRun: async () => ({
         output: { data: audio, dims: [1, audio.length] },
       }),
@@ -522,9 +566,10 @@ describe('synthesize() short-text mitigation integration', { skip }, () => {
       audio[i] = 0.5;
     }
 
-    const longIds = new Array(45).fill(4);
+    const longLen = MIN_PHONEME_IDS + 5;
+    const longIds = new Array(longLen).fill(4);
     longIds[0] = 1;
-    longIds[44] = 2;
+    longIds[longLen - 1] = 2;
 
     const instance = createMockInstance({
       encode: () => ({ phonemeIds: longIds, prosodyFeatures: null }),
@@ -547,7 +592,8 @@ describe('synthesize() short-text mitigation integration', { skip }, () => {
         inference: { noise_scale: 0.667, length_scale: 1.0, noise_w: 0.8 },
         phoneme_id_map: { _: [0] },
       },
-      phonemeIds: [1, 4, 2],
+      // body must be >= MIN_BODY_FOR_STRATEGY_A so the path exercises padding too.
+      phonemeIds: [1, ...new Array(MIN_BODY_FOR_STRATEGY_A).fill(4), 2],
     });
 
     const result = await instance.synthesize('hi');
@@ -558,10 +604,10 @@ describe('synthesize() short-text mitigation integration', { skip }, () => {
 
   it('passes prosody features through padding correctly', async () => {
     let capturedFeeds = null;
+    const bodySize = MIN_BODY_FOR_STRATEGY_A;
     const prosody = [
       [0, 0, 0], // BOS
-      [1, 2, 3],
-      [4, 5, 6],
+      ...new Array(bodySize).fill(null).map((_, i) => [i + 1, i + 2, i + 3]),
       [0, 0, 0], // EOS
     ];
 
@@ -573,7 +619,7 @@ describe('synthesize() short-text mitigation integration', { skip }, () => {
         prosody_id_map: { a1: 0, a2: 1, a3: 2 },
       },
       encode: () => ({
-        phonemeIds: [1, 4, 4, 2],
+        phonemeIds: [1, ...new Array(bodySize).fill(4), 2],
         prosodyFeatures: prosody,
       }),
       sessionRun: async (feeds) => {
@@ -586,14 +632,16 @@ describe('synthesize() short-text mitigation integration', { skip }, () => {
 
     // prosody_features tensor should exist and match padded length
     assert.ok(capturedFeeds.prosody_features, 'prosody_features tensor should exist');
-    // Padded to 40 phonemes, each with 3 features
-    assert.deepEqual(capturedFeeds.prosody_features.dims, [1, 40, 3]);
+    // Padded to MIN_PHONEME_IDS phonemes, each with 3 features
+    assert.deepEqual(capturedFeeds.prosody_features.dims, [1, MIN_PHONEME_IDS, 3]);
   });
 
   it('Strategy B uses original phoneme count (before padding) for ratio', async () => {
     let capturedFeeds = null;
-    // 10 phoneme IDs -> ratio = 10/40 = 0.25, clamped to 0.5 for noise, 0.4 for noiseW
-    const ids = [1, 4, 4, 4, 4, 4, 4, 4, 4, 2];
+    // Pick a length so ratio is below the noise_scale floor (0.5).
+    const len = Math.max(2 + MIN_BODY_FOR_STRATEGY_A,
+                         Math.floor(MIN_PHONEME_IDS / 2) + 1);
+    const ids = [1, ...new Array(len - 2).fill(4), 2];
 
     const instance = createMockInstance({
       phonemeIds: ids,
@@ -606,12 +654,11 @@ describe('synthesize() short-text mitigation integration', { skip }, () => {
     await instance.synthesize('test');
 
     const scales = Array.from(capturedFeeds.scales.data);
-    // noiseScale: 0.667 * max(0.5, 10/40) = 0.667 * 0.5 = 0.3335
-    const expectedNoise = 0.667 * 0.5;
+    const ratio = ids.length / MIN_PHONEME_IDS;
+    const expectedNoise = 0.667 * Math.max(0.5, ratio);
+    const expectedNoiseW = 0.8 * Math.max(0.4, ratio);
     assert.ok(Math.abs(scales[0] - expectedNoise) < 1e-4,
       `noiseScale: expected ~${expectedNoise}, got ${scales[0]}`);
-    // noiseW: 0.8 * max(0.4, 10/40) = 0.8 * 0.4 = 0.32
-    const expectedNoiseW = 0.8 * 0.4;
     assert.ok(Math.abs(scales[2] - expectedNoiseW) < 1e-4,
       `noiseW: expected ~${expectedNoiseW}, got ${scales[2]}`);
   });

--- a/src/wasm/openjtalk-web/types/index.d.ts
+++ b/src/wasm/openjtalk-web/types/index.d.ts
@@ -100,10 +100,37 @@ export interface StreamingSynthesizeOptions extends SynthesizeOptions {
 // ---------------------------------------------------------------------------
 
 /**
+ * Minimum phoneme ID count below which Strategy A padding is applied.
+ * See docs/spec/short-text-contract.toml.
+ */
+export const MIN_PHONEME_IDS: number;
+
+/**
+ * Minimum body length (= phoneme IDs minus BOS/EOS) for Strategy A to
+ * apply. Below this threshold pad-token audio dominates the actual
+ * content (issue #356); the runtime emits raw VITS output instead.
+ */
+export const MIN_BODY_FOR_STRATEGY_A: number;
+
+/**
+ * Number of EOS frames retained by `trimPaddingByDurations`. Defaults
+ * to 0 (drop the entire EOS) — see issue #356.
+ */
+export const TRIM_EOS_MAX_FRAMES: number;
+
+/**
+ * Default hop length when `config.json` does not declare
+ * `audio.hop_size`. Used by `trimPaddingByDurations`.
+ */
+export const DEFAULT_HOP_SIZE: number;
+
+/**
  * Strategy A: Pad short phoneme ID sequences with silence tokens.
  *
- * Inserts pause tokens (ID = 0) evenly after BOS and before EOS until the
- * sequence reaches MIN_PHONEME_IDS (40) length.
+ * Inserts pause tokens (ID = 0) evenly after BOS and before EOS until
+ * the sequence reaches MIN_PHONEME_IDS length. The result also carries
+ * `frontPad` and `backPad` so the durations-based post-trim can locate
+ * the padding precisely (added in 0.5.0; existing fields are unchanged).
  */
 export function padPhonemeIds(
   phonemeIds: number[],
@@ -112,11 +139,35 @@ export function padPhonemeIds(
   phonemeIds: number[];
   prosodyFeatures: number[][] | null;
   wasPadded: boolean;
+  /** Pad tokens inserted after BOS (0 when wasPadded is false). */
+  frontPad: number;
+  /** Pad tokens inserted before EOS (0 when wasPadded is false). */
+  backPad: number;
 };
 
 /**
+ * Strategy A precise post-trim: drop padding-induced samples using the
+ * model's `durations` output. Mirrors the cross-runtime contract — every
+ * runtime trims by the same number of samples for the same inputs
+ * (issue #356).
+ *
+ * Returns the input unchanged when arguments are inconsistent (null
+ * `durations`, non-positive `hopSize`, or fewer durations than
+ * `1 + frontPad + backPad + 1`).
+ */
+export function trimPaddingByDurations(
+  audio: Float32Array,
+  durations: ArrayLike<number> | null,
+  frontPad: number,
+  backPad: number,
+  hopSize: number,
+  eosMaxFrames?: number,
+): Float32Array;
+
+/**
  * Strategy A (post-step): Trim leading and trailing silence from audio
- * using a sliding RMS window.
+ * using a sliding RMS window. Used as a fallback when the model does
+ * not expose a `durations` output.
  *
  * Keeps at least TRIM_MIN_SAMPLES (2205) to avoid producing empty audio.
  */
@@ -125,7 +176,7 @@ export function trimSilence(audio: Float32Array, windowSize?: number): Float32Ar
 /**
  * Strategy B: Adjust noise scales for short inputs.
  *
- * For inputs shorter than MIN_PHONEME_IDS (40), attenuate noiseScale and
+ * For inputs shorter than MIN_PHONEME_IDS, attenuate noiseScale and
  * noiseW proportionally while keeping lengthScale unchanged.
  */
 export function adjustScalesForShortInput(


### PR DESCRIPTION
## Summary

Issue #356: 「こんにちは。」が「あこんにちはた」のように崩壊する問題を修正。

短文 padding (Strategy A) のしきい値が過剰で、本来安定して合成できる短文 (22 phonemes) にも発動し、padding 由来の音が前後に残っていた。`MIN_PHONEME_IDS` を 40 → 15 に引き下げ、加えて極短文向けに `MIN_BODY_FOR_STRATEGY_A = 3` のスキップ条件を新設し、全 7 ランタイムへ展開した。

## 原因

| 項目 | 値 |
|---|---|
| 旧しきい値 | `MIN_PHONEME_IDS = 40` (推測値、根拠なし) |
| 実機での安定下限 | 8 phoneme 程度 (tsukuyomi 6lang 計測) |
| 「こんにちは。」の長さ | 22 phonemes |
| pause token (ID=0) の合成結果 | RMS 0.2-0.3 の母音的音 (= 無音にならない) |
| RMS ベースの post-trim | padding 音を voiced と誤判定して剥がせない |

結果、22 phoneme クラスでも Strategy A が発動し、padding 由来の「あ」「た」が前後に残っていた。

## 変更内容

### 共通定数の見直し (docs/spec/short-text-contract.toml)

| 定数 | 旧 | 新 | 役割 |
|---|---:|---:|---|
| `min_phoneme_ids` | 40 | **15** | これ未満で Strategy A 発動 |
| `min_body_for_strategy_a` | (なし) | **3** | body (phoneme_ids - BOS - EOS) がこの値未満なら Strategy A をスキップ |

### 動作の変化

| 入力例 | 旧動作 | 新動作 |
|---|---|---|
| 「こんにちは。」(22 phonemes, body=20) | Strategy A 発動 → 余分音残存 (NG) | スキップ → PyPI 1.11.0 と同一の合成 |
| 「はい。」(12 phonemes, body=10) | Strategy A 発動 (padding 28個) | Strategy A 発動 (padding 3個、影響軽微) |
| 「あ。」(4 phonemes, body=2) | Strategy A 発動 (padding 11個) → 「あ」音消失 | スキップ → raw VITS 出力 |
| 40 phoneme 以上 | Strategy A スキップ (変化なし) | Strategy A スキップ (変化なし) |

### 反映先ファイル (全 7 ランタイム同一の閾値・ロジック)

| ランタイム | ファイル |
|---|---|
| 共通 spec | `docs/spec/short-text-contract.toml` |
| Python (runtime) | `src/python_run/piper/voice.py` |
| Python (training) | `src/python/piper_train/infer_onnx.py` |
| Go | `src/go/piperplus/short_text.go` |
| Rust | `src/rust/piper-core/src/engine.rs` + `src/rust/piper-core/src/lib.rs` (re-export) |
| C# | `src/csharp/PiperPlus.Core/Inference/ShortTextProcessor.cs` |
| C++ | `src/cpp/piper.cpp` |
| JS/WASM | `src/wasm/openjtalk-web/src/index.js` |

各ランタイムの `padPhonemeIds()` 系関数の冒頭に「body < `MIN_BODY_FOR_STRATEGY_A` ならスキップ」のガードを追加し、テストコードのハードコード定数 (40, 35, 39 など) を新しい閾値に追従するよう動的計算に置き換えた。

### 関連の補助修正 (python_run のみ)

`MIN_PHONEME_IDS = 15` への引き下げで主要ケースは解決するが、Strategy A が発動する短文 (15 ≦ phonemes < ~) で padding が残る場合に備えて以下を python_run に実装した。Go / Rust / C# / C++ / JS-WASM はしきい値見直しだけで実用上問題ない範囲だったため未展開。

- `_trim_padding_by_durations()`: ONNX `durations` 出力から pad token 由来サンプルを正確に切り落とす関数を新設 (RMS フォールバックは残す)
- `TRIM_EOS_MAX_FRAMES = 0`: padding 適用時の EOS は完全削除 (VITS が context で過大な duration を予測するため)

## 検証結果

### kun432 氏の再現ケース (phoneme_ids `[1,32,0,14,...,2]` 22個)

| | 修正前 | 修正後 | 期待値 |
|---|---:|---:|---:|
| 出力サイズ | 37932 bytes (NG) | **29228 bytes** | 29228 bytes (PyPI 1.11.0) |
| 末尾 voiced region (>RMS 0.01) | 150ms (「た」と認識) | **なし** | なし |

PyPI 1.11.0 と byte 単位で完全一致。

### 多文パターン試聴 (Python 実装で 15 ケース確認、user 試聴)

| カテゴリ | テキスト | phonemes | 結果 |
|---|---|---:|---|
| 極短文 | 「あ。」「はい。」 | 4, 12 | OK (cd980079 で「あ。」修正確定) |
| 短文 | 「こんにちは。」「ありがとう。」「おはよう。」 | 16-22 | OK |
| 中文 | 「今日は良い天気ですね。」「日本語のテストを行います。」「つくよみちゃんと申します。」 | 52-64 | OK |
| 長文 | 「桜の花びらが風に舞い、春の訪れを告げています。」 | 126 | OK |
| 多言語 | EN / ZH / ES / FR の短文 | 8-22 | OK |

### テスト

| ランタイム | 結果 |
|---|---|
| Python (python_run, test_short_text_mitigation) | 38/38 pass |
| Python (piper_train, test_infer_onnx) | 38/38 pass |
| Rust (cargo test engine::tests --features onnx) | 47/47 pass |
| C# (dotnet test ShortTextProcessorTests) | 67/67 pass |
| C++ (test_short_text_mitigation) | 41/41 pass |
| JS/WASM (node --test) | 37/37 pass |
| Go | ローカル ORT 依存でビルド不可、CI で確認予定 |

## Test plan

- [x] 「こんにちは。」が PyPI 1.11.0 と一致するサイズ (29228 bytes) で合成される
- [x] 「あ。」が極短文として raw VITS 出力で合成される (Strategy A スキップ)
- [x] 中・長文・多言語で副作用なし
- [x] python_run / piper_train / Rust / C# / C++ / JS/WASM の単体テスト全 pass
- [ ] Go の CI テスト pass (PR CI で確認)
- [ ] クロスランタイム CI pass (PR CI で確認)

## 関連

- Issue: #356
- Zenn スクラップ (kun432 氏): https://zenn.dev/kun432/scraps/cddbfcd75b8b34
- Strategy A 導入元: PR #337 (`7233428`)