### PR TITLE
fix(ci): sliding @master tag を固定 version に置換 (action-pin-gate 違反解消)

### DIFF
--- a/.github/workflows/g2p-rust-ci.yml
+++ b/.github/workflows/g2p-rust-ci.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -267,7 +267,7 @@ jobs:
       - name: Trivy config scan (Dockerfile)
         # Dockerfile の misconfiguration (USER root のまま終わる、HEALTHCHECK
         # 未設定など) を build なしで検出。CRITICAL/HIGH のみ fail。
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: config
           scan-ref: docker/${{ matrix.image }}
@@ -287,7 +287,7 @@ jobs:
             -f docker/${{ matrix.image }}/Dockerfile docker/${{ matrix.image }}
       - name: Trivy image scan
         if: steps.build.outcome == 'success'
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: image
           image-ref: piper-plus-${{ matrix.image }}:scan

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -267,7 +267,7 @@ jobs:
       - name: Trivy config scan (Dockerfile)
         # Dockerfile の misconfiguration (USER root のまま終わる、HEALTHCHECK
         # 未設定など) を build なしで検出。CRITICAL/HIGH のみ fail。
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: config
           scan-ref: docker/${{ matrix.image }}
@@ -287,7 +287,7 @@ jobs:
             -f docker/${{ matrix.image }}/Dockerfile docker/${{ matrix.image }}
       - name: Trivy image scan
         if: steps.build.outcome == 'success'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: image
           image-ref: piper-plus-${{ matrix.image }}:scan


### PR DESCRIPTION
## Summary

- `dtolnay/rust-toolchain@master` (`.github/workflows/g2p-rust-ci.yml:63`) を `@stable` に変更。リポジトリ内の他 32 箇所が既に `@stable` を採用済みで、本箇所だけ drift していたものを揃える。
- `aquasecurity/trivy-action@master` (`.github/workflows/security-audit.yml:270, 290`) を `@0.28.0` に固定。既存の trivy pin は無いため、SemVer 安定 tag を選択 (Dependabot 経由で今後の bump 可能)。

## Why

PR #414 の `cosign-installer@v4` 削除事故 (sliding tag が upstream で消えて 7 jobs crash) と PR #419 の silently-skipped baseline 事故を踏まえ、`action-pin-gate.yml` で sliding-tag refs を gate 化中。本 PR 対象の 3 行はそのポリシー違反 (`@master` branch ref) で、`scripts/check_action_pins.py` の "other" warning に該当していた。固定 version 化により upstream 削除/breaking change への耐性と Dependabot による通知性を確保。

## Pin form 選択ロジック (Copilot review への応答)

PR タイトル「固定 version に置換」は trivy-action (SemVer 化) を主眼にしており、`dtolnay/rust-toolchain@stable` は厳密には SemVer/SHA pin ではない (Rust release channel を指す branch ref)。本 PR は 2 つの異なる方針を採用している:

| Action | 旧 | 新 | 根拠 |
|--------|----|----|------|
| `dtolnay/rust-toolchain@master` | branch (moving HEAD) | `@stable` (Rust channel ref) | リポジトリ内の他 33 箇所が既に `@stable`、`check_action_pins.py` は branch ref を `other` warning として許容 (fail せず) しているリポジトリ標準ポリシー。33 箇所を SHA pin に変更するのは scope 拡大のため見送り。 |
| `aquasecurity/trivy-action@master` | branch (moving HEAD) | `@0.28.0` (SemVer) | 既存の trivy pin が repo 内に存在せず標準が無いため、`feedback_pin_actions_sha.md` の優先ポリシーに従い SemVer 固定を新規採用。Dependabot による patch/minor bump 通知が機能する。 |

`action-pin-gate` の fail 条件は `@v<major>` sliding-major-tag のみ。branch ref (`@stable` / `@master`) は warning レベルで、`@master` (moving HEAD) → `@stable` (rust-channel-named ref) への置換は gate ポリシー範囲内かつ既存 33 箇所との整合性を優先した保守的選択。

## Test plan

- [x] `python3 scripts/check_action_pins.py` 通過 (新規 sliding-tag violation 0、warning は既存 `@stable` のみ)
- [x] pre-commit hook 全 stage 通過 (action-pin-gate stage 含む)
- [ ] CI 上で g2p-rust-ci.yml (matrix: stable/1.88) が toolchain インストール成功
- [ ] CI 上で security-audit.yml の trivy-docker-scan (matrix: python-inference/wyoming/webui) が成功