### PR TITLE
ci(security): pip-audit src/python_run の対象を requirements.txt に限定

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -95,9 +95,15 @@ jobs:
           pip-audit --requirement <(uv pip compile pyproject.toml 2>/dev/null) --strict --vulnerability-service osv || \
           pip-audit --strict --vulnerability-service osv
       - name: Audit src/python_run
+        # 引数なし `pip-audit --strict` は working-directory に依存せず runner の
+        # グローバル Python 環境を audit してしまい、プリインストール pip 自体の
+        # CVE で fail する (PR #447 後の push run で CVE-2026-3219 / CVE-2026-6357
+        # により発覚)。`--requirement requirements.txt` で配布対象の production
+        # 依存だけを対象にする。dev / gpu / webui は optional extras で
+        # 配布 wheel には含まれないため audit 対象外。
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         working-directory: src/python_run
-        run: pip-audit --strict --vulnerability-service osv
+        run: pip-audit --strict --vulnerability-service osv --requirement requirements.txt
 
   # Rust: cargo-audit
   # fail-on-severity 統一 (High 以上): cargo-audit はデフォルトで vulnerability


### PR DESCRIPTION
## Summary

- `Audit src/python_run` step が引数なし `pip-audit --strict` を実行しており、`working-directory: src/python_run` を指定していても **runner のグローバル Python 環境全体** を audit していた。
- そのため CI runner にプリインストールされた pip 26.0.1 自体の CVE-2026-3219 / CVE-2026-6357 を検出して fail。
- PR では `continue-on-error: ${{ github.event_name == 'pull_request' }}` により warning に降格されるため見えず、push (dev/main) で初めて顕在化 (run [25772299657](https://github.com/ayutaz/piper-plus/actions/runs/25772299657/job/75697783432) で観測)。
- 修正: `--requirement requirements.txt` を追加し、配布対象 (production install) の依存だけを audit するように変更。dev / gpu / webui は optional extras で配布 wheel には含まれないため対象外。

## 観測されたログ抜粋

\`\`\`
Found 2 known vulnerabilities in 1 package
Name Version ID            Fix Versions
pip  26.0.1  CVE-2026-3219
pip  26.0.1  CVE-2026-6357 26.1
\`\`\`

これは src/python_run の依存ではなく runner プリインストール pip のもの。

## 影響範囲

- 変更ファイル: `.github/workflows/security-audit.yml` 1 ファイル、`pip-audit src/python_run` step のみ。
- `pip-audit root requirements` step は変更なし (既に `--requirement <(uv pip compile ...)` で対象を絞っており正常)。
- 他の audit job (cargo-audit / npm-audit / govulncheck / nuget-audit / trivy-docker) も無関係。

## Test plan

- [ ] PR push 時に `Security Audit / pip-audit (Python)` が pass することを確認 (PR の `continue-on-error` で warning 化されないことの確認は merge 後の dev push で行う)。
- [ ] merge 後の dev push run でも同 job が pass することを確認。