### PR TITLE
fix(docker): Python base image を手動で 3.11 → 3.13 に bump (wyoming + webui)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -269,6 +269,13 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # Python base image の minor bump (例: 3.13 → 3.14) は production の
+      # ライフサイクル判断を要するため自動 PR にせず手動で計画的に更新する。
+      # 過去事例: PR #413 で 3.11 → 3.14 (3 minor jump) が提案されたが、
+      # 3.14 が GA から間もない (2025-10) ため stable な 3.13 に手動 bump。
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-minor"
 
   # Docker: webui (Gradio)
   - package-ecosystem: "docker"
@@ -292,6 +299,11 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # Python base image の minor bump は手動で計画的に更新する
+      # (PR #415 の経緯。docker-python-inference と同方針)。
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-minor"
 
   # Docker: wyoming (Home Assistant 連携)
   - package-ecosystem: "docker"
@@ -315,3 +327,8 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # Python base image の minor bump は手動で計画的に更新する
+      # (PR #416 の経緯。docker-python-inference と同方針)。
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-minor"

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -14,6 +14,10 @@ ignored:
             # Rationale: not applicable in our Dockerfiles (we use specific tags)
   - DL3018  # Pin versions in apk add
             # Rationale: only relevant if alpine-based; our images use debian/ubuntu
+  - DL3059  # Multiple consecutive RUN instructions
+            # Rationale: layer separation is intentional in our multi-stage builds
+            # for cache granularity (rebuilding wheels shouldn't bust pip-install
+            # layers). info-level rule, not worth consolidating into one RUN.
 
 trustedRegistries:
   - docker.io

--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -1,5 +1,5 @@
 # WebUI Docker image for piper-plus
-FROM python:3.11-slim-trixie
+FROM python:3.13-slim-trixie
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/wyoming/Dockerfile
+++ b/docker/wyoming/Dockerfile
@@ -10,7 +10,7 @@
 # ============================================================
 # Stage 1: Builder -- compile C extensions (pyopenjtalk, etc.)
 # ============================================================
-FROM python:3.11-slim-trixie AS builder
+FROM python:3.13-slim-trixie AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -41,7 +41,7 @@ COPY src/python/ /build/src/python/
 # Building wheels first sidesteps this entirely (archive_info instead of dir_info
 # in dist-info/direct_url.json).
 RUN uv build /build/src/python/g2p --wheel --out-dir /tmp/wheels/ \
- && uv build /build/src/python      --wheel --out-dir /tmp/wheels/
+    && uv build /build/src/python      --wheel --out-dir /tmp/wheels/
 
 # Install piper_plus_g2p (standalone G2P -- all languages)
 RUN uv pip install --system "$(ls /tmp/wheels/piper_plus_g2p-*.whl)[all]"
@@ -70,7 +70,7 @@ nltk.download('cmudict', download_dir='/usr/share/nltk_data')"
 # ============================================================
 # Stage 2: Runtime -- minimal image
 # ============================================================
-FROM python:3.11-slim-trixie
+FROM python:3.13-slim-trixie
 
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -82,9 +82,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Copy installed Python packages from builder
-COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
+# Copy installed Python packages from builder.
+# Use `/usr/local` as a whole instead of `/usr/local/lib/python3.X/site-packages`
+# so the Dockerfile stays valid across future Python minor bumps (e.g. 3.13 → 3.14).
+# Same base image in both stages → no /usr/local conflicts.
+COPY --from=builder /usr/local /usr/local
 
 # Copy NLTK data
 COPY --from=builder /usr/share/nltk_data /usr/share/nltk_data
@@ -129,7 +131,7 @@ EXPOSE 10200
 
 # Healthcheck: TCP connection to the Wyoming server
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-  CMD python -c "import socket; s=socket.socket(); s.settimeout(5); s.connect(('localhost', 10200)); s.close()" || exit 1
+    CMD python -c "import socket; s=socket.socket(); s.settimeout(5); s.connect(('localhost', 10200)); s.close()" || exit 1
 
 ENTRYPOINT ["python", "-m", "piper_wyoming"]
 CMD ["--model", "tsukuyomi", "--uri", "tcp://0.0.0.0:10200"]


### PR DESCRIPTION
## Summary

- `docker/wyoming/Dockerfile` と `docker/webui/Dockerfile` の Python base image を `python:3.11-slim-trixie` → `python:3.13-slim-trixie` に手動 bump。
- `docker/wyoming/Dockerfile` の `COPY --from=builder /usr/local/lib/python3.X/site-packages` を `/usr/local` 全体コピーに変更し、将来の Python minor bump で壊れない構造に。
- `.github/dependabot.yml` の 3 docker ecosystem (wyoming / webui / python-inference) で Python image の **minor bump も** ignore に追加。今後の Python 移行は計画的な手動 PR に切替。
- `.hadolint.yaml` で DL3059 (連続 RUN) を ignored 追加 (multi-stage layer cache 粒度のため意図的)。

## Background

Dependabot が PR #416 / #415 / #413 で `python:3.11-slim-trixie` → `python:3.14-slim-trixie` (3 minor jump) を提案していたが、 Python 3.14 は GA から 7 ヶ月 (2025-10-07) で production base image として時期尚早。 stable な 3.13 (GA 2025-03、 ~1.5 年経過) を選択。 3 PR は close 済み。

| 項目 | 3.11 (現行) | 3.13 (今回) | 3.14 (Dependabot 案) |
|------|------------|-------------|---------------------|
| GA | 2022-10-24 | 2025-03 | 2025-10-07 |
| EOL | 2027-10 | 2029-10 | 2030-10 |
| 経過 | ~3.5 年 | ~1.5 年 | ~7 ヶ月 |

## Out of scope

- `docker/python-inference/Dockerfile` は `FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` + `apt install python3.11` 構造のため、 3.13 化には deadsnakes PPA 追加か base image 変更が必要。別 PR で個別検討する。

## Test plan

- [ ] CI の wyoming Docker build + smoke test pass を確認
- [ ] CI の webui Docker build + smoke test pass を確認
- [ ] `pyopenjtalk-plus`, `onnxruntime`, `wyoming`, `huggingface-hub` の 3.13 wheel install が CI で成功することを確認
- [ ] hadolint / editorconfig / pre-commit lint が pass することを確認