### PR TITLE
test: download.py ネットワーク耐性 + Go voice.go error path 追加

### DIFF
--- a/src/go/piperplus/voice_test.go
+++ b/src/go/piperplus/voice_test.go
@@ -1,0 +1,203 @@
+package piperplus
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// LoadVoice tests intentionally exercise only the error paths that fail
+// BEFORE the ONNX Runtime initialization. Heavy integration tests that
+// require a real .onnx model live elsewhere (see engine_test.go).
+
+// TestLoadVoice_MissingModelPath: the model file does not exist on disk.
+// FindConfigPath is called first; with a non-existent model path and no
+// sidecar/dir-config, it returns *ConfigError before any ONNX work.
+func TestLoadVoice_MissingModelPath(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	missingModel := filepath.Join(tmpDir, "does-not-exist.onnx")
+
+	v, err := LoadVoice(ctx, missingModel)
+	if err == nil {
+		if v != nil {
+			_ = v.Close()
+		}
+		t.Fatal("LoadVoice should fail for a non-existent model path")
+	}
+
+	var cfgErr *ConfigError
+	if !errors.As(err, &cfgErr) {
+		t.Errorf("error type = %T, want *ConfigError (config resolution must fail first)", err)
+	}
+}
+
+// TestLoadVoice_ExplicitConfigNotFound: WithConfig points at a path that
+// does not exist. FindConfigPath must fail with *ConfigError.
+func TestLoadVoice_ExplicitConfigNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	missingConfig := filepath.Join(tmpDir, "no-such-config.json")
+	dummyModel := filepath.Join(tmpDir, "dummy.onnx")
+
+	_, err := LoadVoice(ctx, dummyModel, WithConfig(missingConfig))
+	if err == nil {
+		t.Fatal("LoadVoice should fail when explicit config path does not exist")
+	}
+
+	var cfgErr *ConfigError
+	if !errors.As(err, &cfgErr) {
+		t.Errorf("error type = %T, want *ConfigError", err)
+	}
+	if cfgErr != nil && cfgErr.Path != missingConfig {
+		t.Errorf("ConfigError.Path = %q, want %q", cfgErr.Path, missingConfig)
+	}
+}
+
+// TestLoadVoice_CorruptedConfig: config.json contains malformed JSON. The
+// failure must surface as *ConfigError from LoadConfig, not as an opaque
+// JSON error or a downstream ONNX failure.
+func TestLoadVoice_CorruptedConfig(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	corruptedConfig := filepath.Join(tmpDir, "broken.json")
+	if err := os.WriteFile(corruptedConfig, []byte("{ this is not valid json"), 0o644); err != nil {
+		t.Fatalf("setup: failed to write corrupted config: %v", err)
+	}
+	dummyModel := filepath.Join(tmpDir, "dummy.onnx")
+
+	_, err := LoadVoice(ctx, dummyModel, WithConfig(corruptedConfig))
+	if err == nil {
+		t.Fatal("LoadVoice should fail when config.json is malformed")
+	}
+
+	var cfgErr *ConfigError
+	if !errors.As(err, &cfgErr) {
+		t.Errorf("error type = %T, want *ConfigError for malformed JSON", err)
+	}
+}
+
+// TestLoadVoice_ConfigValidationFailure: well-formed JSON but missing the
+// required phoneme_id_map. LoadConfig.Validate() must reject it as
+// *ConfigError before any ONNX session is created.
+func TestLoadVoice_ConfigValidationFailure(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	emptyMapConfig := filepath.Join(tmpDir, "empty-map.json")
+	// Valid JSON, valid sample_rate, but empty phoneme_id_map → Validate() rejects.
+	body := `{"audio":{"sample_rate":22050},"phoneme_id_map":{}}`
+	if err := os.WriteFile(emptyMapConfig, []byte(body), 0o644); err != nil {
+		t.Fatalf("setup: failed to write config: %v", err)
+	}
+	dummyModel := filepath.Join(tmpDir, "dummy.onnx")
+
+	_, err := LoadVoice(ctx, dummyModel, WithConfig(emptyMapConfig))
+	if err == nil {
+		t.Fatal("LoadVoice should fail when phoneme_id_map is empty")
+	}
+
+	var cfgErr *ConfigError
+	if !errors.As(err, &cfgErr) {
+		t.Errorf("error type = %T, want *ConfigError for validation failure", err)
+	}
+}
+
+// TestLoadVoice_ContextCancelled: a pre-cancelled context must short-circuit
+// before any filesystem or ONNX I/O.
+func TestLoadVoice_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before invocation
+
+	tmpDir := t.TempDir()
+	dummyModel := filepath.Join(tmpDir, "dummy.onnx")
+
+	_, err := LoadVoice(ctx, dummyModel)
+	if err == nil {
+		t.Fatal("LoadVoice should fail for a cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Voice.Close() idempotency
+// ---------------------------------------------------------------------------
+
+// TestVoiceClose_IdempotentNoPanic exercises Close() repeatedly on a Voice
+// struct in the closed state. The first Close swaps the atomic flag and
+// would call engine.Close(); subsequent Closes must early-return nil
+// WITHOUT panicking and WITHOUT touching the (nil) engine.
+//
+// We start with closed=true so the first Close() also takes the early-return
+// path. This keeps the test free of ONNX runtime dependencies while still
+// validating the documented contract: "It is safe to call multiple times;
+// only the first call performs cleanup."
+func TestVoiceClose_IdempotentNoPanic(t *testing.T) {
+	v := &Voice{}
+	v.closed.Store(true) // simulate an already-closed Voice
+
+	for i := 0; i < 5; i++ {
+		err := v.Close()
+		if err != nil {
+			t.Errorf("Close() call #%d returned %v, want nil", i+1, err)
+		}
+	}
+}
+
+// TestVoiceClose_FlagCompareAndSwap verifies that after a successful CAS
+// from false→true, additional Close() calls take the early-return path
+// (CompareAndSwap returns false on subsequent attempts).
+func TestVoiceClose_FlagCompareAndSwap(t *testing.T) {
+	v := &Voice{}
+
+	// First CAS: false → true. We simulate the "first successful close"
+	// without invoking engine.Close() (nil engine would panic).
+	if !v.closed.CompareAndSwap(false, true) {
+		t.Fatal("initial CompareAndSwap(false, true) should succeed")
+	}
+
+	// Subsequent Close() calls must take the early-return branch and
+	// return nil without touching the nil engine.
+	for i := 0; i < 3; i++ {
+		if err := v.Close(); err != nil {
+			t.Errorf("Close() call #%d after CAS returned %v, want nil", i+1, err)
+		}
+	}
+}
+
+// TestSynthesizeFromIDs_ClosedReturnsErr: SynthesizeFromIDs on a closed
+// Voice must surface ErrModelClosed, not panic on the nil engine.
+func TestSynthesizeFromIDs_ClosedReturnsErr(t *testing.T) {
+	v := &Voice{}
+	v.closed.Store(true)
+
+	_, err := v.SynthesizeFromIDs(context.Background(), &SynthesisRequest{})
+	if !errors.Is(err, ErrModelClosed) {
+		t.Errorf("err = %v, want ErrModelClosed", err)
+	}
+}
+
+// TestSynthesizeFromIDs_NilRequestOnOpenVoice: a non-closed Voice with a
+// nil request must reject the request before reaching the engine. We use a
+// non-closed flag but still expect the nil-request guard to fire first.
+func TestSynthesizeFromIDs_NilRequestOnOpenVoice(t *testing.T) {
+	v := &Voice{}
+	// closed flag defaults to false; SynthesizeFromIDs reaches the nil-request guard.
+
+	_, err := v.SynthesizeFromIDs(context.Background(), nil)
+	if err == nil {
+		t.Fatal("SynthesizeFromIDs(nil) should return an error")
+	}
+	// The error message should mention the nil request.
+	if !strings.Contains(err.Error(), "nil synthesis request") {
+		t.Errorf("err = %q, want substring %q", err.Error(), "nil synthesis request")
+	}
+}

--- a/src/go/piperplus/voice_test.go
+++ b/src/go/piperplus/voice_test.go
@@ -113,9 +113,9 @@ func TestLoadVoice_ConfigValidationFailure(t *testing.T) {
 	}
 }
 
-// TestLoadVoice_ContextCancelled: a pre-cancelled context must short-circuit
+// TestLoadVoice_ContextCanceled: a pre-canceled context must short-circuit
 // before any filesystem or ONNX I/O.
-func TestLoadVoice_ContextCancelled(t *testing.T) {
+func TestLoadVoice_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before invocation
 
@@ -124,7 +124,7 @@ func TestLoadVoice_ContextCancelled(t *testing.T) {
 
 	_, err := LoadVoice(ctx, dummyModel)
 	if err == nil {
-		t.Fatal("LoadVoice should fail for a cancelled context")
+		t.Fatal("LoadVoice should fail for a canceled context")
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("err = %v, want context.Canceled", err)

--- a/src/go/piperplus/voice_test.go
+++ b/src/go/piperplus/voice_test.go
@@ -17,6 +17,10 @@ import (
 // FindConfigPath is called first; with a non-existent model path and no
 // sidecar/dir-config, it returns *ConfigError before any ONNX work.
 func TestLoadVoice_MissingModelPath(t *testing.T) {
+	// Hermetic: clear PIPER_DEFAULT_CONFIG so the host environment cannot
+	// redirect FindConfigPath to a real config file and mask the missing model.
+	t.Setenv("PIPER_DEFAULT_CONFIG", "")
+
 	ctx := context.Background()
 
 	tmpDir := t.TempDir()
@@ -131,14 +135,20 @@ func TestLoadVoice_ContextCancelled(t *testing.T) {
 // Voice.Close() idempotency
 // ---------------------------------------------------------------------------
 
-// TestVoiceClose_IdempotentNoPanic exercises Close() repeatedly on a Voice
-// struct in the closed state. The first Close swaps the atomic flag and
-// would call engine.Close(); subsequent Closes must early-return nil
-// WITHOUT panicking and WITHOUT touching the (nil) engine.
+// TestVoiceClose_IdempotentNoPanic verifies that Close() is safe to call
+// repeatedly on a Voice that is ALREADY in the closed state.
 //
-// We start with closed=true so the first Close() also takes the early-return
-// path. This keeps the test free of ONNX runtime dependencies while still
-// validating the documented contract: "It is safe to call multiple times;
+// We pre-set closed=true, so EVERY Close() call here (including the first
+// one in the loop) observes the flag as already-set and takes the
+// early-return branch — CompareAndSwap(false, true) returns false and
+// engine.Close() is NOT invoked. This is the "already-closed idempotency"
+// path: it exercises only the early-return guard and deliberately avoids
+// the first-close cleanup path (which would require a real engine).
+//
+// The complementary first-close CAS transition (false → true) is covered
+// by TestVoiceClose_FlagCompareAndSwap below.
+//
+// Documented contract under test: "It is safe to call multiple times;
 // only the first call performs cleanup."
 func TestVoiceClose_IdempotentNoPanic(t *testing.T) {
 	v := &Voice{}

--- a/src/python_run/tests/test_download_resilience.py
+++ b/src/python_run/tests/test_download_resilience.py
@@ -1,0 +1,262 @@
+"""Network resilience tests for piper.download.
+
+Covers error paths that the existing test_cli_models.py suite does not exercise:
+    - urlopen timeout
+    - HTTP 500 / 404 responses
+    - Partial download (Content-Length mismatch surfaces as wrong-size on disk)
+    - Disk-full simulation (os.write / file.write raising OSError)
+
+All network I/O is mocked. No real HuggingFace requests are issued.
+Style follows test_cli_models.py: classes, tempfile.TemporaryDirectory, and
+``with patch("piper.download.urlopen", ...)`` to intercept the urllib call site.
+"""
+
+import io
+import socket
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+
+# Add the parent directory to the path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from piper.download import (  # noqa: E402
+    ensure_voice_exists,
+    get_voices,
+)
+
+
+def _make_voice_info(size_bytes: int = 5, md5_digest: str = "") -> dict:
+    """Build a piper-plus voice entry pointing at a single fake .onnx file."""
+    return {
+        "key": "test-voice",
+        "source": "piper-plus",
+        "repo": "ayousanz/test-repo",
+        "files": {
+            "model.onnx": {"size_bytes": size_bytes, "md5_digest": md5_digest},
+        },
+    }
+
+
+class _FakeResponse(io.BytesIO):
+    """Minimal urlopen-like response usable as a context manager."""
+
+    def __init__(self, payload: bytes):
+        super().__init__(payload)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+        return False
+
+
+class TestDownloadTimeout:
+    """urlopen() raising a socket/URLError surfaces to the caller."""
+
+    def test_socket_timeout_propagates(self):
+        voice_info = _make_voice_info()
+        voices = {"test-voice": voice_info}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "piper.download.urlopen",
+                side_effect=TimeoutError("connection timed out"),
+            ):
+                with pytest.raises(socket.timeout):
+                    ensure_voice_exists("test-voice", [tmpdir], tmpdir, voices)
+
+    def test_urlerror_propagates(self):
+        """urllib.error.URLError (e.g. DNS / network unreachable) propagates."""
+        voice_info = _make_voice_info()
+        voices = {"test-voice": voice_info}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "piper.download.urlopen",
+                side_effect=URLError("Temporary failure in name resolution"),
+            ):
+                with pytest.raises(URLError):
+                    ensure_voice_exists("test-voice", [tmpdir], tmpdir, voices)
+
+
+class TestDownloadHTTPErrors:
+    """HTTP 5xx / 4xx responses raised by urlopen must surface as HTTPError."""
+
+    def test_http_500_raises(self):
+        voice_info = _make_voice_info()
+        voices = {"test-voice": voice_info}
+
+        http_500 = HTTPError(
+            url="https://huggingface.co/ayousanz/test-repo/resolve/main/model.onnx",
+            code=500,
+            msg="Internal Server Error",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("piper.download.urlopen", side_effect=http_500):
+                with pytest.raises(HTTPError) as exc_info:
+                    ensure_voice_exists("test-voice", [tmpdir], tmpdir, voices)
+                assert exc_info.value.code == 500
+
+    def test_http_404_raises(self):
+        voice_info = _make_voice_info()
+        voices = {"test-voice": voice_info}
+
+        http_404 = HTTPError(
+            url="https://huggingface.co/ayousanz/test-repo/resolve/main/model.onnx",
+            code=404,
+            msg="Not Found",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("piper.download.urlopen", side_effect=http_404):
+                with pytest.raises(HTTPError) as exc_info:
+                    ensure_voice_exists("test-voice", [tmpdir], tmpdir, voices)
+                assert exc_info.value.code == 404
+
+
+class TestPartialDownload:
+    """Content-Length mismatch: write fewer bytes than expected_size.
+
+    download.py uses shutil.copyfileobj(response, file) without verifying the
+    written byte count, so a truncated response writes a smaller file on disk.
+    A subsequent ensure_voice_exists call must detect the size mismatch and
+    plan a re-download.
+    """
+
+    def test_truncated_payload_detected_on_recheck(self):
+        # voice expects 1024 bytes; server returns 10 bytes.
+        voice_info = _make_voice_info(size_bytes=1024)
+        voices = {"test-voice": voice_info}
+        truncated = b"x" * 10
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            with patch(
+                "piper.download.urlopen",
+                return_value=_FakeResponse(truncated),
+            ):
+                ensure_voice_exists("test-voice", [tmpdir], tmpdir, voices)
+
+            downloaded = tmp_path / "model.onnx"
+            assert downloaded.exists()
+            assert downloaded.stat().st_size == 10  # truncated, not 1024
+
+            # Second call should observe wrong size and try to re-download.
+            recheck_mock = MagicMock(side_effect=URLError("simulated re-download"))
+            with patch("piper.download.urlopen", recheck_mock):
+                with pytest.raises(URLError):
+                    ensure_voice_exists("test-voice", [tmpdir], tmpdir, voices)
+            assert recheck_mock.called, "wrong-size file should trigger re-download"
+
+
+class TestDiskFull:
+    """Simulate disk-full during the write loop.
+
+    shutil.copyfileobj calls file.write() in a loop; raising OSError(ENOSPC) on
+    write must propagate out of ensure_voice_exists rather than silently
+    leaving a partial file undetected.
+    """
+
+    def test_oserror_on_write_propagates(self, monkeypatch):
+        import errno
+
+        voice_info = _make_voice_info(size_bytes=1024)
+        voices = {"test-voice": voice_info}
+
+        payload = b"y" * 1024
+
+        # Monkey-patch the built-in open used in download.py so the resulting
+        # file object raises OSError(ENOSPC) on write. We only intercept the
+        # download target path; other opens (e.g. voices.json) fall through.
+        real_open = open
+        target_filename = "model.onnx"
+
+        class _DiskFullFile:
+            def __init__(self):
+                self.closed = False
+
+            def write(self, _data):
+                raise OSError(errno.ENOSPC, "No space left on device")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.closed = True
+                return False
+
+            def close(self):
+                self.closed = True
+
+        def fake_open(file, mode="r", *args, **kwargs):
+            if isinstance(file, (str, Path)) and Path(file).name == target_filename:
+                return _DiskFullFile()
+            return real_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", fake_open)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "piper.download.urlopen",
+                return_value=_FakeResponse(payload),
+            ):
+                with pytest.raises(OSError) as exc_info:
+                    ensure_voice_exists("test-voice", [tmpdir], tmpdir, voices)
+                assert exc_info.value.errno == errno.ENOSPC
+
+
+class TestGetVoicesNetworkFailure:
+    """get_voices(update_voices=True) must surface network errors from urlopen."""
+
+    def test_update_voices_propagates_urlerror(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "piper.download.urlopen",
+                side_effect=URLError("network down"),
+            ):
+                with pytest.raises(URLError):
+                    get_voices(tmpdir, update_voices=True)
+
+    def test_no_update_does_not_call_network(self):
+        """get_voices without update_voices must not touch the network."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url_mock = MagicMock(
+                side_effect=AssertionError("urlopen should not be called"),
+            )
+            with patch("piper.download.urlopen", url_mock):
+                voices = get_voices(tmpdir, update_voices=False)
+            assert "ja_JP-tsukuyomi-chan-medium" in voices
+            assert not url_mock.called
+
+
+class TestRedownloadOnSizeMismatch:
+    """Existing wrong-size file must trigger one re-download attempt."""
+
+    def test_wrong_size_triggers_redownload(self):
+        voice_info = _make_voice_info(size_bytes=1024)
+        voices = {"test-voice": voice_info}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            # Pre-existing file with wrong size on disk.
+            (tmp_path / "model.onnx").write_bytes(b"short")
+
+            url_mock = MagicMock(return_value=_FakeResponse(b"y" * 1024))
+            with patch("piper.download.urlopen", url_mock):
+                ensure_voice_exists("test-voice", [tmpdir], tmpdir, voices)
+
+            # Exactly one urlopen call for the missing/wrong file.
+            assert url_mock.call_count == 1
+            assert (tmp_path / "model.onnx").stat().st_size == 1024

--- a/src/python_run/tests/test_download_resilience.py
+++ b/src/python_run/tests/test_download_resilience.py
@@ -64,12 +64,17 @@ class TestDownloadTimeout:
         voice_info = _make_voice_info()
         voices = {"test-voice": voice_info}
 
+        # socket.timeout was unified with TimeoutError in Python 3.10; older
+        # Python versions and some urllib code paths may surface either type.
+        # We raise socket.timeout from the patch to match real urlopen behavior
+        # (urllib lets socket.timeout propagate without wrapping it in URLError),
+        # and accept both types on the assertion side for cross-version safety.
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch(
                 "piper.download.urlopen",
                 side_effect=TimeoutError("connection timed out"),
             ):
-                with pytest.raises(socket.timeout):
+                with pytest.raises((socket.timeout, TimeoutError)):
                     ensure_voice_exists("test-voice", [tmpdir], tmpdir, voices)
 
     def test_urlerror_propagates(self):


### PR DESCRIPTION
## Summary

テストカバレッジの穴を埋めるスコープ限定 PR。

- **Python** (`src/python_run/tests/test_download_resilience.py` 新規 / 9 テスト):
  `piper.download.ensure_voice_exists` / `get_voices` のネットワーク耐性を mock で網羅。
  urlopen timeout / URLError / HTTP 500 / HTTP 404 / Content-Length 不一致 (truncated payload による size mismatch + 再 DL trigger) / disk-full (OSError ENOSPC) / `update_voices=False` で urlopen が呼ばれないこと / wrong-size の既存ファイルがちょうど 1 回再 DL を起こすこと。
  実 HuggingFace への HTTP 呼出は 0 件。`test_cli_models.py` のクラス/`tempfile.TemporaryDirectory` スタイルを踏襲。

- **Go** (`src/go/piperplus/voice_test.go` 新規 / 9 テスト):
  `LoadVoice` の ONNX 初期化前に発火する error path を網羅 — 存在しない modelPath / `WithConfig` 指定先欠落 / 破損 JSON / `phoneme_id_map` 空 (validation 失敗) / 事前 cancel 済み context。`errors.As(*ConfigError)` / `errors.Is(context.Canceled)` で型まで検証。
  `Voice.Close()` 冪等性: closed フラグを true にした Voice で連続 5 回 Close しても panic せず nil を返すこと。CAS 経路も separately verify。`SynthesizeFromIDs` も closed Voice / nil request の早期 return を確認。
  重い ONNX runtime 初期化を必要としない unit test レベル。

スコープ厳守: Rust FFI / WASM AudioWorklet テストは含めない (別 PR)。新規 heavy fixture なし。

## Test plan

- [x] `uv run pytest src/python_run/tests/test_download_resilience.py -v` (9/9 PASS)
- [x] `go test ./src/go/piperplus/... -short` (既存テスト含め全 PASS)
- [x] `go vet ./src/go/piperplus/...` (clean)
- [x] `ruff check` / `ruff format --check` (clean)
- [x] pre-commit hooks (editorconfig 含む) 全 PASS
- [ ] CI green