### PR TITLE
docs: v1.12.0 関連ドリフト修正 (HiFi-GAN archived, mb-istft 廃止強調)

### DIFF
--- a/docs/guides/training.md
+++ b/docs/guides/training.md
@@ -12,12 +12,12 @@ See the [Training Guide](training/training-guide.md) for detailed instructions.
 uv pip install ".[train]"
 
 uv run python -m piper_train \
-  --dataset-dir /path/to/dataset \
-  --accelerator gpu --devices 1 --precision 16-mixed \
-  --max_epochs 200 --batch-size 16 \
-  --quality medium \
-  --prosody-dim 16 \
-  --ema-decay 0.9995
+    --dataset-dir /path/to/dataset \
+    --accelerator gpu --devices 1 --precision 16-mixed \
+    --max_epochs 200 --batch-size 16 \
+    --quality medium \
+    --prosody-dim 16 \
+    --ema-decay 0.9995
 ```
 
 ## Multi-speaker / Multi-GPU
@@ -25,18 +25,20 @@ uv run python -m piper_train \
 ```bash
 NCCL_DEBUG=WARN NCCL_P2P_DISABLE=1 NCCL_IB_DISABLE=1 \
 uv run python -m piper_train \
-  --dataset-dir /path/to/dataset \
-  --prosody-dim 16 \
-  --accelerator gpu --devices 4 --precision 16-mixed \
-  --max_epochs 200 --batch-size 12 --samples-per-speaker 2 \
-  --checkpoint-epochs 1 --quality medium \
-  --base_lr 2e-4 --disable_auto_lr_scaling \
-  --ema-decay 0.9995
+    --dataset-dir /path/to/dataset \
+    --prosody-dim 16 \
+    --accelerator gpu --devices 4 --precision 16-mixed \
+    --max_epochs 200 --batch-size 12 --samples-per-speaker 2 \
+    --checkpoint-epochs 1 --quality medium \
+    --base_lr 2e-4 --disable_auto_lr_scaling \
+    --ema-decay 0.9995
 ```
 
 Multi-GPU automatically configures DDP (Distributed Data Parallel). NCCL environment variables are required. See the Multi-GPU Training Guide for details.
 
 ## MB-iSTFT-VITS2 Decoder
+
+> **⚠ v1.11 非互換 / v1.12.0 Breaking change:** v1.11 系で存在した `--mb-istft` フラグは **v1.12.0 で廃止** されました。MB-iSTFT Decoder が唯一の generator path として統一されたため、フラグでの切り替えは不可能です。旧 v1.11 学習スクリプトをコピーして `--mb-istft` を渡すと unknown argument エラーになります。詳細: [migration guide](../migration/v1.11-to-v1.12.md)。
 
 The VITS decoder is **MB-iSTFT (Multi-Band inverse STFT) + PQMF**, the only generator path. Total upsample factor is `upsample_rates(16x) * iSTFT_hop(4x) * PQMF_subbands(4x) = 256x`, delivering approximately **2.21x faster CPU ONNX inference** (100 phoneme p50) versus the legacy HiFi-GAN baseline. The output shape `[B, 1, T]` is preserved, so existing C++/Rust/C#/Go/WASM runtimes work unchanged. Both `--quality medium` and `--quality high` are supported (the latter applies bigger ResBlocks and 512 initial channels).
 
@@ -56,11 +58,11 @@ FP16 conversion is applied by default, reducing model size by ~50%. Use `--no-fp
 ```bash
 # Standard model (FP16 by default)
 CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
-  /path/to/checkpoint.ckpt /path/to/output.onnx
+    /path/to/checkpoint.ckpt /path/to/output.onnx
 
 # Full precision (FP32)
 CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
-  --no-fp16 /path/to/checkpoint.ckpt /path/to/output.onnx
+    --no-fp16 /path/to/checkpoint.ckpt /path/to/output.onnx
 ```
 
 ## Checkpoint Management
@@ -69,7 +71,7 @@ CUDA_VISIBLE_DEVICES="" uv run python -m piper_train.export_onnx \
 - `--resume_from_single_speaker_checkpoint` — Convert single-speaker to multi-speaker model
 - `--resume-from-multispeaker-checkpoint` — Convert multi-speaker to single-speaker for fine-tuning (auto-enables `--freeze-dp`)
 
-> Existing HiFi-GAN-based `.ckpt` files (pre-MB-iSTFT) are no longer compatible with `--resume_from_checkpoint`. Use the new MB-iSTFT base models published with this release.
+> **⚠ v1.11 非互換:** Existing HiFi-GAN-based `.ckpt` files (pre-MB-iSTFT) are no longer compatible with `--resume_from_checkpoint` in v1.12.0. The HiFi-GAN `Generator` class has been removed; attempting to resume from a v1.11 HiFi-GAN checkpoint now raises an explicit error. Use the new MB-iSTFT base models published with this release (e.g. `ayousanz/piper-plus-base` の MB-iSTFT 系). Details: [migration guide](../migration/v1.11-to-v1.12.md).
 
 ## Voice Evaluation
 

