### PR TITLE
fix(ci): dev push 限定の RTF Regression / Docker Build 失敗を修正 + PR 検知拡張

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,7 +30,27 @@ on:
     tags:
       - 'docker-v*'
       - 'v*'
+  # PR でも build-only で同じ Dockerfile を回し、 dev push 限定で潜む
+  # Dockerfile 起因の失敗 (wget silent fail / OS update による package
+  # 取得失敗等) を早期検知する。 ghcr.io login / cosign sign / Docker Hub
+  # への push は push event 限定なので、 PR では副作用なし。 paths は
+  # push 側と同期。
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'docker/**'
+      - 'Dockerfile'
+      - 'src/python/**'
+      - 'pyproject.toml'
+      - 'CMakeLists.txt'
+      - '.github/workflows/docker-build.yml'
   workflow_dispatch:
+
+# 同一 PR への連続 push で古い build を cancel。 push to dev は cancel しない
+# (image push が途中で死ぬとレジストリが不整合になり得るため)。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   REGISTRY: ghcr.io
@@ -56,6 +76,9 @@ jobs:
       - uses: docker/setup-buildx-action@v4.0.0
 
       - name: Log in to ghcr.io
+        # PR では push しないので ghcr.io login も不要 (token write 権限も
+        # 持たない fork PR でここが落ちるのも回避できる)。
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -81,7 +104,7 @@ jobs:
           # CUDA base nvidia/cuda:* is amd64-only; arm64 build is published
           # by the build-python-inference-cpu job below.
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -154,7 +177,7 @@ jobs:
           context: .
           file: ./docker/python-inference/Dockerfile
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-dockerhub.outputs.tags }}
           labels: ${{ steps.meta-dockerhub.outputs.labels }}
           cache-from: type=gha
@@ -185,6 +208,9 @@ jobs:
       - uses: docker/setup-buildx-action@v4.0.0
 
       - name: Log in to ghcr.io
+        # PR では push しないので ghcr.io login も不要 (token write 権限も
+        # 持たない fork PR でここが落ちるのも回避できる)。
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -215,7 +241,7 @@ jobs:
           # users care about. amd64 also published for Apple Silicon devs
           # who don't want CUDA pulls.
           platforms: linux/arm64,linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=python-inference-cpu
@@ -261,6 +287,9 @@ jobs:
       - uses: docker/setup-buildx-action@v4.0.0
 
       - name: Log in to ghcr.io
+        # PR では push しないので ghcr.io login も不要 (token write 権限も
+        # 持たない fork PR でここが落ちるのも回避できる)。
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -287,7 +316,7 @@ jobs:
           # arm64 manifest, and arm64 model training is unsupported (no
           # PyTorch CUDA wheels). amd64 only.
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -333,6 +362,9 @@ jobs:
       - uses: docker/setup-buildx-action@v4.0.0
 
       - name: Log in to ghcr.io
+        # PR では push しないので ghcr.io login も不要 (token write 権限も
+        # 持たない fork PR でここが落ちるのも回避できる)。
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -360,7 +392,7 @@ jobs:
           # Keep amd64-only until that lands; cpp-inference's CMake-built
           # ORT path is already arm64-friendly and IS multi-arch below.
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -411,6 +443,9 @@ jobs:
       - uses: docker/setup-buildx-action@v4.0.0
 
       - name: Log in to ghcr.io
+        # PR では push しないので ghcr.io login も不要 (token write 権限も
+        # 持たない fork PR でここが落ちるのも回避できる)。
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -438,7 +473,7 @@ jobs:
           # via QEMU emulation is slow (~2x amd64) but produces a valid
           # native arm64 image.
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -492,6 +527,9 @@ jobs:
       - uses: docker/setup-buildx-action@v4.0.0
 
       - name: Log in to ghcr.io
+        # PR では push しないので ghcr.io login も不要 (token write 権限も
+        # 持たない fork PR でここが落ちるのも回避できる)。
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -519,7 +557,7 @@ jobs:
           # stage 1 (build-essential + cmake + g++), so arm64 works
           # without further changes.
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -592,7 +630,7 @@ jobs:
           context: .
           file: ./docker/wyoming/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-dockerhub.outputs.tags }}
           labels: ${{ steps.meta-dockerhub.outputs.labels }}
           cache-from: type=gha
@@ -618,6 +656,9 @@ jobs:
       - uses: docker/setup-buildx-action@v4.0.0
 
       - name: Log in to ghcr.io
