### PR TITLE
ci(security): OpenSSF Scorecard workflow を追加

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,77 @@
+name: OpenSSF Scorecard
+
+# Continuously evaluates the repository against the OpenSSF Scorecard
+# checks (branch protection, code review, dependency update tooling,
+# pinned dependencies, SAST, signed releases, etc.) and publishes the
+# SARIF result to:
+#   - GitHub Security → Code scanning alerts (security-events:write)
+#   - https://api.securityscorecards.dev/projects/github.com/<owner>/<repo>
+#     so we can surface the badge in README later.
+#
+# Trigger rationale:
+#   - schedule (weekly): keeps the score current.
+#   - branch_protection_rule: re-runs when branch protection changes
+#     (so the score reflects the new posture immediately, not after the
+#     next weekly run).
+#   - push to dev: catches workflow / security-tooling regressions on
+#     the integration branch.
+#   - workflow_dispatch: manual trigger for verification.
+#
+# Permissions are intentionally narrow per the OpenSSF Scorecard runbook:
+# `security-events:write` for SARIF upload, `id-token:write` for OIDC
+# attestation when publishing to the OpenSSF API. All other tokens at
+# `read` or absent.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 0 * * 0'  # Sundays 00:00 UTC
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # `publish_results: true` posts the score to the OpenSSF API so
+          # a public badge URL becomes available at
+          # api.securityscorecards.dev. Set to `false` to keep results
+          # private (still uploaded to the Security tab below).
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 14
+
+      - name: Upload to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3.35.4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,7 +30,10 @@ on:
     branches: [dev]
   workflow_dispatch:
 
-permissions: read-all
+# Workflow-level permissions: explicit empty default。後続で job が追加
+# されても read を含む暗黙の継承が起きないよう {} を明示。必要な権限
+# は jobs.<job>.permissions で都度宣言する (least-privilege)。
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- `.github/workflows/scorecard.yml` を新規。
- Trigger: weekly schedule + `branch_protection_rule` + push to dev + workflow_dispatch。
- SARIF を GitHub Security tab と OpenSSF API (api.securityscorecards.dev) の両方にアップロード。
- Permissions は read-all デフォルト、job 単体で `security-events: write` + `id-token: write` のみ昇格 (OpenSSF Scorecard runbook 準拠)。
- 全 action は full SemVer pin (ossf/scorecard-action@v2.4.2 / actions/checkout@v6.0.2 / actions/upload-artifact@v7.0.1 / github/codeql-action/upload-sarif@v3.35.4) で action-pin-gate 通過。
- README への Scorecard badge は scorecard 初回実行後に別 PR で追加予定。

## Test plan

- [x] pre-commit + action-pin-gate pass
- [ ] (merge 後) Scorecard workflow が weekly schedule で起動することを確認
- [ ] Security tab に Code scanning alerts として SARIF が登録されるか