### PR TITLE
fix(bench): RTF baseline 自動初期化 + P50 threshold チェック追加

### DIFF
--- a/.github/workflows/memory-regression.yml
+++ b/.github/workflows/memory-regression.yml
@@ -41,6 +41,11 @@ on:
       - 'test/models/multilingual-test-medium.onnx*'
       - '.github/workflows/memory-regression.yml'
   workflow_dispatch:
+    inputs:
+      initialize_baseline:
+        description: 'Observed values を baseline として commit する (初回初期化用)'
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -57,7 +62,7 @@ jobs:
     # Fork PRs cannot post comments; matches rtf-regression.yml.
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     permissions:
-      contents: read
+      contents: write  # read normally; write needed for initialize_baseline commit
       pull-requests: write
     steps:
       - uses: actions/checkout@v6.0.2
@@ -167,3 +172,38 @@ jobs:
                 owner, repo, issue_number, body: payload,
               });
             }
+
+      - name: Initialize baseline (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch' && inputs.initialize_baseline == true
+        run: |
+          uv run python - <<'EOF'
+          import json, pathlib
+
+          baseline_path = pathlib.Path("tests/fixtures/memory-baseline.json")
+          baseline = json.loads(baseline_path.read_text())
+
+          for lang in ("ja", "en", "zh", "es", "fr", "pt"):
+              result_path = pathlib.Path(f"memory-results/{lang}.json")
+              if not result_path.exists():
+                  continue
+              try:
+                  data = json.loads(result_path.read_text())
+                  obs_mb = data[0]["peak_memory_mb"] if isinstance(data, list) else data.get("peak_memory_mb")
+              except Exception as e:
+                  print(f"WARN: could not read memory-results/{lang}.json: {e}")
+                  continue
+              if obs_mb is not None:
+                  baseline["languages"].setdefault(lang, {})["peak_memory_mb"] = round(obs_mb, 1)
+                  print(f"  {lang}: {obs_mb:.1f} MB")
+
+          baseline_path.write_text(json.dumps(baseline, indent=2, ensure_ascii=False) + "\n")
+          print("memory baseline updated")
+          EOF
+        shell: bash
+
+      - name: Commit initialized baseline
+        if: github.event_name == 'workflow_dispatch' && inputs.initialize_baseline == true
+        uses: stefanzweifel/git-auto-commit-action@v5.2.0
+        with:
+          commit_message: "chore(bench): initialize memory baseline from first run"
+          file_pattern: tests/fixtures/memory-baseline.json

--- a/.github/workflows/multi-runtime-rtf.yml
+++ b/.github/workflows/multi-runtime-rtf.yml
@@ -62,6 +62,11 @@ on:
       - 'test/models/multilingual-test-medium.onnx*'
       - '.github/workflows/multi-runtime-rtf.yml'
   workflow_dispatch:
+    inputs:
+      initialize_baseline:
+        description: 'Observed values を baseline として commit する (初回初期化用)'
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -235,7 +240,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: always() && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
     permissions:
-      contents: read
+      contents: write  # read normally; write needed for initialize_baseline commit
       pull-requests: write  # sticky comment via actions/github-script
     steps:
       - uses: actions/checkout@v6.0.2
@@ -266,6 +271,7 @@ jobs:
           )
           thresholds = baseline.get("thresholds", {})
           rtf_pct = thresholds.get("rtf_pct", 0.10)
+          p50_pct = thresholds.get("latency_p50_pct", 0.10)
           p95_pct = thresholds.get("latency_p95_pct", 0.15)
           policy = baseline.get("policy", "warn-only")
 
@@ -291,6 +297,7 @@ jobs:
           lines.append(
               f"Policy: **{policy}** "
               f"(thresholds: RTF +/-{rtf_pct * 100:.0f}%, "
+              f"P50 +/-{p50_pct * 100:.0f}%, "
               f"P95 +/-{p95_pct * 100:.0f}%)"
           )
           lines.append("")
@@ -301,11 +308,11 @@ jobs:
           lines.append("")
           lines.append(
               "| Runtime | Text | RTF | P50 (ms) | P95 (ms) | "
-              "Baseline RTF | RTF Δ | Baseline P95 | P95 Δ |"
+              "Baseline RTF | RTF Δ | Baseline P50 | P50 Δ | Baseline P95 | P95 Δ |"
           )
           lines.append(
               "|---------|------|-----|----------|----------|"
-              "--------------|-------|--------------|-------|"
+              "--------------|-------|--------------|-------|--------------|-------|"
           )
 
           any_regression = False
@@ -318,11 +325,13 @@ jobs:
                       .get(tk, {})
                   )
                   base_rtf = base.get("rtf")
+                  base_p50 = base.get("latency_p50_ms")
                   base_p95 = base.get("latency_p95_ms")
                   if obs is None:
                       lines.append(
                           f"| {rt} | {tk} | (missing) | - | - | "
                           f"{base_rtf if base_rtf is not None else 'n/a'} | - | "
+                          f"{base_p50 if base_p50 is not None else 'n/a'} | - | "
                           f"{base_p95 if base_p95 is not None else 'n/a'} | - |"
                       )
                       continue
@@ -337,6 +346,14 @@ jobs:
                       if ratio > rtf_pct:
                           rtf_flag = " :warning:"
                           any_regression = True
+                  p50_delta = "n/a"
+                  p50_flag = ""
+                  if base_p50 is not None and p50 is not None and base_p50 > 0:
+                      ratio_p50 = (p50 - base_p50) / base_p50
+                      p50_delta = f"{ratio_p50 * 100:+.1f}%"
+                      if ratio_p50 > p50_pct:
+                          p50_flag = " :warning:"
+                          any_regression = True
                   p95_delta = "n/a"
                   p95_flag = ""
                   if base_p95 is not None and p95 is not None and base_p95 > 0:
