### PR TITLE
feat(release): HF Hub モデル config 配布パイプライン (A)

### DIFF
--- a/.github/workflows/release-model-config.yml
+++ b/.github/workflows/release-model-config.yml
@@ -1,0 +1,125 @@
+name: Release Model Config to HF Hub
+
+# Manual workflow that uploads a Piper-Plus model config (and optionally
+# the .onnx) to Hugging Face Hub, with a mandatory pre-flight validation
+# step that would have prevented the v1.12.0 ɔɪ/œ̃/ɐ̃ leak.
+#
+# Usage (GitHub UI):
+#   1. Go to Actions → "Release Model Config to HF Hub" → Run workflow.
+#   2. Fill in:
+#      - hf_repo: e.g. ayousanz/piper-plus-tsukuyomi-chan
+#      - config_artifact_url: a published artifact URL from a prior CI run
+#        (or upload via repo file input — see workflow_dispatch inputs)
+#      - dry_run: true to validate only without pushing to HF
+#
+# The HF_TOKEN secret must be configured at repo or org level.
+
+on:
+  workflow_dispatch:
+    inputs:
+      hf_repo:
+        description: 'HuggingFace repo id (e.g. ayousanz/piper-plus-tsukuyomi-chan)'
+        required: true
+        type: string
+      config_path:
+        description: >
+          Path inside the repo to the config.json to upload
+          (e.g. tmp/tsukuyomi-chan-6lang-fp16.onnx.json).
+          Must already be checked into a branch or uploaded as workflow artifact.
+        required: true
+        type: string
+      onnx_path:
+        description: 'Optional: path to .onnx in repo to upload alongside the config'
+        required: false
+        type: string
+        default: ''
+      config_remote_name:
+        description: 'Optional: filename to use on the HF Hub side for config'
+        required: false
+        type: string
+        default: ''
+      onnx_remote_name:
+        description: 'Optional: filename to use on the HF Hub side for onnx'
+        required: false
+        type: string
+        default: ''
+      commit_message:
+        description: 'Commit message for the HF upload'
+        required: false
+        type: string
+        default: 'Update model config (validated by release-model-config workflow)'
+      dry_run:
+        description: 'Validate only — do not call HF API'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate-and-upload:
+    name: Pre-flight validate + HF upload
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install piper_train + huggingface_hub
+        working-directory: src/python
+        run: |
+          uv sync --extra test
+          uv pip install huggingface_hub
+
+      - name: Verify config exists
+        run: |
+          if [ ! -f "${{ inputs.config_path }}" ]; then
+            echo "::error::config_path '${{ inputs.config_path }}' does not exist in the repo at ref ${{ github.sha }}"
+            exit 1
+          fi
+          if [ -n "${{ inputs.onnx_path }}" ] && [ ! -f "${{ inputs.onnx_path }}" ]; then
+            echo "::error::onnx_path '${{ inputs.onnx_path }}' does not exist"
+            exit 1
+          fi
+
+      - name: Validate + upload via upload_model_to_hf.py
+        working-directory: src/python
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -e
+          ARGS=(--repo "${{ inputs.hf_repo }}" --config "${GITHUB_WORKSPACE}/${{ inputs.config_path }}")
+          if [ -n "${{ inputs.onnx_path }}" ]; then
+            ARGS+=(--onnx "${GITHUB_WORKSPACE}/${{ inputs.onnx_path }}")
+          fi
+          if [ -n "${{ inputs.config_remote_name }}" ]; then
+            ARGS+=(--config-remote-name "${{ inputs.config_remote_name }}")
+          fi
+          if [ -n "${{ inputs.onnx_remote_name }}" ]; then
+            ARGS+=(--onnx-remote-name "${{ inputs.onnx_remote_name }}")
+          fi
+          ARGS+=(--commit-message "${{ inputs.commit_message }}")
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          uv run python "${GITHUB_WORKSPACE}/scripts/upload_model_to_hf.py" "${ARGS[@]}"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## HF Hub Upload"
+            echo ""
+            echo "- Repo: \`${{ inputs.hf_repo }}\`"
+            echo "- Config: \`${{ inputs.config_path }}\`"
+            if [ -n "${{ inputs.onnx_path }}" ]; then
+              echo "- Onnx:   \`${{ inputs.onnx_path }}\`"
+            fi
+            echo "- Dry run: \`${{ inputs.dry_run }}\`"
+            echo ""
+            echo "Validation: \`update_model_config.py --validate-only\` was enforced before any upload."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-model-config.yml
+++ b/.github/workflows/release-model-config.yml
@@ -5,12 +5,13 @@ name: Release Model Config to HF Hub
 # step that would have prevented the v1.12.0 ɔɪ/œ̃/ɐ̃ leak.
 #
 # Usage (GitHub UI):
