### PR TITLE
chore(pua): fixture 自動生成 + 数値ハードコード集約 (B + B')

### DIFF
--- a/.github/workflows/pua-consistency.yml
+++ b/.github/workflows/pua-consistency.yml
@@ -63,6 +63,19 @@ jobs:
       - name: Verify cross-runtime PUA mapping consistency
         run: python scripts/check_pua_consistency.py --verbose --check-version
 
+  fixture-drift:
+    name: Test fixture in sync with pua.json
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Detect drift between pua.json and phoneme_test_cases.json
+        run: python scripts/regenerate_test_fixture.py --check
+
   inventory-and-fail-fast-tests:
     name: Inventory coverage + fail-fast guards
     runs-on: ubuntu-latest

--- a/scripts/regenerate_test_fixture.py
+++ b/scripts/regenerate_test_fixture.py
@@ -54,33 +54,61 @@ def _build_pua_map_block(entries: list[dict], indent: str = "  ") -> str:
     return ",\n".join(lines)
 
 
+class FixtureFormatError(RuntimeError):
+    """Raised when the fixture JSON does not match the expected layout.
+
+    The script intentionally relies on a small structural assumption (top-level
+    `pua_map_count`/`pua_map` blocks at indent 2). Failing fast here prevents
+    silent no-op rewrites if the fixture format is ever restructured.
+    """
+
+
 def regenerate(text: str, pua_data: dict) -> str:
     """Return the fixture JSON text with `pua_map_count` and `pua_map` updated.
 
     Idempotent: running the function twice on its output yields the same string.
+
+    Raises:
+        FixtureFormatError: if either of the two fields cannot be located.
+            ``re.sub`` would otherwise return the input unchanged on a missed
+            match, hiding the failure.
     """
     entries = pua_data["entries"]
     pua_map_count = len(entries)
 
     # 1) Replace pua_map_count
-    text = re.sub(
+    text, n = re.subn(
         r'"pua_map_count":\s*\d+',
         f'"pua_map_count": {pua_map_count}',
         text,
         count=1,
     )
+    if n != 1:
+        raise FixtureFormatError(
+            "could not locate `\"pua_map_count\": <int>` in the fixture; "
+            "regenerate_test_fixture.py needs an update if the schema changed."
+        )
 
-    # 2) Replace pua_map dict body. The fixture has no nested {} inside this
-    #    block, so a non-greedy match between `{` and the matching closing `}`
-    #    on its own line is unambiguous.
+    # 2) Replace pua_map dict body. The fixture's top-level `pua_map` is
+    #    written at 2-space indent (matching the rest of the JSON), and
+    #    contains no nested objects, so the closing brace is always
+    #    `\n  }` on its own line. We anchor on that and on `[^{}]*` (any
+    #    character except braces) so a future stray brace inside the block
+    #    would surface as a match failure rather than a silent no-op.
     new_body = _build_pua_map_block(entries)
-    text = re.sub(
-        r'("pua_map":\s*\{)[^}]*(\n  \})',
+    text, n = re.subn(
+        r'("pua_map":\s*\{)[^{}]*(\n  \})',
         lambda m: f"{m.group(1)}\n{new_body}{m.group(2)}",
         text,
         count=1,
         flags=re.DOTALL,
     )
+    if n != 1:
+        raise FixtureFormatError(
+            "could not locate the top-level `\"pua_map\": { ... \\n  }` block "
+            "in the fixture; regenerate_test_fixture.py needs an update if "
+            "the schema changed."
+        )
 
     return text
 

--- a/scripts/regenerate_test_fixture.py
+++ b/scripts/regenerate_test_fixture.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Regenerate the PUA-related sections of `tests/fixtures/g2p/phoneme_test_cases.json`
+from the canonical source (`src/python/g2p/piper_plus_g2p/data/pua.json`).
+
+Why this script exists
+----------------------
+The fixture is consumed by all 6 runtime test suites (Python/Rust/Go/JS/C#/C++),
+and its `pua_map_count` + `pua_map` block must always agree with `pua.json`.
+A drift here is exactly what broke Windows CI in PR #389 — the `pua_map_count`
+was bumped to 99 while the `pua_map` dict still carried 96 entries, so the Rust
+`test_pua_map_individual` assertion fired.
+
+Re-emitting the full JSON via `json.dump` would reflow every inline array
+(e.g. `expected_contains: ["k", "o", "n", "i", "a"]`) into 6 lines, producing
+hundreds of spurious diff lines. We instead update the two PUA-related fields
+**in place** with a small regex pass, leaving all hand-curated test cases
+untouched.
+
+Usage
+-----
+    python scripts/regenerate_test_fixture.py            # writes back in place
+    python scripts/regenerate_test_fixture.py --check    # exit 1 on drift (CI)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PUA_JSON = REPO_ROOT / "src" / "python" / "g2p" / "piper_plus_g2p" / "data" / "pua.json"
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "g2p" / "phoneme_test_cases.json"
+
+
+def _build_pua_map_block(entries: list[dict], indent: str = "  ") -> str:
+    """Format the `pua_map` dict body matching the fixture's existing style.
+
+    The fixture writes one entry per line with 4-space indentation under the
+    top-level key (i.e. `    "token": "0xE000",`). Returns the inner body only —
+    the surrounding `"pua_map": {` / `}` is preserved by the caller.
+    """
+    body_indent = indent * 2  # top-level key has 2-space indent → entries 4-space
+    lines = []
+    for e in entries:
+        # ensure_ascii=True keeps the existing fixture style: non-ASCII glyphs
+        # become \uXXXX escapes (e.g. "pʰ" rather than "pʰ").
+        token = json.dumps(e["token"])
+        codepoint = json.dumps(e["codepoint"])
+        lines.append(f"{body_indent}{token}: {codepoint}")
+    return ",\n".join(lines)
+
+
+def regenerate(text: str, pua_data: dict) -> str:
+    """Return the fixture JSON text with `pua_map_count` and `pua_map` updated.
+
+    Idempotent: running the function twice on its output yields the same string.
+    """
+    entries = pua_data["entries"]
+    pua_map_count = len(entries)
+
+    # 1) Replace pua_map_count
+    text = re.sub(
+        r'"pua_map_count":\s*\d+',
+        f'"pua_map_count": {pua_map_count}',
+        text,
+        count=1,
+    )
+
+    # 2) Replace pua_map dict body. The fixture has no nested {} inside this
+    #    block, so a non-greedy match between `{` and the matching closing `}`
+    #    on its own line is unambiguous.
+    new_body = _build_pua_map_block(entries)
+    text = re.sub(
+        r'("pua_map":\s*\{)[^}]*(\n  \})',
+        lambda m: f"{m.group(1)}\n{new_body}{m.group(2)}",
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit with status 1 if regeneration would change the fixture "
+        "(used by CI to detect drift). Does not write anything.",
+    )
+    args = parser.parse_args()
+
+    pua_data = json.loads(PUA_JSON.read_text(encoding="utf-8"))
+    original = FIXTURE.read_text(encoding="utf-8")
+    updated = regenerate(original, pua_data)
+
+    if updated == original:
+        print(f"OK: {FIXTURE.relative_to(REPO_ROOT)} already in sync with pua.json")
+        return 0
+
+    if args.check:
+        print(
+            f"DRIFT: {FIXTURE.relative_to(REPO_ROOT)} is out of sync with "
+            f"{PUA_JSON.relative_to(REPO_ROOT)}.\n"
+            "Run `python scripts/regenerate_test_fixture.py` to refresh.",
+            file=sys.stderr,
+        )
+        return 1
+
+    FIXTURE.write_text(updated, encoding="utf-8")
+    print(
+        f"Updated {FIXTURE.relative_to(REPO_ROOT)} "
+        f"({len(pua_data['entries'])} pua_map entries)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regenerate_test_fixture.py
+++ b/scripts/regenerate_test_fixture.py
@@ -30,6 +30,7 @@ import re
 import sys
 from pathlib import Path
 
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PUA_JSON = REPO_ROOT / "src" / "python" / "g2p" / "piper_plus_g2p" / "data" / "pua.json"
 FIXTURE = REPO_ROOT / "tests" / "fixtures" / "g2p" / "phoneme_test_cases.json"

--- a/scripts/regenerate_test_fixture.py
+++ b/scripts/regenerate_test_fixture.py
@@ -85,7 +85,7 @@ def regenerate(text: str, pua_data: dict) -> str:
     )
     if n != 1:
         raise FixtureFormatError(
-            "could not locate `\"pua_map_count\": <int>` in the fixture; "
+            'could not locate `"pua_map_count": <int>` in the fixture; '
             "regenerate_test_fixture.py needs an update if the schema changed."
         )
 
@@ -105,7 +105,7 @@ def regenerate(text: str, pua_data: dict) -> str:
     )
     if n != 1:
         raise FixtureFormatError(
-            "could not locate the top-level `\"pua_map\": { ... \\n  }` block "
+            'could not locate the top-level `"pua_map": { ... \\n  }` block '
             "in the fixture; regenerate_test_fixture.py needs an update if "
             "the schema changed."
         )

--- a/src/csharp/PiperPlus.Core.Tests/PhonemeConverterTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/PhonemeConverterTests.cs
@@ -63,8 +63,12 @@ public sealed class PhonemeConverterTests
 
         var actual = OpenJTalkToPiperMapping.TokenToChar;
 
-        // PUA v2: 99 total = 29 JA + 2 shared + 43 ZH + 8 KO + 2 ES/PT + 3 FR + 9 SV + 3 multi-CP v2
-        Assert.Equal(99, actual.Count);
+        // Sanity: the table is populated. The strong invariant ("byte-for-byte
+        // identical to pua.json") is enforced by the cross-runtime-table-consistency
+        // CI gate; baking in an absolute count would only duplicate that check
+        // and drift on every PUA bump (the bug class behind PR #389).
+        Assert.True(actual.Count >= 50,
+            $"OpenJTalkToPiperMapping.TokenToChar unexpectedly small: {actual.Count}");
 
         foreach (var (token, expectedChar) in expected)
         {

--- a/src/csharp/PiperPlus.Core.Tests/SwedishPhonemizerTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/SwedishPhonemizerTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+using System.Text.Json;
 using PiperPlus.Core.Mapping;
 using PiperPlus.Core.Phonemize;
 
@@ -605,17 +607,39 @@ public sealed class SwedishPhonemizerTests
     }
 
     // ================================================================
-    // 27. PuaMapping_IsPopulated (sanity; strong check is in CI gate)
+    // 27. PuaMapping_CountMatchesCanonical
     // ================================================================
 
     [Fact]
-    public void PuaMapping_IsPopulated()
+    public void PuaMapping_CountMatchesCanonical()
     {
-        // Sanity: the table is non-trivially populated. The strong invariant
-        // ("byte-for-byte identical to pua.json") is enforced by the
-        // cross-runtime-table-consistency CI gate.
-        Assert.True(OpenJTalkToPiperMapping.TokenToChar.Count >= 50,
-            $"OpenJTalkToPiperMapping.TokenToChar unexpectedly small: {OpenJTalkToPiperMapping.TokenToChar.Count}");
+        // Compare the C# table size against the canonical pua.json. This
+        // catches partial truncation (Copilot review on PR #392) — the
+        // previous `>= 50` sanity guard was too weak.
+        string puaJsonPath = FindRepoFile(Path.Combine(
+            "src", "python", "g2p", "piper_plus_g2p", "data", "pua.json"));
+        using var doc = JsonDocument.Parse(File.ReadAllText(puaJsonPath));
+        int expected = doc.RootElement.GetProperty("entries").GetArrayLength();
+
+        Assert.Equal(expected, OpenJTalkToPiperMapping.TokenToChar.Count);
+    }
+
+    /// <summary>
+    /// Walk up from the test binary location until <paramref name="relative"/>
+    /// resolves to an existing file. Mirrors the discovery pattern in
+    /// SpeakerEncoderTests.FindGoldenPath.
+    /// </summary>
+    private static string FindRepoFile(string relative)
+    {
+        string dir = AppDomain.CurrentDomain.BaseDirectory;
+        for (int i = 0; i < 10; i++)
+        {
+            string candidate = Path.Combine(dir, relative);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir) ?? dir;
+        }
+        throw new FileNotFoundException(
+            $"Cannot find {relative} walking up from test binary directory.");
     }
 
     // ================================================================

--- a/src/csharp/PiperPlus.Core.Tests/SwedishPhonemizerTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/SwedishPhonemizerTests.cs
@@ -605,14 +605,17 @@ public sealed class SwedishPhonemizerTests
     }
 
     // ================================================================
-    // 27. PuaMapping_TotalCount_Is99
+    // 27. PuaMapping_IsPopulated (sanity; strong check is in CI gate)
     // ================================================================
 
     [Fact]
-    public void PuaMapping_TotalCount_Is99()
+    public void PuaMapping_IsPopulated()
     {
-        // PUA v2: 29 JA + 2 shared + 43 ZH + 8 KO + 2 ES/PT + 3 FR + 9 SV + 3 multi-CP v2 = 99
-        Assert.Equal(99, OpenJTalkToPiperMapping.TokenToChar.Count);
+        // Sanity: the table is non-trivially populated. The strong invariant
+        // ("byte-for-byte identical to pua.json") is enforced by the
+        // cross-runtime-table-consistency CI gate.
+        Assert.True(OpenJTalkToPiperMapping.TokenToChar.Count >= 50,
+            $"OpenJTalkToPiperMapping.TokenToChar unexpectedly small: {OpenJTalkToPiperMapping.TokenToChar.Count}");
     }
 
     // ================================================================

--- a/src/go/phonemize/pua_test.go
+++ b/src/go/phonemize/pua_test.go
@@ -146,17 +146,20 @@ var allFixedPUA = []struct {
 	{"ɐ̃", 0xE064, "MULTI_V2"}, // ɐ̃   Portuguese nasal near-open central vowel
 }
 
-// TestFixedPUA_TotalCount ensures the Go fixedPUA map has exactly 99 entries,
-// matching the Python FIXED_PUA_MAPPING plus Swedish long vowels and PUA v2 additions.
+// TestFixedPUA_TotalCount ensures the Go fixedPUA map has the same number
+// of entries as the test-side reference list (allFixedPUA). Both lists are
+// kept in sync with Python FIXED_PUA_MAPPING via the cross-platform CI gate.
+// Using len(allFixedPUA) rather than a literal avoids the dual-update bug
+// that bit PR #389 (where 96 was bumped to 99 in some places but not others).
 func TestFixedPUA_TotalCount(t *testing.T) {
-	const want = 99
+	want := len(allFixedPUA)
 	if got := len(fixedPUA); got != want {
-		t.Errorf("fixedPUA has %d entries, want %d (must match Python FIXED_PUA_MAPPING)", got, want)
+		t.Errorf("fixedPUA has %d entries, want %d (must match allFixedPUA reference)", got, want)
 	}
 }
 
-// TestFixedPUA_AllEntries verifies every single one of the 99 fixed PUA
-// entries against the Python reference. This is an exhaustive golden test.
+// TestFixedPUA_AllEntries verifies every fixed PUA entry against the Python
+// reference list. This is an exhaustive golden test.
 func TestFixedPUA_AllEntries(t *testing.T) {
 	for _, tc := range allFixedPUA {
 		t.Run(fmt.Sprintf("%s_U+%04X", tc.group, tc.want), func(t *testing.T) {

--- a/src/python/g2p/tests/test_compat.py
+++ b/src/python/g2p/tests/test_compat.py
@@ -31,10 +31,22 @@ class TestJACorrectness:
         assert len(pua_tokens) > 2  # more than just BOS+EOS
 
     def test_pua_mapping_count(self):
-        """FIXED_PUA_MAPPING should have the expected number of entries."""
+        """FIXED_PUA_MAPPING entry count matches the cross-platform fixture."""
+        import json
+        from pathlib import Path
+
         from piper_plus_g2p.encode.pua import FIXED_PUA_MAPPING
 
-        assert len(FIXED_PUA_MAPPING) == 99
+        fixture = (
+            Path(__file__).resolve().parents[4]
+            / "tests"
+            / "fixtures"
+            / "g2p"
+            / "phoneme_test_cases.json"
+        )
+        with open(fixture, encoding="utf-8") as f:
+            expected = json.load(f)["pua_map_count"]
+        assert len(FIXED_PUA_MAPPING) == expected
 
     def test_ja_id_map_format(self):
         """get_phoneme_id_map('ja') should return a valid id map."""

--- a/src/python/g2p/tests/test_encode.py
+++ b/src/python/g2p/tests/test_encode.py
@@ -35,8 +35,10 @@ def _load_pua_spot_checks() -> list[dict]:
 
 class TestPUAMapping:
     def test_pua_mapping_count(self):
-        """FIXED_PUA_MAPPING has exactly 99 entries."""
-        assert len(FIXED_PUA_MAPPING) == 99
+        """FIXED_PUA_MAPPING entry count matches the cross-platform fixture."""
+        with open(_FIXTURE_PATH, encoding="utf-8") as f:
+            expected = json.load(f)["pua_map_count"]
+        assert len(FIXED_PUA_MAPPING) == expected
 
     def test_pua_single_char_passthrough(self):
         """Single-character tokens pass through map_token unchanged."""

--- a/src/rust/piper-core/tests/test_g2p_golden.rs
+++ b/src/rust/piper-core/tests/test_g2p_golden.rs
@@ -438,14 +438,18 @@ fn test_encode_golden() {
 }
 
 // ---------------------------------------------------------------------------
-// PUA map individual match test (all 99 entries — PUA v2)
+// PUA map individual match test — all entries from the fixture round-trip
+// through FIXED_PUA_MAP. The fixture is regenerated from pua.json, so any
+// drift between the canonical source and the runtime is caught here without
+// any absolute count baked into the test.
 // ---------------------------------------------------------------------------
 
 #[test]
 fn test_pua_map_individual() {
     let fixture = load_fixture();
 
-    // Verify fixture has the expected number of entries
+    // Fixture self-consistency: pua_map dict size matches its declared count.
+    // Drift would mean someone updated one but not the other.
     assert_eq!(
         fixture.pua_map.len(),
         fixture.pua_map_count,
@@ -453,13 +457,9 @@ fn test_pua_map_individual() {
         fixture.pua_map.len(),
         fixture.pua_map_count,
     );
-    assert_eq!(
-        fixture.pua_map_count, 99,
-        "pua_map_count should be 99 (PUA v2), got {}",
-        fixture.pua_map_count,
-    );
 
-    // Verify FIXED_PUA_MAP count matches fixture
+    // Runtime parity: FIXED_PUA_MAP must have the same number of entries
+    // as the fixture (and therefore as pua.json after regenerate_test_fixture).
     assert_eq!(
         piper_plus_g2p::token_map::FIXED_PUA_MAP.len(),
         fixture.pua_map_count,

--- a/src/rust/piper-core/tests/test_token_map_parity.rs
+++ b/src/rust/piper-core/tests/test_token_map_parity.rs
@@ -225,8 +225,29 @@ fn test_nonexistent_tokens_return_none() {
 
 #[test]
 fn test_total_entry_count_matches_python() {
-    // Python FIXED_PUA_MAPPING has exactly 99 entries (PUA v2)
-    assert_eq!(FIXED_PUA_MAP.len(), 99);
+    // The Rust map must always agree with the canonical pua.json. Reading the
+    // count from pua.json (rather than baking the literal in) removes the
+    // class of bug where someone bumps the table but forgets to update this
+    // test — a regression that bit PR #389.
+    let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let pua_json = repo_root
+        .join("src/python/g2p/piper_plus_g2p/data/pua.json");
+    let content = std::fs::read_to_string(&pua_json)
+        .unwrap_or_else(|e| panic!("Failed to read pua.json {pua_json:?}: {e}"));
+    let parsed: serde_json::Value =
+        serde_json::from_str(&content).expect("Failed to parse pua.json");
+    let expected = parsed["entries"]
+        .as_array()
+        .expect("pua.json must contain an entries array")
+        .len();
+    assert_eq!(FIXED_PUA_MAP.len(), expected);
 }
 
 #[test]

--- a/src/rust/piper-core/tests/test_token_map_parity.rs
+++ b/src/rust/piper-core/tests/test_token_map_parity.rs
@@ -237,8 +237,7 @@ fn test_total_entry_count_matches_python() {
         .parent()
         .unwrap()
         .to_path_buf();
-    let pua_json = repo_root
-        .join("src/python/g2p/piper_plus_g2p/data/pua.json");
+    let pua_json = repo_root.join("src/python/g2p/piper_plus_g2p/data/pua.json");
     let content = std::fs::read_to_string(&pua_json)
         .unwrap_or_else(|e| panic!("Failed to read pua.json {pua_json:?}: {e}"));
     let parsed: serde_json::Value =

--- a/src/rust/piper-core/tests/test_token_map_parity.rs
+++ b/src/rust/piper-core/tests/test_token_map_parity.rs
@@ -223,21 +223,24 @@ fn test_nonexistent_tokens_return_none() {
 // Structural invariants
 // =========================================================================
 
+/// Walk up from this crate's `Cargo.toml` to the repo root.
+/// `src/rust/piper-core` -> `src/rust` -> `src` -> repo root.
+fn repo_root() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .expect("CARGO_MANIFEST_DIR should resolve to repo root after 3 parent() hops")
+        .to_path_buf()
+}
+
 #[test]
 fn test_total_entry_count_matches_python() {
     // The Rust map must always agree with the canonical pua.json. Reading the
     // count from pua.json (rather than baking the literal in) removes the
     // class of bug where someone bumps the table but forgets to update this
     // test — a regression that bit PR #389.
-    let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .to_path_buf();
-    let pua_json = repo_root.join("src/python/g2p/piper_plus_g2p/data/pua.json");
+    let pua_json = repo_root().join("src/python/g2p/piper_plus_g2p/data/pua.json");
     let content = std::fs::read_to_string(&pua_json)
         .unwrap_or_else(|e| panic!("Failed to read pua.json {pua_json:?}: {e}"));
     let parsed: serde_json::Value =

--- a/src/rust/piper-plus-g2p/src/token_map.rs
+++ b/src/rust/piper-plus-g2p/src/token_map.rs
@@ -190,14 +190,25 @@ mod tests {
 
     #[test]
     fn test_fixed_pua_count() {
-        // Sanity: the table is non-trivially populated. The strong invariant
-        // ("byte-for-byte identical to pua.json") is enforced by the
-        // `cross-runtime-table-consistency` CI gate, so a literal count here
-        // would only duplicate that check while drifting on every PUA bump.
-        assert!(
-            FIXED_PUA_MAP.len() >= 50,
-            "FIXED_PUA_MAP unexpectedly small: {}",
-            FIXED_PUA_MAP.len()
+        // Compare against the canonical pua.json embedded at compile time.
+        // This catches partial truncation (Copilot review on PR #392) — a
+        // weakness of the previous `>= 50` sanity check — without baking in
+        // a literal count that drifts on every PUA bump.
+        const PUA_JSON: &str = include_str!(
+            "../../../python/g2p/piper_plus_g2p/data/pua.json"
+        );
+        let parsed: serde_json::Value = serde_json::from_str(PUA_JSON)
+            .expect("embedded pua.json should be valid JSON");
+        let expected = parsed["entries"]
+            .as_array()
+            .expect("pua.json must contain an entries array")
+            .len();
+        assert_eq!(
+            FIXED_PUA_MAP.len(),
+            expected,
+            "FIXED_PUA_MAP ({}) does not match pua.json entries ({})",
+            FIXED_PUA_MAP.len(),
+            expected,
         );
     }
 

--- a/src/rust/piper-plus-g2p/src/token_map.rs
+++ b/src/rust/piper-plus-g2p/src/token_map.rs
@@ -190,8 +190,15 @@ mod tests {
 
     #[test]
     fn test_fixed_pua_count() {
-        // Must match Python token_mapper.py FIXED_PUA_MAPPING count exactly
-        assert_eq!(FIXED_PUA_MAP.len(), 99);
+        // Sanity: the table is non-trivially populated. The strong invariant
+        // ("byte-for-byte identical to pua.json") is enforced by the
+        // `cross-runtime-table-consistency` CI gate, so a literal count here
+        // would only duplicate that check while drifting on every PUA bump.
+        assert!(
+            FIXED_PUA_MAP.len() >= 50,
+            "FIXED_PUA_MAP unexpectedly small: {}",
+            FIXED_PUA_MAP.len()
+        );
     }
 
     #[test]

--- a/src/rust/piper-plus-g2p/src/token_map.rs
+++ b/src/rust/piper-plus-g2p/src/token_map.rs
@@ -194,11 +194,9 @@ mod tests {
         // This catches partial truncation (Copilot review on PR #392) — a
         // weakness of the previous `>= 50` sanity check — without baking in
         // a literal count that drifts on every PUA bump.
-        const PUA_JSON: &str = include_str!(
-            "../../../python/g2p/piper_plus_g2p/data/pua.json"
-        );
-        let parsed: serde_json::Value = serde_json::from_str(PUA_JSON)
-            .expect("embedded pua.json should be valid JSON");
+        const PUA_JSON: &str = include_str!("../../../python/g2p/piper_plus_g2p/data/pua.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(PUA_JSON).expect("embedded pua.json should be valid JSON");
         let expected = parsed["entries"]
             .as_array()
             .expect("pua.json must contain an entries array")

--- a/src/wasm/g2p/test/test-pua-map.js
+++ b/src/wasm/g2p/test/test-pua-map.js
@@ -241,8 +241,11 @@ describe('PUA fixture: pua_spot_checks', () => {
 
 describe('PUA full individual verification', () => {
     const entries = Object.entries(PUA_MAP);
-    assert.equal(entries.length, FIXTURE.pua_map_count,
-        'PUA_MAP entry count must match fixture pua_map_count');
+
+    it('PUA_MAP entry count must match fixture pua_map_count', () => {
+        assert.equal(entries.length, FIXTURE.pua_map_count,
+            'PUA_MAP entry count must match fixture pua_map_count');
+    });
 
     for (const [token, puaChar] of entries) {
         it(`mapToken("${token}") -> U+${puaChar.codePointAt(0).toString(16).toUpperCase()}`, () => {

--- a/src/wasm/g2p/test/test-pua-map.js
+++ b/src/wasm/g2p/test/test-pua-map.js
@@ -4,7 +4,7 @@
  * Validates the forward/reverse PUA mapping table and the mapToken/unmapToken
  * helper functions used by the Encoder.
  *
- * Also validates all 99 PUA entries and spot-check codepoints against the
+ * Also validates all PUA entries and spot-check codepoints against the
  * cross-platform fixture (tests/fixtures/g2p/phoneme_test_cases.json).
  *
  * Run: node --test src/wasm/g2p/test/test-pua-map.js
@@ -36,8 +36,8 @@ const FIXTURE = JSON.parse(readFileSync(FIXTURE_PATH, 'utf-8'));
 // ---------------------------------------------------------------------------
 
 describe('PUA_MAP table', () => {
-    it('should have exactly 99 entries', () => {
-        assert.equal(Object.keys(PUA_MAP).length, 99);
+    it('entry count matches the cross-platform fixture', () => {
+        assert.equal(Object.keys(PUA_MAP).length, FIXTURE.pua_map_count);
     });
 
     it('should have unique PUA codepoints (no duplicates)', () => {
@@ -231,7 +231,7 @@ describe('PUA fixture: pua_spot_checks', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Full 99-entry individual verification
+// Full individual verification
 //
 // Checks every single entry in PUA_MAP:
 // 1. mapToken(token) returns the correct PUA char
@@ -239,9 +239,10 @@ describe('PUA fixture: pua_spot_checks', () => {
 // 3. The codepoint is within the valid PUA range
 // ---------------------------------------------------------------------------
 
-describe('PUA full 99-entry individual verification', () => {
+describe('PUA full individual verification', () => {
     const entries = Object.entries(PUA_MAP);
-    assert.equal(entries.length, 99, 'PUA_MAP should have exactly 99 entries');
+    assert.equal(entries.length, FIXTURE.pua_map_count,
+        'PUA_MAP entry count must match fixture pua_map_count');
 
     for (const [token, puaChar] of entries) {
         it(`mapToken("${token}") -> U+${puaChar.codePointAt(0).toString(16).toUpperCase()}`, () => {


### PR DESCRIPTION
## Summary

PR #389 で踏んだ「`pua_map_count` を 99 に bump したが `pua_map` dict は 96 のまま」というドリフトの再発防止。fixture を `pua.json` から自動生成 + drift 検知 CI、各ランタイムテストの絶対値 `99` を fixture / pua.json / サニティ由来に置換。

> **Note**: PR #389 を base にした stack PR です。先に #389 をマージしてください。マージ後 GitHub が自動的に base を `dev` に切り替えます。

## 何が問題だったか

PR #389 で `tests/fixtures/g2p/phoneme_test_cases.json` の `pua_map_count` を 99 に bump したが `pua_map` dict は 96 entries のままで、Rust `test_pua_map_individual` が `pua_map entry count (96) != pua_map_count (99)` で fail。

加えて 5 ランタイム x 複数ファイルに `99` がハードコードされ、PUA テーブル拡張時に「数箇所だけ更新漏れ」のドリフト発生源が散在していた。

## 変更内容

### B (fixture 自動生成)
- **`scripts/regenerate_test_fixture.py` 新設**
  - `pua.json` を canonical として fixture の `pua_map_count` / `pua_map` セクションだけを再生成
  - 配列フォーマット (`expected_contains: ["a", "b"]`) は触らない (= 差分最小)
  - `--check` モードで drift 検出 (CI 用、exit 1)
- **`.github/workflows/pua-consistency.yml` に `fixture-drift` job 追加**

### B' (数値ハードコード集約)
| 言語 | ファイル | Before | After |
|------|---------|--------|-------|
| Python | test_compat.py / test_encode.py | `== 99` | fixture `pua_map_count` 由来 |
| Rust | test_g2p_golden.rs | `pua_map_count, 99` | 削除 (`FIXED_PUA_MAP.len() vs fixture` で十分) |
| Rust | test_token_map_parity.rs | `assert_eq!(.., 99)` | pua.json 直読み |
| Rust | token_map.rs (unit test) | `assert_eq!(.., 99)` | `>= 50` サニティ |
| Go | pua_test.go | `const want = 99` | `len(allFixedPUA)` |
| JS | test-pua-map.js | `99` x 2 箇所 | `FIXTURE.pua_map_count` |
| C# | PhonemeConverterTests | `Assert.Equal(99, ..)` | サニティ (`>= 50`) |
| C# | SwedishPhonemizerTests | `PuaMapping_TotalCount_Is99` | `PuaMapping_IsPopulated` (リネーム) |

「強い不変条件」 (= pua.json と各ランタイムが byte-for-byte 一致) は既存の `cross-runtime-table-consistency` CI gate が保証。各テストでは `len(internal) == fixture.pua_map_count` のサニティに集約。

## ローカル検証

- Python: `pytest test_pua_invariants.py test_encode.py::TestPUAMapping` → **31/31 pass**
- JS: `node --test test/test-pua-map.js` → **140/140 pass**
- Go: `go test ./phonemize/... -run "TestFixedPUA"` → **all pass**

## Test plan

- [ ] CI: All 6 runtime PUA tables match pua.json
- [ ] CI: Test fixture in sync with pua.json (新規 job)
- [ ] CI: Inventory coverage + fail-fast guards
- [ ] CI: Rust / Go / JS-WASM PUA table tests
- [ ] CI: Pre-flight config validator
- [ ] CI: csharp-tests