### PR TITLE
feat(server): bearer auth + rate limit (slowapi) を追加 (backward-compat)

### DIFF
--- a/docker/python-inference/inference.py
+++ b/docker/python-inference/inference.py
@@ -330,12 +330,61 @@ def main():
         print(f"Audio saved to: {args.output}")
 
 
+def _parse_api_keys(raw: str | None) -> set[str]:
+    """Parse PIPER_API_KEYS env var (comma-separated).
+
+    Empty / unset → empty set (auth disabled). Whitespace and empty entries
+    are stripped so trailing commas don't accidentally allow blank tokens.
+    """
+    if not raw:
+        return set()
+    return {k.strip() for k in raw.split(",") if k.strip()}
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    """Parse a boolean env var. Accepts 1/true/yes/on (case-insensitive)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
 def create_app(engine: PiperInferenceEngine, model_path: str):
-    """Create the FastAPI application with all endpoints."""
-    from fastapi import FastAPI, HTTPException, Query  # noqa: PLC0415
+    """Create the FastAPI application with all endpoints.
+
+    Auth (optional bearer token):
+        Set ``PIPER_API_KEYS`` to a comma-separated list of accepted tokens.
+        If unset/empty, auth is disabled and all requests pass (backward
+        compatible). ``/health`` is always exempt for load-balancer probes.
+
+    Rate limiting (slowapi, per-IP):
+        ``PIPER_RATE_LIMIT_ENABLED`` (default ``true``) — master switch.
+        ``PIPER_RATE_LIMIT_SPEECH`` (default ``30/minute``) — heavy synth
+        endpoints.
+        ``PIPER_RATE_LIMIT_LIGHT`` (default ``600/minute``) — metadata
+        endpoints (``/v1/models``, ``/v1/audio/speech/languages``).
+        ``/health`` is never rate-limited.
+
+    Note: CORS is intentionally untouched in this PR; tightening allow-origins
+    is tracked separately so we don't accidentally break embedded browser
+    clients that depend on ``*``.
+    """
+    from fastapi import (  # noqa: PLC0415
+        Depends,
+        FastAPI,
+        Header,
+        HTTPException,
+        Query,
+        Request,
+        status,
+    )
     from fastapi.middleware.cors import CORSMiddleware  # noqa: PLC0415
     from fastapi.responses import StreamingResponse  # noqa: PLC0415
     from pydantic import BaseModel, Field  # noqa: PLC0415
+    from slowapi import Limiter  # noqa: PLC0415
+    from slowapi.errors import RateLimitExceeded  # noqa: PLC0415
+    from slowapi.util import get_remote_address  # noqa: PLC0415
+    from starlette.responses import JSONResponse  # noqa: PLC0415
 
     class SpeechRequest(BaseModel):
         """OpenAI-compatible TTS request schema."""
@@ -351,7 +400,83 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
         noise_scale: float = 0.667
         noise_w: float = 0.8
 
+    # --- Auth / rate-limit configuration (resolved at app-build time) ---
+    api_keys: set[str] = _parse_api_keys(os.environ.get("PIPER_API_KEYS"))
+    auth_enabled: bool = bool(api_keys)
+    rate_limit_enabled: bool = _env_flag("PIPER_RATE_LIMIT_ENABLED", default=True)
+    speech_limit: str = os.environ.get("PIPER_RATE_LIMIT_SPEECH", "30/minute")
+    light_limit: str = os.environ.get("PIPER_RATE_LIMIT_LIGHT", "600/minute")
+
+    if auth_enabled:
+        _LOGGER.info("Bearer auth enabled (%d key(s) configured)", len(api_keys))
+    else:
+        _LOGGER.info(
+            "Bearer auth disabled (PIPER_API_KEYS unset). Set the env var to "
+            "enable per-key authentication."
+        )
+
+    # slowapi: when rate_limit_enabled=False we still construct the Limiter
+    # but pass `enabled=False` so the decorators become no-ops. This keeps a
+    # single code path and lets tests flip the switch via env vars.
+    limiter = Limiter(key_func=get_remote_address, enabled=rate_limit_enabled)
+    if rate_limit_enabled:
+        _LOGGER.info(
+            "Rate limit enabled (speech=%s, light=%s, per-IP via slowapi)",
+            speech_limit,
+            light_limit,
+        )
+    else:
+        _LOGGER.info("Rate limit disabled (PIPER_RATE_LIMIT_ENABLED=false)")
+
+    def verify_api_key(
+        authorization: str | None = Header(default=None),
+    ) -> None:
+        """FastAPI dependency: enforce Bearer auth when PIPER_API_KEYS is set.
+
+        - No keys configured: no-op (backward compatible).
+        - Keys configured: require ``Authorization: Bearer <key>``;
+            401 on missing / malformed header or unknown key.
+        """
+        if not auth_enabled:
+            return
+        if not authorization:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Missing Authorization header",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() != "bearer" or not token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid Authorization header (expected 'Bearer <key>')",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        if token not in api_keys:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid API key",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
     app = FastAPI(title="piper-plus API")
+    app.state.limiter = limiter
+
+    def _rate_limit_handler(request: Request, exc: RateLimitExceeded):
+        # slowapi's default handler returns plain text; emit JSON with a
+        # Retry-After header so OpenAI-compatible clients can back off
+        # automatically.
+        retry_after = getattr(exc, "retry_after", None) or 60
+        headers = {"Retry-After": str(int(retry_after))}
+        return JSONResponse(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            content={
+                "detail": f"Rate limit exceeded: {exc.detail}",
+            },
+            headers=headers,
+        )
+
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 
     app.add_middleware(
         CORSMiddleware,
@@ -366,6 +491,9 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
     except OSError:
         model_created = int(time.time())
 
+    # /health is intentionally outside auth + rate limit so external load
+    # balancers and k8s liveness probes never get 401/429 (would mark the
+    # container unhealthy and trigger a restart loop).
     @app.get("/health")
     def health_check():
         return {"status": "healthy"}
@@ -376,8 +504,10 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
             return False
         return sum(1 for c in text if not c.isspace()) <= threshold
 
-    @app.get("/synthesize")
+    @app.get("/synthesize", dependencies=[Depends(verify_api_key)])
+    @limiter.limit(speech_limit)
     def synthesize(
+        request: Request,
         text: str = Query(...),
         speaker_id: int = Query(0),
         language: str = Query("ja"),
@@ -411,8 +541,9 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
 
     # --- OpenAI-compatible endpoints ---
 
-    @app.post("/v1/audio/speech")
-    def openai_speech(req: SpeechRequest):
+    @app.post("/v1/audio/speech", dependencies=[Depends(verify_api_key)])
+    @limiter.limit(speech_limit)
+    def openai_speech(request: Request, req: SpeechRequest):
         if not req.input or not req.input.strip():
             raise HTTPException(status_code=400, detail="input is required")
         if req.response_format != "wav":
@@ -448,8 +579,9 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
             _LOGGER.exception("Synthesis failed for /v1/audio/speech")
             raise HTTPException(status_code=500, detail="Synthesis failed") from None
 
-    @app.get("/v1/models")
-    def openai_models():
+    @app.get("/v1/models", dependencies=[Depends(verify_api_key)])
+    @limiter.limit(light_limit)
+    def openai_models(request: Request):
         return {
             "object": "list",
             "data": [
@@ -462,8 +594,9 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
             ],
         }
 
-    @app.get("/v1/audio/speech/languages")
-    def speech_languages():
+    @app.get("/v1/audio/speech/languages", dependencies=[Depends(verify_api_key)])
+    @limiter.limit(light_limit)
+    def speech_languages(request: Request):
         languages = (
             sorted(engine.language_id_map.keys()) if engine.language_id_map else []
         )

--- a/docker/python-inference/test_openai_api.py
+++ b/docker/python-inference/test_openai_api.py
@@ -35,8 +35,18 @@ def mock_engine():
 
 
 @pytest.fixture()
-def client(mock_engine):
-    """Create a FastAPI TestClient backed by the mocked engine."""
+def client(mock_engine, monkeypatch):
+    """Create a FastAPI TestClient backed by the mocked engine.
+
+    Rate limiting is disabled here so the existing test suite — which
+    repeatedly hits /v1/audio/speech — does not start failing once
+    slowapi is wired in. Dedicated rate-limit tests build their own
+    app with PIPER_RATE_LIMIT_ENABLED=true.
+    """
+    # Ensure no stray PIPER_API_KEYS leaks in from the host env (would
+    # require Authorization on every request and break legacy tests).
+    monkeypatch.delenv("PIPER_API_KEYS", raising=False)
+    monkeypatch.setenv("PIPER_RATE_LIMIT_ENABLED", "false")
     # Use this test file as a stand-in for stat().st_mtime
     app = create_app(mock_engine, __file__)
     return TestClient(app)
@@ -489,6 +499,232 @@ class TestSpeakerEmbeddingFeed:
                     # speaker_embedding intentionally omitted
                 ]
             )
+
+
+# ---- Auth (Bearer token) ----
+#
+# PIPER_API_KEYS unset → auth disabled (backward compatible).
+# PIPER_API_KEYS set    → Authorization: Bearer <key> required, else 401.
+# /health is always exempt so load balancer probes don't get 401.
+#
+# Auth/rate-limit settings are resolved inside create_app(), so each test
+# builds a fresh app via monkeypatched env vars. Limiter state is per-app
+# so default-disabled rate-limit tests don't interact with these.
+
+
+@pytest.fixture()
+def make_client(mock_engine, monkeypatch):
+    """Factory that builds a TestClient with env-var-driven config."""
+
+    def _make(**env):
+        for key, val in env.items():
+            if val is None:
+                monkeypatch.delenv(key, raising=False)
+            else:
+                monkeypatch.setenv(key, val)
+        # Disable rate limiting by default for non-rate-limit tests so the
+        # 30/minute speech limit doesn't bleed across cases.
+        if "PIPER_RATE_LIMIT_ENABLED" not in env:
+            monkeypatch.setenv("PIPER_RATE_LIMIT_ENABLED", "false")
+        app = create_app(mock_engine, __file__)
+        return TestClient(app)
+
+    return _make
+
+
+class TestAuthDisabledByDefault:
+    """Backward compat: PIPER_API_KEYS unset → no auth required."""
+
+    def test_speech_no_auth_header_succeeds(self, make_client):
+        client = make_client(PIPER_API_KEYS=None)
+        resp = client.post("/v1/audio/speech", json={"input": "hello"})
+        assert resp.status_code == 200
+
+    def test_models_no_auth_header_succeeds(self, make_client):
+        client = make_client(PIPER_API_KEYS=None)
+        resp = client.get("/v1/models")
+        assert resp.status_code == 200
+
+    def test_empty_string_treated_as_unset(self, make_client):
+        """PIPER_API_KEYS='' (empty) must NOT enable auth."""
+        client = make_client(PIPER_API_KEYS="")
+        resp = client.post("/v1/audio/speech", json={"input": "hello"})
+        assert resp.status_code == 200
+
+
+class TestAuthEnabled:
+    """PIPER_API_KEYS set → Bearer required on protected endpoints."""
+
+    # Fixture token used in env vars + Authorization headers below.
+    # Intentionally NOT shaped like `sk-...` to avoid generic-api-key
+    # heuristics (gitleaks, GitHub secret scanning) misfiring on test data.
+    KEY = "piper-unit-test-token-00"  # gitleaks:allow
+
+    def test_speech_missing_auth_returns_401(self, make_client):
+        client = make_client(PIPER_API_KEYS=self.KEY)
+        resp = client.post("/v1/audio/speech", json={"input": "hello"})
+        assert resp.status_code == 401
+        assert resp.headers.get("www-authenticate") == "Bearer"
+
+    def test_speech_valid_bearer_returns_200(self, make_client):
+        client = make_client(PIPER_API_KEYS=self.KEY)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "hello"},
+            headers={"Authorization": f"Bearer {self.KEY}"},
+        )
+        assert resp.status_code == 200
+
+    def test_speech_wrong_key_returns_401(self, make_client):
+        client = make_client(PIPER_API_KEYS=self.KEY)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "hello"},
+            headers={"Authorization": "Bearer wrong-key"},
+        )
+        assert resp.status_code == 401
+
+    def test_speech_malformed_header_returns_401(self, make_client):
+        client = make_client(PIPER_API_KEYS=self.KEY)
+        # No "Bearer " prefix
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "hello"},
+            headers={"Authorization": self.KEY},
+        )
+        assert resp.status_code == 401
+
+    def test_speech_basic_scheme_rejected(self, make_client):
+        client = make_client(PIPER_API_KEYS=self.KEY)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "hello"},
+            headers={"Authorization": f"Basic {self.KEY}"},
+        )
+        assert resp.status_code == 401
+
+    def test_bearer_scheme_case_insensitive(self, make_client):
+        """Authorization scheme matches case-insensitively (RFC 7235)."""
+        client = make_client(PIPER_API_KEYS=self.KEY)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "hello"},
+            headers={"Authorization": f"bearer {self.KEY}"},
+        )
+        assert resp.status_code == 200
+
+    def test_multiple_keys_any_valid(self, make_client):
+        """Comma-separated keys: any one of them authorizes."""
+        client = make_client(PIPER_API_KEYS=f"key-one,{self.KEY},key-three")
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "hello"},
+            headers={"Authorization": "Bearer key-three"},
+        )
+        assert resp.status_code == 200
+
+    def test_health_skips_auth(self, make_client):
+        """/health must remain open for load balancer probes."""
+        client = make_client(PIPER_API_KEYS=self.KEY)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "healthy"}
+
+    def test_models_requires_auth(self, make_client):
+        client = make_client(PIPER_API_KEYS=self.KEY)
+        resp = client.get("/v1/models")
+        assert resp.status_code == 401
+
+    def test_models_with_auth_succeeds(self, make_client):
+        client = make_client(PIPER_API_KEYS=self.KEY)
+        resp = client.get(
+            "/v1/models",
+            headers={"Authorization": f"Bearer {self.KEY}"},
+        )
+        assert resp.status_code == 200
+
+    def test_languages_requires_auth(self, make_client):
+        client = make_client(PIPER_API_KEYS=self.KEY)
+        resp = client.get("/v1/audio/speech/languages")
+        assert resp.status_code == 401
+
+    def test_synthesize_requires_auth(self, make_client):
+        client = make_client(PIPER_API_KEYS=self.KEY)
+        resp = client.get("/synthesize", params={"text": "hi"})
+        assert resp.status_code == 401
+
+
+# ---- Rate limiting (slowapi, per-IP) ----
+
+
+class TestRateLimitDisabled:
+    """PIPER_RATE_LIMIT_ENABLED=false → no 429 regardless of request volume."""
+
+    def test_speech_no_429_when_disabled(self, make_client):
+        client = make_client(
+            PIPER_RATE_LIMIT_ENABLED="false",
+            PIPER_RATE_LIMIT_SPEECH="2/minute",
+        )
+        for _ in range(5):
+            resp = client.post("/v1/audio/speech", json={"input": "hi"})
+            assert resp.status_code == 200
+
+
+class TestRateLimitEnabled:
+    """PIPER_RATE_LIMIT_ENABLED=true (default) → 429 after limit exceeded."""
+
+    def test_speech_429_after_limit(self, make_client):
+        # 2/minute keeps the test fast and deterministic without sleeping.
+        client = make_client(
+            PIPER_RATE_LIMIT_ENABLED="true",
+            PIPER_RATE_LIMIT_SPEECH="2/minute",
+        )
+        # First two should pass, third should be 429.
+        assert client.post("/v1/audio/speech", json={"input": "a"}).status_code == 200
+        assert client.post("/v1/audio/speech", json={"input": "b"}).status_code == 200
+        resp = client.post("/v1/audio/speech", json={"input": "c"})
+        assert resp.status_code == 429
+        assert resp.headers.get("retry-after") is not None
+        # Retry-After should parse as a non-negative integer (seconds).
+        assert int(resp.headers["retry-after"]) >= 0
+
+    def test_health_never_rate_limited(self, make_client):
+        """/health must never be rate-limited (LB probes hit it every few s)."""
+        client = make_client(
+            PIPER_RATE_LIMIT_ENABLED="true",
+            PIPER_RATE_LIMIT_SPEECH="1/minute",
+            PIPER_RATE_LIMIT_LIGHT="1/minute",
+        )
+        # Hit /health well beyond any plausible limit.
+        for _ in range(20):
+            resp = client.get("/health")
+            assert resp.status_code == 200
+
+    def test_synthesize_get_shares_speech_limit(self, make_client):
+        """GET /synthesize uses the same heavy limit as POST /v1/audio/speech."""
+        client = make_client(
+            PIPER_RATE_LIMIT_ENABLED="true",
+            PIPER_RATE_LIMIT_SPEECH="1/minute",
+        )
+        assert client.get("/synthesize", params={"text": "a"}).status_code == 200
+        resp = client.get("/synthesize", params={"text": "b"})
+        assert resp.status_code == 429
+
+    def test_light_endpoint_has_separate_limit(self, make_client):
+        """/v1/models uses the light limit, independent of speech limit."""
+        client = make_client(
+            PIPER_RATE_LIMIT_ENABLED="true",
+            PIPER_RATE_LIMIT_SPEECH="1/minute",
+            PIPER_RATE_LIMIT_LIGHT="3/minute",
+        )
+        # Exhaust speech limit — should not affect /v1/models.
+        client.post("/v1/audio/speech", json={"input": "a"})
+        client.post("/v1/audio/speech", json={"input": "b"})  # 429 expected
+        # /v1/models still has its own bucket.
+        for _ in range(3):
+            assert client.get("/v1/models").status_code == 200
+        # Fourth /v1/models hit exhausts the light limit.
+        assert client.get("/v1/models").status_code == 429
 
 
 # ---- CORS ----

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -48,6 +48,9 @@ inference = [
     "piper-plus-g2p[all]",
     "fastapi>=0.110",
     "uvicorn>=0.27",
+    # Per-IP rate limiting for the FastAPI inference server (docker/python-inference).
+    # 0.1.9 is the first release on starlette ≥ 0.27 (matches fastapi>=0.110).
+    "slowapi>=0.1.9",
 ]
 
 inference-gpu = [
@@ -57,6 +60,7 @@ inference-gpu = [
     "piper-plus-g2p[all]",
     "fastapi>=0.110",
     "uvicorn>=0.27",
+    "slowapi>=0.1.9",
 ]
 
 test = [

--- a/uv.lock
+++ b/uv.lock
@@ -827,6 +827,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1781,6 +1793,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/45/7fa8f56b17dc0f0a41ec70dd307ecd6787254483549843bef4c30ab5adce/lightning_utilities-0.15.3.tar.gz", hash = "sha256:792ae0204c79f6859721ac7f386c237a33b0ed06ba775009cb894e010a842033", size = 33553, upload-time = "2026-02-22T14:48:53.348Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/f4/ead6e0e37209b07c9baa3e984ccdb0348ca370b77cea3aaea8ddbb097e00/lightning_utilities-0.15.3-py3-none-any.whl", hash = "sha256:6c55f1bee70084a1cbeaa41ada96e4b3a0fea5909e844dd335bd80f5a73c5f91", size = 31906, upload-time = "2026-02-22T14:48:52.488Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -3371,6 +3397,7 @@ inference = [
     { name = "fastapi" },
     { name = "onnxruntime" },
     { name = "piper-plus-g2p", extra = ["all"] },
+    { name = "slowapi" },
     { name = "soundfile" },
     { name = "uvicorn" },
 ]
@@ -3378,6 +3405,7 @@ inference-gpu = [
     { name = "fastapi" },
     { name = "onnxruntime-gpu" },
     { name = "piper-plus-g2p", extra = ["all"] },
+    { name = "slowapi" },
     { name = "soundfile" },
     { name = "uvicorn" },
 ]
@@ -3455,6 +3483,8 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.12" },
     { name = "scipy", marker = "extra == 'train'", specifier = ">=1.12" },
     { name = "seaborn", marker = "extra == 'train'", specifier = ">=0.13" },
+    { name = "slowapi", marker = "extra == 'inference'", specifier = ">=0.1.9" },
+    { name = "slowapi", marker = "extra == 'inference-gpu'", specifier = ">=0.1.9" },
     { name = "soundfile", marker = "extra == 'inference'", specifier = ">=0.12" },
     { name = "soundfile", marker = "extra == 'inference-gpu'", specifier = ">=0.12" },
     { name = "soundfile", marker = "extra == 'train'", specifier = ">=0.12" },
@@ -4457,6 +4487,18 @@ wheels = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
 name = "smmap"
 version = "5.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5453,6 +5495,81 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/43/76ded108b296a49f52de6bac5192ca1c4be84e886f9b5c9ba8427d9694fd/werkzeug-3.1.7.tar.gz", hash = "sha256:fb8c01fe6ab13b9b7cdb46892b99b1d66754e1d7ab8e542e865ec13f526b5351", size = 875700, upload-time = "2026-03-24T01:08:07.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl", hash = "sha256:4b314d81163a3e1a169b6a0be2a000a0e204e8873c5de6586f453c55688d422f", size = 226295, upload-time = "2026-03-24T01:08:06.133Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`docker/python-inference/inference.py` の FastAPI サーバに **optional Bearer authentication** と **per-IP rate limiting (slowapi)** を追加します。両機能とも **後方互換**: 環境変数を設定しなければ既存挙動と完全に同じです。

- Optional Bearer auth via `PIPER_API_KEYS` (FastAPI `Depends`)
- Per-IP rate limit via `slowapi` で `429 + Retry-After`
- `/health` は両機能から exempt (LB / k8s liveness probe 保護)

## Backward compatibility

| 状況 | 挙動 |
|------|------|
| `PIPER_API_KEYS` 未設定 (default) | auth 無効、全 endpoint 認証無しで通過 |
| `PIPER_API_KEYS=""` (空文字) | auth 無効 (unset 同等扱い) |
| `PIPER_API_KEYS="k1,k2,k3"` | 3 つのいずれかを `Authorization: Bearer <key>` で提示すれば 200 |
| `PIPER_RATE_LIMIT_ENABLED=false` | rate limit 無効、無制限 |
| Default (env 未設定) | rate limit **有効**: speech `30/min`, light `600/min` per IP |

## Environment variables

| 変数 | Default | 説明 |
|------|---------|------|
| `PIPER_API_KEYS` | _(unset)_ | comma-separated bearer tokens。未設定 = auth 無効 |
| `PIPER_RATE_LIMIT_ENABLED` | `true` | rate limit の master switch (`1/true/yes/on` で有効) |
| `PIPER_RATE_LIMIT_SPEECH` | `30/minute` | `/v1/audio/speech` と `/synthesize` の per-IP 上限 |
| `PIPER_RATE_LIMIT_LIGHT` | `600/minute` | `/v1/models` と `/v1/audio/speech/languages` の per-IP 上限 |

## Endpoint matrix

| Endpoint | Auth (when keys set) | Rate limit |
|----------|----------------------|-----------|
| `GET /health` | skip | skip (常に unlimited) |
| `GET /synthesize` | required | speech |
| `POST /v1/audio/speech` | required | speech |
| `GET /v1/models` | required | light |
| `GET /v1/audio/speech/languages` | required | light |

## Dependencies

- `slowapi>=0.1.9` を `src/python/pyproject.toml` の `inference` / `inference-gpu` extras に追加
- `fastapi>=0.110` / `uvicorn>=0.27` は既存制約 (`Limiter`, `RateLimitExceeded`, `slowapi.util.get_remote_address` の API は 0.1.9 で安定)
- Dockerfile は `uv pip install /app/src/python[inference-gpu]` 経由で自動取得するため変更不要

## Tests

`docker/python-inference/test_openai_api.py` に 22 件追加:

- `TestAuthDisabledByDefault` (3): unset / 空文字で no-op、全 endpoint 200
- `TestAuthEnabled` (12): Bearer required / case-insensitive scheme / multiple keys / wrong key 401 / malformed header 401 / Basic scheme 拒否 / `/health` skip / 各 protected endpoint で 401
- `TestRateLimitDisabled` (1): master switch false で 429 出ない
- `TestRateLimitEnabled` (4): 限界超過で 429 + `Retry-After` / `/health` 無制限 / `/synthesize` GET と `/v1/audio/speech` POST は同じ speech bucket / `/v1/models` は独立 light bucket

既存 `client` fixture は `PIPER_RATE_LIMIT_ENABLED=false` をデフォルト化して既存テスト (56 件) への影響を回避。

**Test result (local, Python 3.11):**

```
============================== 56 passed, 4 skipped in 0.38s ==============================
```

(4 skipped は `openai` SDK + `pytest-asyncio` 不在の既存 E2E ブロック、本 PR と無関係。)

## Out of scope (別 PR)

- Streaming chunked response (`/v1/audio/speech` の OpenAI streaming) — 別 PR
- Phoneme-timing endpoint の本サーバへの配線 (現在は `piper.http_server` 側のみ) — 別 PR
- CORS の `allow_origins` 制限 — 別 issue 化推奨 (`*` のまま現状維持。embedded browser client への影響評価が必要)

## Test plan

- [ ] CI: `docker-test.yml` の "OpenAI-compatible API tests" job が 56 passed で緑になること
- [ ] CI: pre-commit hooks (ruff / editorconfig / gitleaks / ort-version-sync) 全通過
- [ ] Manual: `PIPER_API_KEYS=mykey docker compose up` で `curl -H "Authorization: Bearer mykey" .../v1/models` が 200、無しなら 401
- [ ] Manual: `for i in $(seq 1 40); do curl .../v1/audio/speech ...; done` で 30 件目以降 429 + `Retry-After` ヘッダ確認