### PR TITLE
ci(release): release-drafter で release note ドラフトを自動生成

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -74,10 +74,12 @@ change-title-escapes: '\<*_&'
 
 # PR タイトル先頭の Conventional Commits prefix から自動ラベル付与。
 # 既に対応ラベルが付いている場合は noop。
+# Review #460: 各 prefix は (scope) を許容する `(\(.*\))?` を含める
+# (例: `feat(api)!:` や `chore(deps):` などの scoped 形式に対応)。
 autolabeler:
   - label: 'breaking'
     title:
-      - '/^(feat|fix|refactor|chore|docs|ci|build|perf|test)!:/'
+      - '/^(feat|fix|refactor|chore|docs|ci|build|perf|test)(\(.*\))?!:/'
       - '/BREAKING CHANGE:/'
   - label: 'enhancement'
     title:
@@ -94,6 +96,16 @@ autolabeler:
   - label: 'chore'
     title:
       - '/^(chore|refactor|style|test|perf)(\(.*\))?:/'
+  # Review #460: Dependencies カテゴリは label 付与の規則を持たず空に
+  # なる懸念があった。Dependabot の典型タイトル (`chore(deps): ...` /
+  # `deps: ...` / `build(deps): ...`) と scope に deps を含むものを
+  # マップする。chore(deps) は上の chore ルールと併発するが、
+  # release-drafter の category は labels の AND/OR を最初に
+  # マッチしたカテゴリに割り振るため Dependencies が優先される。
+  - label: 'dependencies'
+    title:
+      - '/^(chore|build|fix|deps)\(deps(-dev)?\):/'
+      - '/^deps(\(.*\))?:/'
 
 exclude-labels:
   - 'skip-changelog'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,111 @@
+# release-drafter configuration — PR ラベルからドラフトリリースノートを
+# 自動生成する。merge された PR ごとにドラフト release が更新され、tag
+# push 時に既存ドラフトを公開する運用を想定。
+#
+# How to use:
+#   1. PR に適切なラベル (bug / enhancement / breaking / docs / ci /
+#      dependencies など) を付与する。
+#   2. dev ブランチに merge される。
+#   3. .github/workflows/release-drafter.yml が GitHub Releases の
+#      "Draft" を upsert する (https://github.com/ayutaz/piper-plus/releases)。
+#   4. release-shared-lib.yml が tag push で実 release を作成する際、
+#      この本文を踏襲する (将来 #3 GitHub Releases 自動化と統合)。
+#
+# Conventional Commits との関係: PR タイトルから自動でラベル付与する
+# ロジックは ``autolabeler`` セクションで定義 (feat: → enhancement,
+# fix: → bug, など)。ラベル運用が定着するまでは手動付与でも動く。
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# semver bump rules — labels から RESOLVED_VERSION を決定する。
+version-resolver:
+  major:
+    labels:
+      - 'major'
+      - 'breaking'
+      - 'breaking-change'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'patch'
+      - 'bug'
+      - 'fix'
+      - 'docs'
+      - 'ci'
+      - 'chore'
+      - 'dependencies'
+      - 'automated'
+  default: patch
+
+categories:
+  - title: 'Breaking Changes'
+    labels:
+      - 'breaking'
+      - 'breaking-change'
+  - title: 'Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'bug'
+      - 'fix'
+  - title: 'Documentation'
+    labels:
+      - 'docs'
+      - 'documentation'
+  - title: 'CI / Infrastructure'
+    labels:
+      - 'ci'
+      - 'infrastructure'
+  - title: 'Dependencies'
+    labels:
+      - 'dependencies'
+      - 'automated'
+  - title: 'Other Changes'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+# PR タイトル先頭の Conventional Commits prefix から自動ラベル付与。
+# 既に対応ラベルが付いている場合は noop。
+autolabeler:
+  - label: 'breaking'
+    title:
+      - '/^(feat|fix|refactor|chore|docs|ci|build|perf|test)!:/'
+      - '/BREAKING CHANGE:/'
+  - label: 'enhancement'
+    title:
+      - '/^feat(\(.*\))?:/'
+  - label: 'bug'
+    title:
+      - '/^fix(\(.*\))?:/'
+  - label: 'docs'
+    title:
+      - '/^docs(\(.*\))?:/'
+  - label: 'ci'
+    title:
+      - '/^(ci|build)(\(.*\))?:/'
+  - label: 'chore'
+    title:
+      - '/^(chore|refactor|style|test|perf)(\(.*\))?:/'
+
+exclude-labels:
+  - 'skip-changelog'
+  - 'no-release'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,10 +22,14 @@ name: Release Drafter
 on:
   push:
     branches: [dev]
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
-    branches: [dev]
   workflow_dispatch:
