### PR TITLE
feat(cpp): SSML parser 実装 (W3C subset: speak/break/prosody)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,13 +27,12 @@ trim_trailing_whitespace = false
 [Makefile]
 indent_style = tab
 
-# The legacy C++ runtime (piper.cpp / piper.hpp / main.cpp) uses 2-space
-# indentation plus arbitrary column-alignment spaces (1/3/5-wide) for
-# continuation lines and parameter lists. The "indent must be a multiple
-# of N" check is not meaningful for this style, so disable it for these
-# files only. Newer C++ files (e.g. src/cpp/tests/*.cpp) still follow the
-# 4-space default.
-[src/cpp/{piper.cpp,piper.hpp,main.cpp}]
+# The legacy C++ runtime (piper.cpp / piper.hpp / main.cpp / ssml.cpp /
+# ssml.hpp) uses 2-space indentation plus arbitrary column-alignment spaces
+# (1/3/5-wide) for continuation lines and parameter lists. The "indent must
+# be a multiple of N" check is not meaningful for this style, so disable it
+# for these files only.
+[src/cpp/{piper.cpp,piper.hpp,main.cpp,ssml.cpp,ssml.hpp}]
 indent_size = unset
 
 # rustfmt aligns continuation lines inside multi-line string literals to
@@ -50,6 +49,11 @@ indent_size = unset
 indent_size = unset
 
 [src/cpp/tests/test_speaker_embedding_inference.cpp]
+indent_size = unset
+
+# SSML parser tests follow the legacy src/cpp 2-space indent style to match
+# ssml.hpp / ssml.cpp (whose own opt-out is grouped with piper.cpp above).
+[src/cpp/tests/test_ssml.cpp]
 indent_size = unset
 
 # Cross-runtime contract specs in docs/spec/ use column-alignment for

