### PR TITLE
fix(security): HTTP server の log-injection 対策 (CodeQL py/log-injection)

### DIFF
--- a/.codespell-ignore-words.txt
+++ b/.codespell-ignore-words.txt
@@ -127,3 +127,13 @@ padd
 statics
 unparseable
 Unparseable
+
+# Non-English words in webui.py sample_texts (de_DE / fr_FR).  CI workflow
+# already skips webui.py via git ls-files allow-list, but pre-commit's
+# codespell scans whatever git shows as modified.  Listing the foreign words
+# here is more robust than path-based skip (which uses fnmatch and may not
+# match relative paths consistently across CI vs pre-commit).
+# Sie — German "you" (formal)
+Sie
+# informations — French "informations" (plural)
+informations

--- a/.codespellrc
+++ b/.codespellrc
@@ -6,7 +6,7 @@
 #  3. Phoneme / pinyin / mecab dictionaries — these are large (1–4 MB) data
 #     files full of non-English fragments that codespell flags as typos and
 #     also dominate the scan runtime.  Triplicated across rust / wasm / test.
-skip = ./.git,./.build,./node_modules,./build,./dist,./target,./.cache,./test/models,./tools/benchmark/issue-383,./pkg,./.next,./out,./vendor,./third_party,./external,./_deps,./.venv,./venv,./*.lock,./*.min.js,./*.min.css,./*.map,./README_DE.md,./README_ES.md,./README_FR.md,./README_HI.md,./README_KO.md,./README_PT.md,./README_RU.md,./README_SV.md,./README_ZH.md,./src/rust/piper-plus-g2p/data/*.json,./src/wasm/openjtalk-web/assets/*.json,./data/dictionaries/*.json
+skip = ./.git,./.build,./node_modules,./build,./dist,./target,./.cache,./test/models,./tools/benchmark/issue-383,./pkg,./.next,./out,./vendor,./third_party,./external,./_deps,./.venv,./venv,./*.lock,./*.min.js,./*.min.css,./*.map,./README_DE.md,./README_ES.md,./README_FR.md,./README_HI.md,./README_KO.md,./README_PT.md,./README_RU.md,./README_SV.md,./README_ZH.md,./src/rust/piper-plus-g2p/data/*.json,./src/wasm/openjtalk-web/assets/*.json,./data/dictionaries/*.json,./src/python_run/piper/sample_texts.py,./src/python_run/piper/webui.py
 # Files to skip
 ignore-words = .codespell-ignore-words.txt
 # Don't check these files (typically generated/lockfiles)

--- a/docker/python-inference/inference.py
+++ b/docker/python-inference/inference.py
@@ -6,8 +6,8 @@ CLI and FastAPI server modes supported.
 Server mode exposes:
 - Native endpoint: ``GET /synthesize`` for direct piper-plus usage
 - OpenAI-compatible endpoints (PR #321): ``POST /v1/audio/speech``,
-  ``GET /v1/models``, ``GET /v1/audio/speech/languages`` so existing OpenAI
-  clients can drop in unchanged
+    ``GET /v1/models``, ``GET /v1/audio/speech/languages`` so existing OpenAI
+    clients can drop in unchanged
 - ``GET /health`` for orchestrator health checks
 
 Note: phoneme-timing JSON/TSV/SRT output is exposed by the separate
@@ -36,6 +36,14 @@ from piper_train.ort_utils import create_session_with_cache, warmup_onnx_session
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _sanitize_for_log(value: str) -> str:
+    # Strip CR/LF/control chars from user-controlled values before logging
+    # to prevent log forging via line-break injection (CWE-117). Used at
+    # HTTP request boundaries (/v1/audio/speech, /tts).
+    return value.replace("\r", "").replace("\n", " ")
+
 
 # FastAPI (optional)
 try:
@@ -356,7 +364,7 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
                 _LOGGER.warning(
                     "Short text input detected (%d chars excl. spaces): %r",
                     len(text.replace(" ", "").replace("\u3000", "").strip()),
-                    text,
+                    _sanitize_for_log(text),
                 )
             return StreamingResponse(buf, media_type="audio/wav", headers=headers)
         except Exception as e:
@@ -394,7 +402,7 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
                 _LOGGER.warning(
                     "Short text input detected (%d chars excl. spaces): %r",
                     len(req.input.replace(" ", "").replace("\u3000", "").strip()),
-                    req.input,
+                    _sanitize_for_log(req.input),
                 )
             return StreamingResponse(buf, media_type="audio/wav", headers=headers)
         except Exception:

--- a/docker/python-inference/inference.py
+++ b/docker/python-inference/inference.py
@@ -39,9 +39,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _sanitize_for_log(value: str) -> str:
-    # Strip CR/LF/control chars from user-controlled values before logging
-    # to prevent log forging via line-break injection (CWE-117). Used at
-    # HTTP request boundaries (/v1/audio/speech, /tts).
+    # Strip CR/LF from user-controlled values before logging to prevent
+    # log forging via line-break injection (CWE-117). Used at the HTTP
+    # request boundaries `/synthesize` and `/v1/audio/speech`.
     return value.replace("\r", "").replace("\n", " ")
 
 

--- a/src/python_run/piper/http_server.py
+++ b/src/python_run/piper/http_server.py
@@ -36,6 +36,13 @@ from .timing import timing_to_json, timing_to_tsv
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _sanitize_for_log(value: str) -> str:
+    # Strip CR/LF from user-controlled values before logging to prevent
+    # log forging via line-break injection (CWE-117).
+    return value.replace("\r", "").replace("\n", " ")
+
+
 # Default channel/bit-depth assumptions match `PiperVoice.synthesize` output.
 _WAV_CHANNELS = 1
 _WAV_BIT_DEPTH = 16
@@ -191,7 +198,7 @@ def create_app(voice: Any, synthesize_args: dict[str, Any]) -> FastAPI:
         is_streaming = _parse_bool_flag(streaming)
         _LOGGER.debug(
             "Synthesizing text: %s (language_id=%s, streaming=%s)",
-            body_text,
+            _sanitize_for_log(body_text),
             resolved_language_id,
             is_streaming,
         )

--- a/src/python_run/piper/webui.py
+++ b/src/python_run/piper/webui.py
@@ -32,6 +32,15 @@ from .training_manager import training_manager
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def _sanitize_for_log(value: str) -> str:
+    # Strip CR/LF from user-controlled values before logging to prevent
+    # log forging via line-break injection (CWE-117). Gradio dropdown
+    # values are normally controlled but the public Gradio API allows
+    # arbitrary strings via the /api/predict endpoint.
+    return value.replace("\r", "").replace("\n", " ")
+
+
 _voice_cache: dict[str, "PiperVoice"] = {}
 _voice_cache_lock = threading.Lock()
 
@@ -313,7 +322,7 @@ def synthesize_speech(
                     logger.warning(
                         "Language '%s' not found in model's language_id_map; "
                         "falling back to model default",
-                        language_code,
+                        _sanitize_for_log(language_code),
                     )
 
         # Create in-memory WAV file


### PR DESCRIPTION
## Summary
- CodeQL `py/log-injection` (medium) のうち、 HTTP server (untrusted input boundary) に該当する 4 件を sanitize
- CWE-117 line-break injection 防止

## 修正対象

| ファイル | 行 | 用途 | alert |
|---|---|---|---|
| `docker/python-inference/inference.py` | 359 | `/tts` endpoint で `text` を log | #43 |
| `docker/python-inference/inference.py` | 397 | `/v1/audio/speech` で `req.input` を log | #42 |
| `src/python_run/piper/http_server.py` | 194 | `/synthesize` で `body_text` を log | #41 |
| `src/python_run/piper/webui.py` | 316 | Gradio UI で `language_code` を log | #65 |

## 対応内容

各ファイルに module-local `_sanitize_for_log(value)` helper を追加し、 CR / LF を除去してから log call に渡す。
```python
def _sanitize_for_log(value: str) -> str:
    return value.replace("\r", "").replace("\n", " ")
```

helper を共通モジュール化することも検討したが、 3 ファイルそれぞれが独立した entrypoint (Docker container / piper.http_server CLI / piper.webui CLI) で、新規 module を共有させると import 依存が増える。最小スコープで同等のコードを duplicate する方が保守的と判断。

## 副次変更
- `.codespellrc`: skip リストに `sample_texts.py` / `webui.py` を追加 (CI workflow と一貫)
- `.codespell-ignore-words.txt`: webui.py の de_DE / fr_FR sample texts で使われている `Sie` / `informations` を ignore に追加 (skip は fnmatch 依存で pre-commit と CI で path 表現差異により挙動が変わるため、 ignore-words 側で確実化)
- `inference.py` docstring: 既存の 2-space continuation indent を editorconfig 準拠の 4-space に修正 (lines 9-10)

## Test plan
- [ ] CI で CodeQL re-scan により alert #41 / #42 / #43 / #65 が消える
- [ ] pre-commit / CI の lint pass (ローカルで pre-commit 全 hook pass を確認済み)
- [ ] inference.py / http_server.py / webui.py のローカル smoke test で sanitize が "\n\r\t" → " \t" に変換することを確認済み

## 関連
- PR #434: 先行 PR で vendored noise を paths-ignore + cs/unsafe-double-checked-lock を修正
- これにより Code Scanning open alert は medium severity 0 件、残りは warning/note 品質系のみとなる見込み