### PR TITLE
fix(ci): dev 連続失敗修正 (cosign / gitleaks) + PR 時検知ゲート追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,18 @@
 #
 # Reference:
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# ── 既知の失敗パターン: Dependency Graph (GitHub Dependency Submission API) ──
+# GitHub 側で動的生成される `Dependency Graph` チェック (`event: dynamic`、
+# 本ファイルに対応する yaml は無く `github/dependabot-action@main` 内蔵) は、
+# `pyproject.toml` を見つけると uv updater を試行する仕様で、
+# `src/python/`, `src/python_run/` のように pyproject はあるが
+# `uv.lock` が無い subdirectory では `update-uv-graph` ジョブが
+#   "ERROR No uv.lock or pyproject.toml present."
+# で fail する (sha 1595f630 で観測)。
+# このチェックは GitHub の dynamic workflow であり PR では走らないため、
+# dev push 後にしか発覚しない。 構造的解決には該当 directory への
+# `uv.lock` commit が必要 (Issue で別途トラッキング)。
 
 version: 2
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,17 @@
 # GitHub 側で動的生成される `Dependency Graph` チェック (`event: dynamic`、
 # 本ファイルに対応する yaml は無く `github/dependabot-action@main` 内蔵) は、
 # `pyproject.toml` を見つけると uv updater を試行する仕様で、
-# `src/python/`, `src/python_run/` のように pyproject はあるが
-# `uv.lock` が無い subdirectory では `update-uv-graph` ジョブが
+# subdirectory に独立 `uv.lock` が無いと `update-uv-graph` ジョブが
 #   "ERROR No uv.lock or pyproject.toml present."
-# で fail する (sha 1595f630 で観測)。
-# このチェックは GitHub の dynamic workflow であり PR では走らないため、
-# dev push 後にしか発覚しない。 構造的解決には該当 directory への
-# `uv.lock` commit が必要 (Issue で別途トラッキング)。
+# で fail する (sha 1595f630 で観測)。 PR では走らないため dev push 後に
+# しか発覚しない。
+#
+# 本ファイルでの対応:
+#   1. uv workspace member (src/python, src/python/g2p) は root の uv
+#      ecosystem 1 本に統合 (root `uv.lock` を canonical 視させる)。
+#   2. src/python_run は setup.py + requirements.txt 管理で `[project]`
+#      テーブルが無いため uv lock 不可、 pip ecosystem のまま残す
+#      (構造的解決は別 issue で minimal `[project]` 追加方針を検討)。
 
 version: 2
 
@@ -46,9 +50,16 @@ updates:
         update-types:
           - "version-update:semver-major"
 
-  # Python: src/python (学習側)
-  - package-ecosystem: "pip"
-    directory: "/src/python"
+  # Python (uv workspace): root が uv workspace の統括点
+  # ([tool.uv.workspace] members = src/python, src/python/g2p)。
+  # root の `uv.lock` に member 全依存を集約しているため、 Dependabot uv
+  # ecosystem を root 1 箇所に登録するだけで両 member を update できる。
+  # GitHub Dependency Submission API ("Dependency Graph" check) も同 lock を
+  # canonical 視するため、 subdirectory pyproject.toml の uv updater 試行
+  # (sha 1595f630 で `update-uv-graph` が `uv.lock` 不在で fail した経緯) を
+  # 抑止できる見込み。
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -59,7 +70,7 @@ updates:
       - "dependencies"
       - "automated"
     groups:
-      python-train:
+      python-uv-workspace:
         applies-to: version-updates
         update-types:
           - "minor"
@@ -69,7 +80,13 @@ updates:
         update-types:
           - "version-update:semver-major"
 