-#   1. Go to Actions → "Release Model Config to HF Hub" → Run workflow.
-#   2. Fill in:
-#      - hf_repo: e.g. ayousanz/piper-plus-tsukuyomi-chan
-#      - config_artifact_url: a published artifact URL from a prior CI run
-#        (or upload via repo file input — see workflow_dispatch inputs)
-#      - dry_run: true to validate only without pushing to HF
+#   1. Push the prepared config.json (and optionally .onnx) to a branch.
+#   2. Go to Actions → "Release Model Config to HF Hub" → Run workflow.
+#   3. Select that branch and fill in:
+#      - hf_repo:     e.g. ayousanz/piper-plus-tsukuyomi-chan
+#      - config_path: repo-relative path to config.json on the selected branch
+#      - onnx_path:   (optional) repo-relative path to model.onnx
+#      - dry_run:     true to validate only without pushing to HF
 #
 # The HF_TOKEN secret must be configured at repo or org level.
 
@@ -25,7 +26,7 @@ on:
         description: >
           Path inside the repo to the config.json to upload
           (e.g. tmp/tsukuyomi-chan-6lang-fp16.onnx.json).
-          Must already be checked into a branch or uploaded as workflow artifact.
+          The file must already be checked into the branch selected for this run.
         required: true
         type: string
       onnx_path:

--- a/CONTRIBUTING_MODELS.md
+++ b/CONTRIBUTING_MODELS.md
@@ -315,6 +315,24 @@ Issue 投稿時に以下のテンプレートを記入してください。
    - `config.json` -- モデル設定ファイル
    - `README.md` -- Model Card (後述)
 
+**重要**: 直接アップロードする代わりに `scripts/upload_model_to_hf.py` を使ってください。このスクリプトは `update_model_config.py --validate-only` を必ず先に走らせるので、`phoneme_id_map` に multi-codepoint key (例: `ɔɪ`/`œ̃`/`ɐ̃`) が残ったままアップロードされる事故 (v1.12.0 で発生) を防げます。
+
+```bash
+# 検証 + アップロード (config + onnx)
+HF_TOKEN=hf_xxx python scripts/upload_model_to_hf.py \
+    --repo username/piper-plus-my-model \
+    --config path/to/config.json \
+    --onnx   path/to/model.onnx
+
+# 検証のみ (dry run)
+python scripts/upload_model_to_hf.py \
+    --repo username/piper-plus-my-model \
+    --config path/to/config.json \
+    --dry-run
+```
+
+CI 経由で投稿する場合は GitHub Actions の `Release Model Config to HF Hub` workflow (`workflow_dispatch`) も利用できます。
+
 ### Step 2: Model Card (README.md) を作成
 
 HuggingFace リポジトリの README.md に以下の情報を含めてください。

