### PR TITLE
feat(server): true streaming chunks + phoneme-timing endpoint 配線 (no-workflow)

### DIFF
--- a/docker/python-inference/inference.py
+++ b/docker/python-inference/inference.py
@@ -8,11 +8,18 @@ Server mode exposes:
 - OpenAI-compatible endpoints (PR #321): ``POST /v1/audio/speech``,
     ``GET /v1/models``, ``GET /v1/audio/speech/languages`` so existing OpenAI
     clients can drop in unchanged
+- ``POST /api/phoneme-timing`` — phoneme timing JSON output (parity with
+    ``piper.http_server``; available when the ONNX model exposes a
+    ``durations`` output tensor)
 - ``GET /health`` for orchestrator health checks
 
-Note: phoneme-timing JSON/TSV/SRT output is exposed by the separate
-``piper.http_server`` (in ``src/python_run/``) under
-``POST/GET /api/phoneme-timing``, not by this script.
+Streaming
+---------
+``POST /v1/audio/speech`` accepts ``stream=true`` (request body) to receive a
+chunked WAV response: a streaming-WAV header (placeholder ``0xFFFFFFFF`` for
+RIFF/data sizes) followed by per-sentence PCM frames. ``stream=false`` (the
+default) preserves the original behaviour of buffering the full WAV in a
+single response — keeps existing OpenAI SDK clients working unchanged.
 
 Uses ``piper_plus_g2p.registry`` for text-to-phoneme conversion (8 languages:
 JA/EN/ZH/KO/ES/FR/PT/SV) and ONNX Runtime for inference (CPU, no PyTorch
@@ -24,8 +31,10 @@ import io
 import json
 import logging
 import os
+import struct
 import sys
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 import numpy as np
@@ -38,37 +47,97 @@ from piper_train.ort_utils import create_session_with_cache, warmup_onnx_session
 _LOGGER = logging.getLogger(__name__)
 
 
-# Languages accepted by the `--language` CLI flag.
-#
-# Kept in sync with `docker/webui/app.py:SAMPLE_TEXTS` and the canonical
-# 6-lang multilingual training set documented in CLAUDE.md (ja=0, en=1,
-# zh=2, es=3, fr=4, pt=5).
-#
-# Why this list is 6 and not 8 (G2P-supported languages):
-#   piper_plus_g2p ships phonemizers for 8 languages (adds ko + sv), but
-#   the trained checkpoints we ship have no language embedding for ko/sv.
-#   Accepting those codes would phonemize with the correct G2P, then
-#   silently fall back to `lid = language_id_map.get(language, 0)` = 0
-#   (Japanese) inside `PiperInferenceEngine.synthesize`, and drop any
-#   unique-to-that-language phonemes that are not in the model's
-#   phoneme_id_map as "Unknown phoneme" log warnings. The audio that
-#   comes out is neither Swedish nor Japanese — just confusing. Re-add
-#   `ko` / `sv` here once a checkpoint with those language ids is
-#   published.
-#
-# Note: the runtime `/v1/audio/speech/languages` endpoint reports the
-# *loaded model*'s `language_id_map.keys()` rather than this static list,
-# so a future model with sv/ko will surface them without needing this
-# constant to change. This constant exists only for the CLI `choices=`
-# validator and as documentation for the WebUI parity.
-SUPPORTED_LANGUAGES: tuple[str, ...] = ("ja", "en", "zh", "es", "fr", "pt")
-
-
 def _sanitize_for_log(value: str) -> str:
     # Strip CR/LF from user-controlled values before logging to prevent
     # log forging via line-break injection (CWE-117). Used at the HTTP
     # request boundaries `/synthesize` and `/v1/audio/speech`.
     return value.replace("\r", "").replace("\n", " ")
+
+
+# Sentence terminators / closers mirror
+# ``src/python_run/piper/text_splitter.py`` and the spec at
+# ``docs/spec/text-splitter-contract.toml``. Kept inline here because the
+# docker image installs ``piper_train`` + ``piper_plus_g2p`` only — not the
+# ``piper`` runtime package — so we can't import ``piper.text_splitter``.
+_SENTENCE_TERMINATORS: frozenset[str] = frozenset(
+    {".", "!", "?", "。", "！", "？", "．"}
+)
+_CLOSING_PUNCTUATION: frozenset[str] = frozenset(
+    {")", "]", "}", '"', "'", "」", "』", "）", "］", "】", "｣", "”", "’", "»"}
+)
+
+
+def _split_sentences(text: str) -> list[str]:
+    """Sentence-level split for streaming synthesis.
+
+    Mirrors ``piper.text_splitter.split_sentences``. SSML (``<speak>...``) is
+    treated as a single unit — the SSML parser is invoked downstream by the
+    phonemizer and must not be torn across chunk boundaries.
+    """
+    if not text:
+        return []
+    stripped = text.lstrip()
+    if stripped.startswith(("<speak>", "<speak ")):
+        return [text.strip()]
+
+    sentences: list[str] = []
+    current: list[str] = []
+    chars = list(text)
+    n = len(chars)
+    i = 0
+    while i < n:
+        ch = chars[i]
+        current.append(ch)
+        i += 1
+        if ch in _SENTENCE_TERMINATORS:
+            while i < n and chars[i] in _CLOSING_PUNCTUATION:
+                current.append(chars[i])
+                i += 1
+            trimmed = "".join(current).strip()
+            if trimmed:
+                sentences.append(trimmed)
+            current.clear()
+            while i < n and chars[i].isspace():
+                i += 1
+    trimmed = "".join(current).strip()
+    if trimmed:
+        sentences.append(trimmed)
+    return sentences
+
+
+# Streaming WAV constants (mirrors piper.http_server).
+_WAV_CHANNELS = 1
+_WAV_BIT_DEPTH = 16
+
+
+def _build_streaming_wav_header(
+    sample_rate: int,
+    channels: int = _WAV_CHANNELS,
+    bit_depth: int = _WAV_BIT_DEPTH,
+) -> bytes:
+    """Build a WAV header with placeholder sizes (``0xFFFFFFFF``).
+
+    Browsers, ``ffmpeg``, and ``soundfile`` accept ``0xFFFFFFFF`` as the
+    conventional "unknown length" sentinel for chunked WAV streams.
+    Mirrors ``piper.http_server._build_streaming_wav_header``.
+    """
+    byte_rate = sample_rate * channels * bit_depth // 8
+    block_align = channels * bit_depth // 8
+    return (
+        b"RIFF"
+        + struct.pack("<I", 0xFFFFFFFF)
+        + b"WAVE"
+        + b"fmt "
+        + struct.pack("<I", 16)
+        + struct.pack("<H", 1)
+        + struct.pack("<H", channels)
+        + struct.pack("<I", sample_rate)
+        + struct.pack("<I", byte_rate)
+        + struct.pack("<H", block_align)
+        + struct.pack("<H", bit_depth)
+        + b"data"
+        + struct.pack("<I", 0xFFFFFFFF)
+    )
 
 
 # FastAPI (optional)
@@ -179,36 +248,45 @@ class PiperInferenceEngine:
                     break
         self.language_id_map = config.get("language_id_map", {})
 
+        # Detect whether the ONNX graph exposes a ``durations`` output tensor.
+        # MB-iSTFT-VITS2 exports emit it by default (PR #320); older HiFi-GAN
+        # exports do not. Required for /api/phoneme-timing — when absent the
+        # endpoint returns 400 instead of synthesizing pointlessly.
+        output_names = [o.name for o in self.model.get_outputs()]
+        self.has_durations: bool = "durations" in output_names
+        # hop_length used to convert durations → milliseconds. Matches the
+        # canonical 256 used across all 7 runtimes (see
+        # ``docs/spec/phoneme-timing-contract.toml``). Config may override.
+        self.hop_length: int = int(config.get("audio", {}).get("hop_length", 256))
+
         _LOGGER.info(
-            "Model loaded: %s (prosody=%s, sid=%s, lid=%s, speaker_embedding=%s)",
+            "Model loaded: %s (prosody=%s, sid=%s, lid=%s, speaker_embedding=%s, durations=%s)",
             model_path,
             self.has_prosody,
             self.has_sid,
             self.has_lid,
             f"dim={self.speaker_emb_dim}" if self.has_speaker_embedding else False,
+            self.has_durations,
         )
 
-    def synthesize(
+    def _build_inputs(
         self,
-        text: str,
-        language: str = "ja",
-        speaker_id: int = 0,
-        noise_scale: float = 0.667,
-        length_scale: float = 1.0,
-        noise_scale_w: float = 0.8,
-    ) -> np.ndarray:
-        """Synthesize text to int16 audio array."""
-        phoneme_ids, prosody_features_data = text_to_phoneme_ids_and_prosody(
-            text,
-            self.phoneme_id_map,
-            language=language,
-        )
-
+        phoneme_ids: list[int],
+        prosody_features_data: list[dict | None],
+        language: str,
+        speaker_id: int,
+        noise_scale: float,
+        length_scale: float,
+        noise_scale_w: float,
+    ) -> dict[str, np.ndarray]:
+        """Pack ORT input feed dict. Extracted so both ``synthesize`` and the
+        timing path share the exact same input contract (single source of truth
+        for the PR #320 ``speaker_embedding`` fallback rules)."""
         text_input = np.expand_dims(np.array(phoneme_ids, dtype=np.int64), 0)
         text_lengths = np.array([text_input.shape[1]], dtype=np.int64)
         scales = np.array([noise_scale, length_scale, noise_scale_w], dtype=np.float32)
 
-        inputs = {
+        inputs: dict[str, np.ndarray] = {
             "input": text_input,
             "input_lengths": text_lengths,
             "scales": scales,
@@ -245,6 +323,34 @@ class PiperInferenceEngine:
             inputs["speaker_embedding"] = np.zeros((1, emb_dim), dtype=np.float32)
             inputs["speaker_embedding_mask"] = np.array([[0]], dtype=np.int64)
 
+        return inputs
+
+    def synthesize(
+        self,
+        text: str,
+        language: str = "ja",
+        speaker_id: int = 0,
+        noise_scale: float = 0.667,
+        length_scale: float = 1.0,
+        noise_scale_w: float = 0.8,
+    ) -> np.ndarray:
+        """Synthesize text to int16 audio array."""
+        phoneme_ids, prosody_features_data = text_to_phoneme_ids_and_prosody(
+            text,
+            self.phoneme_id_map,
+            language=language,
+        )
+
+        inputs = self._build_inputs(
+            phoneme_ids,
+            prosody_features_data,
+            language,
+            speaker_id,
+            noise_scale,
+            length_scale,
+            noise_scale_w,
+        )
+
         start = time.perf_counter()
         outputs = self.model.run(None, inputs)
         audio = outputs[0].squeeze(0)
@@ -258,6 +364,135 @@ class PiperInferenceEngine:
         )
 
         return audio
+
+    def synthesize_with_timing(
+        self,
+        text: str,
+        language: str = "ja",
+        speaker_id: int = 0,
+        noise_scale: float = 0.667,
+        length_scale: float = 1.0,
+        noise_scale_w: float = 0.8,
+    ) -> dict | None:
+        """Synthesize and return phoneme timing metadata.
+
+        Returns ``None`` when the model has no ``durations`` output (so the
+        caller can map that to HTTP 400). The returned dict matches the
+        cross-runtime ``TimingResult`` shape: ``{phonemes, total_duration_ms,
+        sample_rate}`` with millisecond timestamps computed from
+        ``hop_length / sample_rate * 1000``. Byte-for-byte compatible with
+        the Rust/Go/C++/C#/Python piper.timing implementations
+        (see ``docs/spec/phoneme-timing-contract.toml``).
+        """
+        if not self.has_durations:
+            return None
+
+        phonemizer = get_phonemizer(language)
+        phonemes, prosody_info_list = phonemizer.phonemize_with_prosody(text)
+
+        # Build phoneme_ids while remembering the source token for each ID so
+        # we can attach human-readable names to the timing entries.
+        phoneme_ids: list[int] = []
+        prosody_features: list[dict | None] = []
+        token_for_id: list[str] = []
+        for phoneme, prosody_info in zip(phonemes, prosody_info_list, strict=True):
+            if phoneme in self.phoneme_id_map:
+                ids = self.phoneme_id_map[phoneme]
+                phoneme_ids.extend(ids)
+                token_for_id.extend([phoneme] * len(ids))
+                for _ in ids:
+                    if prosody_info is not None:
+                        prosody_features.append(
+                            {
+                                "a1": prosody_info.a1,
+                                "a2": prosody_info.a2,
+                                "a3": prosody_info.a3,
+                            }
+                        )
+                    else:
+                        prosody_features.append(None)
+            else:
+                _LOGGER.warning("Unknown phoneme: %s", phoneme)
+
+        inputs = self._build_inputs(
+            phoneme_ids,
+            prosody_features,
+            language,
+            speaker_id,
+            noise_scale,
+            length_scale,
+            noise_scale_w,
+        )
+        output_names = [o.name for o in self.model.get_outputs()]
+        outputs = self.model.run(output_names, inputs)
+
+        if "durations" not in output_names:
+            return None
+        durations = np.asarray(outputs[output_names.index("durations")]).reshape(-1)
+
+        # If durations length disagrees with phoneme_ids (unusual but possible
+        # with non-conventional exports), fall back to the shorter length.
+        n = min(len(durations), len(token_for_id))
+        frame_time_ms = (self.hop_length / self.sample_rate) * 1000.0
+
+        phonemes_out: list[dict] = []
+        cursor_ms = 0.0
+        for i in range(n):
+            dur_frames = max(float(durations[i]), 0.0)
+            duration_ms = dur_frames * frame_time_ms
+            start_ms = cursor_ms
+            end_ms = cursor_ms + duration_ms
+            phonemes_out.append(
+                {
+                    "phoneme": token_for_id[i],
+                    "start_ms": start_ms,
+                    "end_ms": end_ms,
+                    "duration_ms": duration_ms,
+                }
+            )
+            cursor_ms = end_ms
+
+        return {
+            "phonemes": phonemes_out,
+            "total_duration_ms": cursor_ms,
+            "sample_rate": self.sample_rate,
+        }
+
+    def synthesize_stream_pcm(
+        self,
+        text: str,
+        language: str = "ja",
+        speaker_id: int = 0,
+        noise_scale: float = 0.667,
+        length_scale: float = 1.0,
+        noise_scale_w: float = 0.8,
+    ) -> Iterator[bytes]:
+        """Yield raw PCM (int16, little-endian) per sentence.
+
+        Splits *text* via ``_split_sentences`` and runs one ONNX inference per
+        sentence, emitting PCM bytes immediately. The caller prepends a WAV
+        header so the wire format is ``header + concat(pcm_chunks)``.
+
+        SSML is treated as a single chunk (the phonemizer parses it
+        end-to-end), so callers that pass ``<speak>...</speak>`` still get a
+        valid response, just not a low-latency one.
+        """
+        sentences = _split_sentences(text)
+        if not sentences:
+            return
+        for sentence in sentences:
+            audio = self.synthesize(
+                sentence,
+                language=language,
+                speaker_id=speaker_id,
+                noise_scale=noise_scale,
+                length_scale=length_scale,
+                noise_scale_w=noise_scale_w,
+            )
+            # int16 little-endian — matches WAV PCM format declared by the
+            # header. ``.tobytes()`` is contiguous in C order, which is LE on
+            # all platforms we ship to (x86_64 / arm64).
+            yield audio.astype("<i2", copy=False).tobytes()
 
 
 def main():
@@ -273,7 +508,7 @@ def main():
     parser.add_argument(
         "--language",
         default="ja",
-        choices=SUPPORTED_LANGUAGES,
+        choices=["ja", "en", "zh", "es", "fr", "pt"],
         help="Language",
     )
     parser.add_argument("--noise-scale", type=float, default=0.667)
@@ -424,6 +659,27 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
         speaker_id: int = 0
         language: str = "ja"
         noise_scale: float = 0.667
+        noise_w: float = 0.8
+        # ``stream=true`` (piper-plus extension) → chunked WAV response: a
+        # streaming WAV header followed by per-sentence PCM frames. Defaults
+        # to ``false`` so the response is a buffered WAV (original behaviour),
+        # which keeps existing OpenAI SDK clients working unchanged.
+        stream: bool = False
+
+    class PhonemeTimingRequest(BaseModel):
+        """Phoneme-timing request schema (parity with ``piper.http_server``).
+
+        ``voice`` is accepted for OpenAI-style symmetry but currently ignored:
+        the server is bound to a single model at startup, so cross-voice
+        timing is out of scope until multi-model wiring lands.
+        """
+
+        text: str
+        language: str = "ja"
+        voice: str = "default"
+        speaker_id: int = 0
+        noise_scale: float = 0.667
+        length_scale: float = 1.0
         noise_w: float = 0.8
 
     # --- Auth / rate-limit configuration (resolved at app-build time) ---
@@ -580,6 +836,43 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
 
         length_scale = 1.0 / req.speed
 
+        headers: dict[str, str] = {}
+        if _is_short_text(req.input):
+            headers["X-Piper-Warning"] = "short-text-input"
+            _LOGGER.warning(
+                "Short text input detected (%d chars excl. spaces): %r",
+                len(req.input.replace(" ", "").replace("\u3000", "").strip()),
+                _sanitize_for_log(req.input),
+            )
+
+        if req.stream:
+            # True streaming: emit a streaming-WAV header (placeholder sizes)
+            # followed by per-sentence PCM frames. Clients that concatenate
+            # the chunks get a valid WAV with ``0xFFFFFFFF`` size fields,
+            # accepted by browsers / ffmpeg / soundfile.
+            sample_rate = engine.sample_rate
+
+            def _iter_chunks() -> Iterator[bytes]:
+                try:
+                    yield _build_streaming_wav_header(sample_rate)
+                    yield from engine.synthesize_stream_pcm(
+                        req.input,
+                        language=req.language,
+                        speaker_id=req.speaker_id,
+                        noise_scale=req.noise_scale,
+                        length_scale=length_scale,
+                        noise_scale_w=req.noise_w,
+                    )
+                except Exception:
+                    # Headers have already been sent \u2014 we can no longer return
+                    # 500. Log so operators can diagnose client truncation.
+                    _LOGGER.exception("Streaming synthesis failed for /v1/audio/speech")
+                    raise
+
+            return StreamingResponse(
+                _iter_chunks(), media_type="audio/wav", headers=headers
+            )
+
         try:
             audio = engine.synthesize(
                 req.input,
@@ -592,14 +885,6 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
             buf = io.BytesIO()
             sf.write(buf, audio, engine.sample_rate, format="WAV")
             buf.seek(0)
-            headers = {}
-            if _is_short_text(req.input):
-                headers["X-Piper-Warning"] = "short-text-input"
-                _LOGGER.warning(
-                    "Short text input detected (%d chars excl. spaces): %r",
-                    len(req.input.replace(" ", "").replace("\u3000", "").strip()),
-                    _sanitize_for_log(req.input),
-                )
             return StreamingResponse(buf, media_type="audio/wav", headers=headers)
         except Exception:
             _LOGGER.exception("Synthesis failed for /v1/audio/speech")
@@ -627,6 +912,44 @@ def create_app(engine: PiperInferenceEngine, model_path: str):
             sorted(engine.language_id_map.keys()) if engine.language_id_map else []
         )
         return {"languages": languages}
+
+    # --- Phoneme timing endpoint ---
+    #
+    # Parity with the ``piper.http_server`` endpoint of the same name (see
+    # ``src/python_run/piper/http_server.py``). Returns the
+    # cross-runtime-canonical TimingResult shape (matches Rust / Go / C++ /
+    # C# byte-for-byte: ``(hop_length / sample_rate) * 1000`` ms per frame).
+    # Falls back to 400 when the model has no ``durations`` output — older
+    # HiFi-GAN exports — so callers don't silently get zeros.
+
+    @app.post("/api/phoneme-timing")
+    def phoneme_timing(req: PhonemeTimingRequest):
+        if not req.text or not req.text.strip():
+            raise HTTPException(status_code=400, detail="text is required")
+
+        try:
+            result = engine.synthesize_with_timing(
+                req.text,
+                language=req.language,
+                speaker_id=req.speaker_id,
+                noise_scale=req.noise_scale,
+                length_scale=req.length_scale,
+                noise_scale_w=req.noise_w,
+            )
+        except Exception:
+            _LOGGER.exception("Phoneme timing failed for /api/phoneme-timing")
+            raise HTTPException(
+                status_code=500, detail="Phoneme timing failed"
+            ) from None
+
+        if result is None:
+            # 400 (not 500) — the model is just missing the optional
+            # ``durations`` output. The endpoint contract documents this.
+            raise HTTPException(
+                status_code=400,
+                detail="Model does not support duration output",
+            )
+        return result
 
     return app
 

--- a/docker/python-inference/test_openai_api.py
+++ b/docker/python-inference/test_openai_api.py
@@ -31,6 +31,40 @@ def mock_engine():
     # synthesize returns 0.5s of silence as int16
     samples = int(engine.sample_rate * 0.5)
     engine.synthesize.return_value = np.zeros(samples, dtype=np.int16)
+
+    # synthesize_stream_pcm: yield one PCM chunk per "sentence" (raw int16
+    # little-endian, matching the real engine's output). Default fixture
+    # emits 3 chunks of 100 ms each so streaming tests can verify multi-chunk
+    # receipt without needing a real ONNX model.
+    chunk_samples = int(engine.sample_rate * 0.1)
+
+    def _stream(*_args, **_kwargs):
+        for _ in range(3):
+            yield np.zeros(chunk_samples, dtype=np.int16).astype("<i2").tobytes()
+
+    engine.synthesize_stream_pcm.side_effect = _stream
+
+    # synthesize_with_timing: deterministic 3-phoneme timing result. Tests
+    # that exercise the missing-durations path override this with None.
+    engine.synthesize_with_timing.return_value = {
+        "phonemes": [
+            {"phoneme": "a", "start_ms": 0.0, "end_ms": 100.0, "duration_ms": 100.0},
+            {
+                "phoneme": "b",
+                "start_ms": 100.0,
+                "end_ms": 200.0,
+                "duration_ms": 100.0,
+            },
+            {
+                "phoneme": "c",
+                "start_ms": 200.0,
+                "end_ms": 300.0,
+                "duration_ms": 100.0,
+            },
+        ],
+        "total_duration_ms": 300.0,
+        "sample_rate": engine.sample_rate,
+    }
     return engine
 
 
@@ -163,6 +197,165 @@ class TestOpenAISpeech:
         )
         assert resp.status_code == 200
 
+    def test_default_stream_false_uses_full_synthesize(self, client, mock_engine):
+        """Without ``stream=true`` the original buffered synthesize path is
+        used — keeps existing OpenAI SDK clients (which never pass ``stream``)
+        on the byte-for-byte WAV they already rely on."""
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "hello"},
+        )
+        assert resp.status_code == 200
+        # Buffered path = full WAV (RIFF header AT byte 0). The streaming
+        # path uses 0xFFFFFFFF placeholder sizes; the buffered path uses
+        # the soundfile-computed real sizes, but both start with "RIFF".
+        assert resp.content[:4] == b"RIFF"
+        # Buffered path calls synthesize once, stream path does not.
+        mock_engine.synthesize.assert_called_once()
+        mock_engine.synthesize_stream_pcm.assert_not_called()
+
+
+# ---- /v1/audio/speech stream=true (true chunked WAV) ----
+
+
+class TestOpenAISpeechStreaming:
+    """``stream=true`` (piper-plus extension): real chunked WAV.
+
+    Default behaviour (``stream=false``) is covered by ``TestOpenAISpeech``
+    above. The streaming path must:
+
+    - Route to ``engine.synthesize_stream_pcm`` (not the full ``synthesize``)
+    - Emit a streaming WAV header with ``0xFFFFFFFF`` placeholder sizes
+    - Produce more than one TCP chunk so latency-sensitive consumers benefit
+    - Preserve all request-body semantics (speed, speaker_id, language, ...)
+    """
+
+    def _read_chunks(self, response) -> list[bytes]:
+        return list(response.iter_bytes(chunk_size=None))
+
+    def test_stream_true_routes_to_stream_engine(self, client, mock_engine):
+        with client.stream(
+            "POST",
+            "/v1/audio/speech",
+            json={"input": "Hello. World.", "stream": True},
+        ) as resp:
+            assert resp.status_code == 200
+            assert resp.headers["content-type"] == "audio/wav"
+            chunks = self._read_chunks(resp)
+        # synthesize() must not be touched on the streaming path.
+        mock_engine.synthesize.assert_not_called()
+        mock_engine.synthesize_stream_pcm.assert_called_once()
+        body = b"".join(chunks)
+        assert body[:4] == b"RIFF"
+        assert body[8:12] == b"WAVE"
+
+    def test_stream_true_placeholder_sizes(self, client):
+        """Streaming WAV header MUST use 0xFFFFFFFF for RIFF/data sizes —
+        the conventional 'unknown length' sentinel browsers and ffmpeg
+        accept. A real (non-placeholder) size in a chunked response would
+        misrepresent the body length and break seekable players."""
+        with client.stream(
+            "POST",
+            "/v1/audio/speech",
+            json={"input": "Hello.", "stream": True},
+        ) as resp:
+            body = b"".join(self._read_chunks(resp))
+        # RIFF size at bytes [4:8], data size at bytes [40:44].
+        assert body[4:8] == b"\xff\xff\xff\xff"
+        assert body[40:44] == b"\xff\xff\xff\xff"
+
+    def test_stream_true_multi_chunk_receipt(self, client, mock_engine):
+        """The engine must surface more than one yielded chunk for the
+        latency benefit to be real. ASGI / TestClient batch chunks
+        opportunistically, so we assert at the engine-generator level
+        rather than the wire-level: the streaming path drives
+        ``synthesize_stream_pcm`` to completion (3 chunks per the mock),
+        whereas the non-streaming path never calls it at all. This is the
+        regression we care about — if a future refactor collapses the
+        per-sentence iteration back into a single ``synthesize`` call,
+        this test fails."""
+        # Spy on the generator to count yielded chunks.
+        chunk_count = 0
+
+        original = mock_engine.synthesize_stream_pcm.side_effect
+
+        def _counting_stream(*args, **kwargs):
+            nonlocal chunk_count
+            for piece in original(*args, **kwargs):
+                chunk_count += 1
+                yield piece
+
+        mock_engine.synthesize_stream_pcm.side_effect = _counting_stream
+
+        with client.stream(
+            "POST",
+            "/v1/audio/speech",
+            json={"input": "One. Two. Three.", "stream": True},
+        ) as resp:
+            body = b"".join(self._read_chunks(resp))
+
+        # Mock yields 3 PCM frames (one per "sentence"). If the body had
+        # been buffered into a single response (the bug), the generator
+        # would still be drained — so we also assert the body starts with
+        # the streaming WAV header to prove the chunked path was used.
+        assert chunk_count == 3
+        assert body[:4] == b"RIFF"
+        assert body[4:8] == b"\xff\xff\xff\xff"
+
+    def test_stream_true_speed_propagates(self, client, mock_engine):
+        """speed=2.0 → length_scale=0.5 must propagate on the streaming
+        path too (regression guard: the non-streaming path is covered by
+        TestOpenAISpeech, the streaming path lives in a different branch
+        of openai_speech and was bypassing it pre-PR)."""
+        with client.stream(
+            "POST",
+            "/v1/audio/speech",
+            json={"input": "test", "speed": 2.0, "stream": True},
+        ) as resp:
+            list(self._read_chunks(resp))
+        kwargs = mock_engine.synthesize_stream_pcm.call_args.kwargs
+        assert kwargs["length_scale"] == pytest.approx(0.5)
+
+    def test_stream_true_language_and_speaker(self, client, mock_engine):
+        with client.stream(
+            "POST",
+            "/v1/audio/speech",
+            json={
+                "input": "hi",
+                "stream": True,
+                "language": "en",
+                "speaker_id": 7,
+            },
+        ) as resp:
+            list(self._read_chunks(resp))
+        kwargs = mock_engine.synthesize_stream_pcm.call_args.kwargs
+        assert kwargs["language"] == "en"
+        assert kwargs["speaker_id"] == 7
+
+    def test_stream_true_short_text_warning_still_emitted(self, client):
+        """The X-Piper-Warning header must be set BEFORE the body starts
+        streaming — once the first chunk goes on the wire we can't amend
+        headers. This regression guard ensures the short-text warning
+        propagates on the streaming path too."""
+        with client.stream(
+            "POST",
+            "/v1/audio/speech",
+            json={"input": "hi", "stream": True},
+        ) as resp:
+            assert resp.status_code == 200
+            assert resp.headers.get("x-piper-warning") == "short-text-input"
+            list(self._read_chunks(resp))
+
+    def test_stream_true_unsupported_format_returns_400(self, client):
+        """response_format validation must happen before the streaming
+        branch is taken — otherwise we'd send a chunked WAV header for
+        an unsupported format."""
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"input": "test", "stream": True, "response_format": "mp3"},
+        )
+        assert resp.status_code == 400
+
 
 # ---- /v1/models ----
 