-  # Python: src/python_run (PyPI piper-plus ランタイム)
+  # Python: src/python_run (PyPI piper-plus ランタイム、 setup.py +
+  # requirements.txt 管理)。
+  # 意図的に `[project]` テーブル無し (setup.py と二重定義しない方針) で
+  # `uv lock` は実行不可。 そのため uv ecosystem へは寄せず pip のままに
+  # するが、 GitHub Dependency Submission API が `pyproject.toml` を見て
+  # uv updater を起動する可能性は残る (構造的解決には minimal `[project]`
+  # 追加 + setup.py 整合性確認が必要、 別 issue でフォロー)。
   - package-ecosystem: "pip"
     directory: "/src/python_run"
     schedule:
@@ -83,29 +100,6 @@ updates:
       - "automated"
     groups:
       python-runtime:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
-
-  # Python: src/python/g2p (独立 G2P)
-  - package-ecosystem: "pip"
-    directory: "/src/python/g2p"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "deps"
-      include: "scope"
-    labels:
-      - "dependencies"
-      - "automated"
-    groups:
-      python-g2p:
         applies-to: version-updates
         update-types:
           - "minor"

--- a/.github/workflows/docker-build-validate.yml
+++ b/.github/workflows/docker-build-validate.yml
@@ -55,10 +55,11 @@ jobs:
           echo "All docker-build.yml actions resolved successfully"
 
       - name: Verify docker-build.yml uses pinned cosign tag
-        # @v4 のような sliding tag を再導入しないように grep gate を追加。
+        # @v4 のような sliding major tag を再導入しないように grep gate を追加。
+        # 末尾が行末・空白・コメント (`# foo`) いずれの場合でも検知する。
         run: |
           set -euo pipefail
-          if grep -E 'sigstore/cosign-installer@v[0-9]+$' \
+          if grep -E 'sigstore/cosign-installer@v[0-9]+([[:space:]]|#|$)' \
               .github/workflows/docker-build.yml; then
             echo "::error::docker-build.yml references sigstore/cosign-installer with a major-only tag (e.g. @v4). sliding major tag does not exist for this action; pin to a concrete version like @v4.1.2."
             exit 1

--- a/.github/workflows/docker-build-validate.yml
+++ b/.github/workflows/docker-build-validate.yml
@@ -1,0 +1,66 @@
+name: Docker Build Validate
+
+# PR 時に docker-build.yml で参照される全 GitHub Actions が「解決可能」か
+# を検証する軽量ワークフロー。
+#
+# 背景:
+#   docker-build.yml は `on: push: dev` のみで PR では走らないため、 PR #401
+#   で sigstore/cosign-installer@v4 (sliding tag が存在しない) を導入した
+#   差分が dev push 後の 7 ジョブ全滅まで気付かれなかった。
+#
+# 検証戦略:
+#   docker-build.yml が参照する action を全部この workflow からも参照する
+#   ことで、 GitHub Actions runner の "Set up job" フェーズで action を
+#   解決させ、不在タグ (e.g. `@v4`) を merge 前に検知する。
+#   実ビルドは行わず、 cosign --help 程度の動作確認のみ。
+#   (実 image build は既存 docker-test.yml が PR で 4 image をカバーする;
+#    本 workflow は残り 3 image の Dockerfile も含めた hadolint との 2 段
+#    で多層防御する。)
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - '.github/workflows/docker-build.yml'
+      - '.github/workflows/docker-build-validate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve-actions:
+    name: Resolve docker-build.yml actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # 以下の uses: は docker-build.yml と必ず同期させること。
+      # 不一致が起きた場合は CI が落ちて気付ける。
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Resolve sigstore/cosign-installer
+        uses: sigstore/cosign-installer@v4.1.2
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Smoke check cosign binary
+        run: |
+          cosign version
+          echo "All docker-build.yml actions resolved successfully"
+
+      - name: Verify docker-build.yml uses pinned cosign tag
+        # @v4 のような sliding tag を再導入しないように grep gate を追加。
+        run: |
+          set -euo pipefail
+          if grep -E 'sigstore/cosign-installer@v[0-9]+$' \
+              .github/workflows/docker-build.yml; then
+            echo "::error::docker-build.yml references sigstore/cosign-installer with a major-only tag (e.g. @v4). sliding major tag does not exist for this action; pin to a concrete version like @v4.1.2."
+            exit 1
+          fi
+          echo "docker-build.yml cosign refs are pinned to concrete versions."

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install Cosign
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: 'v2.4.1'
 
