### PR TITLE
fix(server): WebUI と FastAPI CLI で言語リスト整合 (sv 取扱を統一)

### DIFF
--- a/docker/python-inference/inference.py
+++ b/docker/python-inference/inference.py
@@ -38,6 +38,32 @@ from piper_train.ort_utils import create_session_with_cache, warmup_onnx_session
 _LOGGER = logging.getLogger(__name__)
 
 
+# Languages accepted by the `--language` CLI flag.
+#
+# Kept in sync with `docker/webui/app.py:SAMPLE_TEXTS` and the canonical
+# 6-lang multilingual training set documented in CLAUDE.md (ja=0, en=1,
+# zh=2, es=3, fr=4, pt=5).
+#
+# Why this list is 6 and not 8 (G2P-supported languages):
+#   piper_plus_g2p ships phonemizers for 8 languages (adds ko + sv), but
+#   the trained checkpoints we ship have no language embedding for ko/sv.
+#   Accepting those codes would phonemize with the correct G2P, then
+#   silently fall back to `lid = language_id_map.get(language, 0)` = 0
+#   (Japanese) inside `PiperInferenceEngine.synthesize`, and drop any
+#   unique-to-that-language phonemes that are not in the model's
+#   phoneme_id_map as "Unknown phoneme" log warnings. The audio that
+#   comes out is neither Swedish nor Japanese — just confusing. Re-add
+#   `ko` / `sv` here once a checkpoint with those language ids is
+#   published.
+#
+# Note: the runtime `/v1/audio/speech/languages` endpoint reports the
+# *loaded model*'s `language_id_map.keys()` rather than this static list,
+# so a future model with sv/ko will surface them without needing this
+# constant to change. This constant exists only for the CLI `choices=`
+# validator and as documentation for the WebUI parity.
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("ja", "en", "zh", "es", "fr", "pt")
+
+
 def _sanitize_for_log(value: str) -> str:
     # Strip CR/LF from user-controlled values before logging to prevent
     # log forging via line-break injection (CWE-117). Used at the HTTP
@@ -247,7 +273,7 @@ def main():
     parser.add_argument(
         "--language",
         default="ja",
-        choices=["ja", "en", "zh", "es", "fr", "pt"],
+        choices=SUPPORTED_LANGUAGES,
         help="Language",
     )
     parser.add_argument("--noise-scale", type=float, default=0.667)

--- a/docker/python-inference/test_openai_api.py
+++ b/docker/python-inference/test_openai_api.py
@@ -186,6 +186,55 @@ class TestLanguages:
         languages = resp.json()["languages"]
         assert languages == sorted(languages)
 
+    def test_languages_endpoint_matches_supported_languages(self, client):
+        """`/v1/audio/speech/languages` must return exactly the canonical
+        `SUPPORTED_LANGUAGES` set when the model exposes a 6-lang
+        `language_id_map`. Mock fixture's map mirrors the shipped
+        checkpoints (ja/en/zh/es/fr/pt — CLAUDE.md)."""
+        from inference import SUPPORTED_LANGUAGES  # noqa: PLC0415
+
+        resp = client.get("/v1/audio/speech/languages")
+        assert resp.status_code == 200
+        returned = set(resp.json()["languages"])
+        assert returned == set(SUPPORTED_LANGUAGES), (
+            f"endpoint returned {returned}, expected {set(SUPPORTED_LANGUAGES)}"
+        )
+
+    def test_supported_languages_matches_webui_sample_texts(self):
+        """CLI `SUPPORTED_LANGUAGES` and WebUI `SAMPLE_TEXTS` keys must
+        match exactly so the two server entry points expose the same set
+        of languages. The WebUI extraction goes via `ast` rather than
+        importing `docker/webui/app.py`, which depends on gradio (not in
+        the test virtualenv — same trick the WebUI's own test_app.py
+        uses)."""
+        import ast  # noqa: PLC0415
+
+        from inference import SUPPORTED_LANGUAGES  # noqa: PLC0415
+
+        webui_path = Path(__file__).resolve().parent.parent / "webui" / "app.py"
+        tree = ast.parse(webui_path.read_text(encoding="utf-8"))
+        sample_texts_keys: list[str] | None = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if (
+                        isinstance(target, ast.Name)
+                        and target.id == "SAMPLE_TEXTS"
+                        and isinstance(node.value, ast.Dict)
+                    ):
+                        sample_texts_keys = [
+                            ast.literal_eval(k) for k in node.value.keys
+                        ]
+                        break
+                if sample_texts_keys is not None:
+                    break
+
+        assert sample_texts_keys is not None, "SAMPLE_TEXTS not found in webui/app.py"
+        assert set(sample_texts_keys) == set(SUPPORTED_LANGUAGES), (
+            f"WebUI SAMPLE_TEXTS keys {set(sample_texts_keys)} do not match "
+            f"CLI SUPPORTED_LANGUAGES {set(SUPPORTED_LANGUAGES)}"
+        )
+
 
 # ---- existing endpoints still work ----
 