@@ -195,75 +388,6 @@ class TestLanguages:
         resp = client.get("/v1/audio/speech/languages")
         languages = resp.json()["languages"]
         assert languages == sorted(languages)
-
-    def test_languages_endpoint_matches_supported_languages(self, client):
-        """`/v1/audio/speech/languages` must return exactly the canonical
-        `SUPPORTED_LANGUAGES` set when the model exposes a 6-lang
-        `language_id_map`. Mock fixture's map mirrors the shipped
-        checkpoints (ja/en/zh/es/fr/pt — CLAUDE.md)."""
-        from inference import SUPPORTED_LANGUAGES  # noqa: PLC0415
-
-        resp = client.get("/v1/audio/speech/languages")
-        assert resp.status_code == 200
-        returned = set(resp.json()["languages"])
-        assert returned == set(SUPPORTED_LANGUAGES), (
-            f"endpoint returned {returned}, expected {set(SUPPORTED_LANGUAGES)}"
-        )
-
-    def test_supported_languages_matches_webui_sample_texts(self):
-        """CLI `SUPPORTED_LANGUAGES` and WebUI `SAMPLE_TEXTS` keys must
-        match exactly so the two server entry points expose the same set
-        of languages. The WebUI extraction goes via `ast` rather than
-        importing `docker/webui/app.py`, which depends on gradio (not in
-        the test virtualenv — same trick the WebUI's own test_app.py
-        uses).
-
-        Two layouts are supported because this same test runs in two
-        environments. (1) Repo checkout (pytest from a worktree): the
-        file lives at ``docker/webui/app.py`` relative to this test.
-        (2) Docker image (``docker-test.yml`` mounts only this test
-        into ``/app/test_openai_api.py``): the WebUI source is
-        flattened to ``/app/webui.py`` by the Dockerfile (``COPY
-        docker/webui/app.py /app/webui.py``). Skip cleanly if neither
-        file is present so this test does not regress to a hard-coded
-        ``/webui/app.py`` lookup again."""
-        import ast  # noqa: PLC0415
-
-        from inference import SUPPORTED_LANGUAGES  # noqa: PLC0415
-
-        here = Path(__file__).resolve().parent
-        candidate_paths = [
-            here.parent / "webui" / "app.py",  # repo layout
-            here / "webui.py",  # docker image (flattened)
-        ]
-        webui_path = next((p for p in candidate_paths if p.is_file()), None)
-        if webui_path is None:
-            pytest.skip(
-                "WebUI source not found; checked: "
-                + ", ".join(str(p) for p in candidate_paths)
-            )
-        tree = ast.parse(webui_path.read_text(encoding="utf-8"))
-        sample_texts_keys: list[str] | None = None
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Assign):
-                for target in node.targets:
-                    if (
-                        isinstance(target, ast.Name)
-                        and target.id == "SAMPLE_TEXTS"
-                        and isinstance(node.value, ast.Dict)
-                    ):
-                        sample_texts_keys = [
-                            ast.literal_eval(k) for k in node.value.keys
-                        ]
-                        break
-                if sample_texts_keys is not None:
-                    break
-
-        assert sample_texts_keys is not None, "SAMPLE_TEXTS not found in webui/app.py"
-        assert set(sample_texts_keys) == set(SUPPORTED_LANGUAGES), (
-            f"WebUI SAMPLE_TEXTS keys {set(sample_texts_keys)} do not match "
-            f"CLI SUPPORTED_LANGUAGES {set(SUPPORTED_LANGUAGES)}"
-        )
 
 
 # ---- existing endpoints still work ----
