### PR TITLE
chore(post-merge): MB-iSTFT 公開用 ckpt 変換スクリプトを復活 + gitignore 補完

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ dataset-*/
 libritts-r/
 moe-speech-*/
 downloads/
+hf_upload/
 hf_readme.md
 rebuild_cache.py
 upload_webdataset.py

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ output-*/
 dataset-*/
 libritts-r/
 moe-speech-*/
+css10-*/
 downloads/
 hf_upload/
 hf_readme.md

--- a/scripts/README_convert_multi_to_single.md
+++ b/scripts/README_convert_multi_to_single.md
@@ -10,13 +10,20 @@
 | `optimizer_states` 削除 | ~600 MB |
 | `lr_schedulers` / `ema_discriminator_state` / `loops` / `callbacks` 削除 | 数 MB |
 | `state_dict` から `model_g.emb_g.weight` 削除 | ~1 MB (= num_speakers x 512 x 4) |
-| `ema_generator_state` 内の `emb_g` 系キー削除 | 数 KB |
 | `hyper_parameters.num_speakers = 0` に書き換え | — |
 
 `cond_layer` 系 (`model_g.dec.cond.*`, `dp.cond.*`, `enc_q.enc.cond_layer.*`,
 `flow.flows.*.enc.cond_layer.*`, `enc_p.cond_layer.*`) は **保持** する。
 学習側の `--resume-from-multispeaker-checkpoint` が起動時に動的に
 `emb_g.mean()` を bias に吸収する設計のため。
+
+`ema_generator_state` は decoder の `shadow_params` だけを保持しており
+`emb_g` 系は元から EMA の対象外。そのまま残しても問題ないので clean-up しない。
+
+> **Security**: `torch.load(weights_only=False)` を使用。Lightning ckpt は
+> `hyper_parameters` に `pathlib.Path` をピクルするので weights_only=True では
+> 読めない。**信頼できる ckpt にのみ使用すること**。Windows では Linux 由来の
+> ckpt をロードするため `pathlib.PosixPath` の互換パッチを自動適用。
 
 ## 使い方
 
@@ -69,10 +76,14 @@ python -m piper_train \
 ## 履歴
 
 PR #170 (2025-08-28) で初導入、PR #229 (M1+M1.5 リファクタ) で削除。
-PR #320 (MB-iSTFT 統一 Decoder) で復活させ、現行アーキ向けに簡素化:
+PR #320 (MB-iSTFT 統一 Decoder) のマージ後に取り残された再追加分として、
+follow-up PR #369 で復活 + 現行アーキ向けに簡素化:
 
 - 旧版: `cond_layer` 系も全部削除していた
 - 現行版: `cond_layer` 系は保持 (`--resume-from-multispeaker-checkpoint` の
   動的吸収ロジックに任せる)
 - 旧版: `optimizer_states` / `lr_schedulers` のみ top-level 削除
 - 現行版: 加えて `ema_discriminator_state` / `loops` / `callbacks` も削除
+- 旧版: 推測で `ema_generator_state["module"]` 内の `emb_g` キーを削除しようと
+  していたが、現行 EMA 実装は `shadow_params` 形式 + decoder のみで `emb_g`
+  対象外なのでそのブロックを削除

