### PR TITLE
fix(dependabot): production-impacting な依存を minor bump ignore に追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -200,6 +200,15 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # onnxruntime_go の minor bump は ORT バージョン整合性に直結するため
+      # 手動で計画的に更新する。Issue #372 (ORT バージョン floor 統一)。
+      # 過去事例: PR #417 で 1.27 → 1.30 (内部で ORT 1.25 へ upgrade) が
+      # 提案されたが、CI の libonnxruntime.so (ORT 1.20 系) と API 不整合で
+      # integration-test fail。Python/Rust/C#/C++ と同時更新する PR で
+      # unignore する想定。
+      - dependency-name: "github.com/yalue/onnxruntime_go"
+        update-types:
+          - "version-update:semver-minor"
 
   # Gradle: android/piper-plus-g2p
   - package-ecosystem: "gradle"
@@ -274,6 +283,12 @@ updates:
       # 過去事例: PR #413 で 3.11 → 3.14 (3 minor jump) が提案されたが、
       # 3.14 が GA から間もない (2025-10) ため stable な 3.13 に手動 bump。
       - dependency-name: "python"
+        update-types:
+          - "version-update:semver-minor"
+      # CUDA image の minor bump (例: 12.4 → 12.9) も同様に production の
+      # GPU driver / cuDNN 互換性判断を要するため手動更新方針。
+      # 過去事例: PR #427 で 12.4.1 → 12.9.1 (5 minor jump) が提案された。
+      - dependency-name: "nvidia/cuda"
         update-types:
           - "version-update:semver-minor"
 


### PR DESCRIPTION
## Summary

ユーザー方針「影響が大きい変更は避ける」に従い、 production 用の重い依存については自動 minor bump を ignore して、 必要時に手動で計画的に更新する方針に切替。

## 追加した ignore

### gomod ecosystem
- `github.com/yalue/onnxruntime_go` の minor bump
  - Issue #372 (cross-runtime ORT バージョン floor 統一) との整合性確保
  - 過去事例: PR #417 で 1.27 → 1.30 提案、内部で ORT 1.25 へ upgrade されており、 CI の `libonnxruntime.so` (ORT 1.20 系) と API 不整合で integration-test fail
  - Python/Rust/C#/C++ と同時更新する PR で unignore する想定

### docker-python-inference ecosystem
- `nvidia/cuda` の minor bump
  - 過去事例: PR #427 で 12.4.1 → 12.9.1 (5 minor jump) 提案
  - GPU driver / cuDNN 互換性判断を要するため、 Python image と同じ手動更新方針に揃える

## 関連 close PR (本 PR とセットで対応)
- #417 (gomod `onnxruntime_go` 1.30 + `x/text`)
- #427 (nvidia/cuda 12.9.1)
- #424 (python-uv-workspace 27 packages、license allow-list 違反) — 設定変更なしで close のみ

## Test plan

- [ ] dependabot.yml の YAML syntax が valid であることを CI で確認 (`check-yaml` pre-commit hook)
- [ ] 次回 schedule (月次) で `onnxruntime_go` / `nvidia/cuda` の自動 PR が提案されないことを確認
- [ ] 既存の他依存の minor bump (gradio, numpy 等) は引き続き提案されることを確認