@@ -226,7 +226,7 @@ jobs:
 
       - name: Install Cosign
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: 'v2.4.1'
 
@@ -298,7 +298,7 @@ jobs:
 
       - name: Install Cosign
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: 'v2.4.1'
 
@@ -371,7 +371,7 @@ jobs:
 
       - name: Install Cosign
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: 'v2.4.1'
 
@@ -449,7 +449,7 @@ jobs:
 
       - name: Install Cosign
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: 'v2.4.1'
 
@@ -530,7 +530,7 @@ jobs:
 
       - name: Install Cosign
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: 'v2.4.1'
 
@@ -653,7 +653,7 @@ jobs:
 
       - name: Install Cosign
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: 'v2.4.1'
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -44,3 +44,25 @@ jobs:
           # 構成にしているため GITLEAKS_LICENSE は省略可能。
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
           GITLEAKS_ENABLE_SUMMARY: "true"
+
+      # gitleaks-action は PR では base...head 差分のみスキャンするため、
+      # squash merge で「base 既存行が新規行として再出現する」ケースを
+      # 検出できない (PR #401 で ja_JP-css10-6lang-medium 文字列が dev push
+      # 時の HEAD-1commit スキャンで初めて誤検出された事例)。push 時と同じ
+      # working-tree 全件スキャンを PR でも追加実行し、 allowlist 漏れを
+      # マージ前に検知する。
+      - name: Run Gitleaks (full working-tree parity scan)
+        if: github.event_name == 'pull_request'
+        env:
+          GITLEAKS_VERSION: "8.21.2"
+        run: |
+          set -euo pipefail
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp gitleaks
+          /tmp/gitleaks dir \
+            --config .gitleaks.toml \
+            --redact \
+            --no-banner \
+            --exit-code 1 \
+            .

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -51,15 +51,28 @@ jobs:
       # 時の HEAD-1commit スキャンで初めて誤検出された事例)。push 時と同じ
       # working-tree 全件スキャンを PR でも追加実行し、 allowlist 漏れを
       # マージ前に検知する。
+      #
+      # バイナリ取得は GitHub Releases から直接行うが、 リリースに同梱の
+      # checksums.txt を用いて sha256 検証することでサプライチェーン上の
+      # 改ざん検知を担保する (Copilot review 指摘)。
       - name: Run Gitleaks (full working-tree parity scan)
         if: github.event_name == 'pull_request'
         env:
           GITLEAKS_VERSION: "8.21.2"
         run: |
           set -euo pipefail