+
+# Note: pull_request トリガーは意図的に省略。release-drafter は config
+# (.github/release-drafter.yml) が *default branch* に存在することを
+# 要求するため、本 workflow を最初に導入する PR では必ず "config
+# unfound" で fail する (chicken-and-egg)。merge 後の push トリガー
+# から安定して動作する。autolabeler を PR 時にも動かしたい場合は、
+# merge 後に pull_request_target を別 PR で追加する。
 
 permissions:
   contents: read

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -54,4 +54,7 @@ jobs:
           # に true。autolabeler は config 側で定義済みなのでデフォルト
           # の false (有効) のまま。
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Review #460: ${{ github.token }} の方が GitHub Actions
+          # 慣習として idiomatic (secrets.GITHUB_TOKEN と同一の値を
+          # 指すが、明示的にトークンであることが文脈で読みやすい)。
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,53 @@
+name: Release Drafter
+
+# Merge ごとに GitHub Releases のドラフトを upsert する。PR ラベル
+# (autolabeler が PR タイトル先頭の Conventional Commits prefix から
+# 自動付与する) を元に Features / Bug Fixes / Documentation などの
+# セクション別 release note を生成する。
+#
+# Config: .github/release-drafter.yml
+#
+# 連携:
+#   - quality-assurance.md §10 改善 Top 10 #3 (GitHub Releases 自動化)
+#     と #10 (release-drafter) の橋渡し。
+#   - tag push 時の実際の Release 作成は release-shared-lib.yml が
+#     担っており、本 workflow はドラフト管理のみ。手動 tag push 前に
+#     ドラフトを確認 → そのまま publish する運用を想定。
+#
+# Permissions:
+#   - workflow 全体: contents: read (デフォルト最小)
+#   - update_release_draft job: contents: write (Releases 編集) +
+#     pull-requests: write (autolabeler が PR にラベル付与)
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+    branches: [dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update_release_draft:
+    name: Update release draft
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: release-drafter/release-drafter@v6.1.0
+        with:
+          config-name: release-drafter.yml
+          # disable-autolabeler: PR title から自動ラベル付与しない場合
+          # に true。autolabeler は config 側で定義済みなのでデフォルト
+          # の false (有効) のまま。
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `.github/release-drafter.yml` (categories / autolabeler / version-resolver / template) と `.github/workflows/release-drafter.yml` を新規追加。
- autolabeler が PR タイトル先頭の Conventional Commits prefix (feat: / fix: / docs: / ci: / chore: / breaking:) を見てラベル付与。
- Features / Bug Fixes / Documentation / CI / Infrastructure / Dependencies / Breaking Changes のセクションで release note を組み立て。
- tag push 時の実 Release 作成は既存 `release-shared-lib.yml` がそのまま担う。本 PR は draft 管理のみで、maintainer が tag を切る前に draft を確認 → publish する流れ。
- `skip-changelog` / `no-release` ラベルでセクション除外可。
- action: release-drafter/release-drafter@v6.1.0 (full SemVer pin)。

## Test plan

- [x] pre-commit + action-pin-gate pass
- [ ] (merge 後) この PR 自体が `ci` ラベルで autolabel され、draft release の "CI / Infrastructure" セクションに表示されること