--- a/docker/python-inference/test_openai_api.py
+++ b/docker/python-inference/test_openai_api.py
@@ -206,12 +206,32 @@ class TestLanguages:
         of languages. The WebUI extraction goes via `ast` rather than
         importing `docker/webui/app.py`, which depends on gradio (not in
         the test virtualenv — same trick the WebUI's own test_app.py
-        uses)."""
+        uses).
+
+        Two layouts are supported because this same test runs in two
+        environments. (1) Repo checkout (pytest from a worktree): the
+        file lives at ``docker/webui/app.py`` relative to this test.
+        (2) Docker image (``docker-test.yml`` mounts only this test
+        into ``/app/test_openai_api.py``): the WebUI source is
+        flattened to ``/app/webui.py`` by the Dockerfile (``COPY
+        docker/webui/app.py /app/webui.py``). Skip cleanly if neither
+        file is present so this test does not regress to a hard-coded
+        ``/webui/app.py`` lookup again."""
         import ast  # noqa: PLC0415
 
         from inference import SUPPORTED_LANGUAGES  # noqa: PLC0415
 
-        webui_path = Path(__file__).resolve().parent.parent / "webui" / "app.py"
+        here = Path(__file__).resolve().parent
+        candidate_paths = [
+            here.parent / "webui" / "app.py",  # repo layout
+            here / "webui.py",  # docker image (flattened)
+        ]
+        webui_path = next((p for p in candidate_paths if p.is_file()), None)
+        if webui_path is None:
+            pytest.skip(
+                "WebUI source not found; checked: "
+                + ", ".join(str(p) for p in candidate_paths)
+            )
         tree = ast.parse(webui_path.read_text(encoding="utf-8"))
         sample_texts_keys: list[str] | None = None
         for node in ast.walk(tree):

--- a/docker/webui/app.py
+++ b/docker/webui/app.py
@@ -14,6 +14,23 @@ from piper_train.infer_onnx import text_to_phoneme_ids_and_prosody
 from piper_train.ort_utils import create_session_with_cache, warmup_onnx_session
 
 
+# Languages exposed in the WebUI dropdown.
+#
+# Kept in sync with `docker/python-inference/inference.py:SUPPORTED_LANGUAGES`
+# and the canonical 6-lang multilingual training set documented in CLAUDE.md
+# (ja=0, en=1, zh=2, es=3, fr=4, pt=5).
+#
+# Why this list is 6 and not 8 (G2P-supported languages):
+#   piper_plus_g2p ships phonemizers for 8 languages (adds ko + sv), but the
+#   only trained checkpoints we ship — 6lang base / Tsukuyomi-chan FT / CSS10
+#   JA — have no language embedding for ko/sv. Selecting an unsupported
+#   language in the UI would (a) phonemize with the correct G2P, then (b)
+#   silently fall back to `lid=0` (Japanese) in `synthesize()` and (c) drop
+#   any unique-to-that-language phonemes that are not in the model's
+#   phoneme_id_map as "Unknown phoneme" warnings. The audio that comes out
+#   is neither Swedish nor Japanese — just confusing. We hide these
+#   languages from the UI rather than ship that footgun. Re-add `ko` / `sv`
+#   here once a checkpoint with those language ids is published.
 SAMPLE_TEXTS = {
     "ja": "こんにちは、今日はとても良い天気ですね。散歩に出かけましょう。",
     "en": "Hello, how are you today? The weather is beautiful, let's go for a walk.",
@@ -21,7 +38,6 @@ SAMPLE_TEXTS = {
     "es": "Hola, ¿cómo estás hoy? El clima es hermoso, vamos a dar un paseo.",
     "fr": "Bonjour, comment allez-vous aujourd'hui? Il fait beau, allons nous promener.",
     "pt": "Olá, como você está hoje? O tempo está lindo, vamos dar um passeio.",
-    "sv": "Hej, hur mår du idag?",
 }
 
 
@@ -261,8 +277,10 @@ def create_ui(model_dir: str, output_dir: str):
                     label="Model",
                     value=model_choices[0] if models else None,
                 )