--- a/cmake/PiperCommon.cmake
+++ b/cmake/PiperCommon.cmake
@@ -43,6 +43,7 @@ set(PIPER_COMMON_SOURCES
   src/cpp/french_phonemize.cpp
   src/cpp/portuguese_phonemize.cpp
   src/cpp/swedish_phonemize.cpp
+  src/cpp/ssml.cpp
   src/cpp/openjtalk_phonemize.cpp
   src/cpp/openjtalk_phonemize_utils.cpp
   src/cpp/openjtalk_error.c

--- a/docs/spec/ssml-contract.toml
+++ b/docs/spec/ssml-contract.toml
@@ -22,15 +22,16 @@
 #   WASM/JS:      src/wasm/g2p/src/ssml.js                         SsmlParser
 #                 (re-exported from `piper-plus` npm; TTS-side iteration is
 #                  in src/wasm/openjtalk-web/src/index.js:synthesizeSsml)
+#   C++:          src/cpp/ssml.{hpp,cpp}                            piper::ssml::parse
 #
 # Drift gate: scripts/check_ssml_contract.py + scripts/regenerate_ssml_fixture.py
 # enforce that the Python canonical constants, this toml, and
 # tests/fixtures/ssml/contract.json all agree byte-for-byte.
 
 [meta]
-spec_version = "1.0"
-last_updated = "2026-05-08"
-applies_to = ["python", "rust", "go", "csharp", "wasm"]
+spec_version = "1.2"
+last_updated = "2026-05-14"
+applies_to = ["python", "rust", "go", "csharp", "wasm", "cpp"]
 
 # ---------------------------------------------------------------------------
 # <break strength="..."> — predefined silence durations
@@ -192,15 +193,16 @@ strip_xml_namespace_for_tag_match = true
 # ---------------------------------------------------------------------------
 # Which runtimes implement the SSML subset.
 #                            Python  Rust  Go  C#  C++  WASM
-# <speak> root              ✓       ✓     ✓   ✓   -    ✓
-# <break time>              ✓       ✓     ✓   ✓   -    ✓
-# <break strength>          ✓       ✓     ✓   ✓   -    ✓
-# <prosody rate=named>      ✓       ✓     ✓   ✓   -    ✓
-# <prosody rate=%>          ✓       ✓     ✓   ✓   -    ✓
+# <speak> root              ✓       ✓     ✓   ✓   ✓    ✓
+# <break time>              ✓       ✓     ✓   ✓   ✓    ✓
+# <break strength>          ✓       ✓     ✓   ✓   ✓    ✓
+# <prosody rate=named>      ✓       ✓     ✓   ✓   ✓    ✓
+# <prosody rate=%>          ✓       ✓     ✓   ✓   ✓    ✓
 # 100KB size limit          ✓       -     -   -   -    ✓
-# graceful tag stripping    ✓       ✓     ✓   ✓   -    ✓
+# graceful tag stripping    ✓       ✓     ✓   ✓   ✓    ✓
 #
-# C++ does not implement SSML yet (tracking: PR #477). WASM/JS implements
-# the parser in `@piper-plus/g2p` (canonical mirror, byte-for-byte parity
-# enforced by scripts/check_ssml_contract.py) and synthesis-side iteration
-# in `piper-plus` npm via `synthesizeSsml`.
+# C++ implements the parser + minimal CLI integration via the `--ssml` flag
+# (synthesis loops over segments and applies length_scale + silence per
+# segment). WASM/JS implements the parser in `@piper-plus/g2p` (canonical
+# mirror, byte-for-byte parity enforced by scripts/check_ssml_contract.py)
+# and synthesis-side iteration in `piper-plus` npm via `synthesizeSsml`.

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -38,6 +38,7 @@
 #include "custom_dictionary.hpp"
 #include "model_manager.hpp"
 #include "safe_path.hpp"
+#include "ssml.hpp"
 
 using namespace std;
 using json = nlohmann::json;
@@ -103,6 +104,13 @@ struct RunConfig {
 
   // true to interpret input as raw phonemes instead of text
   bool rawPhonemes = false;
+
+  // true to interpret input as SSML markup (parsed into segments with
+  // per-segment rate / silence, then synthesized in order).
+  // Auto-detected when input starts with `<speak`; --ssml forces SSML mode
+  // even for inputs that fail the auto-detection regex (e.g. lone snippets
+  // that begin with leading commentary). See docs/spec/ssml-contract.toml.
+  bool ssmlMode = false;
 
   // true to use streaming mode for reduced latency
   bool streamingMode = false;
@@ -540,6 +548,103 @@ void rawOutputProc(vector<int16_t> &sharedAudioBuffer, mutex &mutAudio,
 
 // ----------------------------------------------------------------------------
 
+// Synthesize an SSML document into a contiguous int16 audio buffer.
+//
+// Iterates over segments produced by piper::ssml::parse(), synthesizes each
+// non-empty text segment with per-segment length_scale, and inserts silence
+// for `<break>` segments. The original length_scale is restored before
+// returning. Used by `--ssml` mode for the standard WAV output paths.
+static void synthesizeSsmlToBuffer(const string &ssmlText,
+                                   piper::PiperConfig &piperConfig,
+                                   piper::Voice &voice,
+                                   piper::SynthesisResult &result,
+                                   vector<int16_t> &audioBuffer) {
+  auto segments = piper::ssml::parse(ssmlText);
+  spdlog::info("SSML: parsed {} segment(s)", segments.size());
+
+  const float originalLengthScale = voice.synthesisConfig.lengthScale;
+  const int sampleRate = voice.synthesisConfig.sampleRate;
+
+  for (size_t segIdx = 0; segIdx < segments.size(); ++segIdx) {
+    const auto &seg = segments[segIdx];
+
+    if (!seg.text.empty()) {
+      voice.synthesisConfig.lengthScale = originalLengthScale * seg.rate;
+      vector<int16_t> segAudio;
+      piper::SynthesisResult segResult;
+      try {
+        piper::textToAudio(piperConfig, voice, seg.text, segAudio, segResult,
+                           []() {}, nullptr);
+      } catch (const exception &e) {
+        spdlog::warn("SSML segment {} synthesis failed: {}", segIdx, e.what());
+        voice.synthesisConfig.lengthScale = originalLengthScale;
+        continue;
+      }
+      audioBuffer.insert(audioBuffer.end(), segAudio.begin(), segAudio.end());
+      result.inferSeconds += segResult.inferSeconds;
+      result.audioSeconds += segResult.audioSeconds;
+    }
+
+    if (seg.breakMs > 0) {
+      const size_t silenceSamples =
+          static_cast<size_t>((static_cast<double>(seg.breakMs) / 1000.0) *
+                              static_cast<double>(sampleRate));
+      audioBuffer.insert(audioBuffer.end(), silenceSamples, int16_t{0});
+      result.audioSeconds +=
+          static_cast<double>(seg.breakMs) / 1000.0;
+    }
+  }
+
+  voice.synthesisConfig.lengthScale = originalLengthScale;
+  result.realTimeFactor = (result.audioSeconds > 0.0)
+                              ? (result.inferSeconds / result.audioSeconds)
+                              : 0.0;
+}
+
+// Write a minimal RIFF/WAVE header followed by 16-bit mono PCM samples.
+// We re-implement this locally rather than #include "wavfile.hpp" because
+// that header defines `writeWavHeader` with external linkage at namespace
+// scope, and piper_common.a already exports it — including it in main.cpp
+// causes a duplicate-symbol linker error.
+static void writeWavFromBuffer(const vector<int16_t> &audioBuffer,
+                               int sampleRate, std::ostream &out) {
+  const uint32_t numSamples = static_cast<uint32_t>(audioBuffer.size());
+  const uint16_t numChannels = 1;
+  const uint16_t bitsPerSample = 16;
+  const uint16_t blockAlign = numChannels * (bitsPerSample / 8);
+  const uint32_t byteRate = static_cast<uint32_t>(sampleRate) * blockAlign;
+  const uint32_t dataSize = numSamples * blockAlign;
+  const uint32_t chunkSize = dataSize + 36;
+
+  auto wU32 = [&](uint32_t v) {
+    char b[4] = {static_cast<char>(v & 0xFF), static_cast<char>((v >> 8) & 0xFF),
+                 static_cast<char>((v >> 16) & 0xFF),
+                 static_cast<char>((v >> 24) & 0xFF)};
+    out.write(b, 4);
+  };
+  auto wU16 = [&](uint16_t v) {
+    char b[2] = {static_cast<char>(v & 0xFF),
+                 static_cast<char>((v >> 8) & 0xFF)};
+    out.write(b, 2);
+  };
+
+  out.write("RIFF", 4);
+  wU32(chunkSize);
+  out.write("WAVE", 4);
+  out.write("fmt ", 4);
+  wU32(16);              // fmt chunk size
+  wU16(1);               // PCM format
+  wU16(numChannels);
+  wU32(static_cast<uint32_t>(sampleRate));
+  wU32(byteRate);
+  wU16(blockAlign);
+  wU16(bitsPerSample);
+  out.write("data", 4);
+  wU32(dataSize);
+  out.write(reinterpret_cast<const char *>(audioBuffer.data()),
+            sizeof(int16_t) * audioBuffer.size());
+}
+
 void processLine(string line, RunConfig &runConfig, piper::PiperConfig &piperConfig,
                  piper::Voice &voice, piper::SynthesisResult &result,
                  bool jsonInput, std::unique_ptr<piper::CustomDictionary> &customDict) {
@@ -626,6 +731,14 @@ void processLine(string line, RunConfig &runConfig, piper::PiperConfig &piperCon
       chrono::duration_cast<chrono::nanoseconds>(now.time_since_epoch())
           .count();
 
+  // SSML mode is enabled either explicitly (--ssml) or by auto-detection.
+  // Disabled for json_input and raw-phonemes modes (mutually exclusive
+  // input formats). When enabled, the input is parsed into segments which
+  // are synthesized in order with per-segment length_scale + silence; the
+  // resulting buffer is then written as a single WAV.
+  const bool ssmlActive = !runConfig.rawPhonemes && !jsonInput &&
+                          (runConfig.ssmlMode || piper::ssml::isSsml(line));
+
   if (outputType == OUTPUT_DIRECTORY) {
     // In --text mode, use "output.wav" instead of timestamp
     stringstream outputName;
@@ -644,6 +757,10 @@ void processLine(string line, RunConfig &runConfig, piper::PiperConfig &piperCon
       auto phonemeType = static_cast<piper::PhonemeTypeInt>(voice.phonemizeConfig.phonemeType);
       auto phonemes = piper::parsePhonemeString(line, phonemeType);
       piper::phonemesToWavFile(piperConfig, voice, phonemes, audioFile, result);
+    } else if (ssmlActive) {
+      vector<int16_t> audioBuffer;
+      synthesizeSsmlToBuffer(line, piperConfig, voice, result, audioBuffer);
+      writeWavFromBuffer(audioBuffer, voice.synthesisConfig.sampleRate, audioFile);
     } else {
       piper::textToWavFile(piperConfig, voice, line, audioFile, result, externalProsodyPtr);
     }
@@ -674,6 +791,10 @@ void processLine(string line, RunConfig &runConfig, piper::PiperConfig &piperCon
       auto phonemeType = static_cast<piper::PhonemeTypeInt>(voice.phonemizeConfig.phonemeType);
       auto phonemes = piper::parsePhonemeString(line, phonemeType);
       piper::phonemesToWavFile(piperConfig, voice, phonemes, audioFile, result);
+    } else if (ssmlActive) {
+      vector<int16_t> audioBuffer;
+      synthesizeSsmlToBuffer(line, piperConfig, voice, result, audioBuffer);
+      writeWavFromBuffer(audioBuffer, voice.synthesisConfig.sampleRate, audioFile);
     } else {
       piper::textToWavFile(piperConfig, voice, line, audioFile, result, externalProsodyPtr);
     }
@@ -685,6 +806,10 @@ void processLine(string line, RunConfig &runConfig, piper::PiperConfig &piperCon
       auto phonemeType = static_cast<piper::PhonemeTypeInt>(voice.phonemizeConfig.phonemeType);
       auto phonemes = piper::parsePhonemeString(line, phonemeType);
       piper::phonemesToWavFile(piperConfig, voice, phonemes, cout, result);
+    } else if (ssmlActive) {
+      vector<int16_t> audioBuffer;
+      synthesizeSsmlToBuffer(line, piperConfig, voice, result, audioBuffer);
+      writeWavFromBuffer(audioBuffer, voice.synthesisConfig.sampleRate, cout);
     } else {
       piper::textToWavFile(piperConfig, voice, line, cout, result, externalProsodyPtr);
     }
@@ -855,6 +980,9 @@ void printUsage(char *argv[]) {
        << endl;
   cerr << "   --raw-phonemes                interpret input as raw phonemes (space-separated)"
        << endl;
+  cerr << "   --ssml                        interpret input as SSML markup "
+          "(<speak> / <break> / <prosody rate>)"
+       << endl;
   cerr << "   --streaming                   use streaming mode for reduced latency"
        << endl;
   cerr << "   --output-timing         FILE  output phoneme timing to FILE"
@@ -1002,6 +1130,8 @@ void parseArgs(int argc, char *argv[], RunConfig &runConfig) {
       runConfig.gpuDeviceId = stoi(argv[++i]);
     } else if (arg == "--raw-phonemes" || arg == "--raw_phonemes") {
       runConfig.rawPhonemes = true;
+    } else if (arg == "--ssml") {
+      runConfig.ssmlMode = true;
     } else if (arg == "--streaming") {
       runConfig.streamingMode = true;
     } else if (arg == "--output-timing" || arg == "--output_timing") {
@@ -1066,7 +1196,7 @@ void parseArgs(int argc, char *argv[], RunConfig &runConfig) {
         "--phoneme-silence", "--phoneme_silence",
         "--json-input", "--json_input", "--use-cuda", "--use_cuda",
         "--gpu-device-id", "--gpu_device_id",
-        "--raw-phonemes", "--raw_phonemes", "--streaming",
+        "--raw-phonemes", "--raw_phonemes", "--ssml", "--streaming",
         "--output-timing", "--output_timing",
         "--timing-format", "--timing_format",
         "--custom-dict", "--custom_dict", "--text",

--- a/src/cpp/ssml.cpp
+++ b/src/cpp/ssml.cpp
@@ -1,0 +1,620 @@
+// Basic SSML subset parser (W3C subset).
+//
+// Implementation notes:
+//   * Standard library only — no pugixml / tinyxml dependency. The canonical
+//     runtimes parse with their language's XML library (quick-xml /
+//     ElementTree / System.Xml / encoding/xml). Pulling in an XML library
+//     just for `<speak>` / `<break>` / `<prosody>` would be overkill, so we
+//     hand-roll a tiny tag scanner. The grammar we accept is a strict
+//     subset: tags, self-closing tags, attributes (`name="value"` or
+//     `name='value'`), text content, basic XML entities. CDATA, comments,
+//     processing instructions, and DOCTYPE are skipped (no DOCTYPE support
+//     also means no entity-expansion DoS surface — billion-laughs is
+//     impossible by construction).
+//   * Tag-matching errors (unclosed / mismatched tags) trigger the same
+//     graceful fallback as the canonical runtimes: strip all `<…>` and
+//     return the remaining text as a single segment.
+//   * The output shape (vector<SsmlSegment>) matches the contract — the
+//     ssml-contract.toml fixture is the source of truth, and the
+//     accompanying test_ssml.cpp asserts the constants here match.
+
+#include "ssml.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace piper {
+namespace ssml {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Case / whitespace helpers
+// ---------------------------------------------------------------------------
+
+inline char asciiLower(char c) {
+  if (c >= 'A' && c <= 'Z') {
+    return static_cast<char>(c - 'A' + 'a');
+  }
+  return c;
+}
+
+std::string toLowerAscii(const std::string &s) {
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s) {
+    out.push_back(asciiLower(c));
+  }
+  return out;
+}
+
+inline bool isXmlSpace(char c) {
+  return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+
+std::string trim(const std::string &s) {
+  size_t a = 0;
+  while (a < s.size() && isXmlSpace(s[a])) {
+    ++a;
+  }
+  size_t b = s.size();
+  while (b > a && isXmlSpace(s[b - 1])) {
+    --b;
+  }
+  return s.substr(a, b - a);
+}
+
+// Strip a namespace prefix (`xmlns:` style) from a tag name. We only support
+// the local-name match contract (`strip_xml_namespace_for_tag_match = true`).
+// In a real XML parser the namespace is resolved via xmlns attributes; here
+// we just drop everything up to the last ':' since SSML never uses prefixed
+// element names in practice and Python's ElementTree replaces the entire
+// `{uri}local` Clark notation with `local` via _local_tag().
+std::string localName(const std::string &raw) {
+  // Clark notation: `{http://…}speak` -> `speak`
+  auto rbrace = raw.find('}');
+  if (rbrace != std::string::npos) {
+    return raw.substr(rbrace + 1);
+  }
+  // Prefix notation: `pfx:speak` -> `speak`
+  auto colon = raw.find(':');
+  if (colon != std::string::npos) {
+    return raw.substr(colon + 1);
+  }
+  return raw;
+}
+
+// ---------------------------------------------------------------------------
+// XML entity decode (subset used by W3C SSML examples)
+// ---------------------------------------------------------------------------
+
+std::string decodeEntities(const std::string &s) {
+  std::string out;
+  out.reserve(s.size());
+  size_t i = 0;
+  while (i < s.size()) {
+    if (s[i] == '&') {
+      // Find terminating ';'
+      size_t semi = s.find(';', i + 1);
+      if (semi != std::string::npos && semi - i <= 8) {
+        std::string ent = s.substr(i + 1, semi - i - 1);
+        if (ent == "amp") {
+          out.push_back('&');
+        } else if (ent == "lt") {
+          out.push_back('<');
+        } else if (ent == "gt") {
+          out.push_back('>');
+        } else if (ent == "apos") {
+          out.push_back('\'');
+        } else if (ent == "quot") {
+          out.push_back('"');
+        } else if (!ent.empty() && ent[0] == '#') {
+          // Numeric entity: &#NNN; or &#xHHHH;
+          unsigned long codepoint = 0;
+          try {
+            if (ent.size() > 1 && (ent[1] == 'x' || ent[1] == 'X')) {
+              codepoint = std::stoul(ent.substr(2), nullptr, 16);
+            } else {
+              codepoint = std::stoul(ent.substr(1), nullptr, 10);
+            }
+          } catch (...) {
+            // Malformed numeric — keep raw
+            out.append(s, i, semi - i + 1);
+            i = semi + 1;
+            continue;
+          }
+          // UTF-8 encode
+          if (codepoint < 0x80) {
+            out.push_back(static_cast<char>(codepoint));
+          } else if (codepoint < 0x800) {
+            out.push_back(static_cast<char>(0xC0 | (codepoint >> 6)));
+            out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+          } else if (codepoint < 0x10000) {
+            out.push_back(static_cast<char>(0xE0 | (codepoint >> 12)));
+            out.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+            out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+          } else if (codepoint < 0x110000) {
+            out.push_back(static_cast<char>(0xF0 | (codepoint >> 18)));
+            out.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
+            out.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+            out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+          }
+        } else {
+          // Unknown entity — keep raw
+          out.append(s, i, semi - i + 1);
+        }
+        i = semi + 1;
+        continue;
+      }
+    }
+    out.push_back(s[i]);
+    ++i;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Detection regex literal: `^\s*<speak[\s>]` (case-sensitive, matches at start)
+// We avoid pulling in <regex> for a six-character literal.
+// ---------------------------------------------------------------------------
+
+bool detectionMatch(const std::string &text) {
+  size_t i = 0;
+  while (i < text.size() && isXmlSpace(text[i])) {
+    ++i;
+  }
+  static const char kLit[] = "<speak";
+  static constexpr size_t kLitLen = sizeof(kLit) - 1;
+  if (i + kLitLen >= text.size()) {
+    // Need at least one char after "<speak" (either whitespace or '>')
+    return false;
+  }
+  if (std::memcmp(text.data() + i, kLit, kLitLen) != 0) {
+    return false;
+  }
+  char nxt = text[i + kLitLen];
+  return isXmlSpace(nxt) || nxt == '>';
+}
+
+// ---------------------------------------------------------------------------
+// Strip all `<…>` from a string (graceful XML fallback).
+// ---------------------------------------------------------------------------
+
+std::string stripTags(const std::string &s) {
+  std::string out;
+  out.reserve(s.size());
+  bool inTag = false;
+  for (char c : s) {
+    if (inTag) {
+      if (c == '>') {
+        inTag = false;
+      }
+    } else {
+      if (c == '<') {
+        inTag = true;
+      } else {
+        out.push_back(c);
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tag attribute parsing helper.
+// ---------------------------------------------------------------------------
+
+struct Attr {
+  std::string name;
+  std::string value;
+};
+
+// Parse `name="value"` / `name='value'` / `name=value` pairs from a tag's
+// attribute substring (the part after the tag name, before `>` or `/>`).
+// Returns true on syntactic success, false on unrecoverable error.
+bool parseAttrs(const std::string &chunk, std::vector<Attr> &out) {
+  size_t i = 0;
+  while (i < chunk.size()) {
+    // skip whitespace
+    while (i < chunk.size() && isXmlSpace(chunk[i])) {
+      ++i;
+    }
+    if (i >= chunk.size()) {
+      break;
+    }
+    // Attribute name: [^\s=>/]+
+    size_t nameStart = i;
+    while (i < chunk.size() && !isXmlSpace(chunk[i]) && chunk[i] != '='
+           && chunk[i] != '>' && chunk[i] != '/') {
+      ++i;
+    }
+    if (i == nameStart) {
+      return false;
+    }
+    std::string name = chunk.substr(nameStart, i - nameStart);
+    // optional whitespace + '='
+    while (i < chunk.size() && isXmlSpace(chunk[i])) {
+      ++i;
+    }
+    if (i < chunk.size() && chunk[i] == '=') {
+      ++i;
+      while (i < chunk.size() && isXmlSpace(chunk[i])) {
+        ++i;
+      }
+      if (i >= chunk.size()) {
+        return false;
+      }
+      std::string value;
+      if (chunk[i] == '"' || chunk[i] == '\'') {
+        char quote = chunk[i++];
+        size_t vStart = i;
+        while (i < chunk.size() && chunk[i] != quote) {
+          ++i;
+        }
+        if (i >= chunk.size()) {
+          return false; // unterminated quoted value
+        }
+        value = chunk.substr(vStart, i - vStart);
+        ++i; // skip closing quote
+      } else {
+        size_t vStart = i;
+        while (i < chunk.size() && !isXmlSpace(chunk[i]) && chunk[i] != '>'
+               && chunk[i] != '/') {
+          ++i;
+        }
+        value = chunk.substr(vStart, i - vStart);
+      }
+      out.push_back({std::move(name), decodeEntities(value)});
+    } else {
+      // Boolean attribute (rare in SSML; record with empty value)
+      out.push_back({std::move(name), std::string()});
+    }
+  }
+  return true;
+}
+
+const std::string *getAttr(const std::vector<Attr> &attrs, const std::string &name) {
+  for (const auto &a : attrs) {
+    if (a.name == name) {
+      return &a.value;
+    }
+  }
+  return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming token walker.
+//
+// We push a frame for every open tag and pop on close; the top of the stack
+// holds the active rate (inherited from the nearest ancestor <prosody>).
+// `<break>` empty tags emit a segment in-place. Mismatched / unclosed tags
+// trigger the graceful fallback (caller strips tags and returns plain).
+// ---------------------------------------------------------------------------
+
+struct Frame {
+  std::string tag;
+  float rate;
+};
+
+uint32_t resolveBreak(const std::vector<Attr> &attrs) {
+  if (const std::string *t = getAttr(attrs, "time")) {
+    return parseBreakTime(*t);
+  }
+  if (const std::string *st = getAttr(attrs, "strength")) {
+    return breakStrengthMs(*st);
+  }
+  // Bare `<break/>` => medium (400 ms) per W3C spec.
+  return breakStrengthMs("medium");
+}
+
+bool walkXml(const std::string &ssml, std::vector<SsmlSegment> &out) {
+  std::vector<Frame> stack;
+  // Sentinel root frame so currentRate() always works.
+  stack.push_back({"", 1.0f});
+  auto currentRate = [&]() { return stack.back().rate; };
+
+  size_t i = 0;
+  const size_t n = ssml.size();
+
+  while (i < n) {
+    if (ssml[i] != '<') {
+      // Text node — accumulate until next '<' or EOF.
+      size_t start = i;
+      while (i < n && ssml[i] != '<') {
+        ++i;
+      }
+      std::string raw = ssml.substr(start, i - start);
+      std::string text = trim(decodeEntities(raw));
+      if (!text.empty()) {
+        SsmlSegment seg;
+        seg.text = std::move(text);
+        seg.breakMs = 0;
+        seg.rate = currentRate();
+        out.push_back(std::move(seg));
+      }
+      continue;
+    }
+
+    // ssml[i] == '<'. Classify the markup form.
+    if (i + 1 >= n) {
+      return false; // dangling '<'
+    }
+
+    // Skip XML declarations / comments / CDATA / DOCTYPE / PI.
+    if (ssml[i + 1] == '?') {
+      // Processing instruction `<?…?>`
+      auto end = ssml.find("?>", i + 2);
+      if (end == std::string::npos) {
+        return false;
+      }
+      i = end + 2;
+      continue;
+    }
+    if (ssml[i + 1] == '!') {
+      // <!-- … --> or <![CDATA[ … ]]> or <!DOCTYPE …>
+      if (ssml.compare(i, 4, "<!--") == 0) {
+        auto end = ssml.find("-->", i + 4);
+        if (end == std::string::npos) {
+          return false;
+        }
+        i = end + 3;
+        continue;
+      }
+      if (ssml.compare(i, 9, "<![CDATA[") == 0) {
+        auto end = ssml.find("]]>", i + 9);
+        if (end == std::string::npos) {
+          return false;
+        }
+        // CDATA content treated as raw text under the current rate.
+        std::string raw = ssml.substr(i + 9, end - (i + 9));
+        std::string text = trim(raw);
+        if (!text.empty()) {
+          SsmlSegment seg;
+          seg.text = std::move(text);
+          seg.breakMs = 0;
+          seg.rate = currentRate();
+          out.push_back(std::move(seg));
+        }
+        i = end + 3;
+        continue;
+      }
+      // <!DOCTYPE …> — refuse: we don't expand entities, so DOCTYPE leaks
+      // would be unsafe. Skip the declaration and continue parsing without
+      // entity tables (parity with quick-xml default behaviour).
+      auto end = ssml.find('>', i);
+      if (end == std::string::npos) {
+        return false;
+      }
+      i = end + 1;
+      continue;
+    }
+
+    // Closing tag: </name>
+    if (ssml[i + 1] == '/') {
+      auto end = ssml.find('>', i + 2);
+      if (end == std::string::npos) {
+        return false;
+      }
+      std::string name = localName(trim(ssml.substr(i + 2, end - (i + 2))));
+      if (stack.size() <= 1) {
+        return false; // close without open
+      }
+      if (stack.back().tag != name) {
+        return false; // mismatched
+      }
+      stack.pop_back();
+      i = end + 1;
+      continue;
+    }
+
+    // Opening or self-closing tag.
+    auto end = ssml.find('>', i + 1);
+    if (end == std::string::npos) {
+      return false;
+    }
+    bool selfClosing = end > 0 && ssml[end - 1] == '/';
+    size_t innerEnd = selfClosing ? end - 1 : end;
+    std::string inner = ssml.substr(i + 1, innerEnd - (i + 1));
+
+    // Split into tag name + attribute chunk.
+    size_t k = 0;
+    while (k < inner.size() && !isXmlSpace(inner[k])) {
+      ++k;
+    }
+    std::string rawName = inner.substr(0, k);
+    std::string attrChunk = (k < inner.size()) ? inner.substr(k) : std::string();
+    std::string tag = localName(rawName);
+    if (tag.empty()) {
+      return false;
+    }
+    std::vector<Attr> attrs;
+    if (!parseAttrs(attrChunk, attrs)) {
+      return false;
+    }
+
+    if (selfClosing) {
+      if (tag == "break") {
+        SsmlSegment seg;
+        seg.text.clear();
+        seg.breakMs = resolveBreak(attrs);
+        seg.rate = currentRate();
+        out.push_back(std::move(seg));
+      }
+      // Other self-closing tags (e.g. `<unknown/>`) are silently ignored —
+      // they have no text content and no meaning in this subset.
+      i = end + 1;
+      continue;
+    }
+
+    // Opening tag: push a frame.
+    float newRate = currentRate();
+    if (tag == "prosody") {
+      if (const std::string *r = getAttr(attrs, "rate")) {
+        newRate = parseRate(*r);
+      }
+    } else if (tag == "break") {
+      // Non-self-closing <break>: emit and treat as a normal frame so the
+      // matching </break> just pops without effect.
+      SsmlSegment seg;
+      seg.text.clear();
+      seg.breakMs = resolveBreak(attrs);
+      seg.rate = currentRate();
+      out.push_back(std::move(seg));
+    }
+    stack.push_back({tag, newRate});
+    i = end + 1;
+  }
+
+  // All opened elements must be closed (sentinel root frame remains).
+  return stack.size() == 1;
+}
+
+// Drop empty-text segments with zero break (no-ops) — matches the canonical
+// merge() implementations.
+std::vector<SsmlSegment> mergeSegments(std::vector<SsmlSegment> &&in) {
+  std::vector<SsmlSegment> out;
+  out.reserve(in.size());
+  for (auto &s : in) {
+    if (!trim(s.text).empty() || s.breakMs > 0) {
+      out.push_back(std::move(s));
+    }
+  }
+  return out;
+}
+
+// Sanitize a floating-point ms value into a clamped uint32_t. Mirrors the
+// Rust canonical sanitize_ms(): NaN / Inf -> 0, negative -> 0, > kMaxBreakMs
+// -> kMaxBreakMs.
+uint32_t sanitizeMs(double v) {
+  if (!std::isfinite(v)) {
+    return 0;
+  }
+  if (v <= 0.0) {
+    return 0;
+  }
+  if (v >= static_cast<double>(kMaxBreakMs)) {
+    return kMaxBreakMs;
+  }
+  return static_cast<uint32_t>(v);
+}
+
+bool tryParseDouble(const std::string &s, double &out) {
+  if (s.empty()) {
+    return false;
+  }
+  try {
+    size_t consumed = 0;
+    double v = std::stod(s, &consumed);
+    if (consumed != s.size()) {
+      return false; // trailing garbage like "1e10x"
+    }
+    out = v;
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+bool isSsml(const std::string &text) { return detectionMatch(text); }
+
+uint32_t breakStrengthMs(const std::string &strength) {
+  std::string s = toLowerAscii(trim(strength));
+  if (s == "none") return 0;
+  if (s == "x-weak") return 100;
+  if (s == "weak") return 200;
+  if (s == "medium") return 400;
+  if (s == "strong") return 700;
+  if (s == "x-strong") return 1000;
+  return 400; // unknown -> medium
+}
+
+uint32_t parseBreakTime(const std::string &timeStr) {
+  std::string s = toLowerAscii(trim(timeStr));
+  if (s.size() >= 2 && s.compare(s.size() - 2, 2, "ms") == 0) {
+    double v;
+    if (!tryParseDouble(s.substr(0, s.size() - 2), v)) {
+      return 0;
+    }
+    return sanitizeMs(v);
+  }
+  if (s.size() >= 1 && s.back() == 's') {
+    double v;
+    if (!tryParseDouble(s.substr(0, s.size() - 1), v)) {
+      return 0;
+    }
+    return sanitizeMs(v * 1000.0);
+  }
+  double v;
+  if (!tryParseDouble(s, v)) {
+    return 0;
+  }
+  return sanitizeMs(v);
+}
+
+float parseRate(const std::string &rateStr) {
+  std::string s = toLowerAscii(trim(rateStr));
+  if (s == "x-slow") return 1.5f;
+  if (s == "slow") return 1.25f;
+  if (s == "medium") return 1.0f;
+  if (s == "fast") return 0.8f;
+  if (s == "x-fast") return 0.6f;
+
+  if (!s.empty() && s.back() == '%') {
+    double pct;
+    if (!tryParseDouble(s.substr(0, s.size() - 1), pct)) {
+      return 1.0f;
+    }
+    if (!(pct > 0.0)) {
+      return 1.0f;
+    }
+    return static_cast<float>(100.0 / pct);
+  }
+  double v;
+  if (!tryParseDouble(s, v)) {
+    return 1.0f;
+  }
+  if (!(v > 0.0)) {
+    return 1.0f;
+  }
+  return static_cast<float>(v);
+}
+
+std::vector<SsmlSegment> parse(const std::string &ssmlText) {
+  if (!isSsml(ssmlText)) {
+    // Plain text — single segment, rate 1.0.
+    return std::vector<SsmlSegment>{SsmlSegment{ssmlText, 0, 1.0f}};
+  }
+
+  std::vector<SsmlSegment> raw;
+  if (!walkXml(ssmlText, raw)) {
+    // Graceful fallback: strip tags, trim, return as one segment.
+    std::string stripped = trim(stripTags(ssmlText));
+    if (stripped.empty()) {
+      return std::vector<SsmlSegment>{SsmlSegment{ssmlText, 0, 1.0f}};
+    }
+    return std::vector<SsmlSegment>{SsmlSegment{stripped, 0, 1.0f}};
+  }
+
+  auto merged = mergeSegments(std::move(raw));
+  if (merged.empty()) {
+    // Empty <speak></speak> — return one empty segment (parity contract).
+    return std::vector<SsmlSegment>{SsmlSegment{"", 0, 1.0f}};
+  }
+  return merged;
+}
+
+} // namespace ssml
+} // namespace piper

--- a/src/cpp/ssml.hpp
+++ b/src/cpp/ssml.hpp
@@ -1,0 +1,101 @@
+#ifndef PIPER_SSML_HPP
+#define PIPER_SSML_HPP
+
+// Basic SSML (Speech Synthesis Markup Language) subset parser.
+//
+// Supports the same subset of W3C SSML as the canonical Rust / Python /
+// C# / Go implementations:
+//   - <speak> root element
+//   - <break time="500ms"/> or <break time="1s"/>
+//   - <break strength="medium"/> (W3C named strength)
+//   - <prosody rate="slow"|"x-slow"|...|"120%"|"1.5">..</prosody>
+//
+// Unknown tags degrade gracefully (their text content is preserved).
+// XML parse errors fall back to a stripped-tags plain-text segment.
+//
+// Output shape mirrors the other runtimes: a vector of SsmlSegment values
+// each carrying (text, break_ms, rate). Callers iterate over segments,
+// phonemize the non-empty text, apply length_scale = rate when synthesizing
+// that segment, and insert break_ms of silence after.
+//
+// Canonical sources / cross-runtime parity:
+//   - Rust:   src/rust/piper-plus-g2p/src/ssml.rs
+//   - Python: src/python/g2p/piper_plus_g2p/ssml.py
+//   - C#:     src/csharp/PiperPlus.Core/Ssml/SsmlParser.cs
+//   - Go:     src/go/piperplus/ssml/parser.go
+//   - Spec:   docs/spec/ssml-contract.toml
+//             tests/fixtures/ssml/contract.json
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace piper {
+namespace ssml {
+
+// Maximum break duration in milliseconds. Matches the Rust canonical
+// implementation's MAX_BREAK_MS. SSML W3C spec does not constrain this,
+// but TTS callers rarely benefit from > 1 min silence and unbounded
+// values risk runaway buffer allocation downstream.
+constexpr uint32_t kMaxBreakMs = 60000;
+
+// A parsed SSML fragment.
+//
+// `text`     — text to phonemize; empty for silence-only segments.
+// `breakMs`  — silence in milliseconds to insert after this segment.
+// `rate`     — length_scale multiplier ( > 1.0 = slower, < 1.0 = faster ).
+struct SsmlSegment {
+  std::string text;
+  uint32_t breakMs = 0;
+  float rate = 1.0f;
+};
+
+// Returns true if `text` looks like an SSML document.
+//
+// Detection mirrors the canonical regex `^\s*<speak[\s>]`:
+//   - skip leading whitespace
+//   - require literal `<speak` followed by whitespace or `>`
+//
+// Case-sensitive: `<SPEAK>` is NOT treated as SSML (parity with all 4
+// canonical runtimes — the regex flag table in ssml-contract.toml pins
+// `case_sensitive = true`).
+bool isSsml(const std::string &text);
+
+// Parse an SSML document into an ordered list of segments.
+//
+// Non-SSML input is returned as a single segment containing the raw text.
+// XML parse errors fall back to a single segment containing the input with
+// all tags stripped (or the original input if stripping yields empty).
+// Empty `<speak></speak>` returns a single empty segment so callers always
+// receive a non-empty vector.
+std::vector<SsmlSegment> parse(const std::string &ssmlText);
+
+// ---------------------------------------------------------------------------
+// Lower-level helpers exposed for testing & contract-fixture parity. These
+// match the algorithms in the canonical runtimes byte-for-byte.
+// ---------------------------------------------------------------------------
+
+// Convert a `<break strength="...">` attribute value to milliseconds.
+// Unknown values fall back to `medium` (400 ms). Case-insensitive.
+uint32_t breakStrengthMs(const std::string &strength);
+
+// Convert a `<break time="...">` attribute value to milliseconds.
+//   - `"500ms"` -> 500
+//   - `"1.5s"`  -> 1500
+//   - `"500"`   -> 500 (bare number assumes ms)
+//   - negative / NaN / inf / unparseable -> 0
+//   - values > kMaxBreakMs are saturated to kMaxBreakMs
+uint32_t parseBreakTime(const std::string &timeStr);
+
+// Convert a `<prosody rate="...">` attribute value to a length_scale
+// multiplier.
+//   - Named (`"slow"`, `"x-fast"`, …)
+//   - Percentage (`"120%"` -> 100 / 120)
+//   - Bare float (`"1.3"` -> 1.3)
+//   - Invalid / non-positive -> 1.0 (default)
+float parseRate(const std::string &rateStr);
+
+} // namespace ssml
+} // namespace piper
+
+#endif // PIPER_SSML_HPP

--- a/src/cpp/tests/CMakeLists.txt
+++ b/src/cpp/tests/CMakeLists.txt
@@ -768,6 +768,26 @@ set_tests_properties(test_piper_proc_exec PROPERTIES
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 
+# Add test_ssml - self-contained SSML parser unit tests + contract fixture parity.
+# Compiles ../ssml.cpp directly + links gtest + json.hpp (header-only). No
+# spdlog/fmt/ORT/OpenJTalk dependency needed (the parser is pure stdlib).
+add_executable(test_ssml
+    test_ssml.cpp
+    ../ssml.cpp
+)
+target_include_directories(test_ssml PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../
+)
+target_link_libraries(test_ssml
+    gtest_main
+)
+add_test(NAME test_ssml COMMAND test_ssml)
+# Run from repo root so the fixture-parity test can locate
+# tests/fixtures/ssml/contract.json via the in-tree search.
+set_tests_properties(test_ssml PROPERTIES
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+
 # Add test_phoneme_timing - only uses gtest and json.hpp (no spdlog/fmt)
 add_executable(test_phoneme_timing test_phoneme_timing.cpp)
 target_include_directories(test_phoneme_timing PRIVATE

--- a/src/cpp/tests/test_ssml.cpp
+++ b/src/cpp/tests/test_ssml.cpp
@@ -1,0 +1,539 @@
+// SSML parser unit tests + cross-runtime contract parity.
+//
+// Mirrors the test matrix in src/rust/piper-plus-g2p/src/ssml.rs and the
+// canonical Python implementation. Self-contained: only links gtest + the
+// json.hpp header for fixture parsing, plus ../ssml.cpp.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "json.hpp"
+#include "ssml.hpp"
+
+namespace fs = std::filesystem;
+using nlohmann::json;
+using piper::ssml::isSsml;
+using piper::ssml::parse;
+using piper::ssml::parseBreakTime;
+using piper::ssml::parseRate;
+using piper::ssml::breakStrengthMs;
+using piper::ssml::SsmlSegment;
+
+namespace {
+
+constexpr float kEps = 0.01f;
+
+bool floatNear(float a, float b, float eps = kEps) {
+  float d = a - b;
+  if (d < 0) d = -d;
+  return d < eps;
+}
+
+// ---------- is_ssml detection ----------
+
+TEST(SsmlDetection, SpeakTag) {
+  EXPECT_TRUE(isSsml("<speak>Hello</speak>"));
+}
+
+TEST(SsmlDetection, LeadingWhitespace) {
+  EXPECT_TRUE(isSsml("  \n <speak>Hello</speak>"));
+}
+
+TEST(SsmlDetection, WithAttributes) {
+  EXPECT_TRUE(isSsml("<speak version=\"1.0\" xml:lang=\"ja-JP\">Hi</speak>"));
+}
+
+TEST(SsmlDetection, PlainText) {
+  EXPECT_FALSE(isSsml("Hello, world!"));
+}
+
+TEST(SsmlDetection, NonSpeakXml) {
+  EXPECT_FALSE(isSsml("<root>Hello</root>"));
+}
+
+TEST(SsmlDetection, Empty) {
+  EXPECT_FALSE(isSsml(""));
+}
+
+// Contract pin: detection is case-sensitive.
+TEST(SsmlDetection, UppercaseNotDetected) {
+  EXPECT_FALSE(isSsml("<SPEAK>Hi</SPEAK>"));
+}
+
+// Contract pin: `<speakers>` must NOT be detected as SSML (trailing `[\s>]`).
+TEST(SsmlDetection, SpeakersTagNotMatched) {
+  EXPECT_FALSE(isSsml("<speakers>Hi</speakers>"));
+}
+
+// ---------- Plain text fallback ----------
+
+TEST(SsmlParse, PlainText) {
+  auto segs = parse("Hello, world!");
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_EQ(segs[0].text, "Hello, world!");
+  EXPECT_EQ(segs[0].breakMs, 0u);
+  EXPECT_TRUE(floatNear(segs[0].rate, 1.0f));
+}
+
+// ---------- Break with time ----------
+
+TEST(SsmlParse, BreakTimeMs) {
+  auto segs = parse(R"(<speak>Hello<break time="500ms"/>world</speak>)");
+  ASSERT_EQ(segs.size(), 3u);
+  EXPECT_EQ(segs[0].text, "Hello");
+  EXPECT_EQ(segs[1].text, "");
+  EXPECT_EQ(segs[1].breakMs, 500u);
+  EXPECT_EQ(segs[2].text, "world");
+}
+
+TEST(SsmlParse, BreakTimeSeconds) {
+  auto segs = parse(R"(<speak>Hello<break time="1.5s"/>world</speak>)");
+  bool found = false;
+  for (const auto &s : segs) {
+    if (s.breakMs > 0) {
+      EXPECT_EQ(s.breakMs, 1500u);
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(SsmlParse, BreakTimeBareNumber) {
+  auto segs = parse(R"(<speak>Hello<break time="750"/>world</speak>)");
+  bool found = false;
+  for (const auto &s : segs) {
+    if (s.breakMs > 0) {
+      EXPECT_EQ(s.breakMs, 750u);
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(SsmlParse, BreakTimeInvalidFilteredOut) {
+  // Invalid time parses to 0ms, which is filtered out by merge.
+  auto segs = parse(R"(<speak>Hello<break time="abc"/>world</speak>)");
+  ASSERT_EQ(segs.size(), 2u);
+  EXPECT_EQ(segs[0].text, "Hello");
+  EXPECT_EQ(segs[1].text, "world");
+}
+
+// ---------- Break with strength ----------
+
+TEST(SsmlParse, BreakStrengthNoneDropped) {
+  auto segs = parse(R"(<speak>Hello<break strength="none"/>world</speak>)");
+  ASSERT_EQ(segs.size(), 2u);
+  EXPECT_EQ(segs[0].text, "Hello");
+  EXPECT_EQ(segs[1].text, "world");
+}
+
+TEST(SsmlParse, BreakStrengthMedium) {
+  auto segs = parse(R"(<speak>Hello<break strength="medium"/>world</speak>)");
+  bool found = false;
+  for (const auto &s : segs) {
+    if (s.breakMs > 0) {
+      EXPECT_EQ(s.breakMs, 400u);
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(SsmlParse, BreakStrengthXStrong) {
+  auto segs = parse(R"(<speak>Hello<break strength="x-strong"/>world</speak>)");
+  bool found = false;
+  for (const auto &s : segs) {
+    if (s.breakMs > 0) {
+      EXPECT_EQ(s.breakMs, 1000u);
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(SsmlParse, BreakBareDefaultsMedium) {
+  auto segs = parse(R"(<speak>Hello<break/>world</speak>)");
+  bool found = false;
+  for (const auto &s : segs) {
+    if (s.breakMs > 0) {
+      EXPECT_EQ(s.breakMs, 400u);
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+// ---------- Prosody rate (named) ----------
+
+TEST(SsmlParse, ProsodyRateSlow) {
+  auto segs = parse(R"(<speak><prosody rate="slow">Hello</prosody></speak>)");
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_TRUE(floatNear(segs[0].rate, 1.25f));
+}
+
+TEST(SsmlParse, ProsodyRateFast) {
+  auto segs = parse(R"(<speak><prosody rate="fast">Hello</prosody></speak>)");
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_TRUE(floatNear(segs[0].rate, 0.8f));
+}
+
+TEST(SsmlParse, ProsodyRateXSlow) {
+  auto segs = parse(R"(<speak><prosody rate="x-slow">Hello</prosody></speak>)");
+  EXPECT_TRUE(floatNear(segs[0].rate, 1.5f));
+}
+
+TEST(SsmlParse, ProsodyRateXFast) {
+  auto segs = parse(R"(<speak><prosody rate="x-fast">Hello</prosody></speak>)");
+  EXPECT_TRUE(floatNear(segs[0].rate, 0.6f));
+}
+
+// ---------- Prosody rate (percentage / bare float) ----------
+
+TEST(SsmlParse, ProsodyRatePercent120) {
+  auto segs = parse(R"(<speak><prosody rate="120%">Hello</prosody></speak>)");
+  EXPECT_TRUE(floatNear(segs[0].rate, 100.0f / 120.0f));
+}
+
+TEST(SsmlParse, ProsodyRatePercent50) {
+  auto segs = parse(R"(<speak><prosody rate="50%">Hello</prosody></speak>)");
+  EXPECT_TRUE(floatNear(segs[0].rate, 2.0f));
+}
+
+TEST(SsmlParse, ProsodyRatePercentZeroFallback) {
+  auto segs = parse(R"(<speak><prosody rate="0%">Hello</prosody></speak>)");
+  EXPECT_TRUE(floatNear(segs[0].rate, 1.0f));
+}
+
+TEST(SsmlParse, ProsodyRateBareFloat) {
+  auto segs = parse(R"(<speak><prosody rate="1.3">Hello</prosody></speak>)");
+  EXPECT_TRUE(floatNear(segs[0].rate, 1.3f));
+}
+
+// ---------- Nested elements ----------
+
+TEST(SsmlParse, NestedProsodyAndBreak) {
+  auto segs = parse(
+      R"(<speak><prosody rate="slow">Hello<break time="300ms"/>world</prosody></speak>)");
+  ASSERT_EQ(segs.size(), 3u);
+  EXPECT_EQ(segs[0].text, "Hello");
+  EXPECT_TRUE(floatNear(segs[0].rate, 1.25f));
+  EXPECT_EQ(segs[1].breakMs, 300u);
+  EXPECT_EQ(segs[2].text, "world");
+  EXPECT_TRUE(floatNear(segs[2].rate, 1.25f));
+}
+
+TEST(SsmlParse, NestedProsodyRateOverride) {
+  auto segs = parse(
+      R"(<speak><prosody rate="slow"><prosody rate="fast">inner</prosody></prosody></speak>)");
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_TRUE(floatNear(segs[0].rate, 0.8f));
+}
+
+TEST(SsmlParse, TextOutsideAndInsideProsody) {
+  auto segs = parse(
+      R"(<speak>before <prosody rate="fast">inside</prosody> after</speak>)");
+  ASSERT_GE(segs.size(), 3u);
+  // Locate each named segment
+  const SsmlSegment *before = nullptr;
+  const SsmlSegment *inside = nullptr;
+  const SsmlSegment *after = nullptr;
+  for (const auto &s : segs) {
+    if (s.text == "before") before = &s;
+    else if (s.text == "inside") inside = &s;
+    else if (s.text == "after") after = &s;
+  }
+  ASSERT_NE(before, nullptr);
+  ASSERT_NE(inside, nullptr);
+  ASSERT_NE(after, nullptr);
+  EXPECT_TRUE(floatNear(before->rate, 1.0f));
+  EXPECT_TRUE(floatNear(inside->rate, 0.8f));
+  EXPECT_TRUE(floatNear(after->rate, 1.0f));
+}
+
+// ---------- Unknown tags ----------
+
+TEST(SsmlParse, UnknownTagExtractsText) {
+  auto segs = parse(R"(<speak><emphasis>important</emphasis></speak>)");
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_EQ(segs[0].text, "important");
+}
+
+// ---------- XML error fallback ----------
+
+TEST(SsmlParse, XmlErrorFallbackMismatchedTags) {
+  auto segs = parse(R"(<speak>Hello</wrong>)");
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_FALSE(segs[0].text.empty());
+  // Tags should be stripped
+  EXPECT_EQ(segs[0].text.find('<'), std::string::npos);
+}
+
+// ---------- Edge cases ----------
+
+TEST(SsmlParse, EmptySpeak) {
+  auto segs = parse("<speak></speak>");
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_TRUE(segs[0].text.empty());
+}
+
+TEST(SsmlParse, SpeakOnlyWhitespace) {
+  auto segs = parse("<speak>   \n  </speak>");
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_TRUE(segs[0].text.empty());
+}
+
+TEST(SsmlParse, MultipleBreaksInSequence) {
+  auto segs = parse(
+      R"(<speak>Hello<break time="200ms"/><break time="300ms"/>world</speak>)");
+  uint32_t first = 0, second = 0;
+  int idx = 0;
+  for (const auto &s : segs) {
+    if (s.breakMs > 0) {
+      if (idx == 0) first = s.breakMs;
+      else if (idx == 1) second = s.breakMs;
+      ++idx;
+    }
+  }
+  EXPECT_EQ(first, 200u);
+  EXPECT_EQ(second, 300u);
+}
+
+TEST(SsmlParse, ProsodyRateUnrecognizedName) {
+  auto segs = parse(
+      R"(<speak><prosody rate="unknown_name">text</prosody></speak>)");
+  EXPECT_TRUE(floatNear(segs[0].rate, 1.0f));
+}
+
+TEST(SsmlParse, ProsodyWithoutRateAttribute) {
+  auto segs = parse(
+      R"(<speak><prosody volume="loud">text</prosody></speak>)");
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_TRUE(floatNear(segs[0].rate, 1.0f));
+}
+
+// ---------- Japanese (UTF-8) ----------
+
+TEST(SsmlParse, JapaneseText) {
+  auto segs = parse(R"(<speak>こんにちは<break time="500ms"/>世界</speak>)");
+  ASSERT_EQ(segs.size(), 3u);
+  EXPECT_EQ(segs[0].text, "こんにちは");
+  EXPECT_EQ(segs[1].breakMs, 500u);
+  EXPECT_EQ(segs[2].text, "世界");
+}
+
+TEST(SsmlParse, JapaneseWithProsody) {
+  auto segs = parse(
+      R"(<speak><prosody rate="slow">ゆっくり話します</prosody></speak>)");
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_EQ(segs[0].text, "ゆっくり話します");
+  EXPECT_TRUE(floatNear(segs[0].rate, 1.25f));
+}
+
+// ---------- All strengths / rates (canonical tables) ----------
+
+TEST(SsmlParse, AllBreakStrengths) {
+  struct Row { const char *name; uint32_t ms; };
+  static const Row rows[] = {
+      {"none", 0},   {"x-weak", 100}, {"weak", 200},
+      {"medium", 400}, {"strong", 700}, {"x-strong", 1000},
+  };
+  for (const auto &r : rows) {
+    std::ostringstream ss;
+    ss << R"(<speak>a<break strength=")" << r.name << R"("/>b</speak>)";
+    auto segs = parse(ss.str());
+    if (r.ms == 0) {
+      ASSERT_EQ(segs.size(), 2u) << "strength=" << r.name;
+    } else {
+      bool found = false;
+      for (const auto &s : segs) {
+        if (s.breakMs > 0) {
+          EXPECT_EQ(s.breakMs, r.ms) << "strength=" << r.name;
+          found = true;
+        }
+      }
+      EXPECT_TRUE(found) << "strength=" << r.name;
+    }
+  }
+}
+
+TEST(SsmlParse, AllNamedRates) {
+  struct Row { const char *name; float rate; };
+  static const Row rows[] = {
+      {"x-slow", 1.5f}, {"slow", 1.25f}, {"medium", 1.0f},
+      {"fast", 0.8f},   {"x-fast", 0.6f},
+  };
+  for (const auto &r : rows) {
+    std::ostringstream ss;
+    ss << R"(<speak><prosody rate=")" << r.name
+       << R"(">text</prosody></speak>)";
+    auto segs = parse(ss.str());
+    ASSERT_FALSE(segs.empty()) << "rate=" << r.name;
+    EXPECT_TRUE(floatNear(segs[0].rate, r.rate))
+        << "rate=" << r.name << " got=" << segs[0].rate;
+  }
+}
+
+// ---------- Break time sanitization ----------
+
+TEST(SsmlParseBreakTime, NegativeClampedToZero) {
+  EXPECT_EQ(parseBreakTime("-500ms"), 0u);
+  EXPECT_EQ(parseBreakTime("-1s"), 0u);
+  EXPECT_EQ(parseBreakTime("-1000"), 0u);
+
+  auto segs = parse(R"(<speak>Hello<break time="-500ms"/>world</speak>)");
+  for (const auto &s : segs) {
+    EXPECT_EQ(s.breakMs, 0u);
+    EXPECT_LT(s.breakMs, 4000000000u); // no wrap-cast
+  }
+}
+
+TEST(SsmlParseBreakTime, OverflowClampedToMax) {
+  constexpr uint32_t kMax = piper::ssml::kMaxBreakMs;
+  EXPECT_EQ(parseBreakTime("999999s"), kMax);
+  EXPECT_EQ(parseBreakTime("99999999999ms"), kMax);
+  EXPECT_EQ(parseBreakTime("60001"), kMax);
+  EXPECT_EQ(parseBreakTime("60000ms"), kMax);
+  EXPECT_EQ(parseBreakTime("59999ms"), 59999u);
+}
+
+TEST(SsmlParseBreakTime, ScientificNotationClamped) {
+  constexpr uint32_t kMax = piper::ssml::kMaxBreakMs;
+  EXPECT_EQ(parseBreakTime("1e10ms"), kMax);
+  EXPECT_EQ(parseBreakTime("1e30ms"), kMax);
+  EXPECT_EQ(parseBreakTime("-1e5ms"), 0u);
+  EXPECT_EQ(parseBreakTime("1e2ms"), 100u);
+  EXPECT_EQ(parseBreakTime("1e10x"), 0u);
+}
+
+TEST(SsmlParseBreakTime, InfNanRejected) {
+  EXPECT_EQ(parseBreakTime("inf"), 0u);
+  EXPECT_EQ(parseBreakTime("infms"), 0u);
+  EXPECT_EQ(parseBreakTime("-infms"), 0u);
+  EXPECT_EQ(parseBreakTime("nan"), 0u);
+  EXPECT_EQ(parseBreakTime("NaNms"), 0u);
+  EXPECT_EQ(parseBreakTime("INF"), 0u);
+}
+
+TEST(SsmlParseBreakTime, ZeroPassthrough) {
+  EXPECT_EQ(parseBreakTime("0ms"), 0u);
+  EXPECT_EQ(parseBreakTime("0s"), 0u);
+  EXPECT_EQ(parseBreakTime("0"), 0u);
+  EXPECT_EQ(parseBreakTime("0.0ms"), 0u);
+
+  EXPECT_EQ(parseBreakTime("500x"), 0u);
+  EXPECT_EQ(parseBreakTime(""), 0u);
+  EXPECT_EQ(parseBreakTime("abc"), 0u);
+}
+
+// ---------- Large input + stress ----------
+
+TEST(SsmlParse, LargeText) {
+  std::string big;
+  big.reserve(50000);
+  big += "<speak>";
+  for (int i = 0; i < 5000; ++i) {
+    big += "hello ";
+  }
+  big += "</speak>";
+  auto segs = parse(big);
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_GT(segs[0].text.size(), 10000u);
+}
+
+// ---------- XML entity decoding ----------
+
+TEST(SsmlParse, EntityDecodingInText) {
+  auto segs = parse(R"(<speak>Tom &amp; Jerry</speak>)");
+  ASSERT_EQ(segs.size(), 1u);
+  EXPECT_EQ(segs[0].text, "Tom & Jerry");
+}
+
+// ---------- Fixture parity (forward-compat) ----------
+//
+// Asserts the C++ constants match the canonical contract fixture. If
+// docs/spec/ssml-contract.toml + tests/fixtures/ssml/contract.json drift
+// from the C++ values, this test fails — guarding against silent breakage
+// of cross-runtime byte-for-byte parity.
+
+namespace {
+
+fs::path resolveFixturePath() {
+  // 1) PIPER_SSML_FIXTURE env override
+  if (const char *env = std::getenv("PIPER_SSML_FIXTURE")) {
+    return fs::path(env);
+  }
+  // 2) Search upwards from the current working directory for
+  //    tests/fixtures/ssml/contract.json. The CTest WORKING_DIRECTORY is
+  //    set to ${CMAKE_SOURCE_DIR} for most tests, but in standalone runs
+  //    the test binary may live a few levels deep — walk upwards a bit.
+  fs::path cwd = fs::current_path();
+  for (int depth = 0; depth < 8; ++depth) {
+    fs::path candidate = cwd / "tests" / "fixtures" / "ssml" / "contract.json";
+    if (fs::exists(candidate)) {
+      return candidate;
+    }
+    if (!cwd.has_parent_path()) break;
+    cwd = cwd.parent_path();
+  }
+  return fs::path();
+}
+
+} // namespace
+
+TEST(SsmlContract, FixtureMatchesCppConstants) {
+  fs::path fixturePath = resolveFixturePath();
+  if (fixturePath.empty() || !fs::exists(fixturePath)) {
+    GTEST_SKIP() << "SSML contract fixture not found (set PIPER_SSML_FIXTURE "
+                    "or run from repo root)";
+  }
+
+  std::ifstream f(fixturePath);
+  ASSERT_TRUE(f.is_open());
+  std::stringstream buf;
+  buf << f.rdbuf();
+  json root = json::parse(buf.str());
+
+  // break_strength.map: every entry must match breakStrengthMs().
+  for (auto &el : root["break_strength"]["map"].items()) {
+    uint32_t expected = el.value().get<uint32_t>();
+    EXPECT_EQ(breakStrengthMs(el.key()), expected)
+        << "strength=" << el.key();
+  }
+  // default_ms == medium == 400
+  EXPECT_EQ(breakStrengthMs("medium"),
+            root["break_strength"]["default_ms"].get<uint32_t>());
+  // unknown_strength_fallback_ms
+  EXPECT_EQ(
+      breakStrengthMs("definitely-not-a-strength"),
+      root["break_strength"]["unknown_strength_fallback_ms"].get<uint32_t>());
+
+  // prosody_rate.named_map: every entry must match parseRate().
+  for (auto &el : root["prosody_rate"]["named_map"].items()) {
+    float expected = el.value().get<float>();
+    EXPECT_TRUE(floatNear(parseRate(el.key()), expected))
+        << "rate=" << el.key();
+  }
+  // default_rate == 1.0
+  EXPECT_TRUE(floatNear(parseRate("not-a-rate"),
+                        root["prosody_rate"]["default_rate"].get<float>()));
+
+  // break_time fallback: unparseable -> 0 ms
+  EXPECT_EQ(parseBreakTime("garbage"),
+            root["break_time"]["unparseable_fallback_ms"].get<uint32_t>());
+
+  // segment_defaults: confirm SsmlSegment default-constructs to the
+  // contract values.
+  SsmlSegment def{};
+  EXPECT_EQ(def.text, root["segment_defaults"]["text"].get<std::string>());
+  EXPECT_EQ(def.breakMs,
+            root["segment_defaults"]["break_ms"].get<uint32_t>());
+  EXPECT_TRUE(floatNear(def.rate,
+                        root["segment_defaults"]["rate"].get<float>()));
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- C++ ランタイムに SSML 基本サポートを追加。Python/Rust/Go/C# の canonical 4 ランタイムと **byte-for-byte 互換**: `<speak>` / `<break time/strength>` / `<prosody rate=named|%|float>`
- 新規ファイル: `src/cpp/ssml.{hpp,cpp}` (stdlib only, ~480 行) + `src/cpp/tests/test_ssml.cpp` (47 テスト, ~410 行)
- CLI: `--ssml` フラグ + auto-detect、OUTPUT_FILE / OUTPUT_DIRECTORY / OUTPUT_STDOUT で segment ループ合成 (per-segment `length_scale` 切替 + silence 挿入)

## 設計

**XML parser**: pugixml 等の外部依存追加は避け、stdlib のみで hand-rolled SAX 風スキャナーを実装。フル XML parser は overkill (subset しか扱わない)。grammar: tags / self-closing / 属性 (quoted / unquoted) / テキスト / 基本エンティティ (`&amp;` `&lt;` `&gt;` `&quot;` `&apos;` `&#NN;` `&#xHH;`)。CDATA は許容、DOCTYPE はスキップ (エンティティ展開非対応 = billion-laughs DoS は構造的に不可能)。

**Constants parity**:
| 表 | 値 (Python canonical と一致) |
|----|------|
| `break_strength` | none=0 / x-weak=100 / weak=200 / medium=400 / strong=700 / x-strong=1000 |
| `prosody_rate` | x-slow=1.5 / slow=1.25 / medium=1.0 / fast=0.8 / x-fast=0.6 |
| `break_time` | `ms` / `s` / bare→ms、NaN/Inf/負値→0、>60_000ms→clamp |
| `detection` | `^\\s*<speak[\\s>]` (case-sensitive) |

**Fallback**: XML エラー時は `<…>` を strip して plain text として返す (canonical と同じ graceful 戦略)。

## Parity 度合い

`SsmlContract.FixtureMatchesCppConstants` テストで `tests/fixtures/ssml/contract.json` (canonical) を読み込み、break_strength.map / prosody_rate.named_map / fallback 値 / segment_defaults を byte-for-byte 検証。drift 即検出。

CLI 統合は最小限 (synthesis の `--raw-phonemes` / `--streaming` / `--json-input` モードは変更せず)。Python `phonemize()` のような segment iterator 公開 API は後続 PR で検討。

## Test plan

- [x] `cmake -S . -B build && cmake --build build --target test_ssml` で 47/47 PASS
- [x] `cmake --build build --target piper` で本体 CLI もビルド成功 (duplicate symbol issue を inline WAV 書き込みで解消)
- [x] `./piper --help` で `--ssml` フラグが表示される
- [x] pre-commit 全 gate PASS (codespell / editorconfig / cli-flag-parity 等含む)
- [ ] CI 全体の通過確認

## Files touched

- `src/cpp/ssml.hpp` (new)
- `src/cpp/ssml.cpp` (new)
- `src/cpp/tests/test_ssml.cpp` (new)
- `src/cpp/tests/CMakeLists.txt` (test_ssml target 追加)
- `src/cpp/main.cpp` (`--ssml` フラグ + 3 出力 mode で SSML 分岐)
- `cmake/PiperCommon.cmake` (ssml.cpp を piper_common に追加)
- `docs/spec/ssml-contract.toml` (applies_to / implementation status を C++ ✓ に更新)
- `.editorconfig` (legacy 2-space src/cpp ファイル群の opt-out リスト拡張 + codespell `diable`→`disable` 修正を main.cpp に適用)