### PR TITLE
fix(deps): bump gitpython 3.1.49 → 3.1.50 (GHSA-mv93-w799-cj2w)

### DIFF
--- a/.codespell-ignore-words.txt
+++ b/.codespell-ignore-words.txt
@@ -76,6 +76,8 @@ Portugues
 # Library / tool names:
 # fmt — fmt library
 fmt
+# astroid — Python AST library (pylint dep); flagged as "asteroid" in uv.lock
+astroid
 ndarray
 onnxruntime
 ortdef

--- a/uv.lock
+++ b/uv.lock
@@ -1111,14 +1111,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.49"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -3184,7 +3184,7 @@ train = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7.14.0" },
+    { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7.6" },
     { name = "einops", marker = "extra == 'train'", specifier = ">=0.7" },
     { name = "fastapi", marker = "extra == 'inference'", specifier = ">=0.110" },
     { name = "fastapi", marker = "extra == 'inference-gpu'", specifier = ">=0.110" },


### PR DESCRIPTION
## Summary

- Dependabot alert [#147](https://github.com/ayutaz/piper-plus/security/dependabot/147) (high) を解消する transitive dep の patch bump。
- GitPython `<= 3.1.49` の `config_writer()` で newline injection により CVE-2026-42215 のパッチを回避でき、`core.hooksPath` 上書き経由で RCE に繋がる ([GHSA-mv93-w799-cj2w](https://github.com/advisories/GHSA-mv93-w799-cj2w))。
- 本リポジトリでは wandb の transitive (直接利用なし、攻撃面は学習環境のみ) だが、Dependabot alert 解消のため `uv lock --upgrade-package gitpython` で `3.1.49 → 3.1.50` に bump。
- 副次的に `piper-train` workspace の coverage 仕様 (`>=7.6`、`src/python/pyproject.toml`) との metadata drift も是正される。
- `.codespell-ignore-words.txt`: pylint dep の `astroid` を ignore に追加 (uv.lock 内で `asteroid` 誤検知)。

## Test plan

- [x] `uv lock --upgrade-package gitpython` で 3.1.50 に解決
- [x] pre-commit (ruff / codespell / editorconfig) Passed
- [ ] CI green