+                # Choices must stay in sync with `SAMPLE_TEXTS` above and
+                # `docker/python-inference/inference.py:SUPPORTED_LANGUAGES`.
                 language = gr.Radio(
-                    choices=["ja", "en", "zh", "es", "fr", "pt", "sv"],
+                    choices=list(SAMPLE_TEXTS.keys()),
                     label="Language",
                     value="ja",
                 )

--- a/docker/webui/test_app.py
+++ b/docker/webui/test_app.py
@@ -23,11 +23,18 @@ _source = _APP_PY.read_text(encoding="utf-8")
 # Parse the constant
 _tree = ast.parse(_source)
 _SHORT_TEXT_THRESHOLD: int = 10  # fallback
+_SAMPLE_TEXTS_KEYS: list[str] = []
 for _node in ast.walk(_tree):
     if isinstance(_node, ast.Assign):
         for _target in _node.targets:
             if isinstance(_target, ast.Name) and _target.id == "_SHORT_TEXT_THRESHOLD":
                 _SHORT_TEXT_THRESHOLD = ast.literal_eval(_node.value)
+            elif (
+                isinstance(_target, ast.Name)
+                and _target.id == "SAMPLE_TEXTS"
+                and isinstance(_node.value, ast.Dict)
+            ):
+                _SAMPLE_TEXTS_KEYS = [ast.literal_eval(k) for k in _node.value.keys]
 
 
 def _extract_function(name: str) -> str:
@@ -80,6 +87,34 @@ class _FakeOnnxSession:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+class TestSupportedLanguages:
+    """Pin the WebUI's exposed language list to the 6-lang multilingual
+    checkpoints we actually ship (CLAUDE.md: ja=0, en=1, zh=2, es=3, fr=4,
+    pt=5). G2P supports 8 languages (adds ko + sv), but the trained
+    checkpoints have no language embedding for ko/sv, so selecting them
+    in the UI would silently fall back to `lid=0` (Japanese) and drop
+    unique phonemes. Hide them rather than ship a footgun — these tests
+    will fail loudly if anyone re-adds ko/sv without also publishing a
+    checkpoint that supports them."""
+
+    EXPECTED_LANGUAGES = {"ja", "en", "zh", "es", "fr", "pt"}
+
+    def test_sample_texts_keys_match_supported_set(self):
+        assert set(_SAMPLE_TEXTS_KEYS) == self.EXPECTED_LANGUAGES, (
+            f"SAMPLE_TEXTS keys {set(_SAMPLE_TEXTS_KEYS)} drifted from the "
+            f"shipped-checkpoint set {self.EXPECTED_LANGUAGES}"
+        )
+
+    def test_sv_not_in_sample_texts(self):
+        """Regression guard: sv was removed because the 6lang model has no
+        sv language embedding (PR alignment with FastAPI server)."""
+        assert "sv" not in _SAMPLE_TEXTS_KEYS
+
+    def test_ko_not_in_sample_texts(self):
+        """Regression guard: ko is also G2P-supported but checkpoint-less."""
+        assert "ko" not in _SAMPLE_TEXTS_KEYS
+
+
 class TestIsShortText:
     """Boundary-value tests for _is_short_text()."""
 


### PR DESCRIPTION
## Summary