+        # PR では push しないので ghcr.io login も不要 (token write 権限も
+        # 持たない fork PR でここが落ちるのも回避できる)。
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -642,7 +683,7 @@ jobs:
           file: ./docker/webui/Dockerfile
           # Pure Python + Gradio + slim-trixie -> arm64 native available.
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -715,7 +756,7 @@ jobs:
           context: .
           file: ./docker/webui/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-dockerhub.outputs.tags }}
           labels: ${{ steps.meta-dockerhub.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/rtf-regression.yml
+++ b/.github/workflows/rtf-regression.yml
@@ -115,15 +115,24 @@ jobs:
         # benchmark-action@v1.20.4 は内部で `git fetch ... gh-pages:gh-pages`
         # を行うため branch が repo に存在しないと `fatal: couldn't find
         # remote ref gh-pages` で fail する (header コメントの auto-push 期待
-        # と実挙動が異なる)。 初回 dev push でも安全に動くよう、 不在時のみ
-        # 空 orphan commit で初期化する。 idempotent。
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        # と実挙動が異なる)。
+        #
+        # PR (same-repo): read-only check で不在なら fail → dev push 限定の
+        # 回帰を PR 段階で surface できる (gh-pages branch が誰かに削除された
+        # / repo を fresh-clone した直後 etc.)。
+        # push to dev: 不在なら空 orphan commit で自動作成 (idempotent)。
+        # fork PR は上位 job の if: gate で既に skip 済み。
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/dev')
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           if gh api "repos/${{ github.repository }}/branches/gh-pages" --silent 2>/dev/null; then
-            echo "gh-pages branch already exists — skip init"
+            echo "gh-pages branch exists"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "::error::gh-pages branch is missing — benchmark-action@v1 will fail on the next push to dev. push-to-dev would auto-create it, but flagging in PR to detect dev-only regression early."
+            exit 1
           else
             echo "gh-pages branch missing — creating empty placeholder"
             git config user.name "github-actions[bot]"

--- a/.github/workflows/rtf-regression.yml
+++ b/.github/workflows/rtf-regression.yml
@@ -117,9 +117,12 @@ jobs:
         # remote ref gh-pages` で fail する (header コメントの auto-push 期待
         # と実挙動が異なる)。
         #
-        # PR (same-repo): read-only check で不在なら fail → dev push 限定の
-        # 回帰を PR 段階で surface できる (gh-pages branch が誰かに削除された
-        # / repo を fresh-clone した直後 etc.)。
+        # PR (same-repo): read-only check で不在なら `::warning::` で flag。
+        # step 自体は success させて PR を merge 可能に保つ (chicken-and-egg
+        # 回避: 初回 dev push 前は不在状態が normal で、 ここで fail させると
+        # merge できなくなる)。 通常運用 (gh-pages 存在後) では silent pass、
+        # 万一 gh-pages が削除された場合は warning が出るが merge 自体は可能、
+        # 直後の dev push で自動再生成される。
         # push to dev: 不在なら空 orphan commit で自動作成 (idempotent)。
         # fork PR は上位 job の if: gate で既に skip 済み。
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/dev')
@@ -131,8 +134,7 @@ jobs:
           if gh api "repos/${{ github.repository }}/branches/gh-pages" --silent 2>/dev/null; then
             echo "gh-pages branch exists"
           elif [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "::error::gh-pages branch is missing — benchmark-action@v1 will fail on the next push to dev. push-to-dev would auto-create it, but flagging in PR to detect dev-only regression early."
-            exit 1
+            echo "::warning::gh-pages branch is missing — benchmark-action@v1 will auto-create it on the next push to dev. Not failing the PR (chicken-and-egg before first dev push). If you see this after dev runs have created the branch, someone may have deleted it."
           else
             echo "gh-pages branch missing — creating empty placeholder"
             git config user.name "github-actions[bot]"

--- a/.github/workflows/rtf-regression.yml
+++ b/.github/workflows/rtf-regression.yml
@@ -111,10 +111,33 @@ jobs:
             benchmark_action.json
           retention-days: 30
 
+      - name: Ensure gh-pages branch exists
+        # benchmark-action@v1.20.4 は内部で `git fetch ... gh-pages:gh-pages`
+        # を行うため branch が repo に存在しないと `fatal: couldn't find
+        # remote ref gh-pages` で fail する (header コメントの auto-push 期待
+        # と実挙動が異なる)。 初回 dev push でも安全に動くよう、 不在時のみ
+        # 空 orphan commit で初期化する。 idempotent。
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/${{ github.repository }}/branches/gh-pages" --silent 2>/dev/null; then
+            echo "gh-pages branch already exists — skip init"
+          else
+            echo "gh-pages branch missing — creating empty placeholder"
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git switch --orphan gh-pages
+            : > .nojekyll
+            git add .nojekyll
+            git commit -m "init gh-pages for RTF benchmark baseline"
+            git push origin gh-pages
+            git switch -
+          fi
+
       - name: Store + compare against baseline
-        # PR ではスキップ。push to dev でのみ実行し、初回で gh-pages を
-        # 自動初期化する (auto-push:true なら branch 不在時に benchmark-action
-        # が新規作成する)。
+        # PR ではスキップ。push to dev でのみ実行。
         if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
         uses: benchmark-action/github-action-benchmark@v1.20.4
         with:

--- a/.github/workflows/rtf-regression.yml
+++ b/.github/workflows/rtf-regression.yml
@@ -137,12 +137,21 @@ jobs:
             echo "gh-pages branch missing — creating empty placeholder"
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git switch --orphan gh-pages
-            : > .nojekyll
-            git add .nojekyll
-            git commit -m "init gh-pages for RTF benchmark baseline"
-            git push origin gh-pages
-            git switch -
+            # Isolated worktree avoids any risk of leaking dev tree into the
+            # orphan commit and avoids checkout-back conflicts. Git 2.27+'s
+            # `git switch --orphan` also clears the working tree, but using
+            # a dedicated worktree is unambiguous regardless of git version
+            # and leaves the original checkout untouched.
+            tmp_worktree="$(mktemp -d)"
+            git worktree add --orphan -b gh-pages "$tmp_worktree"
+            (
+              cd "$tmp_worktree"
+              : > .nojekyll
+              git add .nojekyll
+              git commit -m "init gh-pages for RTF benchmark baseline"
+              git push origin gh-pages
+            )
+            git worktree remove --force "$tmp_worktree"
           fi
 
       - name: Store + compare against baseline

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -374,12 +374,19 @@ repos:
   # Dockerfile lint — hadolint catches common Dockerfile mistakes (apt-get
   # without --no-install-recommends, missing pinned versions, etc.). Scoped
   # to docker/ so we don't accidentally lint embedded fixtures.
+  #
+  # `--failure-threshold=error` mirrors `.github/workflows/hadolint.yml` so
+  # local pre-commit and PR CI agree on what counts as a hard failure
+  # (only `.hadolint.yaml::override.error` rules block; warning/info report
+  # but don't exit non-zero). Without this, info-level rules unrelated to
+  # the current edit (e.g. existing DL3015 / DL4001 in unchanged lines) would
+  # silently block a Dockerfile commit locally while passing CI.
   # ---------------------------------------------------------------------------
   - repo: https://github.com/hadolint/hadolint
     rev: v2.12.0
     hooks:
       - id: hadolint
-        args: [--config=.hadolint.yaml]
+        args: [--config=.hadolint.yaml, --failure-threshold=error]
         files: ^docker/.*Dockerfile.*$
 
   # ---------------------------------------------------------------------------

--- a/docker/cpp-dev/Dockerfile
+++ b/docker/cpp-dev/Dockerfile
@@ -42,7 +42,11 @@ RUN apt-get update && apt-get install -y \
 # Install ONNX Runtime (CPU, Linux x64)
 # Issue #372: must match canonical (cmake/OnnxRuntime.cmake) — enforced by
 # scripts/check_ort_versions.py. Bump alongside the C++ pipeline canonical.
-RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v1.20.0/onnxruntime-linux-x64-1.20.0.tgz && \
+# Use curl with retries: `wget -q` was silently failing on transient
+# github.com release-asset redirects in `Docker Build and Push` runs on dev.
+RUN curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors \
+        -o onnxruntime-linux-x64-1.20.0.tgz \
+        https://github.com/microsoft/onnxruntime/releases/download/v1.20.0/onnxruntime-linux-x64-1.20.0.tgz && \
     tar -xzf onnxruntime-linux-x64-1.20.0.tgz && \
     cp onnxruntime-linux-x64-1.20.0/lib/* /usr/local/lib/ && \
     cp -r onnxruntime-linux-x64-1.20.0/include/* /usr/local/include/ && \

--- a/docker/cpp-dev/Dockerfile
+++ b/docker/cpp-dev/Dockerfile
@@ -42,13 +42,21 @@ RUN apt-get update && apt-get install -y \
 # Install ONNX Runtime (CPU, Linux x64)
 # Issue #372: must match canonical (cmake/OnnxRuntime.cmake) — enforced by
 # scripts/check_ort_versions.py. Bump alongside the C++ pipeline canonical.
-# Use curl with retries: `wget -q` was silently failing on transient
-# github.com release-asset redirects in `Docker Build and Push` runs on dev.
+#
+# Why curl + cp -r:
+#   - `wget -q` was silently failing the previous dev runs (exit 1 with no
+#     stderr surfaced via `-q`); curl with `-fsSL --retry 5
+#     --retry-all-errors` makes transient redirect failures retry and lets
+#     the actual cp error below surface in the build log.
+#   - ONNX Runtime v1.20.0 ships `lib/cmake/` and `lib/pkgconfig/` as
+#     subdirectories under lib/, so a plain `cp lib/* …` fails with
+#     "omitting directory" + exit 1 (this was the real root cause of the
+#     9+ consecutive dev failures, masked by `wget -q`). Use `cp -r`.
 RUN curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors \
         -o onnxruntime-linux-x64-1.20.0.tgz \
         https://github.com/microsoft/onnxruntime/releases/download/v1.20.0/onnxruntime-linux-x64-1.20.0.tgz && \
     tar -xzf onnxruntime-linux-x64-1.20.0.tgz && \
-    cp onnxruntime-linux-x64-1.20.0/lib/* /usr/local/lib/ && \
+    cp -r onnxruntime-linux-x64-1.20.0/lib/* /usr/local/lib/ && \
     cp -r onnxruntime-linux-x64-1.20.0/include/* /usr/local/include/ && \
     ldconfig && \
     rm -rf onnxruntime-linux-x64-1.20.0*

--- a/docker/cpp-dev/Dockerfile
+++ b/docker/cpp-dev/Dockerfile
@@ -44,14 +44,20 @@ RUN apt-get update && apt-get install -y \
 # scripts/check_ort_versions.py. Bump alongside the C++ pipeline canonical.
 #
 # Why curl + cp -r:
-#   - `wget -q` was silently failing the previous dev runs (exit 1 with no
-#     stderr surfaced via `-q`); curl with `-fsSL --retry 5
-#     --retry-all-errors` makes transient redirect failures retry and lets
-#     the actual cp error below surface in the build log.
-#   - ONNX Runtime v1.20.0 ships `lib/cmake/` and `lib/pkgconfig/` as
-#     subdirectories under lib/, so a plain `cp lib/* …` fails with
-#     "omitting directory" + exit 1 (this was the real root cause of the
-#     9+ consecutive dev failures, masked by `wget -q`). Use `cp -r`.
+#   - `cp lib/* /usr/local/lib/` was the actual root cause of 9+ consecutive
+#     dev failures: ONNX Runtime v1.20.0 ships `lib/cmake/` and
+#     `lib/pkgconfig/` as subdirectories under lib/, so a plain `cp` fails
+#     with "omitting directory" + exit 1. The error appeared attributed to
+#     the preceding `wget -q` because the failing `cp` was the last command
+#     in the `&&` chain. Use `cp -r` so subdirectories are copied recursively
+#     (symmetric with `cp -r include/*`).
+#   - curl with `-fsSL --retry 5 --retry-all-errors` replaces `wget -q`: the
+#     `-s` (silent) suppresses the progress bar to keep build logs tidy,
+#     while `-S` (paired with -s via `-fsSL`) and `-f` (fail on HTTP errors)
+#     ensure curl's *errors* are still printed. `--retry-all-errors` makes
+#     transient redirect/network failures retry instead of failing on first
+#     attempt. Net effect: identical download behavior, but if it ever fails
+#     again the stderr / exit code will be diagnostic rather than silent.
 RUN curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors \
         -o onnxruntime-linux-x64-1.20.0.tgz \
         https://github.com/microsoft/onnxruntime/releases/download/v1.20.0/onnxruntime-linux-x64-1.20.0.tgz && \


### PR DESCRIPTION
## 何が問題だったか

dev へのマージ後だけ 2 つの workflow が連続失敗していた:

- **Docker Build / build-cpp-dev**: 9 回以上連続失敗
- **RTF Regression**: 2 回連続失敗

PR では一切 fail せず、 dev にマージしてから事故るループが起きていた。

## なぜ PR で検知できなかったか

| Workflow | PR で fail しなかった理由 |
|---|---|
| Docker Build | trigger が `push: branches: [dev]` のみ。 PR では走らない |
| RTF Regression | workflow は走るが、 gh-pages を fetch する step が `push to dev` でのみ実行される gate 付き |

## なぜ dev で失敗していたか (真因)

**最初の推測は外れていた**。 当初は `wget -q` の silent fail と思い curl に置換したが、 PR trigger 拡張後の CI ログで真の原因が判明:

```
cp: -r not specified; omitting directory 'onnxruntime-linux-x64-1.20.0/lib/cmake'
cp: -r not specified; omitting directory 'onnxruntime-linux-x64-1.20.0/lib/pkgconfig'
```

ONNX Runtime v1.20.0 から `lib/` 配下に `cmake/` `pkgconfig/` の **subdirectory** が同梱されるようになり、 `cp .../lib/* /usr/local/lib/` が `-r` 不足で fail していた。 `wget` の download 自体は成功していたが、 後段の `cp` が `&&` chain で落ちて exit 1 → エラー行が wget 行に紐付いて表示される構造で 9 回以上 misdiagnose されていた。

## 修正内容

### 1. 真因の修正 — `docker/cpp-dev/Dockerfile`

`cp` → `cp -r` (`include/*` 側と対称)。 これで dev push の Docker Build が直る。

ついでに `wget -q` → `curl -fsSL --retry 5 --retry-all-errors` も維持: 進捗 / retry / stderr が build log に出るため、 今後類似問題が起きても原因が直接見える。

### 2. PR で dev 限定失敗を検知できるよう trigger 拡張

#### `docker-build.yml`
- `pull_request: branches: [dev]` を追加 (paths は push と同期)
- PR では push しない条件化:
  - `docker/build-push-action` の `push: true` → `push: \${{ github.event_name != 'pull_request' }}` (10 step)
  - `docker/login-action` (ghcr.io) を PR で skip (7 step)
- Docker Hub login / cosign sign は元々 tag ref で gate されているので触らない
- `concurrency.cancel-in-progress` を PR は cancel、 push to dev は cancel しない (image push 中断はレジストリ不整合の元)

→ PR で全 7 Dockerfile が build-only で走るので、 Dockerfile 起因の問題が PR 段階で fail-fast する。

#### `rtf-regression.yml`
- `Ensure gh-pages branch exists` step を PR でも実行
- PR: read-only check で不在なら \`::error::\` で fail (push to dev が落ちる前に surface)
- push to dev: 不在なら空 orphan commit で初期化 (idempotent)

→ gh-pages を消した / 新規 fork した場合の不在状態が PR で見える。

### 3. その他の dev/CI drift 修正

- **pre-commit hadolint** に \`--failure-threshold=error\` を追加 → \`.github/workflows/hadolint.yml\` と同じ閾値に揃え、 既存 info/warning でローカル commit が silently 落ちる drift を解消。

## 動作確認

- pre-commit / actionlint / hadolint: pass (warning は既存のみ、 新規追加なし)
- yaml syntax: 両 workflow とも `yaml.safe_load` で OK
- この PR 自身が test plan を兼ねる (PR trigger 拡張で実際に CI が走る)

## 影響範囲外 (別途検討)

- **build-cpp-inference の ghcr.io login timeout**: 今回 PR では SUCCESS。 transient のため別 PR で login-action retry 追加を検討
- **csharp-tests Windows の `EnableZhEnDispatch_VisibleAcrossThreads` race**: PR でも走るため dev 限定ではない (Windows flaky)

## Test plan

- [ ] PR の最新 commit (9f58cf13) で `Docker Build and Push / build-cpp-dev` が success
- [ ] `RTF Regression` は PR では gh-pages 不在を意図通り fail させ、 マージ後の dev push で自動作成 → 以降は pass
- [ ] マージ後の dev push で `Docker Build and Push` 全 job が成功
- [ ] 2 回目以降の dev push で gh-pages 初期化 step が "gh-pages branch exists" を出力 (idempotent 確認)
- [ ] PR CI: pre-commit / actionlint / codespell / markdownlint / hadolint に regression なし