### PR TITLE
fix(quality): CodeQL py 品質指摘 3 件を fix (Phase 2)

### DIFF
--- a/src/python/piper_train/export_onnx.py
+++ b/src/python/piper_train/export_onnx.py
@@ -61,9 +61,9 @@ def build_infer_forward(
         A forward function with signature::
 
             infer_forward(text, text_lengths, scales,
-                          sid=None, lid=None, prosody_features=None,
-                          speaker_embedding=None,
-                          speaker_embedding_mask=None)
+                sid=None, lid=None, prosody_features=None,
+                speaker_embedding=None,
+                speaker_embedding_mask=None)
             -> (audio: Tensor, durations: Tensor)
     """
     # Configure stochastic/deterministic mode ONCE at build time
@@ -418,7 +418,9 @@ def main() -> None:
             unify_emb_lang_weights(model_g, source=args.unify_emb_lang_source)
         except ValueError as e:
             parser.error(str(e))
-    elif do_unify and num_languages <= 1:
+    elif do_unify:
+        # num_languages <= 1 implied by the if branch above; CodeQL flagged
+        # the redundant `and num_languages <= 1` as always-true (py/redundant-comparison).
         _LOGGER.info(
             "Skipping emb_lang unification: model has only %d language(s)",
             num_languages,

--- a/src/python/piper_train/filter_utterances.py
+++ b/src/python/piper_train/filter_utterances.py
@@ -93,8 +93,6 @@ def main():
 
         text_and_audio.append((filename, text, wav_path, speaker))
 
-    writer = csv.writer(sys.stdout, delimiter="|")
-
     # speaker -> [rate]
     utts_by_speaker = defaultdict(list)
     process_utterance = ProcessUtterance()

--- a/src/python_run/piper/webui.py
+++ b/src/python_run/piper/webui.py
@@ -298,7 +298,10 @@ def synthesize_speech(
     if PiperVoice is None:
         # Return dummy audio for UI testing
         logger.warning("PiperVoice not available, returning dummy audio")
-        raise gr.Warning(
+        # gr.Warning displays a UI toast without aborting; previously this was
+        # `raise gr.Warning(...)` which made the fallback synthesis below
+        # unreachable (CodeQL py/unreachable-statement).
+        gr.Warning(
             "PiperVoice is not available. Generating synthetic audio for testing purposes."
         )
         sample_rate = 22050


### PR DESCRIPTION
## Summary
CodeQL Code Scanning の py/* 品質指摘のうち、 1 行修正で安全に fix できる 3 件を対応。

| ファイル | rule | alert | 修正 |
|---|---|---|---|
| `export_onnx.py:421` | `py/redundant-comparison` | #242 | `elif do_unify and num_languages <= 1:` → `elif do_unify:` (補集合により redundant) |
| `webui.py:304` | `py/unreachable-statement` | #175 | `raise gr.Warning(...)` → `gr.Warning(...)` (Gradio は raise 不要、 dummy audio フォールバックが復活) |
| `filter_utterances.py:96` | `py/multiple-definition` | #133 | line 96 の writer 初期化を削除 (line 106 で即再代入されるため dead code) |

## 副次変更
- `export_onnx.py` docstring lines 64-66: 既存の 14-space continuation indent を editorconfig 準拠の 4-space に修正 (file 全体 scan 由来、 既存違反)

## 関連
- 直前: PR #434 (vendored noise paths-ignore + cs/unsafe-double-checked-lock 修正)
- 直前: PR #435 (HTTP server log-injection sanitize)
- Phase 1 (vendored / test / generated alert 一括 dismiss、 計 151 件) と並行で本 PR は Phase 2 として実コード修正
- 残り cpp 3 件 (cpp/empty-if, cpp/commented-out-code, cpp/declaration-hides-variable) は false-positive / 意図的別 scope のため別途 dismiss 予定

## Test plan
- [ ] CI で CodeQL re-scan により alert #133 / #175 / #242 が消える
- [ ] pre-commit / CI の lint pass (ローカル pre-commit 全 hook pass 確認済み)
- [ ] export_onnx の挙動変更なし (補集合の elif、 ログ出力先変更なし)
- [ ] webui の dummy fallback path が動作する (raise していたため従来は到達せず)
- [ ] filter_utterances の出力変更なし (writer 重複初期化の片方削除のみ)