### PR TITLE
chore(community): CoC リンク参照版 + runtime-parity issue テンプレ + Discussions 誘導

### DIFF
--- a/.github/ISSUE_TEMPLATE/runtime-parity-issue.yml
+++ b/.github/ISSUE_TEMPLATE/runtime-parity-issue.yml
@@ -1,0 +1,95 @@
+name: Runtime Parity Issue
+description: Report a feature inconsistency between the 7 piper-plus runtimes
+title: "[parity] "
+labels: ["parity", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to report when a feature is implemented in some runtimes but missing or inconsistent in others.
+        piper-plus targets 7 runtimes: Python / Rust / C# / Go / WASM (npm) / C++ / Kotlin (Android).
+        Python is typically the canonical reference implementation.
+
+  - type: input
+    id: feature
+    attributes:
+      label: Feature name
+      description: Short name of the feature with parity drift.
+      placeholder: e.g. SSML <prosody pitch>, phoneme timing TSV output, ZH-EN loanword schema_v2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: canonical
+    attributes:
+      label: Canonical implementation
+      description: Which runtime is treated as the reference for this feature?
+      options:
+        - Python (piper_train / piper-plus-g2p)
+        - Rust (piper-plus / piper-plus-g2p)
+        - "C# (PiperPlus.Core)"
+        - Go (piperplus / phonemize)
+        - npm / WASM (piper-plus / @piper-plus/g2p)
+        - C++ (libpiper_plus)
+        - Kotlin/Android (piper-plus-g2p-android)
+        - Spec file only (docs/spec/*.toml)
+        - Unsure
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: missing_runtimes
+    attributes:
+      label: Runtimes missing or inconsistent
+      description: Check every runtime where the feature is absent, incomplete, or behaves differently from the canonical one.
+      options:
+        - label: Python
+        - label: Rust
+        - label: "C#"
+        - label: Go
+        - label: npm / WASM
+        - label: "C++"
+        - label: Kotlin/Android
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who is affected and how? Mention user-visible symptoms, broken integrations, or downstream package effects.
+      placeholder: |
+        - Users on runtime X cannot ...
+        - Output differs by ... ms / ... bytes vs Python.
+        - Breaks parity test ...
+    validations:
+      required: true
+
+  - type: input
+    id: spec
+    attributes:
+      label: Related spec file (optional)
+      description: Path to the relevant contract under `docs/spec/`, if any.
+      placeholder: e.g. docs/spec/short-text-contract.toml
+    validations:
+      required: false
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to observe the parity gap. Include inputs, commands, and the diff between canonical vs missing runtime outputs.
+      placeholder: |
+        1. Install ... on Python and on runtime X.
+        2. Run ... with input ...
+        3. Compare outputs: Python returns ..., runtime X returns ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional notes
+      description: Links to related issues, PRs, or upstream discussions.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/runtime-parity-issue.yml
+++ b/.github/ISSUE_TEMPLATE/runtime-parity-issue.yml
@@ -41,7 +41,7 @@ body:
     id: missing_runtimes
     attributes:
       label: Runtimes missing or inconsistent
-      description: Check every runtime where the feature is absent, incomplete, or behaves differently from the canonical one.
+      description: Check every runtime where the feature is absent, incomplete, or behaves differently from the canonical one. Please select at least one.
       options:
         - label: Python
         - label: Rust
@@ -50,8 +50,6 @@ body:
         - label: npm / WASM
         - label: "C++"
         - label: Kotlin/Android
-    validations:
-      required: true
 
   - type: textarea
     id: impact

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project adopts the Contributor Covenant, version 2.1.
+
+The full text is published at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+To report concerns, please contact the maintainer at <ka1357amnbpdr@gmail.com>.

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ piper-plus 専用モデル: [piper-plus-base](https://huggingface.co/ayousanz/pi
 
 ## Contributing
 
-[CONTRIBUTING.md](CONTRIBUTING.md) を参照。質問や雑談は [Discussions](https://github.com/ayutaz/piper-plus/discussions) へどうぞ。行動規範は [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) を参照してください。
+[CONTRIBUTING.md](CONTRIBUTING.md) を参照。質問やバグ報告は [Issues](https://github.com/ayutaz/piper-plus/issues) へどうぞ。行動規範は [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) を参照してください。
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ piper-plus 専用モデル: [piper-plus-base](https://huggingface.co/ayousanz/pi
 
 ## Contributing
 
-[CONTRIBUTING.md](CONTRIBUTING.md) を参照。
+[CONTRIBUTING.md](CONTRIBUTING.md) を参照。質問や雑談は [Discussions](https://github.com/ayutaz/piper-plus/discussions) へどうぞ。行動規範は [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) を参照してください。
 
 ## Changelog
 


### PR DESCRIPTION
## Summary

- **`CODE_OF_CONDUCT.md`**: Contributor Covenant v2.1 への外部リンク参照のみの短縮版。本文は inline 化せず、報告先メアドのみ記載。
- **`.github/ISSUE_TEMPLATE/runtime-parity-issue.yml`**: 7 ランタイム (Python/Rust/C#/Go/WASM/C++/Kotlin-Android) 間の機能不整合を報告するための新テンプレ。canonical 実装の dropdown、欠けている runtimes の checkbox、関連 `docs/spec/*.toml` 参照欄、再現手順を含む。
- **`README.md`** (日本語): Contributing セクションに [Discussions](https://github.com/ayutaz/piper-plus/discussions) 誘導と `CODE_OF_CONDUCT.md` リンクを 1 行追記。

## 範囲メモ

他言語 README (EN/ZH/KO/FR/ES/DE/PT/RU/SV/HI) への同等追記は試みたが、以下の既存違反が再検出されたため本 PR スコープ外とし後続 PR に分離:

- `codespell` が非英語 README に対し `.codespellrc` の `skip` リストを honor せず (pre-commit が変更ファイルを引数として渡すため)。
- `editorconfig-checker` が `README_EN.md` の既存インデントを 15 件 fail (本 PR が触っていない行)。

## Test plan

- [ ] `pre-commit run --all-files` がローカルでパスする (本コミットは pre-commit 全 hook クリーン)。
- [ ] 新 Issue テンプレが GitHub UI で "Runtime Parity Issue" として選択できる。
- [ ] `CODE_OF_CONDUCT.md` のリンクが clickable (Contributor Covenant 公式 + maintainer email)。
- [ ] README.md の Contributing セクションに Discussions / CoC 行が表示される。