### PR TITLE
feat(cpp): voice cloning CLI flags (--reference-audio, --speaker-embedding, --speaker-encoder-model)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,13 +27,13 @@ trim_trailing_whitespace = false
 [Makefile]
 indent_style = tab
 
-# The legacy C++ runtime (piper.cpp / piper.hpp) uses 2-space indentation
-# plus arbitrary column-alignment spaces (1/3/5-wide) for continuation
-# lines and parameter lists. The "indent must be a multiple of N" check
-# is not meaningful for this style, so disable it for these files only.
-# Newer C++ files (e.g. src/cpp/tests/*.cpp) still follow the 4-space
-# default.
-[src/cpp/{piper.cpp,piper.hpp}]
+# The legacy C++ runtime (piper.cpp / piper.hpp / main.cpp) uses 2-space
+# indentation plus arbitrary column-alignment spaces (1/3/5-wide) for
+# continuation lines and parameter lists. The "indent must be a multiple
+# of N" check is not meaningful for this style, so disable it for these
+# files only. Newer C++ files (e.g. src/cpp/tests/*.cpp) still follow the
+# 4-space default.
+[src/cpp/{piper.cpp,piper.hpp,main.cpp}]
 indent_size = unset
 
 # rustfmt aligns continuation lines inside multi-line string literals to

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -128,6 +128,22 @@ struct RunConfig {
   optional<string> listModelsLanguage;
   optional<string> downloadModelName;
   optional<filesystem::path> modelDir;
+
+  // Voice cloning (mirrors Python/Rust/Go/C#/WASM CLI surface).
+  // Reference audio WAV path; requires --speaker-encoder-model.
+  // NOTE: Speaker Encoder inference is not implemented in the C++ runtime
+  //       yet (the C API stub returns "not yet implemented"). Specifying
+  //       --reference-audio currently exits with a clear error directing
+  //       users to pre-compute the embedding via the Python/Rust runtime
+  //       and pass it through --speaker-embedding.
+  optional<filesystem::path> referenceAudioPath;
+  // Pre-computed 256-dim speaker embedding (raw float32 little-endian,
+  // matches the Rust CLI on-disk format produced by other runtimes).
+  optional<filesystem::path> speakerEmbeddingPath;
+  // Speaker encoder ONNX model path (ECAPA-TDNN). Required by
+  // --reference-audio. Accepted on the CLI for forward compatibility but
+  // currently unused (see note on referenceAudioPath above).
+  optional<filesystem::path> speakerEncoderModelPath;
 };
 
 // Define static constants
@@ -141,6 +157,37 @@ void rawOutputProc(vector<int16_t> &sharedAudioBuffer, mutex &mutAudio,
 void processLine(string line, RunConfig &runConfig, piper::PiperConfig &piperConfig,
                  piper::Voice &voice, piper::SynthesisResult &result,
                  bool jsonInput, std::unique_ptr<piper::CustomDictionary> &customDict);
+
+// Load a speaker embedding from a raw float32 little-endian binary file.
+// Format matches the Rust CLI's `--speaker-embedding` (src/rust/piper-cli/
+// src/main.rs:load_speaker_embedding), allowing cross-runtime portability.
+static std::vector<float> loadSpeakerEmbeddingBin(const filesystem::path &path) {
+  ifstream f(path, ios::binary | ios::ate);
+  if (!f.good()) {
+    throw runtime_error("Failed to open speaker embedding file: " +
+                        path.string());
+  }
+  auto bytes = static_cast<std::streamsize>(f.tellg());
+  if (bytes < 0) {
+    throw runtime_error("Failed to stat speaker embedding file: " +
+                        path.string());
+  }
+  if (bytes % 4 != 0) {
+    throw runtime_error(
+        "Speaker embedding file size (" + std::to_string(bytes) +
+        " bytes) is not a multiple of 4 (float32)");
+  }
+  f.seekg(0, ios::beg);
+  std::vector<float> floats(static_cast<size_t>(bytes) / sizeof(float));
+  if (!floats.empty()) {
+    f.read(reinterpret_cast<char *>(floats.data()), bytes);
+    if (!f) {
+      throw runtime_error("Failed to read speaker embedding file: " +
+                          path.string());
+    }
+  }
+  return floats;
+}
 
 // ----------------------------------------------------------------------------
 
@@ -374,6 +421,50 @@ int main(int argc, char *argv[]) {
     }
 
   } // if phonemeSilenceSeconds
