### PR TITLE
chore(pre-commit): PUA 関連ローカルガード追加 (C)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# Pre-commit hooks for piper-plus.
+#
+# Install once with `pre-commit install`. Then every `git commit` will run
+# the hooks below on changed files; if any hook fails, the commit is blocked.
+#
+# These hooks are mirrored by CI (.github/workflows/pua-consistency.yml +
+# ruff job), so the local check just gives faster feedback.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.5
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # PUA-related checks. These only run when files in the regression-prone
+  # set actually change, so the typical `git commit` is unaffected.
+  - repo: local
+    hooks:
+      - id: pua-cross-runtime-consistency
+        name: PUA cross-runtime consistency (6 runtime tables vs pua.json)
+        entry: python scripts/check_pua_consistency.py --check-version
+        language: system
+        # Mirror of paths in .github/workflows/pua-consistency.yml
+        files: ^(src/python/g2p/piper_plus_g2p/data/pua\.json|src/python/g2p/piper_plus_g2p/encode/.+|src/python_run/piper/phonemize/token_mapper\.py|src/rust/piper-plus-g2p/src/token_map\.rs|src/go/phonemize/pua\.go|src/go/phonemize/pua_test\.go|src/wasm/g2p/src/pua-map\.js|src/csharp/PiperPlus\.Core/Mapping/OpenJTalkToPiperMapping\.cs|src/cpp/phoneme_parser\.cpp)$
+        pass_filenames: false
+
+      - id: pua-fixture-drift
+        name: Test fixture in sync with pua.json
+        entry: python scripts/regenerate_test_fixture.py --check
+        language: system
+        files: ^(src/python/g2p/piper_plus_g2p/data/pua\.json|tests/fixtures/g2p/phoneme_test_cases\.json)$
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,25 +41,31 @@ ruff format --check
 ruff format
 ```
 
-#### Pre-commit Hook (Optional)
+#### Pre-commit Hook (Optional, recommended)
 
-To automatically run Ruff before each commit:
+A `.pre-commit-config.yaml` is checked in at the repo root. Install the
+runner once and the hooks will run on every `git commit`:
 
 ```bash
 uv pip install pre-commit
 pre-commit install
 ```
 
-Create `.pre-commit-config.yaml`:
+The hooks include:
 
-```yaml
-repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.5
-    hooks:
-      - id: ruff
-        args: [ --fix ]
-      - id: ruff-format
+- **Ruff** (`ruff` + `ruff format`) on every Python file change.
+- **PUA cross-runtime consistency** when any of the 6 runtime PUA tables
+  or `pua.json` change. Mirrors the CI gate that prevents the
+  multi-codepoint regression class (see `docs/spec/pua-contract.toml`).
+- **Test fixture drift** when `pua.json` or
+  `tests/fixtures/g2p/phoneme_test_cases.json` change. Catches the bug
+  class behind PR #389 (the bumped `pua_map_count` not matching the
+  `pua_map` dict).
+
+To run the hooks manually on the current tree:
+
+```bash
+pre-commit run --all-files
 ```
 
 ## Code Style


### PR DESCRIPTION
## Summary

CI で動いている PUA 系チェックのローカル版を pre-commit に組み込み、push 前の早期検出層を追加。CI と同等のチェックをローカルで先に走らせることで、CI 待ちの time-to-feedback を短縮。

> **Note**: PR #389 を base にした stack PR です。

## 変更内容

### `.pre-commit-config.yaml` 新設

これまで CONTRIBUTING.md に「Create `.pre-commit-config.yaml`」とだけ書かれていて実ファイルは存在しなかったので、checked-in 化。

| Hook | 発動条件 | 内容 |
|------|--------|------|
| ruff (既存) | Python ファイル変更 | `ruff --fix` + `ruff format` |
| pua-cross-runtime-consistency | 6 ランタイム PUA テーブル / pua.json 変更 | `check_pua_consistency.py --check-version` |
| pua-fixture-drift | pua.json / fixture 変更 | `regenerate_test_fixture.py --check` |

### `CONTRIBUTING.md`

hook 説明を「create your own」から「checked-in、`pre-commit install` するだけ」に更新。

## なぜ必要か

PR #389 で起きたドリフト (`pua_map_count` を 99 にしたが `pua_map` dict は 96 のまま) は、CI が走ってから 5 分後に Windows のテストで発覚しました。pre-commit があれば commit 前にブロックできました。

## Test plan

- [ ] `pre-commit install && pre-commit run --all-files` が success
- [ ] `pua.json` に dummy 編集 → commit ブロック確認 (手動)