### PR TITLE
ci(deps): allow dev-tool transitive deps with copyleft/font licenses

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,6 +30,16 @@ jobs:
             MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC,
             Unicode-DFS-2016, Unicode-3.0, CC0-1.0, MPL-2.0,
             Zlib, OpenSSL, BSL-1.0, 0BSD, Apache-2.0 WITH LLVM-exception
+          # dev / lint / docs 用 transitive dependency の例外
+          # (配布バイナリには含まれず copyleft 伝播リスクなし)。
+          # ライセンスを広く allow する代わりに、対象パッケージを明示し
+          # carve-out することで scope を最小化する。
+          allow-dependencies-licenses: >-
+            pkg:pypi/astroid,
+            pkg:pypi/matplotlib,
+            pkg:pypi/mypy,
+            pkg:pypi/pylint,
+            pkg:pypi/sphinx-rtd-theme
           # 自動 fail にせず、PR comment で報告
           warn-only: false
           # vulnerability scope

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -62,6 +62,15 @@ jobs:
           license-check: true
           # 許容ライセンス (OSS 一般 + Unicode/OpenSSL/Zlib などライブラリ系)
           allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, Unicode-DFS-2016, Unicode-3.0, CC0-1.0, MPL-2.0, Zlib, OpenSSL
+          # dev / lint / docs 用 transitive dependency の例外
+          # (配布バイナリには含まれず copyleft 伝播リスクなし)。
+          # dependency-review.yml と同期。
+          allow-dependencies-licenses: >-
+            pkg:pypi/astroid,
+            pkg:pypi/matplotlib,
+            pkg:pypi/mypy,
+            pkg:pypi/pylint,
+            pkg:pypi/sphinx-rtd-theme
 
   # Python: pip-audit
   # PR では false-negative 防止のため block しないが (`continue-on-error: true`)、


### PR DESCRIPTION
## Summary

- `dependency-review-action` が下記 dev/lint/docs 用 transitive dependency を `allow-licenses` 非該当として fail させていた問題を修正
  - `astroid` (LGPL-2.1-only)
  - `matplotlib` (Apache-2.0 AND LicenseRef-scancode-matplotlib-1.3.0 AND Python-2.0)
  - `mypy` (Python-2.0 含む)
  - `pylint` (GPL-2.0-only / CC-BY-4.0 / CC-BY-SA-4.0)
  - `sphinx-rtd-theme` (OFL-1.1)
- これらは全て配布バイナリに含まれない dev/lint/docs ツールで copyleft 伝播リスクなし
- GPL/LGPL/OFL/CC-BY を `allow-licenses` でグローバル許可する代わりに、`allow-dependencies-licenses` で対象パッケージを明示 carve-out する保守的アプローチを採用
- `dependency-review.yml` と `security-audit.yml` の両ワークフローを同期

## 動機

PR #442 (dependabot による python-uv-workspace 24 パッケージ bump) の Dependency Review が上記 5 件のライセンス検出で fail しており、依存更新が block されている。

## Test plan

- [ ] このPRのDependency Review check が pass する
- [ ] マージ後、PR #442 を rebase して全 check が pass することを確認