+
+  // Voice cloning: resolve speaker embedding.
+  // --speaker-embedding: load from raw float32 LE binary (cross-runtime format).
+  // --reference-audio:   currently unsupported in the C++ runtime; emit a
+  //                      clear error rather than silently ignore the user's
+  //                      intent. Use the Python/Rust runtime to pre-compute
+  //                      the embedding and pass it via --speaker-embedding.
+  if (runConfig.referenceAudioPath) {
+    spdlog::error(
+        "--reference-audio is not yet implemented in the C++ runtime. "
+        "Speaker Encoder (ECAPA-TDNN) inference is not wired up yet "
+        "(see src/cpp/piper_plus_c_api.cpp speaker_encoder stub). "
+        "Workaround: pre-compute the embedding with the Python or Rust "
+        "runtime, save it as raw float32 little-endian, and pass it via "
+        "--speaker-embedding <path>.");
+    return EXIT_FAILURE;
+  }
+  if (runConfig.speakerEmbeddingPath) {
+    try {
+      auto emb = loadSpeakerEmbeddingBin(*runConfig.speakerEmbeddingPath);
+      spdlog::info("Loaded speaker embedding: {} dimensions from {}",
+                   emb.size(),
+                   runConfig.speakerEmbeddingPath->string());
+      if (voice.session.hasSpeakerEmbeddingInput) {
+        auto expected =
+            static_cast<size_t>(voice.session.speakerEmbeddingDim);
+        if (emb.size() != expected) {
+          spdlog::error(
+              "Speaker embedding dimension mismatch: file has {} dims, "
+              "model expects {}.",
+              emb.size(), expected);
+          return EXIT_FAILURE;
+        }
+      } else {
+        spdlog::warn(
+            "Model has no speaker_embedding input; --speaker-embedding "
+            "will be ignored.");
+      }
+      voice.synthesisConfig.speakerEmbedding = std::move(emb);
+    } catch (const std::exception &e) {
+      spdlog::error("Failed to load --speaker-embedding: {}", e.what());
+      return EXIT_FAILURE;
+    }
+  }
 
   // カスタム辞書の初期化
   std::unique_ptr<piper::CustomDictionary> customDict;