--- a/scripts/README_convert_multi_to_single.md
+++ b/scripts/README_convert_multi_to_single.md
@@ -1,0 +1,78 @@
+# Multi-speaker checkpoint -> FT-base checkpoint converter
+
+学習直後のマルチスピーカー `last.ckpt` (~938 MB) を、HuggingFace に公開できる
+ファインチューニング用の軽量 ckpt (~316 MB) に変換するスクリプト。
+
+## 何をしているか
+
+| 処理 | 削減量 (典型) |
+|------|--------------|
+| `optimizer_states` 削除 | ~600 MB |
+| `lr_schedulers` / `ema_discriminator_state` / `loops` / `callbacks` 削除 | 数 MB |
+| `state_dict` から `model_g.emb_g.weight` 削除 | ~1 MB (= num_speakers x 512 x 4) |
+| `ema_generator_state` 内の `emb_g` 系キー削除 | 数 KB |
+| `hyper_parameters.num_speakers = 0` に書き換え | — |
+
+`cond_layer` 系 (`model_g.dec.cond.*`, `dp.cond.*`, `enc_q.enc.cond_layer.*`,
+`flow.flows.*.enc.cond_layer.*`, `enc_p.cond_layer.*`) は **保持** する。
+学習側の `--resume-from-multispeaker-checkpoint` が起動時に動的に
+`emb_g.mean()` を bias に吸収する設計のため。
+
+## 使い方
+
+```bash
+uv run python scripts/convert_multi_to_single_speaker.py \
+  --input-checkpoint  /data/piper/output-multilingual-6lang-mb-istft/checkpoints/epoch=74-step=500034.ckpt \
+  --output-checkpoint /data/piper/hf_upload/piper-plus-base/model.ckpt
+```
+
+環境変数経由でも可:
+
+```bash
+INPUT_CHECKPOINT=/path/to/last.ckpt \
+OUTPUT_CHECKPOINT=/path/to/model.ckpt \
+uv run python scripts/convert_multi_to_single_speaker.py
+```
+
+## config.json も合わせて更新
+
+公開時には `num_speakers=0` に揃えた config.json も同時にアップロードする:
+
+```python
+import json
+with open("dataset.../config.json") as f:
+    cfg = json.load(f)
+cfg["num_speakers"] = 0
+cfg.pop("speaker_id_map", None)
+with open("hf_upload/.../config.json", "w") as f:
+    json.dump(cfg, f, ensure_ascii=False, indent=2)
+```
+
+## ファインチューニング側の使い方
+
+変換した `model.ckpt` は通常 `--resume-from-multispeaker-checkpoint` で使う:
+
+```bash
+python -m piper_train \
+  --dataset-dir /path/to/single-speaker-dataset \
+  --resume-from-multispeaker-checkpoint /path/to/model.ckpt \
+  --prosody-dim 16 \
+  --accelerator gpu --devices 1 --precision 32-true \
+  --max_epochs 500 --batch-size 4 --samples-per-speaker 4 \
+  --base_lr 2e-5 --disable_auto_lr_scaling \
+  --ema-decay 0.9995 --max-phoneme-ids 400 \
+  --no-wavlm
+```
+
+`--resume-from-multispeaker-checkpoint` は自動で `--freeze-dp` を有効化する。
+
+## 履歴
+
+PR #170 (2025-08-28) で初導入、PR #229 (M1+M1.5 リファクタ) で削除。
+PR #320 (MB-iSTFT 統一 Decoder) で復活させ、現行アーキ向けに簡素化:
+
+- 旧版: `cond_layer` 系も全部削除していた
+- 現行版: `cond_layer` 系は保持 (`--resume-from-multispeaker-checkpoint` の
+  動的吸収ロジックに任せる)
+- 旧版: `optimizer_states` / `lr_schedulers` のみ top-level 削除
+- 現行版: 加えて `ema_discriminator_state` / `loops` / `callbacks` も削除

--- a/scripts/convert_multi_to_single_speaker.py
+++ b/scripts/convert_multi_to_single_speaker.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 import torch
 
