### PR TITLE
test(training): time.sleep() 依存の race を polling に置換

### DIFF
--- a/src/python_run/tests/test_training_integration.py
+++ b/src/python_run/tests/test_training_integration.py
@@ -23,15 +23,19 @@ def _wait_until(
     """Poll predicate() until True or timeout.
 
     Replaces ``time.sleep(0.2)`` / ``time.sleep(0.3)`` race-prone waits.
-    Returns False if the deadline passed without the predicate going true,
-    so callers can produce a meaningful assertion message.
+    Returns False if the deadline expired without predicate ever returning
+    True, so callers can produce a meaningful assertion message.
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if predicate():
             return True
         time.sleep(interval)
-    return predicate()
+    # Review #455: 以前は ``return predicate()`` としていたが、
+    # deadline 超過後の最後の評価で True が返り得るため "within Ns"
+    # の保証を破っていた (docstring とも不整合)。タイムアウト時は
+    # 必ず False を返すよう修正。
+    return False
 
 
 @pytest.mark.integration
@@ -131,15 +135,18 @@ class TestTrainingIntegration:
 
             assert success
 
-            # Wait for the monitor thread to mark training as running.
-            # Polling avoids the prior race where ``time.sleep(0.3)`` was
-            # sometimes shorter than the thread's first iteration on a
-            # loaded CI runner.
-            assert _wait_until(lambda: manager.status.is_running, timeout=3.0), (
-                "monitor thread did not mark training as running within 3s"
-            )
+            # Review #455: TrainingManager.start_training() は status.is_running
+            # を *同期的に* True にしてから monitor thread を起動するため、
+            # ``_wait_until(is_running)`` は monitor thread が回ったかの確認に
+            # ならない。同期 assert で十分。monitor thread が実際に lines を
+            # 処理したかは最終的な ``final_status.best_loss == 0.3`` などで
+            # 間接的に確認する。
+            assert manager.status.is_running
 
             # Release the monitor thread to see EOF and finish.
+            # こちらは monitor thread が EOF を観測して is_running=False に
+            # するまでを待つ正当な polling (gate.set() 後の thread 状態遷移
+            # は非同期に発生)。
             gate.set()
             assert _wait_until(lambda: not manager.status.is_running, timeout=5.0), (
                 "monitor thread did not finish after gate.set() within 5s"

--- a/src/python_run/tests/test_training_integration.py
+++ b/src/python_run/tests/test_training_integration.py
@@ -4,6 +4,7 @@
 import importlib.util
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -12,6 +13,25 @@ import pytest
 
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def _wait_until(
+    predicate: Callable[[], bool],
+    timeout: float = 5.0,
+    interval: float = 0.02,
+) -> bool:
+    """Poll predicate() until True or timeout.
+
+    Replaces ``time.sleep(0.2)`` / ``time.sleep(0.3)`` race-prone waits.
+    Returns False if the deadline passed without the predicate going true,
+    so callers can produce a meaningful assertion message.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
 
 
 @pytest.mark.integration
@@ -65,16 +85,18 @@ class TestTrainingIntegration:
             """Return training lines, then block until gate is set before EOF."""
             return _readline_side_effect._next()
 
-        lines = iter([
-            "Initializing training...\n",
-            "Epoch 1/3\n",
-            "train_loss: 1.5, val_loss: 1.6\n",
-            "Epoch 2/3\n",
-            "train_loss: 0.8, val_loss: 0.9\n",
-            "Epoch 3/3\n",
-            "train_loss: 0.3, val_loss: 0.4\n",
-            "Training completed!\n",
-        ])
+        lines = iter(
+            [
+                "Initializing training...\n",
+                "Epoch 1/3\n",
+                "train_loss: 1.5, val_loss: 1.6\n",
+                "Epoch 2/3\n",
+                "train_loss: 0.8, val_loss: 0.9\n",
+                "Epoch 3/3\n",
+                "train_loss: 0.3, val_loss: 0.4\n",
+                "Training completed!\n",
+            ]
+        )
 
         def _next():
             try:
@@ -109,13 +131,19 @@ class TestTrainingIntegration:
 
             assert success
 
-            # Allow monitor thread to process the data lines
-            time.sleep(0.3)
-            assert manager.status.is_running
+            # Wait for the monitor thread to mark training as running.
+            # Polling avoids the prior race where ``time.sleep(0.3)`` was
+            # sometimes shorter than the thread's first iteration on a
+            # loaded CI runner.
+            assert _wait_until(lambda: manager.status.is_running, timeout=3.0), (
+                "monitor thread did not mark training as running within 3s"
+            )
 
-            # Release the monitor thread to see EOF and finish
+            # Release the monitor thread to see EOF and finish.
             gate.set()
-            time.sleep(0.3)
+            assert _wait_until(lambda: not manager.status.is_running, timeout=5.0), (
+                "monitor thread did not finish after gate.set() within 5s"
+            )
 
             # Check final status
             final_status = manager.get_status()
@@ -162,8 +190,10 @@ class TestTrainingIntegration:
 
             assert success  # Start succeeds even if process fails later
 
-            # Wait for monitoring to detect failure
-            time.sleep(0.2)
+            # Wait for the monitor thread to detect the failed process.
+            assert _wait_until(
+                lambda: not manager.get_status().is_running, timeout=3.0
+            ), "monitor thread did not detect process failure within 3s"
 
             status = manager.get_status()
             assert not status.is_running


### PR DESCRIPTION
## Summary

- `test_training_manager_lifecycle` と `test_training_error_handling` の 3 箇所 (L113 / L118 / L166) の `time.sleep(0.3)` / `time.sleep(0.2)` を `_wait_until(predicate, timeout=3.0)` polling に置換。
- 失敗時メッセージを明示化 ("monitor thread did not mark training as running within 3s" など)。
- `L308` の `time.sleep(2)` は real subprocess (skipif 適用) のため触らず。

## Test plan

- [x] `uv run pytest src/python_run/tests/test_training_integration.py -v -m integration` → 2 passed (3 skipped) in 1.01s
- [x] pre-commit pass