### PR TITLE
ci(lint): sync ruff version pin to 0.15.12 (matches pyproject.toml)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,7 +436,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --no-cache-dir uv
-          uv pip install --system ruff==0.12.5 mypy
+          uv pip install --system ruff==0.15.12 mypy
 
       - name: Run ruff check
         run: ruff check .

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install Ruff
       run: |
         python -m pip install --upgrade pip
-        pip install ruff==0.12.5
+        pip install ruff==0.15.12
 
     - name: Run Ruff check
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,10 @@
 #   format commits (cf. PR #401 commits 5d9c60e6 / 8dc19e3b).
 #
 # # Version pinning:
-#   ruff version below MUST match the version pinned in
-#   .github/workflows/python-lint.yml (currently 0.12.5). Drift between
-#   pre-commit and CI = local-clean / CI-fail mismatch (PR #401 cause).
+#   ruff version below MUST match the pins in
+#   .github/workflows/python-lint.yml and .github/workflows/ci.yml
+#   (currently 0.15.12). Drift between pre-commit and CI =
+#   local-clean / CI-fail mismatch (PR #401 cause).
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.5
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
## Summary

- PR #442 (dependabot uv-workspace bump) で `pyproject.toml` の ruff が 0.12.5 → 0.15.12 に bump されたが、`.pre-commit-config.yaml` (rev) と `.github/workflows/python-lint.yml` (pip install) は 0.12.5 のまま drift していたため、3 箇所同期。
- CLAUDE.md にも明記:
  > ruff version pin: `.pre-commit-config.yaml` の `rev: vX` と `.github/workflows/python-lint.yml` の `pip install ruff==X` は同期必須。drift = local-clean / CI-fail mismatch (PR #401 の根本原因の一つ)。

## 変更

| ファイル | 修正前 | 修正後 |
|---------|------|------|
| `.pre-commit-config.yaml` | `rev: v0.12.5` | `rev: v0.15.12` |
| `.github/workflows/python-lint.yml` | `pip install ruff==0.12.5` | `pip install ruff==0.15.12` |

## Test plan

- [ ] CI の `ruff (3.11)` check が pass する (新 0.15.12 で既存コードを lint)
- [ ] CI の `pre-commit run --all-files` check が pass する