--- a/scripts/upload_model_to_hf.py
+++ b/scripts/upload_model_to_hf.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Upload a Piper-Plus model config (and optionally the .onnx) to Hugging Face Hub.
+
+Always runs `update_model_config.py --validate-only` before upload. That
+pre-flight check is the gate that would have blocked the v1.12.0
+ɔɪ/œ̃/ɐ̃ regression — without it, multi-codepoint phoneme keys can leak
+into the distributed config.json and break C++ inference.
+
+Usage
+-----
+    # Validate + upload a single config
+    python scripts/upload_model_to_hf.py \
+        --repo ayousanz/piper-plus-tsukuyomi-chan \
+        --config tmp/tsukuyomi-chan-6lang-fp16.onnx.json
+
+    # Validate + upload config and onnx together
+    python scripts/upload_model_to_hf.py \
+        --repo ayousanz/piper-plus-tsukuyomi-chan \
+        --config tmp/tsukuyomi-chan-6lang-fp16.onnx.json \
+        --onnx   tmp/tsukuyomi-chan-6lang-fp16.onnx
+
+    # Dry-run (validate only, do not call HF API)
+    python scripts/upload_model_to_hf.py --repo ... --config ... --dry-run
+
+    # CI usage: skip interactive token prompt (HF_TOKEN env var required)
+    HF_TOKEN=hf_xxx python scripts/upload_model_to_hf.py --repo ... --config ...
+
+The HF token is read from `HF_TOKEN` (preferred) or `HUGGING_FACE_HUB_TOKEN`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class UploadAbortedError(RuntimeError):
+    """Raised when validation fails — upload must not proceed."""
+
+
+def run_validation(config_path: Path) -> None:
+    """Invoke `python -m piper_train.update_model_config --validate-only`.
+
+    Raises UploadAbortedError if the config still contains multi-codepoint
+    phoneme_id_map keys (i.e. PUA normalization didn't fully run).
+    """
+    print(f"==> Pre-flight validation: {config_path}")
+    src_python = REPO_ROOT / "src" / "python"
+    cmd = [
+        sys.executable,
+        "-m",
+        "piper_train.update_model_config",
+        "--validate-only",
+        str(config_path),
+    ]
+    result = subprocess.run(
+        cmd,
+        cwd=src_python,
+        capture_output=True,
+        text=True,
+    )
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        raise UploadAbortedError(
+            f"validate-only check failed (exit {result.returncode}). "
+            "Refusing to upload — fix the config first "
+            "(see scripts/regenerate_tsukuyomi_config.py)."
+        )
+    print("==> Validation passed.")
+
+
+def upload(
+    repo: str,
+    files: list[tuple[Path, str]],
+    *,
+    commit_message: str,
+    dry_run: bool,
+) -> None:
+    """Upload `files` (local_path, repo_path) to HF Hub repo `repo`."""
+    if dry_run:
+        print("==> DRY RUN — would upload to HF Hub:")
+        for local, remote in files:
+            print(f"      {local} -> hf://{repo}/{remote}")
+        return
+
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if not token:
+        raise UploadAbortedError(
+            "HF_TOKEN (or HUGGING_FACE_HUB_TOKEN) env var must be set "
+            "for non-interactive uploads."
+        )
+
+    try:
+        from huggingface_hub import HfApi
+    except ImportError as e:
+        raise UploadAbortedError(
+            "huggingface_hub is not installed. "
+            "Install with `uv pip install huggingface_hub` and retry."
+        ) from e
+
+    api = HfApi(token=token)
+    print(f"==> Uploading {len(files)} file(s) to {repo}")
+    for local, remote in files:
+        print(f"    {local.name} -> {remote}")
+        api.upload_file(
+            path_or_fileobj=str(local),
+            path_in_repo=remote,
+            repo_id=repo,
+            commit_message=commit_message,
+        )
+    print("==> Upload complete.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help="HuggingFace repo id (e.g. ayousanz/piper-plus-tsukuyomi-chan)",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        required=True,
+        help="Local path to the model config.json to validate and upload",
+    )
+    parser.add_argument(
+        "--onnx",
+        type=Path,
+        default=None,
+        help="Optional: local path to the .onnx file to upload alongside config",
+    )
+    parser.add_argument(
+        "--config-remote-name",
+        default=None,
+        help="Repo-side filename for the config (default: same as local)",
+    )
+    parser.add_argument(
+        "--onnx-remote-name",
+        default=None,
+        help="Repo-side filename for the onnx (default: same as local)",
+    )
+    parser.add_argument(
+        "--commit-message",
+        default="Update model config (validated by upload_model_to_hf.py)",
+        help="Commit message for the HF upload",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run validation but do not call HF API",
+    )
+    args = parser.parse_args()
+
+    if not args.config.exists():
+        print(f"ERROR: config not found: {args.config}", file=sys.stderr)
+        return 2
+    if args.onnx and not args.onnx.exists():
+        print(f"ERROR: onnx not found: {args.onnx}", file=sys.stderr)
+        return 2
+
+    try:
+        run_validation(args.config)
+    except UploadAbortedError as e:
+        print(f"ABORT: {e}", file=sys.stderr)
+        return 1
+
+    files: list[tuple[Path, str]] = [
+        (args.config, args.config_remote_name or args.config.name),
+    ]
+    if args.onnx:
+        files.append((args.onnx, args.onnx_remote_name or args.onnx.name))
+
+    try:
+        upload(
+            args.repo,
+            files,
+            commit_message=args.commit_message,
+            dry_run=args.dry_run,
+        )
+    except UploadAbortedError as e:
+        print(f"ABORT: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/upload_model_to_hf.py
+++ b/scripts/upload_model_to_hf.py
@@ -49,19 +49,33 @@ def run_validation(config_path: Path) -> None:
 
     Raises UploadAbortedError if the config still contains multi-codepoint
     phoneme_id_map keys (i.e. PUA normalization didn't fully run).
+
+    Uses PYTHONPATH instead of changing the working directory so a relative
+    --config argument resolves against the user's CWD (Copilot review on
+    PR #393).
     """
-    print(f"==> Pre-flight validation: {config_path}")
-    src_python = REPO_ROOT / "src" / "python"
+    # Resolve to absolute so the subprocess sees the same file regardless of
+    # the cwd it inherits (which we leave at the caller's cwd).
+    abs_config = config_path.resolve()
+    print(f"==> Pre-flight validation: {abs_config}")
+
+    src_python = str(REPO_ROOT / "src" / "python")
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{src_python}{os.pathsep}{existing}" if existing else src_python
+    )
+
     cmd = [
         sys.executable,
         "-m",
         "piper_train.update_model_config",
         "--validate-only",
-        str(config_path),
+        str(abs_config),
     ]
     result = subprocess.run(
         cmd,
-        cwd=src_python,
+        env=env,
         capture_output=True,
         text=True,
         check=False,
@@ -99,7 +113,7 @@ def upload(
         )
 
     try:
-        from huggingface_hub import HfApi
+        from huggingface_hub import CommitOperationAdd, HfApi
     except ImportError as e:
         raise UploadAbortedError(
             "huggingface_hub is not installed. "
@@ -107,15 +121,20 @@ def upload(
         ) from e
 
     api = HfApi(token=token)
-    print(f"==> Uploading {len(files)} file(s) to {repo}")
+    print(f"==> Uploading {len(files)} file(s) to {repo} (single atomic commit)")
     for local, remote in files:
         print(f"    {local.name} -> {remote}")
-        api.upload_file(
-            path_or_fileobj=str(local),
-            path_in_repo=remote,
-            repo_id=repo,
-            commit_message=commit_message,
-        )
+    # Use create_commit so all files land in one commit; if any file errors,
+    # nothing is published. This avoids a half-uploaded release where the
+    # config landed but the .onnx didn't (Copilot review on PR #393).
+    api.create_commit(
+        repo_id=repo,
+        operations=[
+            CommitOperationAdd(path_in_repo=remote, path_or_fileobj=str(local))
+            for local, remote in files
+        ],
+        commit_message=commit_message,
+    )
     print("==> Upload complete.")
 
 

--- a/scripts/upload_model_to_hf.py
+++ b/scripts/upload_model_to_hf.py
@@ -36,6 +36,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -63,6 +64,7 @@ def run_validation(config_path: Path) -> None:
         cwd=src_python,
         capture_output=True,
         text=True,
+        check=False,
     )
     sys.stdout.write(result.stdout)
     sys.stderr.write(result.stderr)


### PR DESCRIPTION
## Summary

v1.12.0 の ɔɪ/œ̃/ɐ̃ multi-codepoint key を含む config.json が HF Hub に直接アップロードされた事故の **真の原因** に対する対策。HF Hub への upload 前に `update_model_config.py --validate-only` を必ず走らせる仕組みを導入。

> **Note**: PR #389 を base にした stack PR です。先に #389 をマージしてください。

## なぜ必要か

PR #389 の修正は「config.json を生成するロジック」を fail-fast 化しましたが、**既に手動でアップロード済みの v1.12.0 config** や **将来の手動アップロード** には効果がありません。

このパイプラインを通せば:
- アップロード前に validate-only が必ず走る
- multi-codepoint key が残っていれば ABORT、HF API は一切呼ばない
- 検証のみ (dry-run) も可能

## 変更内容

### `scripts/upload_model_to_hf.py` 新設

```bash
# 検証 + アップロード
HF_TOKEN=hf_xxx python scripts/upload_model_to_hf.py \
    --repo ayousanz/piper-plus-tsukuyomi-chan \
    --config tmp/tsukuyomi.config.json \
    --onnx   tmp/tsukuyomi.onnx

# dry-run (validate-only)
python scripts/upload_model_to_hf.py --repo ... --config ... --dry-run
```

- `update_model_config.py --validate-only` を必ず先に実行
- 失敗時は ABORT、HF API は呼ばない
- 成功時のみ \`huggingface_hub.HfApi.upload_file\` で upload
- token は \`HF_TOKEN\` (preferred) or \`HUGGING_FACE_HUB_TOKEN\` env var

### `.github/workflows/release-model-config.yml` 新設

`workflow_dispatch` トリガで Actions UI から実行可能:
- inputs: \`hf_repo\`, \`config_path\`, \`onnx_path\`, \`dry_run\` 等
- 内部で \`upload_model_to_hf.py\` を呼ぶ
- \`HF_TOKEN\` は repo secret から
- 既定 \`dry_run: true\` で安全側に倒す

### `CONTRIBUTING_MODELS.md` 更新

Step 1 にこの手順を記載 (直接アップロード代わりに upload_model_to_hf.py を使う旨)。

## Test plan

- [ ] `python scripts/upload_model_to_hf.py --help` で help 表示
- [ ] CI で release-model-config.yml の syntax check
- [ ] (手動) workflow_dispatch で dry-run 実行成功