### PR TITLE
chore(deps): black を 26.3.1 へ更新 (Dependabot #145, #146)

### DIFF
--- a/src/python_run/requirements_dev.txt
+++ b/src/python_run/requirements_dev.txt
@@ -1,4 +1,4 @@
-black==22.12.0
+black==26.3.1
 flake8==6.0.0
 isort==5.11.3
 mypy==0.991


### PR DESCRIPTION
## Summary

`src/python_run/requirements_dev.txt` の black ピン留めを **22.12.0 → 26.3.1** へ更新し、Dependabot アラート #145 (Medium) と #146 (High) を解消します。

## 背景

`pyproject.toml` の `dev` extras (line 84) および `tool.uv.dev-dependencies` (line 141) では既に `black==26.3.1` を指定しており、`uv.lock` 上でも 26.3.1 が解決済み。**`requirements_dev.txt` だけが 22.12.0 のまま取り残されていた**ため、Dependabot がこのファイルを根拠に脆弱性アラートを出していました。

## 解消するアラート

| # | Severity | CVE | 概要 |
|---|---------|-----|------|
| #146 | **High** | CVE-2026-32274 | `--python-cell-magics` の値が unsanitized でキャッシュファイル名に使われ、任意ファイル書き込みが可能 |
| #145 | Medium | - | ReDoS (< 24.3.0) |

**実害評価**: 攻撃条件は「攻撃者が `--python-cell-magics` の値を制御する」こと。piper-plus の CI/開発フローでこのオプションを使う箇所は無いため実害なし。形式的なアラート解消が目的。

## 影響範囲

- **dev-only 依存**: 本番デプロイ・wheel に含まれません。
- **既存コードへの影響**: `pyproject.toml` と `uv.lock` は元から 26.3.1 を指定しているため、`uv sync` 経由で開発している開発者の実環境では既に 26.3.1 が使われており、本 PR でフォーマット差分は発生しません。
- **`uv pip install -r requirements_dev.txt` を使っている開発者**: CONTRIBUTING.md でこの手順が案内されているため、初回 install で 26.3.1 が入るようになります。

## 実施しないこと(意図的なスコープ制限)

`requirements_dev.txt` の他パッケージ (flake8, isort, mypy, pylint, ruff) も `pyproject.toml` の指定と版が乖離していますが、いずれも Dependabot 警告対象外のため本 PR では触りません。

将来的には `requirements_dev.txt` を廃止して `CONTRIBUTING.md` を `uv sync --extra dev` に統合するのがクリーンですが、それは別途検討事項として切り出します。

## Test plan

- [ ] CI の lint / format ジョブが既存通り通過
- [ ] Dependabot アラート #145, #146 が close
- [ ] `uv pip install -r src/python_run/requirements_dev.txt` で black 26.3.1 が入る

## 関連

- 並行 PR: #364 (GitPython / Rust 依存 / protobufjs の patch 更新)
- Dependabot: https://github.com/ayutaz/piper-plus/security/dependabot