@@ -349,6 +366,8 @@ jobs:
                       f"| {rt} | {tk} | {rtf} | {p50} | {p95} | "
                       f"{base_rtf if base_rtf is not None else 'null'} | "
                       f"{rtf_delta}{rtf_flag} | "
+                      f"{base_p50 if base_p50 is not None else 'null'} | "
+                      f"{p50_delta}{p50_flag} | "
                       f"{base_p95 if base_p95 is not None else 'null'} | "
                       f"{p95_delta}{p95_flag} |"
                   )
@@ -357,13 +376,13 @@ jobs:
           if any_regression:
               lines.append(
                   "> :warning: One or more cells regressed beyond the "
-                  "RTF or P95 threshold. **Warn-only** while the baseline "
+                  "RTF, P50, or P95 threshold. **Warn-only** while the baseline "
                   "is being calibrated; this will become a hard gate once "
                   "we have ~2-3 weeks of variance data."
               )
           else:
               lines.append(
-                  "> All cells within RTF and P95 threshold "
+                  "> All cells within RTF, P50, and P95 threshold "
                   "(or baseline=null)."
               )
 
@@ -407,3 +426,38 @@ jobs:
                 owner, repo, issue_number, body: payload,
               });
             }
+
+      - name: Initialize baseline (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch' && inputs.initialize_baseline == true
+        run: |
+          uv run python - <<'EOF'
+          import json, pathlib, glob
+
+          artifacts_dir = pathlib.Path("bench-artifacts")
+          baseline_path = pathlib.Path("tests/fixtures/multi-runtime-rtf-baseline.json")
+          baseline = json.loads(baseline_path.read_text())
+
+          for result_file in sorted(artifacts_dir.glob("bench-*.json")):
+              data = json.loads(result_file.read_text())
+              rt = data.get("runtime")
+              tk = data.get("text_key")
+              if rt and tk and rt in baseline["runtimes"] and tk in baseline["runtimes"][rt]:
+                  cell = baseline["runtimes"][rt][tk]
+                  if data.get("rtf") is not None:
+                      cell["rtf"] = round(data["rtf"], 4)
+                  if data.get("latency_p50_ms") is not None:
+                      cell["latency_p50_ms"] = round(data["latency_p50_ms"], 1)
+                  if data.get("latency_p95_ms") is not None:
+                      cell["latency_p95_ms"] = round(data["latency_p95_ms"], 1)
+
+          baseline_path.write_text(json.dumps(baseline, indent=2, ensure_ascii=False) + "\n")
+          print("baseline updated")
+          EOF
+        shell: bash
+
+      - name: Commit initialized baseline
+        if: github.event_name == 'workflow_dispatch' && inputs.initialize_baseline == true
+        uses: stefanzweifel/git-auto-commit-action@v5.2.0
+        with:
+          commit_message: "chore(bench): initialize multi-runtime RTF baseline from first run"
+          file_pattern: tests/fixtures/multi-runtime-rtf-baseline.json


### PR DESCRIPTION
## Summary

- **Fix 1 (multi-runtime-rtf.yml):** `workflow_dispatch` に `initialize_baseline: boolean` input を追加。`true` で実行すると観測値で `tests/fixtures/multi-runtime-rtf-baseline.json` を自動更新して commit する。初回 baseline 校正を手動 PR なしで完結できる。
- **Fix 2 (multi-runtime-rtf.yml):** aggregate ジョブの Python スクリプトに P50 latency の threshold チェック (`latency_p50_pct`, デフォルト 10%) を追加。Markdown テーブルに `Baseline P50` / `P50 Δ` 列を追加し、閾値超過時は `:warning:` フラグを表示。
- **Fix 3 (memory-regression.yml):** `workflow_dispatch` に `initialize_baseline: boolean` input を追加。`true` で実行すると `memory-results/*.json` の観測値で `tests/fixtures/memory-baseline.json` を自動更新して commit する。

## 変更詳細

### multi-runtime-rtf.yml
- `workflow_dispatch.inputs.initialize_baseline` 追加 (boolean, default: false)
- `aggregate` ジョブの `permissions.contents` を `read` → `write` へ変更 (baseline commit に必要)
- Python スクリプトに `p50_pct = thresholds.get("latency_p50_pct", 0.10)` を追加
- `base_p50` 読み込み + P50 Δ 比較ロジック追加
- Markdown テーブルヘッダー / データ行に P50 列追加
- `Initialize baseline` + `Commit initialized baseline` ステップを追加 (`stefanzweifel/git-auto-commit-action@v5.2.0`)

### memory-regression.yml
- `workflow_dispatch.inputs.initialize_baseline` 追加 (boolean, default: false)
- `memory` ジョブの `permissions.contents` を `read` → `write` へ変更
- `Initialize baseline` + `Commit initialized baseline` ステップを追加 (`stefanzweifel/git-auto-commit-action@v5.2.0`)

## Test plan

- [ ] `workflow_dispatch` で `initialize_baseline: false` (デフォルト) を実行 → baseline commit ステップがスキップされること
- [ ] `workflow_dispatch` で `initialize_baseline: true` を実行 → baseline JSON が観測値で更新され、自動 commit されること
- [ ] PR トリガーで P50 が baseline + 10% 超過した場合に `:warning:` が表示されること
- [ ] `memory-regression.yml` で同様の動作確認