-          curl -sSfL \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C /tmp gitleaks
+          ARCHIVE="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          BASE_URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+          cd /tmp
+          curl -sSfL -o "${ARCHIVE}" "${BASE_URL}/${ARCHIVE}"
+          curl -sSfL -o gitleaks_checksums.txt \
+            "${BASE_URL}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+          # 配布 checksums.txt から該当アーカイブの行だけを抽出して検証。
+          # --ignore-missing は他アーキの行を skip するため必須。
+          grep " ${ARCHIVE}\$" gitleaks_checksums.txt \
+            | sha256sum --check --strict
+          tar -xzf "${ARCHIVE}" gitleaks
+          cd "${GITHUB_WORKSPACE}"
           /tmp/gitleaks dir \
             --config .gitleaks.toml \
             --redact \

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -64,7 +64,10 @@ regexes = [
     # by name in tests, model catalogs, and CLI examples. Pattern is stable
     # and public (matches ja_JP-css10-6lang-medium, en_US-libritts-r-medium,
     # etc.); high entropy comes from concatenated dataset slugs.
-    '''(ja|en|zh|es|fr|pt|ko|sv)_[A-Z]{2}-[a-z0-9][a-z0-9-]*-[a-z0-9-]+''',
+    # ワード境界 (`\b`) を付けて「単独の identifier として出現したケース
+    # のみ」allow し、 より長い token の部分文字列として偶然 voice key
+    # に一致するケースの false-negative を防ぐ。
+    '''\b(ja|en|zh|es|fr|pt|ko|sv)_[A-Z]{2}-[a-z0-9][a-z0-9-]*-[a-z0-9-]+\b''',
 ]
 
 # Stop words that, when present in a match, mark it as a false-positive.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,26 +18,32 @@ description = "piper-plus baseline allowlist"
 # samples that gitleaks frequently flags as "generic high entropy" / "API key"
 # false-positives. None of them contain real credentials.
 paths = [
-  # Lock files contain hashes that look like high-entropy strings.
-  '''(^|/)package-lock\.json$''',
-  '''(^|/)uv\.lock$''',
-  '''(^|/)Cargo\.lock$''',
-  '''(^|/)go\.sum$''',
-  '''(^|/)gradle\.lockfile$''',
-  # Test fixtures / golden outputs.
-  '''(^|/)tests?/.*\.(json|jsonl|txt|csv|tsv)$''',
-  '''(^|/)test/.*\.(json|jsonl|txt|csv|tsv)$''',
-  '''(^|/)testdata/''',
-  '''(^|/)fixtures?/''',
-  # Model / checkpoint metadata (SHA-256, file digests).
-  '''\.onnx\.json$''',
-  '''\.ckpt\.sha256$''',
-  '''(^|/)model_card\.md$''',
-  # Generated docs / migration notes that may quote sample tokens.
-  '''(^|/)docs/.*\.md$''',
-  # PUA / loanword fixtures (deterministic random-looking tables).
-  '''(^|/)data/zh_en_loanword\.json$''',
-  '''(^|/)data/pua\.json$''',
+    # Lock files contain hashes that look like high-entropy strings.
+    '''(^|/)package-lock\.json$''',
+    '''(^|/)uv\.lock$''',
+    '''(^|/)Cargo\.lock$''',
+    '''(^|/)go\.sum$''',
+    '''(^|/)gradle\.lockfile$''',
+    # Test fixtures / golden outputs.
+    '''(^|/)tests?/.*\.(json|jsonl|txt|csv|tsv)$''',
+    '''(^|/)test/.*\.(json|jsonl|txt|csv|tsv)$''',
+    '''(^|/)testdata/''',
+    '''(^|/)fixtures?/''',
+    # Test source files across runtimes contain HF voice keys / model
+    # filenames whose entropy gitleaks flags as generic-api-key
+    # (e.g. "ja_JP-css10-6lang-medium" in PiperPlus.Core.Tests/VoiceCatalogTests.cs
+    # surfaced after PR #401 squash merge re-introduced the lines as additions).
+    '''(^|/)[^/]*\.?[Tt]ests?\.[^/]+/.*\.(cs|rs|go|py|java|kt|ts|js|swift|cpp|h)$''',
+    '''(^|/)[Tt]ests?/.*\.(cs|rs|go|py|java|kt|ts|js|swift|cpp|h)$''',
+    # Model / checkpoint metadata (SHA-256, file digests).
+    '''\.onnx\.json$''',
+    '''\.ckpt\.sha256$''',
+    '''(^|/)model_card\.md$''',
+    # Generated docs / migration notes that may quote sample tokens.
+    '''(^|/)docs/.*\.md$''',
+    # PUA / loanword fixtures (deterministic random-looking tables).
+    '''(^|/)data/zh_en_loanword\.json$''',
+    '''(^|/)data/pua\.json$''',
 ]
 
 # ---------------------------------------------------------------------------
