### PR TITLE
fix(npm): subpath exports に types フィールドを追加

### DIFF
--- a/src/wasm/openjtalk-web/package.json
+++ b/src/wasm/openjtalk-web/package.json
@@ -19,6 +19,7 @@
       "import": "./src/phonemizer-compat.js"
     },
     "./streaming": {
+      "types": "./types/index.d.ts",
       "import": "./src/streaming-pipeline.js"
     },
     "./wasm/multilingual": {


### PR DESCRIPTION
## Summary

- `src/wasm/openjtalk-web/package.json` の `./streaming` subpath export に `types: "./types/index.d.ts"` を追加。TS consumer が `import { StreamingTTSPipeline } from "piper-plus/streaming"` のような subpath import で型解決できるようにする。
- `./streaming` の symbol (`StreamingTTSPipeline`, `TextChunker`, `RingBuffer`, `ChunkCrossfader`) は既に `types/index.d.ts` に declare 済みなので、参照を追加するだけ。
- `./timing` は既に `types` を持っており変更なし。

## 対応 / 非対応

| subpath | 対応 | 理由 |
|---------|------|------|
| `.` | 既存 (変更なし) | 既に `types` あり |
| `./timing` | 既存 (変更なし) | 既に `types` あり (timing 関数は index.d.ts に declare 済み) |
| `./streaming` | **追加** | symbol が index.d.ts に declare 済み、参照を足すだけで TS が型解決可能 |
| `./phonemizer` | **skip** | `@piper-plus/g2p` の re-export。`G2P` / `KoreanG2P` 等が index.d.ts に declare されていないため、false-positive を避けて skip。`@piper-plus/g2p` 側の types を参照する `.d.ts` shim が必要 (別 PR) |
| `./wasm/multilingual` / `./wasm/ja` / `./wasm/ja-lite` | **skip** | wasm-pack 出力。`.d.ts` を同梱していないため types を指す先が無い (wasm-pack の `--target web` で生成される `.d.ts` を将来 `files` 配列に含めれば追加可能、別 PR) |

## Why this matters

`exports` フィールド使用時、Node.js は package の `types` トップレベルフィールドを subpath import で参照しない (subpath ごとの `types` のみを見る)。`./streaming` の場合、TypeScript の `moduleResolution: "bundler"` / `"node16"` / `"nodenext"` で型解決失敗する可能性があった。

## Test plan

- [ ] CI の eslint / prettier / tsc 通過確認
- [ ] `npm test` (test/js/test-npm-package.js) 通過確認
- [ ] (任意) 別プロジェクトで `import { StreamingTTSPipeline } from "piper-plus/streaming"` の型解決を確認

## Out of scope (follow-up 候補)

- `./phonemizer` 用の `.d.ts` shim 生成 (`@piper-plus/g2p` 型を re-export)
- `./wasm/*` の wasm-pack 生成 `.d.ts` を `files` に含めて types で指す