### PR TITLE
fix(deps): Dependabot security alerts (urllib3 high, @protobufjs/utf8 medium)

### DIFF
--- a/src/wasm/openjtalk-web/package-lock.json
+++ b/src/wasm/openjtalk-web/package-lock.json
@@ -86,9 +86,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@types/node": {

--- a/uv.lock
+++ b/uv.lock
@@ -5101,11 +5101,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/55/2b/8cf7514cb57d028ab
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Dependabot security alerts (3 件、いずれも transitive 依存) を lockfile 側のみで解消。

| Alert | Severity | Package | From → To | Manifest |
|-------|----------|---------|-----------|----------|
| [#149](https://github.com/ayutaz/piper-plus/security/dependabot/149) GHSA-qccp-gfcp-xxvc (CVE-2026-44431) | high | urllib3 | 2.6.3 → 2.7.0 | `uv.lock` |
| [#148](https://github.com/ayutaz/piper-plus/security/dependabot/148) GHSA-mf9v-mfxr-j63j (CVE-2026-44432) | high | urllib3 | 2.6.3 → 2.7.0 | `uv.lock` |
| [#150](https://github.com/ayutaz/piper-plus/security/dependabot/150) GHSA-q6x5-8v7m-xcrf (CVE-2026-44288) | medium | @protobufjs/utf8 | 1.1.0 → 1.1.1 | `src/wasm/openjtalk-web/package-lock.json` |

### urllib3 (uv.lock)

`uv lock --upgrade-package urllib3` で更新。直接依存ではなく `requests` / `sentry_sdk` / `types_requests` 経由の transitive。`pyproject.toml` 側の version constraint は変更なし。

### @protobufjs/utf8 (npm)

`onnxruntime-web` → `protobufjs ^7.2.4` → `@protobufjs/utf8 ^1.1.0` の transitive。protobufjs の semver 範囲が `^1.1.0` なので 1.1.1 が受理される。Dependabot 相当の最小 diff (3 行) を手動で適用 — `npm install --package-lock-only` を回すと `package-lock.json` が `package.json` と out-of-sync 状態 (`version`/`devDependencies`/`engines` の drift) を一括補正して 1100+ 行の無関係な変更を産むため、本 PR のスコープを security fix に限定する目的で手書きとした。lockfile sync 自体の再生成は別 PR の方が安全。

## Test plan

- [ ] CI green (python-lint, ruff version sync, cross-runtime gates 含む)
- [ ] npm ベース workflow (g2p-wasm-ci, test-webassembly, npm-publish) が新 lockfile で通る
- [ ] uv ベース workflow (uv sync) が urllib3 2.7.0 で通る
- [ ] PR マージ後に Dependabot alerts #148/#149/#150 が自動 close されることを確認