@@ -46,26 +52,31 @@ paths = [
 # Strings that look like tokens but are documented placeholders or stable
 # public identifiers (HuggingFace model IDs, ONNX runtime version hashes).
 regexes = [
-  # HuggingFace model IDs (org/name).
-  '''ayousanz/piper-plus-[a-z0-9-]+''',
-  # ORT release hashes referenced in docs.
-  '''onnxruntime-(android|osx|linux|win)-[a-z0-9.-]+''',
-  # Sample WandB key placeholder used in docs.
-  '''WANDB_API_KEY=<your[-_]wandb[-_]key>''',
-  # Conventional commit / PR body example tokens.
-  '''ghp_[A-Z]{36}EXAMPLE''',
+    # HuggingFace model IDs (org/name).
+    '''ayousanz/piper-plus-[a-z0-9-]+''',
+    # ORT release hashes referenced in docs.
+    '''onnxruntime-(android|osx|linux|win)-[a-z0-9.-]+''',
+    # Sample WandB key placeholder used in docs.
+    '''WANDB_API_KEY=<your[-_]wandb[-_]key>''',
+    # Conventional commit / PR body example tokens.
+    '''ghp_[A-Z]{36}EXAMPLE''',
+    # Piper voice keys (lang_REGION-dataset-(quality|variant)) referenced
+    # by name in tests, model catalogs, and CLI examples. Pattern is stable
+    # and public (matches ja_JP-css10-6lang-medium, en_US-libritts-r-medium,
+    # etc.); high entropy comes from concatenated dataset slugs.
+    '''(ja|en|zh|es|fr|pt|ko|sv)_[A-Z]{2}-[a-z0-9][a-z0-9-]*-[a-z0-9-]+''',
 ]
 
 # Stop words that, when present in a match, mark it as a false-positive.
 stopwords = [
-  "example",
-  "EXAMPLE",
-  "placeholder",
-  "PLACEHOLDER",
-  "dummy",
-  "DUMMY",
-  "your-",
-  "YOUR-",
-  "<token>",
-  "<secret>",
+    "example",
+    "EXAMPLE",
+    "placeholder",
+    "PLACEHOLDER",
+    "dummy",
+    "DUMMY",
+    "your-",
+    "YOUR-",
+    "<token>",
+    "<secret>",
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -61,13 +61,20 @@ regexes = [
     # Conventional commit / PR body example tokens.
     '''ghp_[A-Z]{36}EXAMPLE''',
     # Piper voice keys (lang_REGION-dataset-(quality|variant)) referenced
-    # by name in tests, model catalogs, and CLI examples. Pattern is stable
-    # and public (matches ja_JP-css10-6lang-medium, en_US-libritts-r-medium,
-    # etc.); high entropy comes from concatenated dataset slugs.
+    # by name in tests, model catalogs (voices.json), and CLI examples.
+    # Pattern is stable and public (matches ja_JP-css10-6lang-medium,
+    # en_US-libritts-r-medium, es_ES-mls_10246-low, etc.); high entropy
+    # comes from concatenated dataset slugs that include digits and
+    # underscores (e.g. `mls_10246`, `mls_9972` from the Multilingual
+    # LibriSpeech dataset).
     # ワード境界 (`\b`) を付けて「単独の identifier として出現したケース
     # のみ」allow し、 より長い token の部分文字列として偶然 voice key
-    # に一致するケースの false-negative を防ぐ。
-    '''\b(ja|en|zh|es|fr|pt|ko|sv)_[A-Z]{2}-[a-z0-9][a-z0-9-]*-[a-z0-9-]+\b''',
+    # に一致するケースの false-negative を防ぐ。dataset slug にアンダー
+    # スコアが含まれるケース (MLS の話者 ID 等) を取りこぼさないよう、
+    # 中央の文字クラスに `_` を含める。
+    # 対応言語コードは voices.json の収録範囲に合わせて拡張。今後 voice
+    # を追加する際は新しい言語コードもここに加えること。
+    '''\b(ca|cs|da|de|el|en|es|fi|fr|hu|is|it|ja|ka|kk|ko|lb|ne|nl|no|pl|pt|ro|ru|sk|sr|sv|sw|tr|uk|vi|zh)_[A-Z]{2}-[a-z0-9][a-z0-9_-]*-[a-z0-9-]+\b''',
 ]
 
 # Stop words that, when present in a match, mark it as a false-positive.


### PR DESCRIPTION
## Summary

PR #401 の dev マージ後、 CI が連続失敗していた根本原因を修正し、 同種事故を **PR 時に事前検知できる仕組み**を追加します。

### 直接修正

| 失敗 | 根本原因 | 修正 |
|------|---------|------|
| `Docker Build and Push` 全 7 ジョブ | `sigstore/cosign-installer@v4` の sliding major tag が存在せず Set up job で fail | `@v4.1.2` に pin (7 箇所) |
| `Secret Scan` (gitleaks) | PR #401 の **squash merge** で `ja_JP-css10-6lang-medium` 文字列が「新規追加行」として再出現し、 entropy 4.13 が generic-api-key として誤検出 | `.gitleaks.toml` に voice key パターン (`(ja\|en\|...)_[A-Z]{2}-...`) と test source path (`*Tests*/`) を allowlist 追加 |
| `Dependency Graph` (GitHub 内蔵) | `pyproject.toml` あるが `uv.lock` 無しの subdir で uv updater が `&&` シェルエスケープミス + lock 不在で fail | `dependabot.yml` に経緯コメント記録 (構造的解決 = 該当 dir に `uv.lock` commit が必要、 別 issue でトラッキング) |

### PR 時検知ゲート (= 「dev マージ後にしか発覚しない」状態を解消)

dev push 後にしか走らないワークフローの失敗を **PR で先に検知**するため:

1. **新規 `.github/workflows/docker-build-validate.yml`**
   - PR 時に `docker-build.yml` が参照する全 actions (cosign-installer, setup-qemu, setup-buildx) を解決させる軽量 job
   - 加えて `grep` で `sigstore/cosign-installer@v[0-9]+$` (sliding major tag) の再導入を block する gate
   - 影響範囲が `docker-build.yml` 自体の変更時のみ走るので CI コスト最小

2. **`secret-scan.yml` の PR 対称化**
   - `gitleaks-action@v2` は PR モードで `base...head` 差分のみスキャン → squash merge 由来の再出現行を見逃す
   - PR 時のみ `gitleaks dir` で **working-tree 全件スキャン**を追加実行 (push と同じ単発スキャン挙動を再現)

3. **`.gitleaks.toml` の 4-space 統一**
   - PR #401 で導入された 2-space インデントが editorconfig (`*.toml = indent_size 4`) に違反していたが pre-commit が PR で動いていなかった事故の cleanup

### 監査結果 (参考)

`.github/workflows/` 配下 70 本を分類:
- Cat A (PR + push 両走): ~50 本
- **Cat B (push: dev のみ)**: 3 本 → `docker-build.yml` / `deploy-huggingface.yml` / `deploy-webassembly-demo.yml`
- Cat C (schedule / workflow_call 等): ~14 本
- GitHub 内蔵 dynamic: `Dependency Graph`

本 PR は Cat B のうち最重要の `docker-build.yml` を validate 化。 残り 2 本 (deploy 系) は今回失敗履歴に出ていないため別 issue で reusable 化を検討。

## Test plan

- [ ] `Docker Build Validate / Resolve docker-build.yml actions` が green (この PR で初動)
- [ ] `Secret Scan / Gitleaks` の **PR 時 working-tree 全件スキャン** step が pass
- [ ] `editorconfig-checker` pre-commit hook が `.gitleaks.toml` で pass
- [ ] dev に merge 後、 `Docker Build and Push` 全 7 ジョブが green に戻る
- [ ] dev に merge 後、 `Secret Scan` (push) が green に戻る
- [ ] (フォローアップ) `Dependency Graph` 修復のための `uv.lock` 生成 issue を作成