### PR TITLE
fix(docker): cpp-dev Dockerfile を python3.12 に切り替え

### DIFF
--- a/docker/cpp-dev/Dockerfile
+++ b/docker/cpp-dev/Dockerfile
@@ -74,8 +74,8 @@ RUN wget https://downloads.sourceforge.net/open-jtalk/open_jtalk-1.11.tar.gz && 
 # Create working directory
 WORKDIR /workspace
 
-# Install development tools
-RUN pip3 install \
+# Install development tools (--break-system-packages: PEP 668 / Ubuntu 24.04)
+RUN pip3 install --break-system-packages \
     conan \
     cpplint \
     cppcheck \

--- a/docker/cpp-dev/Dockerfile
+++ b/docker/cpp-dev/Dockerfile
@@ -28,8 +28,8 @@ RUN apt-get update && apt-get install -y \
     libgtest-dev \
     libgmock-dev \
     libbenchmark-dev \
-    python3.11 \
-    python3.11-dev \
+    python3.12 \
+    python3.12-dev \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/cpp-dev/Dockerfile
+++ b/docker/cpp-dev/Dockerfile
@@ -74,8 +74,18 @@ RUN wget https://downloads.sourceforge.net/open-jtalk/open_jtalk-1.11.tar.gz && 
 # Create working directory
 WORKDIR /workspace
 
-# Install development tools (--break-system-packages: PEP 668 / Ubuntu 24.04)
-RUN pip3 install --break-system-packages \
+# Install uv via official installer
+ENV UV_INSTALL_DIR=/usr/local/bin
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+
+# Create a dedicated venv for development tools (avoids PEP 668 on Ubuntu 24.04 / python3.12)
+ENV VIRTUAL_ENV=/opt/devtools
+RUN uv venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Install development tools into the venv
+RUN uv pip install \
     conan \
     cpplint \
     cppcheck \


### PR DESCRIPTION
## Summary

- Ubuntu 24.04 標準リポジトリに `python3.11` パッケージが無く `build-cpp-dev` ジョブが exit code 100 で失敗していた問題を修正
- `docker/cpp-dev/Dockerfile` の `python3.11` / `python3.11-dev` を Ubuntu 24.04 同梱の `python3.12` / `python3.12-dev` に置き換え (Issue 推奨案 A)
- python3.12 環境では PEP 668 で `pip3 install` がシステムワイド禁止されるため、**`uv` + 専用 venv (`/opt/devtools`)** で対処 (Copilot レビュー反映)
- 他 Docker イメージ (python-inference / python-train / wyoming) と同じく uv ベースで統一感を保ちつつ、venv で PEP 668 を正攻法で回避

## 変更点

| ファイル | 変更内容 |
|---------|---------|
| `docker/cpp-dev/Dockerfile` | `python3.11` → `python3.12` (apt) / `pip3 install` → `uv pip install` (公式インストーラ + venv `/opt/devtools`) |

## Test plan

- [x] ローカルで `docker build -f docker/cpp-dev/Dockerfile .` が成功すること
- [x] python 3.12 + uv 0.11.8 環境で開発ツールが正常動作すること
  - Python 3.12.3 / Conan 2.28.1 / cpplint / cppcheck 2.17.1 / cmake-format 0.6.13 / gcovr 8.6 すべて正常動作
- [x] venv (`/opt/devtools/bin`) が PATH に通り、`which conan` が venv の path を返すこと
- [ ] dev マージ後の `docker-build.yml` の `build-cpp-dev` ジョブが成功すること (PR では `paths` フィルタ + dev push トリガーのため未実行)

Fixes #378