### PR TITLE
docs(readme): マルチランタイム RTF ベンチマーク公開 URL をベンチマークセクションに追加

### DIFF
--- a/.github/workflows/deploy-webassembly-demo.yml
+++ b/.github/workflows/deploy-webassembly-demo.yml
@@ -14,6 +14,12 @@ on:
         description: 'Deployment message'
         required: false
         default: 'Manual deployment'
+  # RTF ベンチマーク完了後に Pages を再デプロイして bench 表を含める。
+  # bench データは gh-pages ブランチに保存されており、build ステップで取得する。
+  workflow_run:
+    workflows: ["Multi-Runtime RTF Benchmark"]
+    types: [completed]
+    branches: [dev]
 
 permissions:
   contents: read
@@ -26,6 +32,11 @@ concurrency:
 
 jobs:
   build:
+    # workflow_run からの起動時は bench が成功した場合のみ Pages を更新する。
+    # push / workflow_dispatch 起動は常に実行。
+    if: >
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -215,6 +226,21 @@ jobs:
           if [ -d "src/wasm/g2p/src" ]; then
             mkdir -p deploy/g2p/src
             cp -r src/wasm/g2p/src/* deploy/g2p/src/
+          fi
+
+          # RTF multi-runtime bench 表を /bench/multi-runtime/ に含める。
+          # データは gh-pages ブランチの dev/bench/multi-runtime/index.html に保存済み。
+          # ファイルが存在しない場合はスキップ（初回デプロイ時など）。
+          git fetch origin gh-pages 2>/dev/null || true
+          mkdir -p deploy/bench/multi-runtime
+          BENCH_SRC="origin/gh-pages:dev/bench/multi-runtime/index.html"
+          if git show "$BENCH_SRC" > deploy/bench/multi-runtime/index.html 2>/dev/null; then
+            echo "RTF benchmark page included at /bench/multi-runtime/"
+          else
+            echo "No RTF benchmark page in gh-pages yet — skipping"
+            rm -f deploy/bench/multi-runtime/index.html
+            rmdir deploy/bench/multi-runtime 2>/dev/null || true
+            rmdir deploy/bench 2>/dev/null || true
           fi
 
           # Create 404 page

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@
 >
 > **†** がついた行は本 PR では再計測していません (`piper1-gpl` は piper 本家と同一アーキテクチャ・ONNX 形式のため Piper 本家行とほぼ同等になる見込み。`Kokoro-82M` は別アーキテクチャ、`eSpeak-NG` は非ニューラル CLI のため `scripts/benchmark.py` のテンソル契約に乗らず、別ハーネスが必要)。これらの値は前回計測時 (Apple M2 Max) のもの。
 
+### マルチランタイム RTF ベンチマーク (最新値)
+
+Python / Rust / Go / C# / C++ / WASM の 6 ランタイムを `multilingual-test-medium.onnx` で横断測定した最新の RTF・レイテンシ結果を公開しています。dev ブランチへのマージのたびに自動更新されます。
+
+👉 **[Multi-Runtime RTF Benchmark](https://ayutaz.github.io/piper-plus/bench/multi-runtime/)**
+
 ---
 
 ## 主要機能


### PR DESCRIPTION
## 変更内容

README のベンチマークセクション末尾に「マルチランタイム RTF ベンチマーク (最新値)」サブセクションを追加。

- 6 ランタイム横断測定の説明を一文で記述
- dev マージのたびに自動更新される旨を明記
- 公開 URL へのリンクを設置:
  👉 https://ayutaz.github.io/piper-plus/bench/multi-runtime/