WebUI (`docker/webui/app.py`) は 7 言語 (ja/en/zh/es/fr/pt/**sv**) を露出していたが、FastAPI CLI (`docker/python-inference/inference.py`) は 6 言語 (sv なし) で食い違っていた。 **sv は WebUI 側から外して 6 言語に統一** した (UI honesty 優先)。

## 実態調査の結果と方針選択

**選択した方針: WebUI 側から sv を外す (学習モデル未対応のため)**

WebUI で `sv` を選んだ時に実際に何が起きるかを追ったところ、 broken footgun と判明:

1. `piper_plus_g2p` は 8 言語の phonemizer を ship (ja/en/zh/ko/es/pt/fr/**sv**) — `CLAUDE.md` の "G2P 8 言語" のうち sv はここに含まれる。
2. しかし `CLAUDE.md` に明記された通り、学習済みモデルは **6 言語マルチリンガル** (ja/en/zh/es/fr/pt) — sv/ko の language embedding は無い。
3. WebUI で sv を選択 → Swedish G2P で音素化 → `language_id_map.get("sv", 0)` が `0` を返し、 **lid=0 (= 日本語) として推論** される。
4. かつ Swedish 固有音素 (`ɫ` など) は 6lang モデルの `phoneme_id_map` に無く、 `"Unknown phoneme"` で silently drop。
5. 出力は **Swedish でも日本語でもない混乱音声**。

UI に並んでいるのに使い物にならない選択肢は footgun なので、 WebUI 側を 6 言語に縮める方針を選択。 sv の音素化コード自体は残しているので、 将来 sv を含む学習モデルを ship したタイミングで再追加可能。

## 変更内容

- **`docker/webui/app.py`** — `SAMPLE_TEXTS` から sv を削除し、 `language` Radio choices を `list(SAMPLE_TEXTS.keys())` で single-source-of-truth 化。 ko/sv を外した理由を inline コメントで明示。
- **`docker/python-inference/inference.py`** — 6-lang リテラルを `SUPPORTED_LANGUAGES` 定数に抽出し、 同じ理由を docstring 化。 `--language` argparse choices も同定数を参照。
- **`/v1/audio/speech/languages` の挙動は変更なし** — model の `language_id_map.keys()` を返す既存仕様のまま。 将来 sv 対応モデルを load した時には自動で sv を返すので、 endpoint 側に hard-code は入れていない。

## Tests

- `docker/python-inference/test_openai_api.py::TestLanguages` に 2 件追加:
  - `test_languages_endpoint_matches_supported_languages` — endpoint と `SUPPORTED_LANGUAGES` が一致。
  - `test_supported_languages_matches_webui_sample_texts` — WebUI `SAMPLE_TEXTS` keys を ast で抽出して `SUPPORTED_LANGUAGES` と byte-for-byte 一致を強制。 gradio import 回避は WebUI 側 test の既存パターンに揃えた。
- `docker/webui/test_app.py::TestSupportedLanguages` (3 件追加):
  - `test_sample_texts_keys_match_supported_set` — `{ja,en,zh,es,fr,pt}` 一致。
  - `test_sv_not_in_sample_texts` / `test_ko_not_in_sample_texts` — regression guard。

ローカルで `pytest docker/webui/test_app.py` (22/22 passed) と `pytest docker/python-inference/test_openai_api.py` (38/38 passed — 残り 4 件の async failure は dev で pre-existing、 本 PR と無関係)。

## スコープ限定 (別 PR 予定)

- auth / API key 認証
- rate limit
- streaming response

## 学習モデル本体は変更なし

CLAUDE.md の "学習済みモデルは 6 言語 (sv/ko 未含有)、 コードは 8 言語対応" の不変条件は維持。

## Test plan

- [ ] CI: `webui-test.yml` が green になる
- [ ] CI: `inference-input-contract.yml` (or 該当 docker test workflow) が green になる
- [ ] `pre-commit run --all-files` がローカルで pass する
- [ ] manual: `python docker/python-inference/inference.py --help` で `--language` choices が 6 個になっている
- [ ] manual: WebUI 起動して language dropdown に sv が無いことを確認