### PR TITLE
chore(codeql): cpp/loop-variable-changed をルール全体で suppress

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -123,3 +123,15 @@ query-filters:
   # taint flow は設計上の意図と一致しない。
   - exclude:
       id: py/command-line-injection
+  # cpp/loop-variable-changed: note-level の style query で、 C/C++ argv parser
+  # の `argv[++i]` イディオムや phonemizer の grapheme state machine など
+  # 意図的なイテレータ前進で大量に false-positive を出す。 PR #434 で 87 件
+  # (src/cpp/main.cpp の parseArgs + src/cpp/phonemize-*.cpp の grapheme loop)
+  # を "won't fix / argument parser idiom / intentional iterator state
+  # manipulation" として bulk dismiss 済み。 PR #476 (voice cloning CLI flags)
+  # / PR #477 (SSML parser) で同じ parseArgs パターンに 4 件再発したため、
+  # 個別 dismiss を続ける代わりにルール全体を suppress する。 security severity
+  # は付かない note-level なので security risk なし。 真の loop-counter bug を
+  # 失う代償は code review (CODEOWNERS + ultrareview) で補う。
+  - exclude:
+      id: cpp/loop-variable-changed


### PR DESCRIPTION
## Summary

GitHub Code Scanning の open alert 4 件 (#1817, #1818, #1819, #1820) を CodeQL config の `query-filters` で持続的に解消する。

- 全 4 件は `src/cpp/main.cpp` の `parseArgs` 内 `argv[++i]` イディオム
  - line 1114 (`--phoneme_silence`)
  - line 1117 (`--reference-audio`, PR #476 で追加)
  - line 1120 (`--speaker-embedding`, PR #476 で追加)
  - line 1123 (`--speaker-encoder-model`, PR #476 で追加)
- ルール `cpp/loop-variable-changed` は **note-level / no security severity** の style query
- PR #434 で同ルールの 87 件 (parseArgs + phonemizer の grapheme state machine) を `won't fix / argument parser idiom / intentional iterator state manipulation` として bulk dismiss 済み
- PR #476 (voice cloning CLI flags) / #477 (SSML) で同じ parseArgs パターンが再発 → 個別 dismiss を続ける代わりにルール全体を query-filter で exclude

## Why this is safe

- security severity 無し (style query)
- 同パターンは parseArgs idiom / grapheme state machine の **意図的** な変更で false-positive
- 真の loop-counter bug を取りこぼすリスクは CODEOWNERS + ultrareview の人手レビューで補う
- 既存の exclude (py/path-injection / py/command-line-injection / cpp/potentially-dangerous-function 等) と同じ運用方針

## Effect on existing alerts

CodeQL config 変更が dev に取り込まれて次回 scan が走ると、4 件の open alert は自動的に "fixed/closed" になる (検出対象から外れるため)。 個別 dismiss は不要。

## Test plan

- [x] YAML syntax 検証 (`yaml.safe_load` 通過)
- [x] `query-filters` リストに `cpp/loop-variable-changed` が含まれることを確認
- [x] pre-commit hooks 通過 (yaml lint / codespell / detect-secrets)
- [ ] PR merge 後、次回 CodeQL scan で 4 alert が closed になることを確認