@@ -741,6 +832,17 @@ void printUsage(char *argv[]) {
           "comma-separated"
        << endl;
   cerr << endl;
+  cerr << "   Voice cloning:" << endl;
+  cerr << "   --reference-audio          FILE  reference WAV for voice cloning "
+          "(requires --speaker-encoder-model; not yet implemented in C++ runtime)"
+       << endl;
+  cerr << "   --speaker-embedding        FILE  pre-computed speaker embedding "
+          "(raw float32 little-endian; mutually exclusive with --reference-audio)"
+       << endl;
+  cerr << "   --speaker-encoder-model    FILE  ECAPA-TDNN speaker encoder ONNX "
+          "(required when using --reference-audio)"
+       << endl;
+  cerr << endl;
   cerr << "   Phoneme input: Use [[ phonemes ]] notation to specify exact pronunciation" << endl;
   cerr << "                  Example: echo \"Hello [[ h ə l oʊ ]] world\" | piper ..." << endl;
   cerr << endl;
@@ -882,6 +984,15 @@ void parseArgs(int argc, char *argv[], RunConfig &runConfig) {
 
       auto phoneme = piper::getCodepoint(phonemeStr);
       (*runConfig.phonemeSilenceSeconds)[phoneme] = stof(argv[++i]);
+    } else if (arg == "--reference-audio" || arg == "--reference_audio") {
+      ensureArg(argc, argv, i);
+      runConfig.referenceAudioPath = filesystem::path(argv[++i]);
+    } else if (arg == "--speaker-embedding" || arg == "--speaker_embedding") {
+      ensureArg(argc, argv, i);
+      runConfig.speakerEmbeddingPath = filesystem::path(argv[++i]);
+    } else if (arg == "--speaker-encoder-model" || arg == "--speaker_encoder_model") {
+      ensureArg(argc, argv, i);
+      runConfig.speakerEncoderModelPath = filesystem::path(argv[++i]);
     } else if (arg == "--json_input" || arg == "--json-input") {
       runConfig.jsonInput = true;
     } else if (arg == "--use_cuda" || arg == "--use-cuda") {
@@ -939,7 +1050,7 @@ void parseArgs(int argc, char *argv[], RunConfig &runConfig) {
       // Set DEBUG logging
       spdlog::set_level(spdlog::level::debug);
     } else if (arg == "-q" || arg == "--quiet") {
-      // diable logging
+      // disable logging
       spdlog::set_level(spdlog::level::off);
     } else if (arg == "-h" || arg == "--help") {
       printUsage(argv);
@@ -962,6 +1073,9 @@ void parseArgs(int argc, char *argv[], RunConfig &runConfig) {
         "--list-models", "--download-model", "--model-dir", "--model_dir",
         "--version", "--test-mode", "--debug", "--quiet", "--help",
         "--no-stochastic", "--no-warmup", "--no_warmup",
+        "--reference-audio", "--reference_audio",
+        "--speaker-embedding", "--speaker_embedding",
+        "--speaker-encoder-model", "--speaker_encoder_model",
       };
       // Find best match by edit distance (simple Levenshtein)
       string bestMatch;
@@ -991,6 +1105,18 @@ void parseArgs(int argc, char *argv[], RunConfig &runConfig) {
   // Validate --text and --json-input are mutually exclusive
   if (runConfig.textInput && runConfig.jsonInput) {
     throw runtime_error("--text and --json-input are mutually exclusive");
+  }
+
+  // Voice cloning argument validation (parity with Python/Rust/Go/C#/WASM).
+  // - --reference-audio and --speaker-embedding are mutually exclusive
+  // - --reference-audio requires --speaker-encoder-model
+  if (runConfig.referenceAudioPath && runConfig.speakerEmbeddingPath) {
+    throw runtime_error(
+        "--reference-audio and --speaker-embedding are mutually exclusive");
+  }
+  if (runConfig.referenceAudioPath && !runConfig.speakerEncoderModelPath) {
+    throw runtime_error(
+        "--speaker-encoder-model is required when using --reference-audio");
   }
 
   // --list-models and --download-model don't require a model file

--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -1148,17 +1148,32 @@ buildInputTensors(
 
   // speaker_embedding + speaker_embedding_mask (Issue #426).
   // MB-iSTFT-VITS2 + Voice Cloning exports declare these unconditionally.
-  // Feed zero embedding + mask=0 so the model falls back to emb_g(sid).
+  // When `inputs.speakerEmbedding` is non-empty (and matches the expected dim),
+  // it is fed with mask=1 → voice cloning path active.
+  // Otherwise feed zero embedding + mask=0 → model falls back to emb_g(sid).
   if (session.hasSpeakerEmbeddingInput) {
     const int64_t embDim = session.speakerEmbeddingDim;
-    speakerEmbeddingBuf.assign(static_cast<size_t>(embDim), 0.0f);
+    const bool haveProvidedEmb =
+        !inputs.speakerEmbedding.empty() &&
+        static_cast<int64_t>(inputs.speakerEmbedding.size()) == embDim;
+    if (!inputs.speakerEmbedding.empty() && !haveProvidedEmb) {
+      spdlog::warn(
+          "Provided speaker_embedding has {} dims but model expects {}; "
+          "falling back to zero embedding (mask=0).",
+          inputs.speakerEmbedding.size(), embDim);
+    }
+    if (haveProvidedEmb) {
+      speakerEmbeddingBuf = inputs.speakerEmbedding;  // copy
+    } else {
+      speakerEmbeddingBuf.assign(static_cast<size_t>(embDim), 0.0f);
+    }
     std::vector<int64_t> embShape{1, embDim};
     names.push_back("speaker_embedding");
     tensors.push_back(Ort::Value::CreateTensor<float>(
         memoryInfo, speakerEmbeddingBuf.data(), speakerEmbeddingBuf.size(),
         embShape.data(), embShape.size()));
 
-    speakerEmbeddingMaskBuf = {0};
+    speakerEmbeddingMaskBuf = {haveProvidedEmb ? int64_t{1} : int64_t{0}};
     std::vector<int64_t> maskShape{1, 1};
     names.push_back("speaker_embedding_mask");
     tensors.push_back(Ort::Value::CreateTensor<int64_t>(
@@ -1223,6 +1238,9 @@ void synthesize(std::vector<PhonemeId> &phonemeIds,
   if (prosodyFeatures) {
     inputs.prosodyFeatures = *prosodyFeatures;
   }
+  // Voice cloning: forward provided speaker embedding (if any) to the
+  // tensor builder, which will switch the mask to 1.
+  inputs.speakerEmbedding = synthesisConfig.speakerEmbedding;
 
   // Buffers must outlive the Run() call
   std::vector<int64_t> phonemeIdsBuf, phonemeIdLengthsBuf, sidBuf, lidBuf, prosodyBuf;
@@ -1432,6 +1450,8 @@ void synthesizeFloat(std::vector<PhonemeId> &phonemeIds,
   if (prosodyFeatures) {
     inputs.prosodyFeatures = *prosodyFeatures;
   }
+  // Voice cloning: forward provided speaker embedding (if any).
+  inputs.speakerEmbedding = synthesisConfig.speakerEmbedding;
 
   // Buffers must outlive the Run() call
   std::vector<int64_t> phonemeIdsBuf, phonemeIdLengthsBuf, sidBuf, lidBuf, prosodyBuf;

--- a/src/cpp/piper.hpp
+++ b/src/cpp/piper.hpp
@@ -123,6 +123,10 @@ struct InferenceInputs {
   std::optional<int64_t> languageId;
   // Flat [a1,a2,a3, a1,a2,a3, ...] per phoneme. Empty = no prosody.
   std::vector<int64_t> prosodyFeatures;
+  // Voice cloning: when non-empty, fed as `speaker_embedding` input with
+  // mask=1 (overriding the default zero/mask=0 fallback). Size must match
+  // ModelSession::speakerEmbeddingDim.
+  std::vector<float> speakerEmbedding;
 };
 
 struct PhonemeInfo {

--- a/src/cpp/tests/CMakeLists.txt
+++ b/src/cpp/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ set(TEST_SOURCES
     test_zh_en_loanword.cpp
     test_g2p_parallelism.cpp
     test_speaker_encoder_golden.cpp
+    test_voice_cloning_cli.cpp
 )
 
 # Add Unix-only tests (require open_jtalk binary or Unix APIs)

--- a/src/cpp/tests/test_voice_cloning_cli.cpp
+++ b/src/cpp/tests/test_voice_cloning_cli.cpp
@@ -1,0 +1,211 @@
+// Voice Cloning CLI argument parse tests (parity gate with Python/Rust/Go/C#/WASM).
+//
+// These tests verify the CLI argument parsing logic for the three voice cloning
+// flags: --reference-audio, --speaker-embedding, --speaker-encoder-model.
+//
+// Following the same pattern as test_text_input.cpp: a local `testParseArgs`
+// mirrors the main.cpp argument-parsing logic so the tests do not require
+// loading an ONNX model. Full E2E (with an actual encoder model) is gated by
+// test_speaker_encoder_e2e.cpp / test_speaker_embedding_inference.cpp.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct TestRunConfig {
+    std::optional<std::filesystem::path> referenceAudioPath;
+    std::optional<std::filesystem::path> speakerEmbeddingPath;
+    std::optional<std::filesystem::path> speakerEncoderModelPath;
+};
+
+// Mirrors the argument-parsing logic + validation in src/cpp/main.cpp for the
+// three voice cloning flags. Keep this in sync with parseArgs() over there.
+void testParseArgs(const std::vector<std::string>& args, TestRunConfig& cfg) {
+    for (size_t i = 0; i < args.size(); ++i) {
+        const auto& arg = args[i];
+        if (arg == "--reference-audio" || arg == "--reference_audio") {
+            if (i + 1 >= args.size()) throw std::runtime_error("Missing argument for --reference-audio");
+            cfg.referenceAudioPath = std::filesystem::path(args[++i]);
+        } else if (arg == "--speaker-embedding" || arg == "--speaker_embedding") {
+            if (i + 1 >= args.size()) throw std::runtime_error("Missing argument for --speaker-embedding");
+            cfg.speakerEmbeddingPath = std::filesystem::path(args[++i]);
+        } else if (arg == "--speaker-encoder-model" || arg == "--speaker_encoder_model") {
+            if (i + 1 >= args.size()) throw std::runtime_error("Missing argument for --speaker-encoder-model");
+            cfg.speakerEncoderModelPath = std::filesystem::path(args[++i]);
+        }
+    }
+
+    // Mutually exclusive: --reference-audio / --speaker-embedding
+    if (cfg.referenceAudioPath && cfg.speakerEmbeddingPath) {
+        throw std::runtime_error("--reference-audio and --speaker-embedding are mutually exclusive");
+    }
+    // --reference-audio requires --speaker-encoder-model
+    if (cfg.referenceAudioPath && !cfg.speakerEncoderModelPath) {
+        throw std::runtime_error("--speaker-encoder-model is required when using --reference-audio");
+    }
+}
+
+// Mirror of loadSpeakerEmbeddingBin() in main.cpp. Reads a raw float32 LE blob.
+std::vector<float> testLoadSpeakerEmbeddingBin(const std::filesystem::path& path) {
+    std::ifstream f(path, std::ios::binary | std::ios::ate);
+    if (!f.good()) {
+        throw std::runtime_error("Failed to open speaker embedding file: " + path.string());
+    }
+    auto bytes = static_cast<std::streamsize>(f.tellg());
+    if (bytes < 0) {
+        throw std::runtime_error("Failed to stat speaker embedding file: " + path.string());
+    }
+    if (bytes % 4 != 0) {
+        throw std::runtime_error("Speaker embedding file size is not a multiple of 4 (float32)");
+    }
+    f.seekg(0, std::ios::beg);
+    std::vector<float> floats(static_cast<size_t>(bytes) / sizeof(float));
+    if (!floats.empty()) {
+        f.read(reinterpret_cast<char*>(floats.data()), bytes);
+        if (!f) {
+            throw std::runtime_error("Failed to read speaker embedding file");
+        }
+    }
+    return floats;
+}
+
+// Write 256 random-looking float32 LE values to a temp file. Returns the path.
+std::filesystem::path writeFakeEmbeddingFile(size_t dim, float seed) {
+    auto path = std::filesystem::temp_directory_path() /
+                ("piper_test_emb_" + std::to_string(static_cast<int>(seed * 1000)) + ".bin");
+    std::ofstream f(path, std::ios::binary);
+    for (size_t i = 0; i < dim; ++i) {
+        float v = seed + 0.001f * static_cast<float>(i);
+        f.write(reinterpret_cast<const char*>(&v), sizeof(float));
+    }
+    return path;
+}
+
+} // namespace
+
+// ============================================
+// CLI flag parsing
+// ============================================
+
+TEST(VoiceCloningCliTest, ParseReferenceAudio) {
+    TestRunConfig cfg;
+    testParseArgs(
+        {"--reference-audio", "/tmp/ref.wav",
+            "--speaker-encoder-model", "/tmp/enc.onnx"},
+        cfg);
+    ASSERT_TRUE(cfg.referenceAudioPath.has_value());
+    EXPECT_EQ(cfg.referenceAudioPath->string(), "/tmp/ref.wav");
+    ASSERT_TRUE(cfg.speakerEncoderModelPath.has_value());
+    EXPECT_EQ(cfg.speakerEncoderModelPath->string(), "/tmp/enc.onnx");
+}
+
+TEST(VoiceCloningCliTest, ParseSpeakerEmbedding) {
+    TestRunConfig cfg;
+    testParseArgs({"--speaker-embedding", "/tmp/emb.bin"}, cfg);
+    ASSERT_TRUE(cfg.speakerEmbeddingPath.has_value());
+    EXPECT_EQ(cfg.speakerEmbeddingPath->string(), "/tmp/emb.bin");
+    EXPECT_FALSE(cfg.referenceAudioPath.has_value());
+}
+
+TEST(VoiceCloningCliTest, ParseUnderscoreAliases) {
+    TestRunConfig cfg;
+    testParseArgs(
+        {"--reference_audio", "/tmp/ref.wav",
+            "--speaker_encoder_model", "/tmp/enc.onnx"},
+        cfg);
+    ASSERT_TRUE(cfg.referenceAudioPath.has_value());
+    ASSERT_TRUE(cfg.speakerEncoderModelPath.has_value());
+}
+
+TEST(VoiceCloningCliTest, ParseSpeakerEmbeddingUnderscore) {
+    TestRunConfig cfg;
+    testParseArgs({"--speaker_embedding", "/tmp/emb.bin"}, cfg);
+    ASSERT_TRUE(cfg.speakerEmbeddingPath.has_value());
+}
+
+// ============================================
+// Mutex validation
+// ============================================
+
+TEST(VoiceCloningCliTest, ReferenceAudioAndSpeakerEmbeddingMutuallyExclusive) {
+    TestRunConfig cfg;
+    EXPECT_THROW(
+        testParseArgs(
+            {"--reference-audio", "/tmp/ref.wav",
+                "--speaker-encoder-model", "/tmp/enc.onnx",
+                "--speaker-embedding", "/tmp/emb.bin"},
+            cfg),
+        std::runtime_error);
+}
+
+TEST(VoiceCloningCliTest, ReferenceAudioRequiresEncoderModel) {
+    TestRunConfig cfg;
+    EXPECT_THROW(
+        testParseArgs({"--reference-audio", "/tmp/ref.wav"}, cfg),
+        std::runtime_error
+    );
+}
+
+TEST(VoiceCloningCliTest, SpeakerEmbeddingAloneIsValid) {
+    TestRunConfig cfg;
+    testParseArgs({"--speaker-embedding", "/tmp/emb.bin"}, cfg);
+    EXPECT_TRUE(cfg.speakerEmbeddingPath.has_value());
+    EXPECT_FALSE(cfg.referenceAudioPath.has_value());
+}
+
+TEST(VoiceCloningCliTest, NoFlagsIsValid) {
+    TestRunConfig cfg;
+    testParseArgs({}, cfg);
+    EXPECT_FALSE(cfg.referenceAudioPath.has_value());
+    EXPECT_FALSE(cfg.speakerEmbeddingPath.has_value());
+    EXPECT_FALSE(cfg.speakerEncoderModelPath.has_value());
+}
+
+TEST(VoiceCloningCliTest, MissingArgumentValueThrows) {
+    TestRunConfig cfg;
+    EXPECT_THROW(testParseArgs({"--reference-audio"}, cfg), std::runtime_error);
+    EXPECT_THROW(testParseArgs({"--speaker-embedding"}, cfg), std::runtime_error);
+    EXPECT_THROW(testParseArgs({"--speaker-encoder-model"}, cfg), std::runtime_error);
+}
+
+// ============================================
+// Embedding loader (raw float32 LE binary format)
+// ============================================
+
+TEST(VoiceCloningEmbeddingLoaderTest, Load256DimEmbedding) {
+    auto path = writeFakeEmbeddingFile(256, 0.5f);
+    auto emb = testLoadSpeakerEmbeddingBin(path);
+    EXPECT_EQ(emb.size(), 256u);
+    // Spot-check first / last values match the seed formula.
+    EXPECT_FLOAT_EQ(emb[0], 0.5f);
+    EXPECT_FLOAT_EQ(emb[255], 0.5f + 0.001f * 255.0f);
+    std::filesystem::remove(path);
+}
+
+TEST(VoiceCloningEmbeddingLoaderTest, MissingFileThrows) {
+    EXPECT_THROW(
+        testLoadSpeakerEmbeddingBin("/nonexistent/path/to/emb.bin"),
+        std::runtime_error
+    );
+}
+
+TEST(VoiceCloningEmbeddingLoaderTest, OddByteCountThrows) {
+    auto path = std::filesystem::temp_directory_path() / "piper_test_emb_odd.bin";
+    {
+        std::ofstream f(path, std::ios::binary);
+        // 5 bytes — not divisible by 4.
+        const char junk[] = {0x01, 0x02, 0x03, 0x04, 0x05};
+        f.write(junk, sizeof(junk));
+    }
+    EXPECT_THROW(testLoadSpeakerEmbeddingBin(path), std::runtime_error);
+    std::filesystem::remove(path);
+}


### PR DESCRIPTION
## Summary

C++ ランタイムに他5ランタイム (Python / Rust / Go / C# / WASM) と同じ Voice Cloning CLI フラグ 3 種を追加し、パリティギャップを解消します。

CLI フラグ:
- `--reference-audio FILE` 参照 WAV (`--speaker-encoder-model` 必須)
- `--speaker-embedding FILE` 事前計算済み 256-dim embedding (raw float32 little-endian、Rust CLI の `load_speaker_embedding` と互換)
- `--speaker-encoder-model FILE` ECAPA-TDNN encoder ONNX

排他性と必須条件 (他ランタイムと一致):
- `--reference-audio` と `--speaker-embedding` は同時指定不可
- `--reference-audio` 指定時は `--speaker-encoder-model` 必須

## スコープ

**partial implementation** — encoder 推論は別 PR に分離。

| flag | 状態 |
|------|------|
| `--speaker-embedding` | **full impl** raw float32 LE binary をロード → `synthesisConfig.speakerEmbedding` → `buildInputTensors()` で `mask=1` を立てて ONNX に投入 (従来は常に zero embedding + mask=0) |
| `--speaker-encoder-model` | CLI 受理のみ (path 保持、未使用)、forward-compat |
| `--reference-audio` | **明示エラー** — 起動時に "not yet implemented in the C++ runtime" を出して `EXIT_FAILURE`。workaround として Python/Rust で embedding を pre-compute → `--speaker-embedding` で渡す手順を案内 |

`--reference-audio` の実装には Speaker Encoder (ECAPA-TDNN) の WAV→mel→ONNX→L2 正規化パイプラインを C++ 側で組む必要があり、`src/cpp/piper_plus_c_api.cpp` の `piper_plus_speaker_encoder_*` は現状 "EXPERIMENTAL — not yet implemented" stub のままです (`set_error("Speaker encoder is not yet implemented in C API"); return -1`)。Rust 側 `src/rust/piper-core/src/speaker_encoder.rs` 相当を C++ に port する作業は本 PR とは独立した follow-up として扱います。

## ファイル変更

- `src/cpp/piper.hpp` — `InferenceInputs` に `speakerEmbedding` フィールド追加
- `src/cpp/piper.cpp` — `buildInputTensors()` が提供 embedding を mask=1 で渡すよう更新、`synthesize()` / `synthesizeFloat()` で `synthesisConfig.speakerEmbedding` を forward
- `src/cpp/main.cpp` — CLI フラグ parse / 排他 + 必須チェック / `loadSpeakerEmbeddingBin()` ヘルパー / `--help` 更新 / 既存 typo `diable` → `disable` 修正
- `src/cpp/tests/test_voice_cloning_cli.cpp` — **新規 12 テスト** (フラグ parse、排他、必須、binary loader)
- `src/cpp/tests/CMakeLists.txt` — 新テストを TEST_SOURCES に追加
- `.editorconfig` — `main.cpp` を既存の `piper.cpp/hpp` の `indent_size = unset` exemption に追加 (legacy 2-space スタイル維持)

## Test plan

- [x] `cmake -S . -B build && cmake --build build` build 通過 (ローカル macOS)
- [x] `./build/src/cpp/tests/test_voice_cloning_cli` 12/12 pass
- [x] `./build/piper --help` で 3 flag が "Voice cloning:" セクションに表示
- [x] `./build/piper --reference-audio x --speaker-embedding y` で mutex エラー
- [x] `./build/piper --reference-audio x` で `--speaker-encoder-model` 必須エラー
- [x] 既存テスト (`test_piper_core`, `test_text_input`, `test_model_speaker_detection`) regression なし
- [x] `test_speaker_embedding_inference` は fixture 未生成のため auto-skip (既存挙動維持)
- [x] pre-commit hook 全 pass (`ruff` / `codespell` / `editorconfig` / parity gates 含む)

## Follow-up

- C++ Speaker Encoder (ECAPA-TDNN) 推論パイプライン本格実装 → `--reference-audio` を full impl 化
- 対応する `piper_plus_c_api.cpp` の `piper_plus_speaker_encoder_encode()` stub 置換