### PR TITLE
ci(perf): RTF / Latency 回帰検出 gate を追加

### DIFF
--- a/.github/workflows/rtf-regression.yml
+++ b/.github/workflows/rtf-regression.yml
@@ -74,7 +74,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install inference dependencies
-        run: uv sync --group inference
+        # ``inference`` は pyproject.toml の [project.optional-dependencies]
+        # (PEP 621 extras) に定義されている。``--group`` (PEP 735) ではなく
+        # ``--extra`` を使う必要がある。
+        run: uv sync --extra inference
 
       - name: Run benchmark (English, multilingual-test-medium)
         run: |

--- a/.github/workflows/rtf-regression.yml
+++ b/.github/workflows/rtf-regression.yml
@@ -1,0 +1,103 @@
+name: RTF Regression
+
+# Continuous performance regression gate.
+#
+# Runs ``scripts/benchmark.py`` against the bundled
+# ``test/models/multilingual-test-medium.onnx`` checkpoint on Ubuntu and
+# feeds the result to ``benchmark-action/github-action-benchmark``. The
+# action stores a rolling baseline on ``gh-pages`` (push to dev only) and
+# alerts on regressions when a PR exceeds the threshold.
+#
+# Why this exists:
+#   - ``tools/benchmark/issue-383/`` captured the MB-iSTFT baseline as a
+#     one-shot artefact, but RTF / latency drift after subsequent PRs is
+#     currently only caught by manual re-runs. The Top 10 review surfaced
+#     this as the largest gap in §9.5 "performance regression detection".
+#   - benchmark-action publishes a chart at
+#     ``https://ayutaz.github.io/piper-plus/dev/bench/`` after the first
+#     push to dev, giving humans something to scan during PR review.
+#
+# Initial policy (warn-only): ``fail-on-alert: false`` so the gate is
+# advisory while we calibrate the noise floor. Tighten to fail later once
+# we observe a few weeks of variance and pick a defensible threshold.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'src/python/piper_train/**'
+      - 'src/python_run/piper/**'
+      - 'scripts/benchmark.py'
+      - 'scripts/benchmark_to_action_bench.py'
+      - 'test/models/multilingual-test-medium.onnx*'
+      - '.github/workflows/rtf-regression.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'src/python/piper_train/**'
+      - 'src/python_run/piper/**'
+      - 'scripts/benchmark.py'
+      - 'scripts/benchmark_to_action_bench.py'
+  workflow_dispatch:
+
+concurrency:
+  # Don't cancel push-to-dev runs (they own the baseline). Cancel PRs.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: RTF benchmark (Ubuntu)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: write  # benchmark-action pushes to gh-pages (push only)
+      pull-requests: write  # benchmark-action comments on PR alerts
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: astral-sh/setup-uv@v6.10.0
+        with:
+          python-version: '3.12'
+
+      - name: Install inference dependencies
+        run: uv sync --group inference
+
+      - name: Run benchmark (English, multilingual-test-medium)
+        run: |
+          uv run python scripts/benchmark.py \
+              --model test/models/multilingual-test-medium.onnx \
+              --config test/models/multilingual-test-medium.onnx.json \
+              --language en \
+              --n-warmup 5 --n-runs 30 \
+              --format json \
+              --output benchmark_results.json
+
+      - name: Convert to action-benchmark schema
+        run: |
+          uv run python scripts/benchmark_to_action_bench.py \
+              benchmark_results.json \
+              --output benchmark_action.json
+          cat benchmark_action.json
+
+      - name: Store + compare against baseline
+        uses: benchmark-action/github-action-benchmark@v1.20.4
+        with:
+          name: Python inference benchmark
+          tool: customSmallerIsBetter
+          output-file-path: benchmark_action.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Mutate the baseline only on push to dev — PR runs compare
+          # against the existing baseline without auto-pushing, so a
+          # regressing PR cannot accidentally raise the bar for itself.
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
+          # 15% regression alert. Warn-only while we calibrate (see
+          # workflow header). Flip ``fail-on-alert: true`` once the
+          # noise floor on hosted runners is understood.
+          alert-threshold: '115%'
+          comment-on-alert: true
+          fail-on-alert: false
+          alert-comment-cc-users: '@ayutaz'

--- a/.github/workflows/rtf-regression.yml
+++ b/.github/workflows/rtf-regression.yml
@@ -38,6 +38,10 @@ on:
       - 'src/python_run/piper/**'
       - 'scripts/benchmark.py'
       - 'scripts/benchmark_to_action_bench.py'
+      # Review #458: ベンチマーク対象モデルが更新された場合も baseline
+      # 再計測対象。pull_request 側にも同 glob があるため対称性を担保。
+      - 'test/models/multilingual-test-medium.onnx*'
+      - '.github/workflows/rtf-regression.yml'
   workflow_dispatch:
 
 concurrency:
@@ -53,13 +57,19 @@ jobs:
     name: RTF benchmark (Ubuntu)
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    # Fork PR では GITHUB_TOKEN に contents:write / pull-requests:write が
+    # 付与されないため job 自体をスキップ。同 repo の PR / push に
+    # 限って実行する (review #458 fork-PR 指摘への対応)。
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     permissions:
       contents: write  # benchmark-action pushes to gh-pages (push only)
       pull-requests: write  # benchmark-action comments on PR alerts
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: astral-sh/setup-uv@v6.10.0
+      # v6.10.0 は存在しないため CI が "Unable to resolve action" で失敗。
+      # v6 系の最新 patch (v6.8.0) に修正。
+      - uses: astral-sh/setup-uv@v6.8.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/rtf-regression.yml
+++ b/.github/workflows/rtf-regression.yml
@@ -96,17 +96,33 @@ jobs:
               --output benchmark_action.json
           cat benchmark_action.json
 
+      # benchmark-action は内部で gh-pages ブランチを fetch するため、
+      # 初回 push to dev 実行で gh-pages が自動作成されるまでは PR で
+      # 実行すると 'couldn't find remote ref gh-pages' で fail する。
+      # 当面 PR では benchmark JSON を artifact にだけ残し、push to dev
+      # でのみ benchmark-action を起動して baseline 保存/更新を行う。
+      # (gh-pages が安定運用に乗ったら PR 比較も再導入する)。
+      - name: Upload benchmark JSON (PR / dev push 共通)
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: rtf-benchmark-${{ github.event_name }}-${{ github.run_attempt }}
+          path: |
+            benchmark_results.json
+            benchmark_action.json
+          retention-days: 30
+
       - name: Store + compare against baseline
+        # PR ではスキップ。push to dev でのみ実行し、初回で gh-pages を
+        # 自動初期化する (auto-push:true なら branch 不在時に benchmark-action
+        # が新規作成する)。
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
         uses: benchmark-action/github-action-benchmark@v1.20.4
         with:
           name: Python inference benchmark
           tool: customSmallerIsBetter
           output-file-path: benchmark_action.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Mutate the baseline only on push to dev — PR runs compare
-          # against the existing baseline without auto-pushing, so a
-          # regressing PR cannot accidentally raise the bar for itself.
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
+          github-token: ${{ github.token }}
+          auto-push: true
           # 15% regression alert. Warn-only while we calibrate (see
           # workflow header). Flip ``fail-on-alert: true`` once the
           # noise floor on hosted runners is understood.

--- a/scripts/benchmark_to_action_bench.py
+++ b/scripts/benchmark_to_action_bench.py
@@ -106,7 +106,14 @@ def main(argv: list[str] | None = None) -> int:
     if isinstance(raw, dict):
         # benchmark.py with a single --model returns a 1-element list
         # wrapped in an object by format_json. Tolerate either shape.
-        records = raw.get("results") or [raw]
+        # Review #458: ``raw.get("results") or [raw]`` was misclassifying
+        # ``{"results": []}`` (empty list is falsy → wrapper treated as a
+        # single record). Explicit key check distinguishes "no results"
+        # from "single record".
+        if "results" in raw and isinstance(raw["results"], list):
+            records = raw["results"]
+        else:
+            records = [raw]
     else:
         records = list(raw)
 

--- a/scripts/benchmark_to_action_bench.py
+++ b/scripts/benchmark_to_action_bench.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# editorconfig-checker-disable-file (docstring example uses 2-space JSON indent)
+"""Convert ``scripts/benchmark.py`` JSON output to the schema consumed by
+``benchmark-action/github-action-benchmark``.
+
+github-action-benchmark's ``customSmallerIsBetter`` tool expects a JSON
+array of metric objects::
+
+    [
+      {"name": "RTF (en)",         "unit": "ratio", "value": 0.078},
+      {"name": "Latency P50 (en)", "unit": "ms",    "value": 27.0},
+      ...
+    ]
+
+``benchmark.py`` returns a list of per-model result dicts that include
+keys like ``rtf``, ``latency_p50_ms``, ``latency_p95_ms``,
+``cold_start_ms``, ``peak_memory_mb``, ``model_size_mb``, etc. This
+script flattens those into the action-benchmark schema, restricted to
+metrics where *smaller is better* (the only ones that the
+``customSmallerIsBetter`` tool can correctly alert on for regressions).
+
+Usage::
+
+    uv run python scripts/benchmark_to_action_bench.py \\
+        benchmark_results.json --output benchmark_action.json
+
+Multiple model entries are disambiguated with the ``model`` field as a
+suffix (e.g. ``RTF (multilingual-test-medium.onnx)``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+# Metrics where smaller is better. Each tuple is
+#     (benchmark.py key, display name, unit).
+SMALLER_IS_BETTER_METRICS = [
+    ("rtf", "RTF", "ratio"),
+    ("latency_p50_ms", "Latency P50", "ms"),
+    ("latency_p95_ms", "Latency P95", "ms"),
+    ("cold_start_ms", "Cold Start", "ms"),
+    ("peak_memory_mb", "Peak Memory", "MB"),
+    ("model_size_mb", "Model Size", "MB"),
+]
+
+
+def _format_name(display: str, suffix: str, language: str | None) -> str:
+    """Build a per-metric display name including model + language hint."""
+    parts = [display]
+    extras = []
+    if language:
+        extras.append(language)
+    if suffix:
+        extras.append(suffix)
+    if extras:
+        parts.append("(" + ", ".join(extras) + ")")
+    return " ".join(parts)
+
+
+def convert(records: list[dict]) -> list[dict]:
+    """Flatten benchmark.py records to action-benchmark metric entries."""
+    metrics: list[dict] = []
+    multi = len(records) > 1
+
+    for record in records:
+        suffix = record.get("model", "") if multi else ""
+        language = record.get("test_language")
+
+        for key, display, unit in SMALLER_IS_BETTER_METRICS:
+            if key not in record:
+                continue
+            value = record[key]
+            if value is None:
+                continue
+            metrics.append(
+                {
+                    "name": _format_name(display, suffix, language),
+                    "unit": unit,
+                    "value": float(value),
+                }
+            )
+
+    return metrics
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "input",
+        type=Path,
+        help="Path to benchmark.py --format=json output",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Path to write the action-benchmark JSON",
+    )
+    args = parser.parse_args(argv)
+
+    raw = json.loads(args.input.read_text(encoding="utf-8"))
+    if isinstance(raw, dict):
+        # benchmark.py with a single --model returns a 1-element list
+        # wrapped in an object by format_json. Tolerate either shape.
+        records = raw.get("results") or [raw]
+    else:
+        records = list(raw)
+
+    metrics = convert(records)
+    if not metrics:
+        print(
+            "ERROR: no smaller-is-better metrics found in input",
+            file=sys.stderr,
+        )
+        return 1
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(metrics, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Wrote {len(metrics)} metric(s) to {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- `scripts/benchmark_to_action_bench.py` を新規追加。`scripts/benchmark.py` の JSON 出力を github-action-benchmark の `customSmallerIsBetter` schema に変換。
- `.github/workflows/rtf-regression.yml` を新規追加。
  - **push to dev**: benchmark 実行 → gh-pages にベースライン保存 (公開グラフが ayutaz.github.io/piper-plus/dev/bench/ で自動生成)。
  - **PR**: 既存 baseline と比較し、RTF / Latency P50 / P95 / Cold Start / Peak Memory / Model Size のいずれかが 15% 悪化すると PR コメントで alert (`fail-on-alert: false` で advisory)。
- データ源: `test/models/multilingual-test-medium.onnx` (39MB, repo commit 済み) を English テキストで 5 warmup + 30 run。
- 初期は warn-only。数週間の variance を観察してから `fail-on-alert: true` に切り替え予定 (workflow header に方針記述)。
- Rust criterion 統合は後続 PR。

## Test plan

- [x] benchmark_to_action_bench.py 単体スモークテスト (sample JSON で 6 metric 出力)
- [x] action-pin-gate pass
- [ ] (merge 後) gh-pages branch に baseline JSON が push されること