### PR TITLE
fix(python): voice-cloning モデルの speaker_embedding 入力欠落を補填 (#385)

### DIFF
--- a/src/python/piper_train/ort_utils.py
+++ b/src/python/piper_train/ort_utils.py
@@ -289,6 +289,15 @@ def warmup_onnx_session(
             inputs["prosody_features"] = np.zeros(
                 (1, phoneme_length, 3), dtype=np.int64
             )
+        if "speaker_embedding" in input_names:
+            emb_dim = 256
+            for inp in session.get_inputs():
+                if inp.name == "speaker_embedding":
+                    if len(inp.shape) >= 2 and isinstance(inp.shape[1], int):
+                        emb_dim = inp.shape[1]
+                    break
+            inputs["speaker_embedding"] = np.zeros((1, emb_dim), dtype=np.float32)
+            inputs["speaker_embedding_mask"] = np.array([[0]], dtype=np.int64)
 
         output_names = [o.name for o in session.get_outputs()]
         t0 = time.perf_counter()

--- a/src/python/tests/test_ort_utils.py
+++ b/src/python/tests/test_ort_utils.py
@@ -232,7 +232,14 @@ class TestGetProviders:
 # ---------------------------------------------------------------------------
 
 
-def _make_mock_session(*, has_sid=False, has_lid=False, has_prosody=False):
+def _make_mock_session(
+    *,
+    has_sid=False,
+    has_lid=False,
+    has_prosody=False,
+    has_speaker_embedding=False,
+    speaker_embedding_dim=256,
+):
     """Create a mock InferenceSession with configurable optional inputs."""
     session = MagicMock(spec=onnxruntime.InferenceSession)
 
@@ -253,6 +260,15 @@ def _make_mock_session(*, has_sid=False, has_lid=False, has_prosody=False):
     if has_prosody:
         inp = MagicMock()
         inp.name = "prosody_features"
+        inputs.append(inp)
+    if has_speaker_embedding:
+        inp = MagicMock()
+        inp.name = "speaker_embedding"
+        inp.shape = ["batch_size", speaker_embedding_dim]
+        inputs.append(inp)
+        inp = MagicMock()
+        inp.name = "speaker_embedding_mask"
+        inp.shape = ["batch_size", 1]
         inputs.append(inp)
 
     session.get_inputs.return_value = inputs
@@ -361,6 +377,32 @@ class TestWarmup:
         prosody = inputs["prosody_features"]
         assert prosody.shape == (1, 100, 3)
         assert prosody.dtype == np.int64
+
+    def test_optional_inputs_speaker_embedding(self):
+        """speaker_embedding 入力がある場合、zeros + mask=0 が渡される (issue #385)."""
+        session = _make_mock_session(
+            has_speaker_embedding=True, speaker_embedding_dim=192
+        )
+        warmup_onnx_session(session)
+        inputs = session.run.call_args[0][1]
+        assert "speaker_embedding" in inputs
+        assert "speaker_embedding_mask" in inputs
+        assert inputs["speaker_embedding"].shape == (1, 192)
+        assert inputs["speaker_embedding"].dtype == np.float32
+        assert np.all(inputs["speaker_embedding"] == 0.0)
+        assert inputs["speaker_embedding_mask"].tolist() == [[0]]
+        assert inputs["speaker_embedding_mask"].dtype == np.int64
+
+    def test_speaker_embedding_symbolic_shape_uses_default_dim(self):
+        """ONNX 入力 shape が symbolic の場合、デフォルト 256 次元を使う."""
+        session = _make_mock_session(has_speaker_embedding=True)
+        for inp in session.get_inputs.return_value:
+            if inp.name == "speaker_embedding":
+                inp.shape = ["batch_size", "emb_dim"]
+                break
+        warmup_onnx_session(session)
+        inputs = session.run.call_args[0][1]
+        assert inputs["speaker_embedding"].shape == (1, 256)
 
 
 # ---------------------------------------------------------------------------

--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -739,10 +739,12 @@ class PiperVoice:
             prosody = np.zeros((1, num_phonemes, 3), dtype=np.int64)
             args["prosody_features"] = prosody
 
-        # Include speaker_embedding when the model expects it. Voice cloning
-        # is not yet exposed via this entry point, so default to zeros with
-        # mask=0 — this matches the masking branch in models.py:VitsModel.infer
-        # and tells the model to fall back to the speaker_id / lid embeddings.
+        # speaker_embedding / speaker_embedding_mask are always declared by
+        # export_onnx.py as a forward-compat hook, but the bundled checkpoints
+        # are not trained for zero-shot speaker transfer (spk_proj is lazy-
+        # initialised and never sees gradients). Feed zeros with mask=0 so the
+        # torch.where branch in models.py:VitsModel.infer falls back to the
+        # trained speaker_id / lid conditioning.
         if "speaker_embedding" in input_names:
             emb_dim = 256
             for inp in self.session.get_inputs():

--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -102,6 +102,15 @@ def _warmup_session(
             inputs["prosody_features"] = np.zeros(
                 (1, phoneme_length, 3), dtype=np.int64
             )
+        if "speaker_embedding" in input_names:
+            emb_dim = 256
+            for inp in session.get_inputs():
+                if inp.name == "speaker_embedding":
+                    if len(inp.shape) >= 2 and isinstance(inp.shape[1], int):
+                        emb_dim = inp.shape[1]
+                    break
+            inputs["speaker_embedding"] = np.zeros((1, emb_dim), dtype=np.float32)
+            inputs["speaker_embedding_mask"] = np.array([[0]], dtype=np.int64)
 
         output_names = [o.name for o in session.get_outputs()]
         for _ in range(runs):
@@ -729,6 +738,20 @@ class PiperVoice:
             num_phonemes = phoneme_ids_array.shape[1]
             prosody = np.zeros((1, num_phonemes, 3), dtype=np.int64)
             args["prosody_features"] = prosody
+
+        # Include speaker_embedding when the model expects it. Voice cloning
+        # is not yet exposed via this entry point, so default to zeros with
+        # mask=0 — this matches the masking branch in models.py:VitsModel.infer
+        # and tells the model to fall back to the speaker_id / lid embeddings.
+        if "speaker_embedding" in input_names:
+            emb_dim = 256
+            for inp in self.session.get_inputs():
+                if inp.name == "speaker_embedding":
+                    if len(inp.shape) >= 2 and isinstance(inp.shape[1], int):
+                        emb_dim = inp.shape[1]
+                    break
+            args["speaker_embedding"] = np.zeros((1, emb_dim), dtype=np.float32)
+            args["speaker_embedding_mask"] = np.array([[0]], dtype=np.int64)
 
         # Synthesize through Onnx
         output_names = [o.name for o in self.session.get_outputs()]

--- a/src/python_run/tests/test_voice_timing.py
+++ b/src/python_run/tests/test_voice_timing.py
@@ -36,6 +36,8 @@ def _make_mock_voice(
     sample_rate: int = 22050,
     has_durations: bool = True,
     phoneme_ids_len: int = 50,
+    has_speaker_embedding: bool = False,
+    speaker_embedding_dim: int = 256,
 ) -> PiperVoice:
     """Create a PiperVoice with a mocked ONNX session.
 
@@ -49,6 +51,11 @@ def _make_mock_voice(
         Whether the mock model advertises a ``durations`` output.
     phoneme_ids_len:
         Length of the durations tensor returned by session.run().
+    has_speaker_embedding:
+        Whether the mock model advertises ``speaker_embedding`` /
+        ``speaker_embedding_mask`` inputs (regression coverage for issue #385).
+    speaker_embedding_dim:
+        Embedding dimension reported by the mocked input shape.
     """
     config = PiperConfig(
         num_symbols=100,
@@ -77,7 +84,16 @@ def _make_mock_voice(
     input_lengths_mock.name = "input_lengths"
     scales_mock = MagicMock()
     scales_mock.name = "scales"
-    session.get_inputs.return_value = [input_mock, input_lengths_mock, scales_mock]
+    inputs_list = [input_mock, input_lengths_mock, scales_mock]
+    if has_speaker_embedding:
+        spk_emb_mock = MagicMock()
+        spk_emb_mock.name = "speaker_embedding"
+        spk_emb_mock.shape = ["batch_size", speaker_embedding_dim]
+        spk_emb_mask_mock = MagicMock()
+        spk_emb_mask_mock.name = "speaker_embedding_mask"
+        spk_emb_mask_mock.shape = ["batch_size", 1]
+        inputs_list.extend([spk_emb_mock, spk_emb_mask_mock])
+    session.get_inputs.return_value = inputs_list
 
     # -- Mock get_outputs (include "durations" when requested) --
     output_mock = MagicMock()
@@ -442,3 +458,71 @@ class TestSynthesizeCoreShortText:
         _, _, original_ids = voice._synthesize_ids_core(short_ids)
 
         assert original_ids == [1, 10, 10, 10, 2]
+
+
+# ---------------------------------------------------------------------------
+# Regression: speaker_embedding inputs (issue #385)
+# ---------------------------------------------------------------------------
+
+
+class TestSpeakerEmbeddingDefaults:
+    """Regression coverage for issue #385.
+
+    Models exported with voice-cloning support (e.g. tsukuyomi-chan-6lang)
+    declare ``speaker_embedding`` / ``speaker_embedding_mask`` ONNX inputs.
+    The runtime must feed default zero values with mask=0 when the caller
+    does not supply a reference embedding, otherwise ORT raises
+    ``ValueError: Required inputs (...) are missing from input feed``.
+    """
+
+    def test_synthesize_passes_zero_embedding_with_mask_off(self):
+        """_synthesize_ids_core supplies zeros + mask=0 by default."""
+        voice = _make_mock_voice(
+            has_durations=True,
+            has_speaker_embedding=True,
+            speaker_embedding_dim=192,
+        )
+        phoneme_ids = [1, 0, 10, 0, 12, 0, 15, 0, 2]
+
+        voice._synthesize_ids_core(phoneme_ids)
+
+        assert voice.session.run.called
+        feeds = voice.session.run.call_args[0][1]
+        assert "speaker_embedding" in feeds
+        assert "speaker_embedding_mask" in feeds
+        assert feeds["speaker_embedding"].shape == (1, 192)
+        assert feeds["speaker_embedding"].dtype == np.float32
+        assert np.all(feeds["speaker_embedding"] == 0.0)
+        assert feeds["speaker_embedding_mask"].tolist() == [[0]]
+        assert feeds["speaker_embedding_mask"].dtype == np.int64
+
+    def test_synthesize_falls_back_to_default_dim_when_shape_unknown(self):
+        """When the ONNX input shape is symbolic, default to 256 dims."""
+        voice = _make_mock_voice(has_speaker_embedding=True)
+        # Overwrite the speaker_embedding input to advertise a symbolic dim
+        for inp in voice.session.get_inputs.return_value:
+            if inp.name == "speaker_embedding":
+                inp.shape = ["batch_size", "emb_dim"]
+                break
+
+        voice._synthesize_ids_core([1, 0, 10, 0, 2])
+
+        feeds = voice.session.run.call_args[0][1]
+        assert feeds["speaker_embedding"].shape == (1, 256)
+
+    def test_warmup_supplies_speaker_embedding_inputs(self):
+        """_warmup_session feeds zero speaker_embedding + mask=0 when required."""
+        from piper.voice import _warmup_session
+
+        voice = _make_mock_voice(
+            has_speaker_embedding=True,
+            speaker_embedding_dim=192,
+        )
+
+        _warmup_session(voice.session, runs=1, phoneme_length=20)
+
+        assert voice.session.run.called
+        feeds = voice.session.run.call_args[0][1]
+        assert feeds["speaker_embedding"].shape == (1, 192)
+        assert feeds["speaker_embedding"].dtype == np.float32
+        assert feeds["speaker_embedding_mask"].tolist() == [[0]]

--- a/src/python_run/tests/test_voice_timing.py
+++ b/src/python_run/tests/test_voice_timing.py
@@ -468,11 +468,13 @@ class TestSynthesizeCoreShortText:
 class TestSpeakerEmbeddingDefaults:
     """Regression coverage for issue #385.
 
-    Models exported with voice-cloning support (e.g. tsukuyomi-chan-6lang)
-    declare ``speaker_embedding`` / ``speaker_embedding_mask`` ONNX inputs.
-    The runtime must feed default zero values with mask=0 when the caller
-    does not supply a reference embedding, otherwise ORT raises
-    ``ValueError: Required inputs (...) are missing from input feed``.
+    ``export_onnx.py`` always declares ``speaker_embedding`` and
+    ``speaker_embedding_mask`` inputs (forward-compat hook for future
+    voice-cloning training; the bundled checkpoints are not trained for
+    zero-shot transfer). The runtime must still feed those inputs to
+    satisfy ORT — zeros with ``mask=0`` — so the inference falls back
+    to the trained ``sid`` / ``lid`` conditioning. Without this, ORT
+    raises ``ValueError: Required inputs (...) are missing from input feed``.
     """
 
     def test_synthesize_passes_zero_embedding_with_mask_off(self):


### PR DESCRIPTION
## Summary
- 配布済み ONNX モデル (`tsukuyomi-chan-6lang-fp16.onnx` 等) が ONNX 入力に持つ `speaker_embedding` / `speaker_embedding_mask` を Python ランタイムが供給しておらず、推論時に `ValueError: Required inputs (...) are missing from input feed` で失敗していた問題を修正 (#385)。
- `_synthesize_ids_core` と warmup (`_warmup_session` / `warmup_onnx_session`) で入力検出時にゼロ埋め込み + `mask=0` を供給する。`mask=0` のゼロ供給により、`models.py:VitsModel.infer` の `torch.where(use_se >= 1, g_se, g_base)` ブランチで `g_base = _get_global_conditioning(sid, lid)` 経路 (= 学習時と同じ sid+lid 条件付け) にフォールバックする。
- emb_dim は ONNX 入力 shape から取得し、symbolic な場合は 256 にフォールバック。

## 補足: モデル側の状態
- `export_onnx.py:499-518` は **常に** `speaker_embedding` / `speaker_embedding_mask` 入力を含めて export する設計（forward-compat hook）。
- ただし学習ループは speaker encoder と統合した訓練を行っていないため、`models.py:_ensure_spk_proj` は lazy init のまま勾配が流れず、現行配布 checkpoint で zero-shot voice cloning は機能しない。
- `mask=0` でゼロを供給するのが現行モデルの唯一正しい運用 (sid+lid 経路に倒す)。
- C# / Rust / Go / C++ / WASM の各ランタイムは既にこの挙動に対応済みで、Python だけが取り残されていた。
- モデル再 export は不要 (入力構造は変わらないため)。

## Test plan
- [x] `pytest src/python_run/tests/test_voice_timing.py` (28/28 pass、回帰テスト 3 件追加)
- [x] `pytest src/python/tests/test_ort_utils.py` (61/61 pass、回帰テスト 2 件追加)
- [x] 学習側 `pytest src/python/tests/test_speaker_embedding.py` (12/12 pass、回帰なし)
- [x] 実モデルでの結合確認: `piper --download-model tsukuyomi` → `piper --model tsukuyomi-chan-6lang-fp16.onnx -f output.wav "こんにちは"` で 22050Hz / 1.355s の WAV を生成、warmup も成功

## Refs
- Fixes #385