### PR TITLE
fix(docker): Go Dockerfile を TARGETARCH で arm64 対応 (#357)

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -146,12 +146,36 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 45
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            tag_suffix: amd64
+          - platform: linux/arm64
+            tag_suffix: arm64
     steps:
       - uses: actions/checkout@v6
         with:
           sparse-checkout: src/go
-      - name: Build Go Docker image
-        run: docker build -t piper-plus-go -f src/go/docker/Dockerfile .
+      - name: Set up QEMU
+        if: matrix.platform != 'linux/amd64'
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build Go Docker image (${{ matrix.platform }})
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: src/go/docker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: false
+          load: true
+          tags: piper-plus-go:test-${{ matrix.tag_suffix }}
+          cache-from: type=gha,scope=go-docker-${{ matrix.tag_suffix }}
+          cache-to: type=gha,mode=max,scope=go-docker-${{ matrix.tag_suffix }}
+      - name: Smoke test (${{ matrix.platform }})
+        run: docker run --rm --platform ${{ matrix.platform }} piper-plus-go:test-${{ matrix.tag_suffix }} --version

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -163,7 +163,9 @@ jobs:
           sparse-checkout: src/go
       - name: Set up QEMU
         if: matrix.platform != 'linux/amd64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Build Go Docker image (${{ matrix.platform }})

--- a/src/go/docker/Dockerfile
+++ b/src/go/docker/Dockerfile
@@ -63,14 +63,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Download ONNX Runtime shared library.
-# Uses x64 naming convention (changed from x86_64 in recent releases).
+# Selects the correct tarball based on docker buildx's TARGETARCH automatic
+# argument so multi-arch builds (linux/amd64, linux/arm64) work transparently.
+ARG TARGETARCH
 ARG ORT_VERSION=1.24.4
-ARG ORT_SHA256=3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747
+ARG ORT_SHA256_AMD64=3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747
+ARG ORT_SHA256_ARM64=866109a9248d057671a039b9d725be4bd86888e3754140e6701ec621be9d4d7e
 RUN set -eux \
-    && wget -q "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
-    && echo "${ORT_SHA256}  onnxruntime-linux-x64-${ORT_VERSION}.tgz" | sha256sum -c - \
-    && tar xzf "onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
-    && cp "onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so" /usr/lib/ \
+    && case "${TARGETARCH:-amd64}" in \
+         amd64) ORT_ARCH=x64;     ORT_SHA256=${ORT_SHA256_AMD64} ;; \
+         arm64) ORT_ARCH=aarch64; ORT_SHA256=${ORT_SHA256_ARM64} ;; \
+         *) echo "Unsupported TARGETARCH: ${TARGETARCH}"; exit 1 ;; \
+       esac \
+    && wget -q "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-${ORT_ARCH}-${ORT_VERSION}.tgz" \
+    && echo "${ORT_SHA256}  onnxruntime-linux-${ORT_ARCH}-${ORT_VERSION}.tgz" | sha256sum -c - \
+    && tar xzf "onnxruntime-linux-${ORT_ARCH}-${ORT_VERSION}.tgz" \
+    && cp "onnxruntime-linux-${ORT_ARCH}-${ORT_VERSION}/lib/libonnxruntime.so" /usr/lib/ \
     && rm -rf onnxruntime-* \
     && ldconfig
 


### PR DESCRIPTION
## Summary

`src/go/docker/Dockerfile` が ONNX Runtime のダウンロード URL を `linux-x64` でハードコードしていたため、`--platform linux/arm64` を指定しても aarch64 環境 (Raspberry Pi 4B 等) で動作しない問題を修正。

- Dockerfile を `docker buildx` の `TARGETARCH` 自動引数で amd64 / arm64 を分岐するように変更
- arm64 用 ONNX Runtime tarball の SHA256 (`866109a9...4d7e`) を実ファイルから検証して固定化
- `go-ci.yml` の `docker-build` ジョブを buildx + QEMU の matrix 化し、`linux/amd64` と `linux/arm64` の両プラットフォームでビルド + smoke test (`--version`) を実行するよう変更
- timeout を 20 分 → 45 分に延長 (QEMU 上の arm64 CGO ビルドのため)

## Issue checklist

- [x] Dockerfile を `TARGETARCH` で分岐するよう修正
- [x] arm64 用 ONNX Runtime tarball の SHA256 を取得して固定化
- [x] CI で `linux/amd64,linux/arm64` のマルチプラットフォームビルドを有効化
- [x] qemu で動作確認 (CI matrix の `linux/arm64` smoke test で実施)

Closes #357

## Test plan

- [ ] CI (`Go CI / docker-build (linux/amd64)`) が成功
- [ ] CI (`Go CI / docker-build (linux/arm64)`) が成功 (QEMU 上の smoke test で `piper-plus --version` が動作)
- [ ] その他の Go CI ジョブ (unit-test / integration-test / build / lint) が引き続き成功