+
 TOP_LEVEL_KEYS_TO_DROP = (
     "optimizer_states",
     "lr_schedulers",

--- a/scripts/convert_multi_to_single_speaker.py
+++ b/scripts/convert_multi_to_single_speaker.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+マルチスピーカー学習チェックポイントから HuggingFace 公開用の
+"ファインチューニング ベース" チェックポイントを作成するスクリプト。
+
+学習直後の `last.ckpt` (~938 MB) には optimizer states や discriminator EMA
+が含まれていて HF にアップロードするには大きすぎるので、推論 / FT に必要な
+要素だけ残した軽量版を生成する。
+
+処理内容:
+  1. top-level から optimizer_states / lr_schedulers / ema_discriminator_state
+     / loops / callbacks を削除 (これだけで ~600 MB 削減)
+  2. state_dict から model_g.emb_g.weight (話者埋め込み) を削除
+  3. hyper_parameters.num_speakers を 0 / speaker_id を None に変更
+  4. ema_generator_state からも emb_g 系キーを削除
+
+Note:
+  cond_layer 系 (model_g.dec.cond.*, dp.cond.*, enc_q/flow.*.cond_layer.*,
+  enc_p.cond_layer.*) は **保持** する。学習側 `--resume-from-multispeaker-checkpoint`
+  が起動時に動的に emb_g.mean() を bias に吸収する設計のため。
+  (PR #170 時点では cond_layer も削除していたが現行アーキでは不要)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import torch
+
+TOP_LEVEL_KEYS_TO_DROP = (
+    "optimizer_states",
+    "lr_schedulers",
+    "ema_discriminator_state",
+    "loops",
+    "callbacks",
+)
+
+STATE_DICT_KEYS_TO_DROP = ("model_g.emb_g.weight",)
+
+
+def _file_size_mb(path: str | Path) -> float:
+    return Path(path).stat().st_size / 1024**2
+
+
+def convert_checkpoint(input_path: str, output_path: str) -> bool:
+    if not Path(input_path).exists():
+        print(f"ERROR: input checkpoint not found: {input_path}", file=sys.stderr)
+        return False
+
+    print(f"Loading checkpoint: {input_path}")
+    print(f"  size: {_file_size_mb(input_path):.1f} MB")
+    ckpt = torch.load(input_path, map_location="cpu", weights_only=False)
+    print(f"  top-level keys: {list(ckpt.keys())}")
+
+    hp = ckpt.get("hyper_parameters", {})
+    print(
+        f"  hparams: num_speakers={hp.get('num_speakers')}, "
+        f"num_languages={hp.get('num_languages')}, "
+        f"epoch={ckpt.get('epoch')}"
+    )
+
+    dropped_top = []
+    for key in TOP_LEVEL_KEYS_TO_DROP:
+        if key in ckpt:
+            del ckpt[key]
+            dropped_top.append(key)
+    print(f"  dropped top-level: {dropped_top}")
+
+    state_dict = ckpt.get("state_dict", {})
+    dropped_sd = []
+    for key in STATE_DICT_KEYS_TO_DROP:
+        if key in state_dict:
+            del state_dict[key]
+            dropped_sd.append(key)
+    print(f"  dropped state_dict: {dropped_sd}")
+
+    ema_gen = ckpt.get("ema_generator_state")
+    if isinstance(ema_gen, dict) and "module" in ema_gen:
+        ema_module = ema_gen["module"]
+        ema_dropped = [k for k in list(ema_module.keys()) if "emb_g" in k]
+        for k in ema_dropped:
+            del ema_module[k]
+        if ema_dropped:
+            print(f"  dropped ema_generator: {ema_dropped}")
+
+    if "hyper_parameters" in ckpt:
+        ckpt["hyper_parameters"]["num_speakers"] = 0
+        if "speaker_id" in ckpt["hyper_parameters"]:
+            ckpt["hyper_parameters"]["speaker_id"] = None
+        print("  hparams.num_speakers -> 0")
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(ckpt, output_path)
+    print(f"\nSaved: {output_path}")
+    print(f"  size: {_file_size_mb(output_path):.1f} MB")
+    return True
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Multi-speaker checkpoint -> FT-base checkpoint converter "
+        "(strips optimizer / discriminator EMA / emb_g for HF publishing)"
+    )
+    p.add_argument(
+        "--input-checkpoint",
+        type=str,
+        default=os.environ.get("INPUT_CHECKPOINT"),
+        required="INPUT_CHECKPOINT" not in os.environ,
+        help="path to source multi-speaker checkpoint (env: INPUT_CHECKPOINT)",
+    )
+    p.add_argument(
+        "--output-checkpoint",
+        type=str,
+        default=os.environ.get("OUTPUT_CHECKPOINT"),
+        required="OUTPUT_CHECKPOINT" not in os.environ,
+        help="path to write the stripped FT-base checkpoint (env: OUTPUT_CHECKPOINT)",
+    )
+    return p
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    ok = convert_checkpoint(args.input_checkpoint, args.output_checkpoint)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/convert_multi_to_single_speaker.py
+++ b/scripts/convert_multi_to_single_speaker.py
@@ -12,23 +12,38 @@
      / loops / callbacks を削除 (これだけで ~600 MB 削減)
   2. state_dict から model_g.emb_g.weight (話者埋め込み) を削除
   3. hyper_parameters.num_speakers を 0 / speaker_id を None に変更
-  4. ema_generator_state からも emb_g 系キーを削除
 
 Note:
   cond_layer 系 (model_g.dec.cond.*, dp.cond.*, enc_q/flow.*.cond_layer.*,
   enc_p.cond_layer.*) は **保持** する。学習側 `--resume-from-multispeaker-checkpoint`
   が起動時に動的に emb_g.mean() を bias に吸収する設計のため。
   (PR #170 時点では cond_layer も削除していたが現行アーキでは不要)
+
+  ema_generator_state は decoder の shadow_params のみを保持しており
+  emb_g 系キーは元々含まれないため処理不要。
+
+Security:
+  torch.load(weights_only=False) は任意のオブジェクトをアンピクルするため
+  **信頼できる ckpt** にのみ使用すること。Lightning ckpt の hyper_parameters に
+  pathlib.Path 等が含まれるため weights_only=True では読み込めない。
 """
 
 from __future__ import annotations
 
 import argparse
 import os
+import pathlib
 import sys
 from pathlib import Path
 
 import torch
+
+
+# Windows で Linux 由来の ckpt をロードするための互換パッチ。
+# (Lightning は hyper_parameters に PosixPath を直接ピクルする)
+if sys.platform == "win32":
+    pathlib.PosixPath = pathlib.WindowsPath  # type: ignore[misc,assignment]
+torch.serialization.add_safe_globals([pathlib.PosixPath, pathlib.WindowsPath])
 
 
 TOP_LEVEL_KEYS_TO_DROP = (
@@ -53,6 +68,8 @@ def convert_checkpoint(input_path: str, output_path: str) -> bool:
 
     print(f"Loading checkpoint: {input_path}")
     print(f"  size: {_file_size_mb(input_path):.1f} MB")
+    # weights_only=False is required because Lightning ckpts pickle pathlib
+    # objects in hyper_parameters. Only run on TRUSTED checkpoint files.
     ckpt = torch.load(input_path, map_location="cpu", weights_only=False)
     print(f"  top-level keys: {list(ckpt.keys())}")
 
@@ -78,14 +95,8 @@ def convert_checkpoint(input_path: str, output_path: str) -> bool:
             dropped_sd.append(key)
     print(f"  dropped state_dict: {dropped_sd}")
 
-    ema_gen = ckpt.get("ema_generator_state")
-    if isinstance(ema_gen, dict) and "module" in ema_gen:
-        ema_module = ema_gen["module"]
-        ema_dropped = [k for k in list(ema_module.keys()) if "emb_g" in k]
-        for k in ema_dropped:
-            del ema_module[k]
-        if ema_dropped:
-            print(f"  dropped ema_generator: {ema_dropped}")
+    # NOTE: 現行 ema (vits/ema.py) は decoder のみ shadow_params で保持しており
+    # emb_g は元々 EMA の対象外。よって ema_generator_state 側の clean-up は不要。
 
     if "hyper_parameters" in ckpt:
         ckpt["hyper_parameters"]["num_speakers"] = 0


### PR DESCRIPTION
## 概要

PR #320 (MB-iSTFT-VITS2 統一 Decoder) のマージ後に取り残された 2 件を回収する小さな follow-up。

## 変更内容

### 1. `scripts/convert_multi_to_single_speaker.py` 復活 (132 行)

学習直後の multi-speaker ckpt (~895 MB) を HuggingFace 公開用の FT ベース ckpt (~316 MB) に変換するツール。

- 元々 PR #170 で追加され PR #229 (M1 リファクタ) で副次的に削除されていた
- 現行 `--resume-from-multispeaker-checkpoint` (動的 emb_g 吸収) に合わせて簡素化
- HF 公開モデル `ayousanz/piper-plus-base` の MB-iSTFT 化 (2026-05-03) で実際に使用済み

| 項目 | 旧 PR #170 | **本 PR (現行アーキ向け)** |
|------|-----------|------------------------|
| `optimizer_states` 削除 | ✓ | ✓ |
| `lr_schedulers` / `ema_discriminator_state` / `loops` / `callbacks` 削除 | (一部) | ✓ |
| `model_g.emb_g.weight` 削除 | ✓ | ✓ |
| `model_g.dec.cond.*` / `dp.cond.*` / `cond_layer.*` 削除 | ✓ | ✗ **保持** (現行 `--resume-from-multispeaker-checkpoint` が動的吸収) |
| `hparams.num_speakers = 0` | ✓ | ✓ |

### 2. `scripts/README_convert_multi_to_single.md` (78 行)

スクリプトの使い方ドキュメント。

### 3. `.gitignore` 補完

- `css10-*/` (CSS10 ja データセット用)
- `hf_upload/` (HF 公開用 staging dir)

PR #320 のスナップショット時点には含まれていなかった分。

## 関連

- 元の MB-iSTFT PR: #320
- 旧バージョンの履歴: PR #170 (追加), PR #229 (削除)
- HF 公開実績: `ayousanz/piper-plus-base`, `ayousanz/piper-plus-tsukuyomi-chan`, `ayousanz/piper-plus-css10-ja-6lang` (全て本スクリプト経由 or 同等処理で MB-iSTFT 化)

## Test plan

- [x] dev からの cherry-pick で衝突なし
- [x] スクリプトを `output-multilingual-6lang-mb-istft/checkpoints/epoch=74-step=500034.ckpt` で実行: 895 MB → 316.4 MB に縮小
- [x] 出力 ckpt を `VitsModel.load_from_checkpoint` で再ロード成功 (`num_speakers=0, num_languages=6, emb_lang shape=(6, 512)`)
- [x] 既存 HF base ckpt との top-level keys 構成一致