### PR TITLE
chore: Rust phoneme_silence TODO + C++ disabled test 整理

### DIFF
--- a/src/cpp/tests/test_dictionary_manager.cpp
+++ b/src/cpp/tests/test_dictionary_manager.cpp
@@ -132,16 +132,23 @@ protected:
     const char* original_offline = nullptr;
 };
 
-// Test dictionary path resolution
-// TODO: Implement openjtalk_get_default_dict_path function
-// TEST_F(DictionaryManagerTest, GetDefaultDictPath) {
-//     char buffer[1024];
+// Test dictionary path resolution (disabled — unimplemented C API)
 //
-//     // Test default path (should use HOME)
-//     EXPECT_EQ(openjtalk_get_default_dict_path(buffer, sizeof(buffer)), 0);
-//     EXPECT_TRUE(strstr(buffer, test_dir) != nullptr);
-//     EXPECT_TRUE(strstr(buffer, ".piper/dictionaries/openjtalk") != nullptr);
-// }
+// The C function `openjtalk_get_default_dict_path()` is not implemented in
+// openjtalk_dictionary_manager.{h,c}. The current public surface exposes
+// `ensure_openjtalk_dictionary()` / `force_openjtalk_dictionary_path()` /
+// `reset_openjtalk_dictionary_cache()` only. Keep this as a DISABLED_ test so
+// the intent is preserved and the test will be auto-picked up once the
+// function is added.
+TEST_F(DictionaryManagerTest, DISABLED_GetDefaultDictPath) {
+    GTEST_SKIP() << "TODO: openjtalk_get_default_dict_path() not yet implemented in C API";
+    // char buffer[1024];
+    //
+    // // Test default path (should use HOME)
+    // EXPECT_EQ(openjtalk_get_default_dict_path(buffer, sizeof(buffer)), 0);
+    // EXPECT_TRUE(strstr(buffer, test_dir) != nullptr);
+    // EXPECT_TRUE(strstr(buffer, ".piper/dictionaries/openjtalk") != nullptr);
+}
 
 // Test custom dictionary path via environment variable
 TEST_F(DictionaryManagerTest, CustomDictPath) {
@@ -159,7 +166,9 @@ TEST_F(DictionaryManagerTest, CustomDictPath) {
     fp = fopen("/tmp/custom_dict_test/unk.dic", "w");
     if (fp) fclose(fp);
 
-    // TODO: Implement openjtalk_get_default_dict_path function
+    // TODO: openjtalk_get_default_dict_path() not yet implemented in C API.
+    // Once added, re-enable the assertions below to verify that
+    // OPENJTALK_DICTIONARY_PATH overrides the default $HOME-based path.
     // char buffer[1024];
     // EXPECT_EQ(openjtalk_get_default_dict_path(buffer, sizeof(buffer)), 0);
     // EXPECT_STREQ(buffer, "/tmp/custom_dict_test");
@@ -170,33 +179,39 @@ TEST_F(DictionaryManagerTest, CustomDictPath) {
     rmdir("/tmp/custom_dict_test");
 }
 
-// Test dictionary existence check
-// TODO: Implement openjtalk_check_dictionary function
-// TEST_F(DictionaryManagerTest, CheckDictionary) {
-//     // Non-existent path
-//     EXPECT_EQ(openjtalk_check_dictionary("/nonexistent/path"), 0);
+// Test dictionary existence check (disabled — unimplemented C API)
 //
-//     // Create a test directory with dictionary files
-//     char test_dict_path[256];
-//     snprintf(test_dict_path, sizeof(test_dict_path), "%s/test_dict", test_dir);
-//     mkdir(test_dict_path, 0755);
-//
-//     // Without dictionary files
-//     EXPECT_EQ(openjtalk_check_dictionary(test_dict_path), 0);
-//
-//     // Create dictionary files
-//     char sys_dic[256], unk_dic[256];
-//     snprintf(sys_dic, sizeof(sys_dic), "%s/sys.dic", test_dict_path);
-//     snprintf(unk_dic, sizeof(unk_dic), "%s/unk.dic", test_dict_path);
-//
-//     FILE* fp = fopen(sys_dic, "w");
-//     if (fp) fclose(fp);
-//     fp = fopen(unk_dic, "w");
-//     if (fp) fclose(fp);
-//
-//     // With dictionary files
-//     EXPECT_EQ(openjtalk_check_dictionary(test_dict_path), 1);
-// }
+// The C function `openjtalk_check_dictionary()` is not implemented in
+// openjtalk_dictionary_manager.{h,c}. Existence is currently inferred via the
+// internal cache populated by `ensure_openjtalk_dictionary()`. Keep this as a
+// DISABLED_ test so the intent is preserved and the test will be auto-picked
+// up once the function is added.
+TEST_F(DictionaryManagerTest, DISABLED_CheckDictionary) {
+    GTEST_SKIP() << "TODO: openjtalk_check_dictionary() not yet implemented in C API";
+    // // Non-existent path
+    // EXPECT_EQ(openjtalk_check_dictionary("/nonexistent/path"), 0);
+    //
+    // // Create a test directory with dictionary files
+    // char test_dict_path[256];
+    // snprintf(test_dict_path, sizeof(test_dict_path), "%s/test_dict", test_dir);
+    // mkdir(test_dict_path, 0755);
+    //
+    // // Without dictionary files
+    // EXPECT_EQ(openjtalk_check_dictionary(test_dict_path), 0);
+    //
+    // // Create dictionary files
+    // char sys_dic[256], unk_dic[256];
+    // snprintf(sys_dic, sizeof(sys_dic), "%s/sys.dic", test_dict_path);
+    // snprintf(unk_dic, sizeof(unk_dic), "%s/unk.dic", test_dict_path);
+    //
+    // FILE* fp = fopen(sys_dic, "w");
+    // if (fp) fclose(fp);
+    // fp = fopen(unk_dic, "w");
+    // if (fp) fclose(fp);
+    //
+    // // With dictionary files
+    // EXPECT_EQ(openjtalk_check_dictionary(test_dict_path), 1);
+}
 
 // Test offline mode
 TEST_F(DictionaryManagerTest, OfflineMode) {

--- a/src/rust/piper-cli/src/main.rs
+++ b/src/rust/piper-cli/src/main.rs
@@ -363,7 +363,12 @@ fn main() -> Result<()> {
 
     // --phoneme-silence パース
     let _phoneme_silence_map = parse_phoneme_silence(&cli.phoneme_silence)?;
-    // TODO: phoneme_silence_map を音素境界で適用する (現在はパース・保持のみ)
+    // TODO: Apply phoneme_silence_map at phoneme boundaries (currently parsed/held
+    // but not applied to silence generation). Other runtimes (Python/C#/Go) already
+    // implement boundary insertion — see src/csharp/PiperPlus.Cli/Program.cs:1051 and
+    // src/go/cmd/piper-plus/main.go:197 for reference. Rust parity is pending;
+    // requires splitting phoneme stream on matched phonemes and inserting zero-padded
+    // audio between adjacent inference calls (similar to --sentence-silence).
     if !_phoneme_silence_map.is_empty() {
         tracing::info!(
             "Phoneme silence: {:?} (parsed but not yet applied to audio)",


### PR DESCRIPTION
## Summary

ロジック変更ゼロのドキュメント / TODO 整理 PR。

- **Rust** (`src/rust/piper-cli/src/main.rs`): `phoneme_silence_map` が現状パース・保持のみで音素境界に適用されていないことを示す TODO を、他ランタイム (Python/C#/Go) の実装箇所への具体的な参照付きに書き換え。
- **C++** (`src/cpp/tests/test_dictionary_manager.cpp`): コメントアウトされていた 2 つの test ブロック (`GetDefaultDictPath` / `CheckDictionary`) を GoogleTest の `DISABLED_` プレフィックス + `GTEST_SKIP()` 形式に置換。未実装 C API (`openjtalk_get_default_dict_path` / `openjtalk_check_dictionary`) を明示し、関数追加時に自動で pick-up される構造に。`CustomDictPath` 内の中間 TODO コメントも文脈を補強。
- **Go** (`src/go/piperplus/config.go`): `PhonemeTypeEspeak` / `PhonemeTypeBilingual` の `// Deprecated:` GoDoc コメントは PR #368 (commit 2bf8dfbc) で既に追加済みのため本 PR では変更なし。

## Rationale

- Rust の TODO は元々 1 行で抽象的だったため、Issue tracker を作らずとも次の実装者が他ランタイムの参考実装 (`Program.cs:1051`, `main.go:197`) にすぐ辿り着けるようにする。
- C++ の commented-out test は IDE で test discovery 対象外になっていたが、`DISABLED_` 化により `--gtest_list_tests` で intent が見えるようになり、未実装 API の関数名も明示される。

## Test plan

- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` (pre-commit hook)
- [x] `cargo check -p piper-plus-cli` ローカル成功
- [x] `clang++ -fsyntax-only -std=c++17` で C++ test 構文確認 (gtest header path 指定下で OK)
- [ ] CI で C++ build (`piperplus_tests` target) が通ることを確認
- [ ] CI で Rust workspace 全 build が通ることを確認

## Notes

- マイルストーン番号は付けていません。
- merge せずレビューをお待ちします。