### PR TITLE
ci(csharp): dorny/test-reporter で C# テスト結果を Checks tab に集約

### DIFF
--- a/.github/workflows/csharp-ci.yml
+++ b/.github/workflows/csharp-ci.yml
@@ -43,9 +43,10 @@ jobs:
     permissions:
       contents: read
       # dorny/test-reporter は GitHub Checks API に annotation を書く
-      # ため checks: write が必須。デフォルトの GITHUB_TOKEN が
-      # workflow_run 起点だと無効化されるが、本 workflow は PR /
-      # push トリガーなので問題ない。
+      # ため checks: write が必須。fork からの pull_request など
+      # GITHUB_TOKEN が read-only に縮退されるトリガーでは Check 生成
+      # に失敗するが、本 workflow は同 repo の PR / push トリガーから
+      # 起動するため通常は問題ない。
       checks: write
 
     steps:
@@ -103,7 +104,12 @@ jobs:
         uses: dorny/test-reporter@v2.1.1
         with:
           name: csharp-tests (${{ matrix.os }})
-          path: '**/TestResults/test-results*.xml'
+          # vstest は LogFileName の通りに直接 TRX を書く場合もあれば、
+          # ``TestResults/<run-id>/test-results.xml`` のように nested
+          # サブディレクトリに書く場合もある (project 構成依存)。
+          # 両ケースを拾うため `**` を中間にも入れる
+          # (review #459 line 97 / 106 への対応)。
+          path: '**/TestResults/**/test-results*.xml'
           reporter: dotnet-trx
           # CI ジョブ自体は dotnet test の exit code で fail させる
           # (既存挙動)。reporter が二重に fail させると signal が

--- a/.github/workflows/csharp-ci.yml
+++ b/.github/workflows/csharp-ci.yml
@@ -40,6 +40,14 @@ jobs:
       matrix:
         os: [ubuntu-24.04, windows-latest, macos-14]
 
+    permissions:
+      contents: read
+      # dorny/test-reporter は GitHub Checks API に annotation を書く
+      # ため checks: write が必須。デフォルトの GITHUB_TOKEN が
+      # workflow_run 起点だと無効化されるが、本 workflow は PR /
+      # push トリガーなので問題ない。
+      checks: write
+
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -84,8 +92,24 @@ jobs:
           dotnet test src/csharp/PiperPlus.sln -c Release --no-build \
             --blame-hang-timeout 30s \
             --logger "trx;LogFileName=test-results.xml" \
+            --results-directory TestResults \
             --collect:"XPlat Code Coverage" \
             --settings src/csharp/PiperPlus.runsettings
+
+      - name: Publish test results to GitHub Checks tab
+        # 失敗時にも結果を表示するため if: always()。dotnet test が non-zero
+        # で抜けても、TRX を読んで Checks UI に変換する。
+        if: always()
+        uses: dorny/test-reporter@v2.1.1
+        with:
+          name: csharp-tests (${{ matrix.os }})
+          path: '**/TestResults/test-results*.xml'
+          reporter: dotnet-trx
+          # CI ジョブ自体は dotnet test の exit code で fail させる
+          # (既存挙動)。reporter が二重に fail させると signal が
+          # 重複するので、test-reporter は表示のみで終了 0。
+          fail-on-error: false
+        continue-on-error: true
 
       - name: Generate coverage report
         if: matrix.os == 'ubuntu-24.04'


### PR DESCRIPTION
## Summary

- `csharp-ci.yml` に dorny/test-reporter@v2.1.1 を追加。
- TRX を読んで GitHub Checks API に annotation を書き込み、失敗テスト名とスタックトレースを PR レビュー時に直接参照可能に。
- `permissions.checks=write` を job に付与、`dotnet test` に `--results-directory TestResults` を明示、Publish step は `if: always()` + `continue-on-error: true` で表示専用 (CI signal は dotnet test の exit code に一本化)。
- 3 OS matrix で別々の Check を作成 (name に `${{ matrix.os }}` を含めて重複回避)。
- Python / Rust / Go は junit-xml / nextest / gotestsum 導入を伴うため別 PR。

## Test plan

- [x] pre-commit + action-pin-gate pass
- [ ] (merge 後) PR の Checks tab に `csharp-tests (ubuntu-24.04) / ...` が表示されること