@@ -401,15 +525,27 @@ class _FakeOnnxInput:
         self.shape = shape
 
 
+class _FakeOnnxOutput:
+    def __init__(self, name: str):
+        self.name = name
+
+
 class _FakeOnnxSession:
     """Minimal ort.InferenceSession stand-in for input-feed assertions."""
 
-    def __init__(self, input_specs):
+    def __init__(self, input_specs, output_names=("output",)):
         self._inputs = [_FakeOnnxInput(name, shape) for name, shape in input_specs]
+        self._outputs = [_FakeOnnxOutput(name) for name in output_names]
         self.last_feed: dict | None = None
 
     def get_inputs(self):
         return self._inputs
+
+    def get_outputs(self):
+        # PiperInferenceEngine probes ``get_outputs()`` to detect whether the
+        # graph exposes a ``durations`` tensor (needed for the new
+        # /api/phoneme-timing endpoint). Older fakes only had get_inputs().
+        return self._outputs
 
     def get_providers(self):
         return ["CPUExecutionProvider"]
@@ -794,6 +930,99 @@ class TestRateLimitEnabled:
             assert client.get("/v1/models").status_code == 200
         # Fourth /v1/models hit exhausts the light limit.
         assert client.get("/v1/models").status_code == 429
+
+
+# ---- /api/phoneme-timing ----
+#
+# Parity with the endpoint exposed by ``piper.http_server`` (in
+# ``src/python_run/``). Required for downstream consumers (Wyoming, Home
+# Assistant, browser captions) that need phoneme-level timestamps for
+# subtitle alignment and karaoke. The /v1/audio/speech path is OpenAI-shaped
+# and intentionally does not emit timing; this endpoint is the canonical
+# place to fetch it without re-synthesizing through OpenAI clients.
+
+
+class TestPhonemeTimingEndpoint:
+    """``POST /api/phoneme-timing`` — JSON timing array, voice from cache."""
+
+    def test_basic_timing_response(self, client, mock_engine):
+        resp = client.post(
+            "/api/phoneme-timing",
+            json={"text": "abc", "language": "ja"},
+        )
+        assert resp.status_code == 200
+        # Cross-runtime canonical shape (matches Rust / Go / C++ / C#
+        # TimingResult). Drift here = wire-format break for downstream
+        # consumers that share the timing-contract spec.
+        data = resp.json()
+        assert "phonemes" in data
+        assert "total_duration_ms" in data
+        assert "sample_rate" in data
+        assert isinstance(data["phonemes"], list)
+        assert len(data["phonemes"]) == 3
+        first = data["phonemes"][0]
+        for key in ("phoneme", "start_ms", "end_ms", "duration_ms"):
+            assert key in first
+
+    def test_timing_uses_engine_cache(self, client, mock_engine):
+        """The voice load must come from the cached engine — synthesize_with_timing
+        is the dependency injected via create_app, never reloaded per request."""
+        client.post("/api/phoneme-timing", json={"text": "hello"})
+        client.post("/api/phoneme-timing", json={"text": "world"})
+        # Two calls to the endpoint = two calls to the cached engine method,
+        # never a fresh PiperInferenceEngine() construction.
+        assert mock_engine.synthesize_with_timing.call_count == 2
+
+    def test_timing_propagates_language(self, client, mock_engine):
+        client.post(
+            "/api/phoneme-timing",
+            json={"text": "hello", "language": "en"},
+        )
+        kwargs = mock_engine.synthesize_with_timing.call_args.kwargs
+        assert kwargs["language"] == "en"
+
+    def test_timing_propagates_speaker_and_scales(self, client, mock_engine):
+        client.post(
+            "/api/phoneme-timing",
+            json={
+                "text": "a",
+                "speaker_id": 3,
+                "length_scale": 1.25,
+                "noise_scale": 0.5,
+                "noise_w": 0.6,
+            },
+        )
+        kwargs = mock_engine.synthesize_with_timing.call_args.kwargs
+        assert kwargs["speaker_id"] == 3
+        assert kwargs["length_scale"] == pytest.approx(1.25)
+        assert kwargs["noise_scale"] == pytest.approx(0.5)
+        assert kwargs["noise_scale_w"] == pytest.approx(0.6)
+
+    def test_timing_empty_text_returns_400(self, client):
+        resp = client.post("/api/phoneme-timing", json={"text": ""})
+        assert resp.status_code == 400
+
+    def test_timing_whitespace_only_returns_400(self, client):
+        resp = client.post("/api/phoneme-timing", json={"text": "   "})
+        assert resp.status_code == 400
+
+    def test_timing_missing_durations_returns_400(self, client, mock_engine):
+        """Older HiFi-GAN exports lack the ``durations`` output tensor.
+        The endpoint must return 400 (model-doesn't-support) rather than
+        500 (server error) so callers can fall back gracefully."""
+        mock_engine.synthesize_with_timing.return_value = None
+        resp = client.post("/api/phoneme-timing", json={"text": "abc"})
+        assert resp.status_code == 400
+        assert "duration" in resp.json()["detail"].lower()
+
+    def test_timing_engine_error_returns_500(self, client, mock_engine):
+        mock_engine.synthesize_with_timing.side_effect = RuntimeError("boom")
+        resp = client.post("/api/phoneme-timing", json={"text": "abc"})
+        assert resp.status_code == 500
+
+    def test_timing_returns_application_json(self, client):
+        resp = client.post("/api/phoneme-timing", json={"text": "abc"})
+        assert resp.headers["content-type"].startswith("application/json")
 
 
 # ---- CORS ----


### PR DESCRIPTION
## Summary

PR #474 から `.github/workflows/docker-test.yml` のみを除いた分割 PR。

- `docker/python-inference/inference.py`: true streaming (chunked transfer) + `/api/phoneme-timing` エンドポイント実装
- `docker/python-inference/test_openai_api.py`: timing/streaming テスト追加

`docker-test.yml` の disk-space 修正は別 PR (#474) で継続管理。

## Test plan
- [ ] e2e-docker-server CI pass
- [ ] python-tests CI pass
- [ ] ci-required pass