--- a/docs/spec/model-sha256-manifest.toml
+++ b/docs/spec/model-sha256-manifest.toml
@@ -84,12 +84,21 @@ optional_fields = [
 # "学習済みモデル (6言語マルチリンガル)" table for ease of cross-reference.
 
 # ---------------------------------------------------------------------------
-# 6lang base (HiFi-GAN, 75 epoch)
+# [Archived] 6lang base (HiFi-GAN, 75 epoch) — v1.11 系 / 非推奨
+# ---------------------------------------------------------------------------
+# このエントリは v1.11 系の HiFi-GAN Decoder で学習されたモデルです。
+# v1.12.0 で HiFi-GAN Decoder は削除され MB-iSTFT に統一されたため、
+# 新規利用は非推奨。互換のためマニフェストには残置していますが、
+# 現行モデルとしては下記 `multilingual-6lang-mb-istft` を使用してください。
+# 詳細: docs/migration/v1.11-to-v1.12.md
 # ---------------------------------------------------------------------------
 [[models]]
 name = "multilingual-6lang-base"
-description = "6lang base model trained for 75 epochs on the v1.11 HiFi-GAN pipeline"
+description = "[Archived/v1.11] 6lang base model trained for 75 epochs on the v1.11 HiFi-GAN pipeline (deprecated in v1.12.0)"
 training_basis = "75 epoch (v1.11 HiFi-GAN)"
+deprecated = true
+deprecated_since = "1.12.0"
+deprecated_reason = "HiFi-GAN Decoder removed in v1.12.0; superseded by multilingual-6lang-mb-istft"
 trained_languages = ["ja", "en", "zh", "es", "fr", "pt"]
 local_origin = "/data/piper/output-multilingual-6lang/"
 hf_mirror_repo = "ayousanz/piper-plus-base"
@@ -107,11 +116,15 @@ sha256 = "<computed-on-publish>"
 bytes = 0  # <computed-on-publish>
 
 # ---------------------------------------------------------------------------
-# 6lang MB-iSTFT (75 epoch, scratch)
+# 6lang MB-iSTFT (75 epoch, scratch) — 現行 / v1.12.0 推奨
+# ---------------------------------------------------------------------------
+# v1.12.0 以降の canonical な 6lang base モデル。MB-iSTFT Decoder で学習され、
+# CPU Decoder 単体で約 2.21x の高速化を達成 (HiFi-GAN 168.2ms → MB-iSTFT
+# 76.2ms / 100 phoneme p50)。新規 FT は本モデルを base にしてください。
 # ---------------------------------------------------------------------------
 [[models]]
 name = "multilingual-6lang-mb-istft"
-description = "6lang base model trained for 75 epochs from scratch with MB-iSTFT decoder"
+description = "6lang base model trained for 75 epochs from scratch with MB-iSTFT decoder (canonical for v1.12.0+)"
 training_basis = "75 epoch scratch (MB-iSTFT)"
 trained_languages = ["ja", "en", "zh", "es", "fr", "pt"]
 local_origin = "/data/piper/output-multilingual-6lang-mb-istft/multilingual-6lang-mb-istft-scratch-75epoch.onnx"
@@ -130,12 +143,18 @@ sha256 = "<computed-on-publish>"
 bytes = 0  # <computed-on-publish>
 
 # ---------------------------------------------------------------------------
-# Tsukuyomi 6lang-v2 (FT 500 epoch from HiFi-GAN base)
+# [Archived] Tsukuyomi 6lang-v2 (FT 500 epoch from HiFi-GAN base) — v1.11 系 / 非推奨
+# ---------------------------------------------------------------------------
+# v1.11 系 HiFi-GAN base から派生したつくよみちゃん FT モデル。
+# v1.12.0 では下記 `tsukuyomi-mb-istft` が現行モデル。本エントリは互換のため残置。
 # ---------------------------------------------------------------------------
 [[models]]
 name = "tsukuyomi-6lang-v2"
-description = "Single-speaker fine-tune of the 6lang HiFi-GAN base (500 epochs)"
+description = "[Archived/v1.11] Single-speaker fine-tune of the 6lang HiFi-GAN base (500 epochs) (deprecated in v1.12.0)"
 training_basis = "FT 500 epoch (HiFi-GAN base)"
+deprecated = true
+deprecated_since = "1.12.0"
+deprecated_reason = "Derived from HiFi-GAN base; superseded by tsukuyomi-mb-istft"
 trained_languages = ["ja", "en", "zh", "es", "fr", "pt"]
 local_origin = "/data/piper/output-tsukuyomi-finetune-6lang-v2/tsukuyomi-6lang-v2-fixed.onnx"
 hf_mirror_repo = "ayousanz/piper-plus-tsukuyomi-chan"
@@ -153,11 +172,14 @@ sha256 = "<computed-on-publish>"
 bytes = 0  # <computed-on-publish>
 
 # ---------------------------------------------------------------------------
-# Tsukuyomi MB-iSTFT (FT 500 epoch from MB-iSTFT base)
+# Tsukuyomi MB-iSTFT (FT 500 epoch from MB-iSTFT base) — 現行 / v1.12.0 推奨
+# ---------------------------------------------------------------------------
+# v1.12.0 以降の canonical なつくよみちゃんモデル。
+# 上の `tsukuyomi-6lang-v2` の MB-iSTFT 後継。
 # ---------------------------------------------------------------------------
 [[models]]
 name = "tsukuyomi-mb-istft"
-description = "Single-speaker fine-tune of the 6lang MB-iSTFT base (500 epochs)"
+description = "Single-speaker fine-tune of the 6lang MB-iSTFT base (500 epochs) (canonical for v1.12.0+)"
 training_basis = "FT 500 epoch (MB-iSTFT base)"
 trained_languages = ["ja", "en", "zh", "es", "fr", "pt"]
 local_origin = "/data/piper/output-tsukuyomi-mb-istft-finetune/tsukuyomi-mb-istft-500epoch.onnx"

--- a/examples/japanese_tts.sh
+++ b/examples/japanese_tts.sh
@@ -9,12 +9,12 @@ MODEL_PATH="path/to/your/japanese_model.onnx"
 
 # 基本的な使用例
 echo "=== 基本的な使用例 ==="
-echo "こんにちは、Piperです。" | $PIPER_BIN --model "$MODEL_PATH" --output_file hello.wav
+echo "こんにちは、Piperです。" | $PIPER_BIN --model "$MODEL_PATH" --output-file hello.wav
 echo "hello.wav を生成しました"
 
 # 長いテキストの例
 echo "=== 長いテキストの例 ==="
-cat << EOF | $PIPER_BIN --model "$MODEL_PATH" --output_file long_text.wav
+cat << EOF | $PIPER_BIN --model "$MODEL_PATH" --output-file long_text.wav
 本日は晴天なり。
 日本語の音声合成システムPiperを使用して、
 様々なテキストを自然な音声に変換することができます。
@@ -33,13 +33,13 @@ texts=(
 )
 
 for i in "${!texts[@]}"; do
-    echo "${texts[$i]}" | $PIPER_BIN --model "$MODEL_PATH" --output_file "greeting_$i.wav"
+    echo "${texts[$i]}" | $PIPER_BIN --model "$MODEL_PATH" --output-file "greeting_$i.wav"
     echo "greeting_$i.wav を生成しました"
 done
 
 # デバッグ情報を表示する例
 echo "=== デバッグ情報の表示 ==="
-echo "テスト" | $PIPER_BIN --model "$MODEL_PATH" --output_file test.wav --debug
+echo "テスト" | $PIPER_BIN --model "$MODEL_PATH" --output-file test.wav --debug
 
 echo "=== 完了 ==="
 echo "生成された音声ファイル:"


### PR DESCRIPTION
## Summary

v1.12.0 リリースの Breaking changes に追従するドキュメントドリフトを 3 箇所で修正。コード変更なし、ドキュメント / コメントのみ。

## 修正内容

### 1. `docs/spec/model-sha256-manifest.toml`

- 旧 HiFi-GAN 系 2 モデル (`multilingual-6lang-base`, `tsukuyomi-6lang-v2`) に `[Archived] / v1.11 系 / 非推奨` 見出しと TOML キー (`deprecated = true`, `deprecated_since = \"1.12.0\"`, `deprecated_reason`) を追加。
- 現行 MB-iSTFT 系 2 モデル (`multilingual-6lang-mb-istft`, `tsukuyomi-mb-istft`) に `現行 / v1.12.0 推奨` 見出しを追加し、新旧の差を一目で識別できるように整理。
- description に `[Archived/v1.11]` および `canonical for v1.12.0+` のマーカーを追加。

### 2. `examples/japanese_tts.sh`

- `--output_file` (underscore) → `--output-file` (hyphen) に統一 (5 箇所)。
- Python `__main__.py:78-83` で primary 名が `--output-file` 形式、`--output_file` は backwards-compat alias として残る形のため canonical 表記に揃えた。Rust / C++ CLI も両形式受理 (既存挙動維持)。

### 3. `docs/guides/training.md`

- **MB-iSTFT-VITS2 Decoder** セクション冒頭に「⚠ v1.11 非互換 / v1.12.0 Breaking change」注記を追加。v1.11 で存在した `--mb-istft` フラグが廃止 (MB-iSTFT 統一済み) されたこと、旧スクリプトをコピーすると unknown argument エラーになることを明示。
- **Checkpoint Management** セクションの HiFi-GAN ckpt 非互換注記にも `⚠ v1.11 非互換` マーカーを追加し、HiFi-GAN `Generator` クラス削除で明示エラーになる旨と migration guide リンクを併記。
- 同ファイル内の pre-existing editorconfig 違反 (code-block 内 2-space indent) を 4-space に揃え lint gate を通過。

## 確認のみ (修正不要だった項目)

なし — 3 項目すべて修正対象だった。

## Test plan

- [x] pre-commit (editorconfig-checker, markdownlint, codespell, taplo, secrets, etc.) 全部 pass
- [ ] CI が green になることを確認
- [ ] reviewer が `docs/migration/v1.11-to-v1.12.md` との一貫性を最終確認