### PR TITLE
fix(security): CodeQL noise 削減 + cs/unsafe-double-checked-lock 修正

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -69,6 +69,14 @@ paths-ignore:
   # Vendored / third-party code (we don't audit upstream).
   - 'src/piper_phonemize_bundled/**'
   - 'src/cpp/openjtalk/**'
+  # nlohmann/json single-header (v3.11.2, MIT) at src/cpp/json.hpp。
+  # Code Scanning alert の上位を占める (cpp/commented-out-code 108 件 /
+  # cpp/unused-local-variable 7 件 / cpp/long-switch 7 件 等)。
+  # 我々は upstream を audit しない。 cpp の compilation DB 経由 include で
+  # paths-ignore がどこまで効くかは extractor 側の都合に依存するが、 新規
+  # PR が `#include "json.hpp"` を増やしたときに analysis 入り口で除外
+  # 候補と見なせるよう、 ここで明示的に列挙しておく。
+  - 'src/cpp/json.hpp'
 
   # Generated/large fixtures.
   - 'tests/fixtures/**'

--- a/src/csharp/PiperPlus.Core/Phonemize/CustomDictionary.cs
+++ b/src/csharp/PiperPlus.Core/Phonemize/CustomDictionary.cs
@@ -47,6 +47,15 @@ namespace PiperPlus.Core.Phonemize;
 ///         <c>description</c>, <c>metadata</c>) are skipped in JSON.</item>
 ///   <item>Higher priority values win when the same key appears in multiple files.</item>
 /// </list>
+/// <para><b>Thread safety:</b> Loading operations (<see cref="LoadDictionary"/>,
+/// <see cref="LoadDictionaries"/>, <see cref="LoadDefaults"/>) are <i>not</i> safe
+/// to invoke concurrently with each other or with <see cref="ApplyToText"/>.
+/// The intended usage is: load all dictionaries from a single thread at startup,
+/// then call <see cref="ApplyToText"/> concurrently from any thread thereafter.
+/// The <c>volatile</c> on <c>_dirty</c>/<c>_sorted</c> covers the double-checked
+/// locking read in <see cref="ApplyToText"/>; it does <i>not</i> make load-while-read
+/// safe (a write to <c>_dirty</c> from <c>AddEntry</c> can be overwritten by the
+/// reader's <c>_dirty = false</c>, leaving the cache stale).</para>
 /// </remarks>
 public sealed class CustomDictionary
 {
@@ -98,13 +107,16 @@ public sealed class CustomDictionary
     private readonly List<DictionaryEntry> _entries = new();
 
     // Track whether the sorted cache is stale.
-    // volatile: ApplyToText の double-checked locking で lock の外側から読むため、
-    // 別スレッドからの書き込み (Add/Remove → _dirty = true) を観測可能にする必要がある。
+    // volatile: ApplyToText performs a double-checked read of this field outside
+    // _sortLock; the volatile semantics ensure writes from AddEntry (invoked by
+    // LoadDictionary/LoadDictionaries/LoadDefaults) become visible to readers.
+    // See class XML doc for thread-safety scope — this does not make load-while-
+    // read safe; loading must complete before concurrent ApplyToText calls.
     private volatile bool _dirty;
 
     // Sorted snapshot used by ApplyToText (rebuilt lazily when _dirty is true).
-    // volatile: 同じく double-checked locking でフィールドを lock の外から読むため、
-    // 別スレッドが構築した List への参照を確実に観測する必要がある。
+    // volatile: the same double-checked read path needs to observe the reference
+    // published by another thread that rebuilt the list under _sortLock.
     private volatile List<DictionaryEntry>? _sorted;
 
     private readonly object _sortLock = new();

--- a/src/csharp/PiperPlus.Core/Phonemize/CustomDictionary.cs
+++ b/src/csharp/PiperPlus.Core/Phonemize/CustomDictionary.cs
@@ -98,10 +98,14 @@ public sealed class CustomDictionary
     private readonly List<DictionaryEntry> _entries = new();
 
     // Track whether the sorted cache is stale.
-    private bool _dirty;
+    // volatile: ApplyToText の double-checked locking で lock の外側から読むため、
+    // 別スレッドからの書き込み (Add/Remove → _dirty = true) を観測可能にする必要がある。
+    private volatile bool _dirty;
 
     // Sorted snapshot used by ApplyToText (rebuilt lazily when _dirty is true).
-    private List<DictionaryEntry>? _sorted;
+    // volatile: 同じく double-checked locking でフィールドを lock の外から読むため、
+    // 別スレッドが構築した List への参照を確実に観測する必要がある。
+    private volatile List<DictionaryEntry>? _sorted;
 
     private readonly object _sortLock = new();
 


### PR DESCRIPTION
## Summary
- Code Scanning open alert 670 件のうち、 noise の上位 (vendored `src/cpp/json.hpp` 由来) を CodeQL config の paths-ignore に列挙
- `cs/unsafe-double-checked-lock` (alert #553) を `volatile` 付与で修正

## 背景

Code Scanning alert 一覧を整理した結果：

| 重要度 | rule (上位) | 件数 | 性質 |
|---|---|---|---|
| **high (security)** | `cpp/integer-multiplication-cast-to-long` | 2 | vendored MeCab (build/o/.../mecab/connector.cpp) |
| **medium (security)** | `py/log-injection` | 24 | CLI/学習 pipeline 20 + HTTP server 4 |
| **error** | `cs/unsafe-double-checked-lock` | 1 | CustomDictionary.cs:389 |
| **warning/note** | `cpp/commented-out-code` 139 等 | 約 643 | コード品質、大半が vendored |

本 PR では「影響が大きい変更は避ける」方針のもと、最小スコープに絞った：

### A: `.github/codeql/codeql-config.yml`
`src/cpp/json.hpp` (nlohmann/json 3.11.2、MIT) を paths-ignore に列挙。
- `cpp/commented-out-code` 108 件、 `cpp/unused-local-variable` 7 件、 `cpp/long-switch` 7 件等の上位 noise source
- 我々は upstream を audit する立場ではない
- cpp の compilation DB 経由 include で paths-ignore が完全に効くかは extractor 依存だが、 新規 PR が `#include "json.hpp"` した時の analysis 入り口で除外候補にできるよう明示

### E: `src/csharp/PiperPlus.Core/Phonemize/CustomDictionary.cs`
`_dirty` / `_sorted` フィールドを `volatile` 化。
- `ApplyToText` の double-checked locking パターンで lock の外側からフィールドを読む
- 他スレッドの書き込み (Add/Remove → `_dirty = true`) を確実に観測する必要がある
- semantic 変更なし (JIT への hint のみ)

CodeQL alert: #553 (`cs/unsafe-double-checked-lock`)

## スコープ外 (別 PR で議論)

- **B**: vendored 由来 alert 約 270 件の `won't fix` dismiss (API 操作のみ、コード変更なし)
- **C**: py/log-injection CLI/学習 pipeline 20 件の `won't fix` dismiss (既存 config の py/path-injection 注記と同方針)
- **D**: HTTP server (inference.py / http_server.py / webui.py) の log sanitize (4 件、 untrusted input への実防御)
- **F**: warning/note 品質系 alert (約 350 件) の一括 dismiss

## Test plan
- [ ] CodeQL workflow が緑になる (本 PR で新規 alert を発生させない)
- [ ] `dotnet format --verify-no-changes` pass (pre-commit で確認済み)
- [ ] CustomDictionaryTests が CI で pass (dotnet 10 ローカル不在のため CI で検証)