### PR TITLE
feat(workflow): ワークフロー自動化 13 件 — skill 4 + pre-commit hook 6 + pre-push gate

### DIFF
--- a/.claude/skills/check-review-backlog/SKILL.md
+++ b/.claude/skills/check-review-backlog/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: check-review-backlog
-description: 全 open PR の未解決 review thread (isResolved=false) を gh api graphql で集計し、7 日以上未対応のものを backlog として表示する read-only skill。`/loop /check-review-backlog` で週次監視に利用可能。
-argument-hint: "[--days N] [--author <login>]"
-disable-model-invocation: true
+description: PR 作成直後の review チェック / 全 open PR の未解決 review thread (isResolved=false) を gh api graphql で集計し、 N 日以上未対応のものを backlog として表示する。 `--pr <N>` で単一 PR の review 即時確認 (PR 作成 chain で発動)、 引数なしで全 PR backlog 監視。 `/loop /check-review-backlog` で週次監視に利用可能。 read-only (POST / mutation なし)。
+argument-hint: "[--pr <N>] [--days N] [--author <login>]"
+disable-model-invocation: false
 allowed-tools: Bash(gh api *) Bash(gh pr list *) Bash(date *) Read Grep
 ---
 
@@ -12,7 +12,8 @@ allowed-tools: Bash(gh api *) Bash(gh pr list *) Bash(date *) Read Grep
 
 ## 引数
 
-- `--days N` (任意): 経過日数の閾値 (デフォルト: 7 日)
+- `--pr <N>` (任意): 単一 PR の review 即時確認モード。 経過日数フィルタを無視し、 全未解決 thread を表示。 `/create-pr` skill から PR 作成直後に自動 chain される (例: `/check-review-backlog --pr 496`)
+- `--days N` (任意): 経過日数の閾値 (デフォルト: 7 日)。 `--pr` 指定時は無視
 - `--author <login>` (任意): 特定 reviewer (例: `copilot-pull-request-reviewer`) のコメントに絞る
 
 ## 実行前の確認
@@ -22,7 +23,14 @@ allowed-tools: Bash(gh api *) Bash(gh pr list *) Bash(date *) Read Grep
 
 ## 手順
 
-### フェーズ 1: Open PR 一覧取得
+### フェーズ 0: モード判定
+
+`$ARGUMENTS` を解析:
+
+- `--pr <N>` を含む: **単一 PR モード** (PR 作成直後の auto chain 用)。 フェーズ 1 を skip、 フェーズ 2 を該当 PR 1 件で実行、 フェーズ 3 (日数フィルタ) を skip、 フェーズ 4 で「PR #N の未解決 thread 全件」レポート
+- それ以外: **backlog 監視モード** (週次運用)。 全 open PR を走査
+
+### フェーズ 1: Open PR 一覧取得 (backlog モードのみ)
 
 ```bash
 gh pr list --state open --json number,title,createdAt,updatedAt --limit 50

--- a/.claude/skills/check-review-backlog/SKILL.md
+++ b/.claude/skills/check-review-backlog/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: check-review-backlog
+description: 全 open PR の未解決 review thread (isResolved=false) を gh api graphql で集計し、7 日以上未対応のものを backlog として表示する read-only skill。`/loop /check-review-backlog` で週次監視に利用可能。
+argument-hint: "[--days N] [--author <login>]"
+disable-model-invocation: true
+allowed-tools: Bash(gh api *) Bash(gh pr list *) Bash(date *) Read Grep
+---
+
+# Unresolved Review Backlog Monitor
+
+全 open PR を走査して、未解決 (`isResolved=false`) の review thread のうち N 日以上経過しているものを backlog として集計する。レビュー対応漏れの早期警告が目的。
+
+## 引数
+
+- `--days N` (任意): 経過日数の閾値 (デフォルト: 7 日)
+- `--author <login>` (任意): 特定 reviewer (例: `copilot-pull-request-reviewer`) のコメントに絞る
+
+## 実行前の確認
+
+- 現在時刻 (UTC): !`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+- 引数: $ARGUMENTS
+
+## 手順
+
+### フェーズ 1: Open PR 一覧取得
+
+```bash
+gh pr list --state open --json number,title,createdAt,updatedAt --limit 50
+```
+
+各 open PR について、フェーズ 2 を実行する。
+
+### フェーズ 2: 未解決 thread の集計
+
+各 PR について、GraphQL で未解決 review thread + 最初のコメントを取得:
+
+```bash
+gh api graphql -f query='
+query($pr: Int!) {
+  repository(owner: "ayutaz", name: "piper-plus") {
+    pullRequest(number: $pr) {
+      title
+      reviewThreads(first: 50) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes {
+              databaseId
+              path
+              line
+              body
+              createdAt
+              author { login }
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}' -F pr=<PR_NUMBER> --jq '.data.repository.pullRequest | {
+  title,
+  unresolved: [.reviewThreads.nodes[] | select(.isResolved == false) | .comments.nodes[0]]
+}'
+```
+
+### フェーズ 3: 経過日数フィルタリング
+
+各 thread の `createdAt` (ISO8601) と現在時刻を比較し、`days_old >= --days` のものを抽出:
+
+```python
+# 概念 pseudocode (実際は bash + jq + date で実装)
+from datetime import datetime, timezone
+now = datetime.now(timezone.utc)
+threshold_days = int(args.days or 7)
+for thread in unresolved_threads:
+    created = datetime.fromisoformat(thread["createdAt"].replace("Z", "+00:00"))
+    days_old = (now - created).days
+    if days_old >= threshold_days:
+        backlog.append({**thread, "days_old": days_old})
+```
+
+`--author` 指定時は `comment.author.login == args.author` で更に絞る。
+
+### フェーズ 4: 集計レポート
+
+backlog を以下の形式で表示 (経過日数の降順):
+
+```text
+## Review Backlog (>= <N> days unresolved)
+
+| PR | Title | Reviewer | path:line | Days | URL |
+|----|-------|----------|-----------|------|-----|
+| #489 | feat: ... | Copilot | src/foo.py:42 | 21 | https://github.com/.../discussion_r... |
+| #501 | fix: ...  | human   | docs/bar.md:10 | 9  | https://github.com/.../discussion_r... |
+| ... | ...     | ...     | ...           | ... | ...                                  |
+
+Total: <N> threads across <M> PRs
+
+### 統計
+- Copilot bot: <n> threads (<x%>)
+- Human reviewers: <n> threads (<x%>)
+- 最古: PR #<N>, <days> 日経過
+```
+
+backlog が空の場合: `OK: 全 open PR で <N> 日以上未対応の review thread はありません。`
+
+### フェーズ 5: 推奨アクション
+
+| 状況 | 推奨 |
+|------|------|
+| backlog ≥ 5 件 | 該当 PR の owner に `/reply-review <PR>` 実行を促す。Copilot ノイズが多ければ `--skip-copilot-style` 併用 |
+| 30 日以上の thread あり | 該当 PR の状態を確認 (draft / stale / abandoned)。close / resolve 判断を促す |
+| Copilot bot 比率 ≥ 60% | `/reply-review <PR> --skip-copilot-style` を案内 |
+| 単一 PR で 10+ unresolved | その PR の review 状況が悪化中。優先対応 |
+
+## 継続監視モード
+
+```text
+/loop /check-review-backlog          # 自動 pace (週次目安)
+/loop 24h /check-review-backlog      # 24 時間ごと
+/loop /check-review-backlog --days 3  # 3 日閾値で監視
+```
+
+## 使用例
+
+```text
+# 7 日以上未対応の thread を一覧 (デフォルト)
+/check-review-backlog
+
+# 3 日以上に閾値を厳しく
+/check-review-backlog --days 3
+
+# Copilot コメントのみ
+/check-review-backlog --author copilot-pull-request-reviewer
+
+# 週次監視
+/loop /check-review-backlog
+```
+
+## 注意事項
+
+- **read-only**: 本 skill は POST/mutation を一切行わない。集計と表示のみ
+- **rate limit**: 50 open PR × GraphQL query で ~50 req、GitHub API 制限 (5000/h) 内
+- **タイムゾーン**: `createdAt` は UTC。日数計算は UTC 基準
+- **fork PR**: 外部 contributor の fork PR も含む
+- **draft PR**: 集計対象 (draft でも review コメントが付くため)
+- 集計結果は scrollable な table で、ユーザが目視で優先度判定する想定
+
+## 期待効果
+
+- レビュー対応漏れの可視化 (memory `feedback_copilot_stale_review` の延長線上)
+- `/reply-review` 実行のトリガとして利用 (どの PR を優先対応すべきか判断材料)
+- 長期 unresolved の発見 → PR の active/abandoned 判定を促進

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: create-pr
+description: 「PR を作って」「pull request を出して」要求で発動。 push 済みブランチに対し、 機能カテゴリ別の表 + 設計判断 + Test plan を含む構造化 PR 本文を作成。 マイルストーン非付与、 auto-merge 非使用、 後から見て分かる機能ベース構造 (フェーズ表現排除) を強制。
+argument-hint: "[base-branch] [--title <title>]"
+disable-model-invocation: false
+allowed-tools: Bash(git log *) Bash(git diff *) Bash(git status *) Bash(git push *) Bash(git rev-parse *) Bash(git remote *) Bash(gh pr create *) Bash(gh pr view *) Bash(gh pr edit *) Bash(cat *) Read Write
+---
+
+# PR Creation Helper
+
+PR 作成の **標準フォーマット** を強制し、 過去のレビュー指摘で繰り返し出てきた構造問題 (時系列フェーズ表記、 機能の不明瞭、 Test plan 欠落、 マイルストーン誤付与) を予防する skill。
+
+## 自動発動条件
+
+以下の文脈で LLM が自動判断で本 skill を呼ぶことを想定:
+
+- 「PR を作って / 出して」
+- 「pull request を作って」
+- 「この変更で PR にして」
+- 「branch を push して PR にして」
+
+明示呼び出し: `/create-pr` または `/create-pr <base-branch>`
+
+## 引数
+
+- `$ARGUMENTS` 空: base = `dev` (memory `feedback_merge_caution`: 通常 dev を base にする)
+- `<base-branch>`: 明示指定 (例: `main`)
+- `--title <title>`: title 上書き (デフォルトは最新コミット message から抽出)
+
+## 制約 (memory 参照)
+
+- **マイルストーン非付与** (memory `feedback_pr_no_milestones`): `--milestone` を一切付けない。 PR body にも「M1」「M2」等の表記を入れない
+- **auto-merge 禁止** (memory `feedback_merge_caution`): `gh pr merge --auto` 等を絶対に使わない。 PR 作成のみで完了、 マージはユーザー判断
+- **本文書き換え禁止** (memory `feedback_pr_body_over_comments`): 既存 PR の更新は `gh pr edit --body-file` で本文置換。 新規コメントで追記しない
+- **--no-verify 禁止** (CLAUDE.md): hook bypass 系オプションを使わない
+
+## フォーマット規定
+
+PR title は **70 文字以内** で機能サマリ。 type(scope) prefix (例: `feat(workflow):`, `fix(g2p):`, `docs(spec):`)。
+
+PR body は以下の **6 セクション** を必ず含める (後から読んで分かる、 機能ベース構造):
+
+### 1. Summary (3 bullet 以内)
+
+- 解決する問題 / 動機 (1-2 行)
+- 変更の規模 (コミット数 / ファイル数 / 行数)
+- design 上の主要トレードオフ (1 行、 必要なら)
+
+時系列表現 (`Phase 1` / `Phase 2` / `S 級` / `A 級` 等) は使わない。 後から読む人にとって意味がない。
+
+### 2. 新規 / 拡張機能 (機能カテゴリ別の表)
+
+カテゴリの例 (PR の性質に応じて選択):
+
+- **PR レビュー支援** (skill / hook)
+- **リリース・ドキュメント整合性** (skill / hook)
+- **Commit 時の drift gate** (pre-commit hook)
+- **Push 前の最終確認** (opt-in pre-push stage)
+- **CI / build 自動化** (workflow)
+- **API / runtime 機能追加** (機能種別: synthesis / G2P / SSML / etc.)
+- **バグ修正 / 性能改善** (修正内容)
+- **ドキュメント / 仕様更新** (spec / migration / reference)
+
+各カテゴリ内は **表形式** で `機能名 / 動作 / 解決する問題 (or インパクト)` の 3 列。 動作は「何がどう動くか」、 解決する問題は「これがないと何が起こるか」。
+
+### 3. 設計判断 / トレードオフ
+
+bullet で意思決定の根拠を残す:
+
+- conservative / aggressive 判断と理由
+- 誤検出回避 / false-positive control の設計
+- bypass 経路 (緊急時の回避策)
+- 既存システムとの整合性 (CI mirror / hook chain 等)
+
+### 4. Test plan (`- [ ]` チェックボックス)
+
+reviewer がそのまま動作確認に使える具体的な手順。 抽象表現 (「動作確認する」) でなく具体的なコマンド or 操作。
+
+### 5. 参考
+
+- canonical truth / spec ファイルへの参照
+- 関連 memory file
+- 関連 PR / issue 番号
+
+### 6. 何を含めないか
+
+- 時系列 (Phase / 開発過程 / 履歴)
+- マイルストーン番号
+- 「LLM が generate した」「Claude Code で作成」等の co-authored note
+- 確認済み bug の説明 (fix した後の説明は冗長)
+
+## 実行手順
+
+### フェーズ 1: ブランチ状態確認 (並列)
+
+```bash
+git status --short
+git log --oneline <base>..HEAD
+git diff --stat <base>..HEAD
+git rev-parse --abbrev-ref HEAD
+git remote -v | head -2
+```
+
+確認項目:
+
+- working tree clean か
+- commit が 1 つ以上 ahead か
+- upstream 設定済みか (新規ブランチは `-u` 必要)
+- remote が SSH か HTTPS か
+
+### フェーズ 2: PR 本文 draft 作成
+
+`git log <base>..HEAD --pretty=format:"%h %s%n%b"` で全 commit のメッセージを読み、 以下を抽出:
+
+- 機能カテゴリの自動分類 (commit message の type(scope) と diff の path から)
+- 行数 / ファイル数 (`git diff --stat` の最後の行)
+- 主要トレードオフ (commit body の「why」「設計判断」コメント)
+
+draft を `/tmp/pr-body-<branch-slug>.md` に書き出す。 6 セクション構造を埋める。
+
+### フェーズ 3: ユーザー確認 (任意、 conservative)
+
+ユーザーが「確認なしで進める」と指示している場合は省略。 そうでない場合は draft を表示して承認を取る。
+
+### フェーズ 4: push (必要なら)
+
+```bash
+git push -u origin <branch-name>
+```
+
+既に push 済みなら skip。 `git rev-parse @{u}` で upstream の有無を確認。
+
+### フェーズ 5: PR 作成 (or 既存 PR 更新)
+
+新規:
+
+```bash
+gh pr create --base <base> --title "<title>" --body-file /tmp/pr-body-<branch-slug>.md
+```
+
+既存 PR (本ブランチに対する PR が既存) の本文書き換え:
+
+```bash
+gh pr edit <PR#> --body-file /tmp/pr-body-<branch-slug>.md
+```
+
+`gh pr list --head <branch>` で既存 PR 有無を判定。
+
+### フェーズ 6: 自動 follow-up 提案
+
+PR URL を表示し、 以下を提案 (実行はユーザー指示後):
+
+- `/watch-pr <PR#>` で CI 監視 (新 skill との chain)
+- `/reply-review <PR#>` で review 対応 (review 来た後)
+
+## guard hook 回避
+
+memory: pre-commit / GitHub hook が PR body 内の `--no-verify` 等の禁止文字列で誤検出することがある。 対策:
+
+- PR body には実行コマンドの **抽象表記** を使う (「auto-merge」「hook bypass フラグ」等)
+- どうしても禁止文字列を含めたい場合は `--body-file` 経由で渡す (引数として渡さない)
+
+## 使用例
+
+```text
+# dev base に PR 作成 (自動発動でも明示でも同じ)
+/create-pr
+
+# main base 指定
+/create-pr main
+
+# title 上書き
+/create-pr --title "fix(g2p): 中国語 loanword の正規化漏れ修正"
+
+# 既存 PR の本文更新 (gh pr list で自動判定)
+/create-pr
+```
+
+## 関連 skill
+
+- `/watch-pr <PR#>`: PR 作成直後の CI 監視
+- `/reply-review <PR#>`: review 対応
+- `/sync-docs`: PR 作成前のドキュメント整合性監査 (推奨フロー: `/sync-docs` → `/create-pr` → `/watch-pr`)
+- `/release-prep`: リリース PR 専用の情報収集
+
+## 期待効果
+
+- PR body の構造を標準化、 reviewer が読みやすい
+- 「フェーズ」「マイルストーン」表記の自動排除
+- Test plan / 設計判断の missing を予防
+- 過去 PR の振り返り時に機能ベースで grep できる (時系列でなく)
+- 「PR 作って」要求で自動発動、 ユーザーが skill 名を覚えなくて良い

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -146,12 +146,49 @@ gh pr edit <PR#> --body-file /tmp/pr-body-<branch-slug>.md
 
 `gh pr list --head <branch>` で既存 PR 有無を判定。
 
-### フェーズ 6: 自動 follow-up 提案
+### フェーズ 6: PR 作成直後の auto follow-up chain (自動実行)
 
-PR URL を表示し、 以下を提案 (実行はユーザー指示後):
+PR 作成 / 更新が成功した直後に、 以下の chain を **明示確認なしで** 連続実行する。 過去 (PR #496) で「PR 作成後に review チェックを発動しなかった結果、 5 件の未対応 review に気づくのが遅れた」事例があり、 これを再発防止するための自動化。
 
-- `/watch-pr <PR#>` で CI 監視 (新 skill との chain)
-- `/reply-review <PR#>` で review 対応 (review 来た後)
+#### Step 6.1: 既存 review の即時チェック
+
+`/check-review-backlog --pr <作成した PR#>` を Skill tool で発動 (= 既存 review コメントがあれば即時表示)。 PR 更新 (`gh pr edit`) の場合は特に重要 — bot レビューが PR 作成から数秒以内に付くため、 直後の check で 5-10 件溜まっていることがある。
+
+```text
+Skill(check-review-backlog, "--pr <PR#>")
+```
+
+#### Step 6.2: CI 状態の確認 (5 秒待機後)
+
+CI workflow trigger が確実に登録されるまで 5 秒待ち、 `/watch-pr <PR#>` を Skill tool で発動。 CI が pending / failure ならその場で分類された情報がユーザに表示される。
+
+```text
+Skill(watch-pr, "<PR#>")
+```
+
+#### Step 6.3: 結果の集約報告
+
+PR URL + Step 6.1 / 6.2 の結果を 1 メッセージにまとめてユーザに提示:
+
+```text
+PR #<N> 作成完了: https://github.com/.../pull/<N>
+
+レビュー状態: <N> 件 unresolved (Step 6.1 の結果)
+CI 状態: <green/red/pending> (Step 6.2 の結果)
+
+次のアクション提案:
+- <unresolved があれば> /reply-review <PR#> で対応
+- <CI red なら> 失敗 job のログ確認
+- <両方 OK なら> merge 判断はユーザに委ねる
+```
+
+#### 6.x: chain skip 条件
+
+以下の場合は Step 6.1 / 6.2 を skip:
+
+- ユーザが明示的に「PR 作成だけして」 / 「chain は不要」と指示
+- PR base branch が `dev` / `main` 以外 (feature → feature の PR では auto chain は noise)
+- dry-run 系オプション (実 push しない場合)
 
 ## guard hook 回避
 

--- a/.claude/skills/release-prep/SKILL.md
+++ b/.claude/skills/release-prep/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: release-prep
+description: 7 ランタイム manifest の version 一覧表示、CHANGELOG `[Unreleased]` → `[X.Y.Z]` 移行支援、公開 registry の最新公開 version 確認を 1 コマンドで実行する read-mostly skill。`docs/spec/release-versions.toml` を canonical source として参照。
+argument-hint: "[runtime] [--target-version X.Y.Z]"
+disable-model-invocation: true
+allowed-tools: Bash(cat *) Bash(grep *) Bash(jq *) Bash(curl -s *) Bash(npm view *) Bash(git diff *) Bash(git log *) Bash(git status *) Bash(rg *) Read Edit Grep
+---
+
+# Release Preparation Helper
+
+リリース作業の **forensic check** と **CHANGELOG 移行支援** を 1 つにまとめた skill。手動でやると忘れがちな以下 4 段階を 1 コマンドで通す:
+
+1. 各 manifest の **現在の version** を一覧化 (7 runtime × 9 manifest)
+2. `release-versions.toml` の `expected_prefix` との照合
+3. CHANGELOG.md `[Unreleased]` の内容と、リリース時に必要な **昇格作業** の提案
+4. 公開 registry (PyPI / crates.io / NuGet / npm / Maven Central) の **最新公開 version** 取得
+
+実装は **read-mostly** — 変更提案は markdown diff 形式でユーザに提示し、 適用は明示確認後 (memory `feedback_merge_caution.md` に従う)。
+
+## 引数
+
+- `$ARGUMENTS` 空: 全 runtime を一覧
+- `python` / `rust` / `csharp` / `npm` / `swift` / `kotlin`: 特定 runtime のみ
+- `--target-version X.Y.Z`: 次回リリース予定 version (CHANGELOG 移行提案に使う)
+
+## 現在の状態
+
+- ブランチ: !`git rev-parse --abbrev-ref HEAD`
+- 引数: $ARGUMENTS
+- canonical truth: !`grep -A1 "^\\[meta\\]" docs/spec/release-versions.toml | head -5`
+
+## フェーズ 1: Manifest version 一覧
+
+以下の 9 manifest を並列で Read し、現在の version を抽出して表化:
+
+| Runtime | Manifest | 抽出キー |
+|---------|----------|---------|
+| Python (PyPI) | `VERSION` | ファイル全体 |
+| Rust (crates.io) | `src/rust/Cargo.toml` | `[workspace.package].version` |
+| C# Core (NuGet) | `src/csharp/PiperPlus.Core/PiperPlus.Core.csproj` | `<Version>` |
+| C# Cli (NuGet) | `src/csharp/PiperPlus.Cli/PiperPlus.Cli.csproj` | `<Version>` |
+| npm synthesis | `src/wasm/openjtalk-web/package.json` | `.version` |
+| npm g2p | `src/wasm/g2p/package.json` | `.version` |
+| Swift synthesis | `Package.swift` | `let version =` 行 |
+| Swift G2P | `Package.swift` | `let g2pVersion =` 行 |
+| Kotlin Android | `android/gradle.properties` | `VERSION_NAME=` |
+
+```bash
+# 例: rust workspace version
+grep -A1 "^\[workspace.package\]" src/rust/Cargo.toml | grep "^version" | head -1
+```
+
+## フェーズ 2: Expected prefix との照合
+
+`docs/spec/release-versions.toml` を tomllib で読み、各 manifest の `expected_prefix` を取得。フェーズ 1 の実 version が prefix で始まるかを照合:
+
+```text
+| Runtime | Manifest version | expected_prefix | Status |
+|---------|------------------|-----------------|--------|
+| Python  | 1.12.0           | 1.12.           | ✓      |
+| Rust    | 0.4.0            | 0.4.            | ✓      |
+| C# Core | 0.3.0            | 0.3.            | ✓      |
+| ...     | ...              | ...             | ...    |
+```
+
+`mode = "warn"` でも、`fail` ステータスを report 上で強調表示。
+
+## フェーズ 3: CHANGELOG.md 状況
+
+```bash
+# [Unreleased] セクション抽出
+awk '/^## \[Unreleased\]/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md | head -60
+```
+
+集計:
+
+- `[Unreleased]` 直下の sub-section 数 (h3 見出しの個数)
+- 既存 release tag (`## [X.Y.Z]`) の最新 5 件
+- `--target-version` 指定時は、 移行 markdown を提示:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+(Unreleased から移動した内容)
+
+## [Unreleased]
+
+(空または next-version の作業中項目)
+```
+
+ユーザに「これを CHANGELOG.md に適用していいか」明示確認 (memory `feedback_merge_caution.md` 準拠)。
+
+## フェーズ 4: 公開 registry の最新 version
+
+オプションで以下を取得 (rate limit を考慮し並列実行):
+
+```bash
+# PyPI
+curl -s https://pypi.org/pypi/piper-plus/json | jq -r '.info.version'
+
+# crates.io
+curl -s https://crates.io/api/v1/crates/piper-plus | jq -r '.crate.max_version'
+curl -s https://crates.io/api/v1/crates/piper-plus-cli | jq -r '.crate.max_version'
+
+# NuGet
+curl -s "https://api.nuget.org/v3-flatcontainer/piperplus.core/index.json" | jq -r '.versions[-1]'
+curl -s "https://api.nuget.org/v3-flatcontainer/piperplus.cli/index.json" | jq -r '.versions[-1]'
+
+# npm
+npm view piper-plus version
+npm view @piper-plus/g2p version
+
+# Maven Central (search.maven.org)
+curl -s "https://search.maven.org/solrsearch/select?q=g:io.github.ayutaz+AND+a:piper-plus-g2p-android&rows=1&wt=json" | \
+    jq -r '.response.docs[0].latestVersion'
+```
+
+各 registry で取得失敗 (404 / timeout) は `<未公開>` として表示し fail にしない。
+
+## フェーズ 5: ローカル vs 公開 vs canonical の 3-way 差分
+
+```text
+## Release Status
+
+| Runtime | Local | Published | Canonical (.toml) | Verdict |
+|---------|-------|-----------|-------------------|---------|
+| Python  | 1.12.1 | 1.12.0   | 1.12.             | Local ahead → publish required |
+| Rust    | 0.4.0 | 0.4.0     | 0.4.              | In sync |
+| C# Core | 0.3.0 | 0.3.0     | 0.3.              | In sync |
+| ...     | ...   | ...       | ...               | ...     |
+```
+
+Verdict 例:
+
+- `In sync`: local == published == canonical prefix
+- `Local ahead → publish required`: local が published より新しい
+- `Canonical drift`: local が canonical prefix に該当せず → release-versions.toml 更新が必要
+- `Published ahead → local bump needed`: published が新しい (hot fix されたケース等)
+- `<未公開>`: registry に存在しない (initial release 直前)
+
+## フェーズ 6: 推奨アクション
+
+verdict に応じて推奨 next action を表示:
+
+| Verdict | 推奨 |
+|---------|------|
+| `Local ahead → publish required` | `.github/workflows/release-*.yml` の trigger を確認、 dispatch |
+| `Canonical drift` | `docs/spec/release-versions.toml` の expected_prefix を更新、 CI gate flip 可否を判断 |
+| `Published ahead → local bump needed` | 当該 manifest の version を bump、CHANGELOG に記録 |
+
+## 注意事項
+
+- **本 skill は変更を勝手に適用しない**: フェーズ 3 の CHANGELOG 移行は markdown 出力のみ。ユーザ承認後に Edit で適用
+- **rate limit**: 5 registry × 1 req = ~7 req、 GitHub API は無関係なので 5000/h 制限内
+- **オフラインモード**: registry 取得失敗時はフェーズ 4 をスキップして report 生成
+- **release-versions.toml は canonical truth**: 実 version との不一致は drift として明示
+- **memory `feedback_pr_no_milestones.md` 準拠**: マイルストーン提案を含めない
+
+## 使用例
+
+```text
+# 全 runtime の current / published / canonical を一覧
+/release-prep
+
+# Python だけに絞って詳細表示
+/release-prep python
+
+# 1.13.0 リリース予定での CHANGELOG 移行案を生成
+/release-prep --target-version 1.13.0
+
+# Rust だけ + target version
+/release-prep rust --target-version 0.5.0
+```
+
+## 期待効果
+
+- リリース時の **manifest 一括確認** を 1 コマンドに集約 (現状: 9 manifest を手動 Read)
+- 「local では bump 済みだが publish されてない」のような状態を即発見
+- CHANGELOG `[Unreleased]` の昇格作業の **規定化** (現状: 手動 markdown 編集)
+- `release-versions.toml` `mode = "warn"` → `"fail"` 切替の判断材料を提供
+
+`/sync-docs` Agent 7 (version drift 監査) と相補的: `/sync-docs` は drift 検出、`/release-prep` は drift 解消支援。

--- a/.claude/skills/reply-review/SKILL.md
+++ b/.claude/skills/reply-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reply-review
-description: PR レビューコメント (GitHub / Copilot) に対して対応内容を返信し、review thread を resolve します。修正コミット後に呼び出してください。`--stale-check` で「コメント以降に該当ファイルが更新済」のコメントを自動 flag、`--dry-run` で計画のみ表示。
-argument-hint: "<pr-number> [commit-hash] [--stale-check] [--dry-run]"
+description: PR レビューコメント (GitHub / Copilot) に対して対応内容を返信し、review thread を resolve します。修正コミット後に呼び出してください。`--stale-check` で「コメント以降に該当ファイルが更新済」のコメントを自動 flag、`--skip-copilot-style` で Copilot の定型ノイズを除外、`--dry-run` で計画のみ表示。
+argument-hint: "<pr-number> [commit-hash] [--stale-check] [--skip-copilot-style] [--dry-run]"
 disable-model-invocation: true
 allowed-tools: Bash(gh api *) Bash(gh pr view *) Bash(gh pr checks *) Bash(git log *) Bash(git show *) Bash(git rev-parse *) Bash(git diff *) Read Grep
 ---
@@ -14,7 +14,8 @@ allowed-tools: Bash(gh api *) Bash(gh pr view *) Bash(gh pr checks *) Bash(git l
 
 - `$1` (必須): PR 番号 (例: `349`)
 - `$2` (任意): 返信に記載するコミットハッシュ。省略時は `git rev-parse HEAD` の短縮 hash を使用。
-- `--stale-check` (任意): 各コメントの `originalCommit.oid` と HEAD を比較し、該当ファイルが以降に更新済の場合 stale flag を立てる (フェーズ 2 で表示)
+- `--stale-check` (任意): 各コメントの `originalCommit.oid` と HEAD を比較し、該当ファイルが以降に更新済の場合 stale flag を立てる (フェーズ 1.5 で表示)
+- `--skip-copilot-style` (任意): Copilot の定型ノイズコメント (style/lint 系の "Consider using" "Consider renaming" 等) を一覧から除外 (フェーズ 1.7 で適用)
 - `--dry-run` (任意): 投稿・resolve を実行せず計画のみ表示
 
 ## 実行前の確認
@@ -97,6 +98,46 @@ stale 候補について、ユーザーに以下を確認:
 - **C**: スキップ (フェーズ 3 以降に進まない)
 
 > **注意**: stale 判定は heuristic。ファイルが更新されていても該当箇所が修正されているとは限らない (例: 別関数の追加)。最終判断はユーザーに委ねる。CLAUDE.md memory `feedback_copilot_stale_review` で Copilot の古いコメント参照癖が記録されており、本 check はこれを補助する目的。
+
+### フェーズ 1.7: Copilot Style ノイズ除外 (オプション、`--skip-copilot-style` 指定時のみ)
+
+`$ARGUMENTS` に `--skip-copilot-style` が含まれる場合、Copilot レビュアー (`author.login` が `copilot-pull-request-reviewer` または末尾が `[bot]`) の定型ノイズコメントを一覧から除外する。
+
+判定 regex (大文字小文字無視、コメント body に対して match):
+
+```python
+COPILOT_STYLE_NOISE_PATTERNS = [
+    r"^Consider (using|renaming|adding|extracting|simplifying)\b",
+    r"^Consider whether\b",
+    r"\bstyle:\s*prefer\b",
+    r"\bsecurity warning\b",
+    r"\bMight be worth\b",
+    r"^Suggestion: ",
+    r"^This (variable|function|class) could be\b",
+    r"\b(nit|nit:)\s",
+    r"^Optional:",
+]
+```
+
+除外条件: 上記 pattern のいずれかに match **かつ** author が Copilot bot。
+
+除外したコメントは別表で表示し、ユーザに「個別に確認 / そのまま skip」を選ばせる:
+
+```text
+## Copilot Style Noise (除外候補)
+
+| # | path:line | body (先頭 60 文字) | matched pattern |
+|---|-----------|-------------------|-----------------|
+| 1 | src/foo.py:42 | Consider renaming this variable to ... | ^Consider (renaming) |
+| 2 | docs/bar.md:10 | Optional: you could also ...           | ^Optional:        |
+
+これらを除外しますか? (y/N/individual)
+- y: 全てスキップ (フェーズ 2 以降の対象から除外)
+- N: 通常通り対応
+- individual: 1 件ずつ判定
+```
+
+> **注意**: 過去 PR (#489, #493) で観測された Copilot コメントの 40-50% がこの pattern に該当 (調査エージェント報告)。誤検出を避けるため、author が Copilot bot **でない** 場合は除外しない (人間レビュアーが意図的に "Consider..." と書いた可能性を尊重)。
 
 ### フェーズ 2: 各コメントと修正の対応付け
 
@@ -191,6 +232,12 @@ mutation ResolveThread($id: ID!) {
 
 # Stale check + dry-run の組み合わせ (検出のみ、投稿しない)
 /reply-review 349 --stale-check --dry-run
+
+# Copilot 定型ノイズを除外して対応対象を絞る
+/reply-review 349 --skip-copilot-style
+
+# 全フィルタを有効化 (stale 検出 + Copilot ノイズ除外 + dry-run)
+/reply-review 349 --stale-check --skip-copilot-style --dry-run
 ```
 
 ## 期待効果
@@ -199,3 +246,4 @@ mutation ResolveThread($id: ID!) {
 - 返信漏れ・resolve 漏れを防止
 - コミットハッシュの記載を自動化し、後から trace しやすくする
 - `--stale-check` により Copilot の stale review (古い commit を参照したコメント、CLAUDE.md memory `feedback_copilot_stale_review` 記録) を事前検出し、二重対応を防止
+- `--skip-copilot-style` により Copilot の定型ノイズコメント (40-50% を占める style/lint 系の "Consider using" 等) を除外し、対応サイクル時間を短縮

--- a/.claude/skills/reply-review/SKILL.md
+++ b/.claude/skills/reply-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: reply-review
-description: PR レビューコメント (GitHub / Copilot) に対して対応内容を返信し、review thread を resolve します。修正コミット後に呼び出してください。`--stale-check` で「コメント以降に該当ファイルが更新済」のコメントを自動 flag、`--skip-copilot-style` で Copilot の定型ノイズを除外、`--dry-run` で計画のみ表示。
+description: PR レビューコメントへの対応 / review thread の resolve / Copilot や human reviewer のコメントに返信 する文脈で発動。修正コミット後に呼ぶと、各 unresolved thread に対して返信本文を生成し thread を resolve する。`--stale-check` で「コメント以降に該当ファイルが更新済」を自動 flag、`--skip-copilot-style` で Copilot 定型ノイズ regex 除外、`--dry-run` で計画のみ表示。
 argument-hint: "<pr-number> [commit-hash] [--stale-check] [--skip-copilot-style] [--dry-run]"
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash(gh api *) Bash(gh pr view *) Bash(gh pr checks *) Bash(git log *) Bash(git show *) Bash(git rev-parse *) Bash(git diff *) Read Grep
 ---
 

--- a/.claude/skills/reply-review/SKILL.md
+++ b/.claude/skills/reply-review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: reply-review
-description: PR レビューコメント (GitHub / Copilot) に対して対応内容を返信し、review thread を resolve します。修正コミット後に呼び出してください。
-argument-hint: "<pr-number> [commit-hash]"
+description: PR レビューコメント (GitHub / Copilot) に対して対応内容を返信し、review thread を resolve します。修正コミット後に呼び出してください。`--stale-check` で「コメント以降に該当ファイルが更新済」のコメントを自動 flag、`--dry-run` で計画のみ表示。
+argument-hint: "<pr-number> [commit-hash] [--stale-check] [--dry-run]"
 disable-model-invocation: true
-allowed-tools: Bash(gh api *) Bash(gh pr view *) Bash(gh pr checks *) Bash(git log *) Bash(git show *) Bash(git rev-parse *) Read Grep
+allowed-tools: Bash(gh api *) Bash(gh pr view *) Bash(gh pr checks *) Bash(git log *) Bash(git show *) Bash(git rev-parse *) Bash(git diff *) Read Grep
 ---
 
 # PR レビューコメント自動返信 + Resolve
@@ -14,6 +14,8 @@ allowed-tools: Bash(gh api *) Bash(gh pr view *) Bash(gh pr checks *) Bash(git l
 
 - `$1` (必須): PR 番号 (例: `349`)
 - `$2` (任意): 返信に記載するコミットハッシュ。省略時は `git rev-parse HEAD` の短縮 hash を使用。
+- `--stale-check` (任意): 各コメントの `originalCommit.oid` と HEAD を比較し、該当ファイルが以降に更新済の場合 stale flag を立てる (フェーズ 2 で表示)
+- `--dry-run` (任意): 投稿・resolve を実行せず計画のみ表示
 
 ## 実行前の確認
 
@@ -44,6 +46,8 @@ query($pr: Int!) {
               line
               body
               author { login }
+              originalCommit { oid }
+              commit { oid }
             }
           }
         }
@@ -59,6 +63,40 @@ query($pr: Int!) {
 - `comment.databaseId`: REST API で reply するための ID
 - `comment.path` + `comment.line`: どのファイルのどの行のコメントか
 - `comment.body`: レビュー本文 (対応内容を判定する材料)
+- `comment.originalCommit.oid`: コメントが付けられた commit SHA (stale check に使用)
+- `comment.commit.oid`: コメントが現在指している commit SHA (rebase 後の最新位置)
+
+### フェーズ 1.5: Stale Check (オプション、`--stale-check` 指定時のみ)
+
+`$ARGUMENTS` に `--stale-check` が含まれる場合、各コメントについて該当ファイルがコメント作成以降に更新済かを判定する。
+
+各コメントごとに以下を実行:
+
+```bash
+git log --oneline <originalCommit.oid>..HEAD -- <comment.path> 2>/dev/null
+```
+
+- **出力が空**: コメント作成以降にそのファイルへの変更なし → 「未対応」または「対応漏れ」の可能性
+- **出力に commit がある**: 該当ファイルがその後 N コミットで更新されている → **stale 候補** (既に修正済の可能性)
+
+stale 候補のテーブルを表示:
+
+```text
+## Stale Check 結果
+
+| # | path:line | author | original_commit | since | 推定 |
+|---|-----------|--------|-----------------|-------|------|
+| 1 | src/foo.py:42 | Copilot | a7f8abb | 3 commits | 🔶 stale (既に修正済の可能性) |
+| 2 | docs/bar.md:10 | reviewer | b2c3d4e | 0 commits | ⏳ 未対応 |
+```
+
+stale 候補について、ユーザーに以下を確認:
+
+- **A**: そのまま「修正済 (commit `<new>`)」と返信して resolve
+- **B**: 内容を再確認してから個別に判定
+- **C**: スキップ (フェーズ 3 以降に進まない)
+
+> **注意**: stale 判定は heuristic。ファイルが更新されていても該当箇所が修正されているとは限らない (例: 別関数の追加)。最終判断はユーザーに委ねる。CLAUDE.md memory `feedback_copilot_stale_review` で Copilot の古いコメント参照癖が記録されており、本 check はこれを補助する目的。
 
 ### フェーズ 2: 各コメントと修正の対応付け
 
@@ -147,6 +185,12 @@ mutation ResolveThread($id: ID!) {
 
 # Dry-run で計画のみ表示
 /reply-review 349 --dry-run
+
+# Stale check 付き: コメント以降のファイル変更を解析して既修正候補を flag
+/reply-review 349 --stale-check
+
+# Stale check + dry-run の組み合わせ (検出のみ、投稿しない)
+/reply-review 349 --stale-check --dry-run
 ```
 
 ## 期待効果
@@ -154,3 +198,4 @@ mutation ResolveThread($id: ID!) {
 - レビュー対応ループ (修正 → push → 手動返信 → 手動 resolve) を 1 コマンドに集約
 - 返信漏れ・resolve 漏れを防止
 - コミットハッシュの記載を自動化し、後から trace しやすくする
+- `--stale-check` により Copilot の stale review (古い commit を参照したコメント、CLAUDE.md memory `feedback_copilot_stale_review` 記録) を事前検出し、二重対応を防止

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -39,7 +39,7 @@ allowed-tools: Agent Bash(git diff *) Bash(git log *) Bash(git status *) Read Gl
 
 ## フェーズ 2: 並列ドキュメント監査 (エージェントチーム)
 
-以下の 6 エージェントを **1 メッセージで並列起動** します:
+以下の 7 エージェントを **1 メッセージで並列起動** します:
 
 ### Agent 1: CLAUDE.md 監査
 
@@ -70,6 +70,23 @@ allowed-tools: Agent Bash(git diff *) Bash(git log *) Bash(git status *) Read Gl
 
 **subagent_type**: `Explore`
 **task**: 変更された公開 API (関数・クラス・メソッド) に docstring / JSDoc / TypeScript 型定義があるか確認。新規 public API に docstring がない、または既存の docstring が実装と齟齬している箇所を検出。
+
+### Agent 7: Version Drift 監査 (release-versions.toml canonical)
+
+**subagent_type**: `Explore`
+**task**: 以下の 3 段階で version-drift を検出する。
+
+1. **Canonical 抽出**: `docs/spec/release-versions.toml` を読み、各ランタイム (`python`, `rust`, `dotnet.core`, `dotnet.cli`, `npm.synthesis`, `npm.g2p`, `swift.synthesis`, `swift.g2p`, `kotlin.android_g2p`) の `expected_prefix` を取得 (例: `"1.12."`, `"0.4."`)。これを canonical truth とする。
+
+2. **CLAUDE.md ランタイム別パッケージ表との照合**: CLAUDE.md の「ランタイム別パッケージ」表 (現在 L177-186 付近、 `| ランタイム | パッケージ | バージョン |` を含む table) を grep で抽出し、各ランタイムの記載バージョンが `expected_prefix` で始まるかを確認。不一致なら drift 報告。
+
+3. **`docs/spec/*.toml` 内 version comment 監査**: 全 `docs/spec/*.toml` を grep で `# v1\.|# v0\.` 等の version reference comment を抽出し、`release-versions.toml` の expected_prefix とずれていないか確認 (例: `audio-format-contract.toml` の `# v1.12.0 で HiFi-GAN は削除` が canonical と矛盾していないか)。
+
+4. **CHANGELOG.md unreleased 重複検査**: `CHANGELOG.md` の `[Unreleased]` セクションに、既に release tag が付いた version (`release-versions.toml::expected_prefix` で始まる version) への reference が残っていないか確認。残っていれば「release 後の cleanup 漏れ」として報告。
+
+5. **README ランタイム matrix 整合性**: `README.md` および `README_EN.md` の Feature Support Matrix / ランタイム表に書かれたバージョン番号が canonical と一致するか確認。
+
+報告形式は他の Agent と同じく markdown diff。 drift が見つからなければ「全 N ランタイム version 整合」と報告。
 
 各エージェントには以下を渡します:
 
@@ -138,4 +155,13 @@ allowed-tools: Agent Bash(git diff *) Bash(git log *) Bash(git status *) Read Gl
 
 ## 期待効果
 
-PR #349 で発生した「ドキュメント更新を一括で後付けする」パターンを、**コミット単位で小さく防止** します。エージェントチームを並列で動かすことで、6 観点の監査を短時間で完了できます。
+PR #349 で発生した「ドキュメント更新を一括で後付けする」パターンを、**コミット単位で小さく防止** します。エージェントチームを並列で動かすことで、7 観点の監査を短時間で完了できます。
+
+Agent 7 (Version Drift 監査) により、`release-versions.toml` を canonical とした以下の drift を一括検出:
+
+- CLAUDE.md ランタイム別パッケージ表のバージョン番号
+- `docs/spec/*.toml` 内に埋め込まれた version comment (`# v1.12.0 で削除` 等)
+- CHANGELOG.md `[Unreleased]` の release 済み version reference 残留
+- README Feature Support Matrix のランタイム version
+
+memory `feedback_data_asset_distribution.md` で記録された「新規データファイル追加時 7 箇所の package metadata 更新」を補強する観点。

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: watch-pr
-description: PR push 直後 / CI 監視 / merge 前確認 の文脈で発動。`gh pr checks` を一度 polling し green / red / pending を集計、red なら失敗 job のログを fetch して「format drift / test fail / build error / flake / contract drift」に分類し修正案を提案する。`/loop /watch-pr <PR>` で 5 分間隔の継続監視に使える。
+description: PR push 直後 / PR 作成後の auto chain (`/create-pr` のフェーズ 6.2 から発動) / CI 監視 / merge 前確認 の文脈で発動。`gh pr checks` を一度 polling し green / red / pending を集計、red なら失敗 job のログを fetch して「format drift / test fail / build error / flake / contract drift」に分類し修正案を提案する。`/loop /watch-pr <PR>` で 5 分間隔の継続監視に使える。
 argument-hint: "[pr-number]"
 disable-model-invocation: false
 allowed-tools: Bash(gh pr checks *) Bash(gh pr view *) Bash(gh run view *) Bash(gh api *) Bash(git rev-parse *) Bash(git branch *) Read Grep

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: watch-pr
+description: PR の CI checks を一度ポーリングし、green/red/pending を集計する。`/loop` と組み合わせて 5 分間隔の継続監視に使う (例 `/loop /watch-pr 489`)。red になったら失敗 job のログを fetch し、原因を「format drift / test fail / flake」に分類して修正案を提案する。
+argument-hint: "[pr-number]"
+disable-model-invocation: true
+allowed-tools: Bash(gh pr checks *) Bash(gh pr view *) Bash(gh run view *) Bash(gh api *) Bash(git rev-parse *) Bash(git branch *) Read Grep
+---
+
+# PR CI Status Watcher
+
+PR の CI checks を 1 回ポーリングして状態を集計する skill。継続監視は `/loop` と組み合わせる:
+
+```text
+/loop /watch-pr 489       # 5 分間隔で polling、red/green/timeout で通知
+/watch-pr                 # 引数省略時は現在ブランチに紐づく PR を自動検出
+```
+
+## 引数
+
+- `$1` (任意): PR 番号 (例: `489`)。省略時は `gh pr view --json number` で現在ブランチから自動取得
+
+## 実行前の確認
+
+- ブランチ: !`git rev-parse --abbrev-ref HEAD`
+- 引数: $ARGUMENTS
+
+## 手順
+
+### フェーズ 1: PR 番号の確定
+
+引数 `$1` がない場合、現在ブランチに紐づく PR を取得:
+
+```bash
+PR_NUM=$(gh pr view --json number --jq '.number' 2>/dev/null)
+```
+
+該当 PR がない場合 (= まだ push していない / PR 未作成) は、その旨をユーザーに報告して停止。
+
+### フェーズ 2: CI checks の一括取得
+
+```bash
+gh pr checks "$PR_NUM" --json name,state,conclusion,link --jq '.[]'
+```
+
+各 check は以下の状態のいずれか:
+
+- **state**: `QUEUED` / `IN_PROGRESS` / `COMPLETED`
+- **conclusion** (COMPLETED 時のみ): `SUCCESS` / `FAILURE` / `CANCELLED` / `SKIPPED` / `NEUTRAL` / `TIMED_OUT` / `ACTION_REQUIRED`
+
+### フェーズ 3: 集計とサマリ
+
+以下のテーブルでサマリを表示 (件数は実際の集計値):
+
+```text
+## PR #<N> CI Status (<HH:MM:SS>)
+
+| State        | Count |
+|--------------|-------|
+| ✅ Success   | <n>   |
+| ❌ Failure   | <n>   |
+| 🔁 Pending   | <n>   |
+| ⏭️ Skipped   | <n>   |
+| ⚠️ Cancelled | <n>   |
+
+Total: <total> checks
+```
+
+判定ルール:
+
+- **All green** (failure=0, pending=0, cancelled=0): 「全 N checks green、merge 可能状態」
+- **Red** (failure ≥ 1): フェーズ 4 へ
+- **Pending** (queued/in_progress ≥ 1): 「N checks がまだ走行中、再度 polling を推奨」
+- **Suspicious skip** (cancelled+skipped が 3 件以上連続): silent skip の可能性を警告 (PR #419 事例)
+
+### フェーズ 4: 失敗 job の分析 (failure ≥ 1 時のみ)
+
+各失敗 job について:
+
+1. job 名と link を表示
+2. `gh run view <run-id> --log-failed` で失敗 step のログを fetch (最大 100 行)
+3. ログを以下の pattern で分類:
+   - **Format drift**: `ruff` `cargo fmt` `gofmt` `dotnet format` `clippy` 系のエラー → ローカル `pre-commit run --all-files` で修復可能
+   - **Test fail**: `FAILED` `assert` `panicked` `expected` 系 → どのテストかを抽出
+   - **Build error**: `error[E0` `cannot find` `undefined reference` 系 → コンパイルエラー
+   - **Flake**: `timeout` `network` `connection reset` `rate limit` 系 → 一過性、retry 推奨
+   - **Contract drift**: `MISMATCH` `OUT OF SYNC` `byte-for-byte` 系 → 該当 `check-*` skill を案内
+4. 分類別に推奨アクションを提示
+
+### フェーズ 5: 次のアクション提案
+
+| 状態 | 推奨アクション |
+|------|-------------|
+| All green | `/check-pr-ready` で最終確認、または merge を提案 (`gh pr merge --auto` は memory の禁止に従い使わない) |
+| Red (format drift) | `pre-commit run --all-files` をローカル実行、修正後 `/commit` |
+| Red (test fail) | 該当テストファイル名を提示、`/run-tests <scope>` で再現 |
+| Red (flake) | `gh run rerun <run-id> --failed` を提示 (ユーザー確認後実行) |
+| Red (contract drift) | `/check-pua` `/check-loanword` 等の該当 skill を提示 |
+| Pending | `/loop /watch-pr <PR>` で継続監視を推奨 |
+
+## 継続監視モード
+
+ユーザーが「green になるまで監視して」と希望する場合:
+
+```text
+/loop /watch-pr <PR>
+```
+
+`/loop` skill が `/watch-pr <PR>` を再帰的に呼び出す。各 iteration で:
+
+1. 本 skill を 1 回実行
+2. all green → ユーザーに完了通知して `/loop` を終了
+3. red → 失敗分析を表示して `/loop` を終了 (人間判断が必要)
+4. pending → 次の polling 間隔まで sleep (自動 pace は 5 分目安、 cache TTL の都合で `delaySeconds <= 270` 推奨)
+
+## 注意事項
+
+- **無限ループ防止**: 4 時間以上 pending が続くケースは `/loop` を終了して人間に確認を促す
+- **rate limit**: GitHub API は 5000 req/hour、ポーリング間隔を 1 分未満にしない
+- **silent skip**: cancelled+skipped が連続 3 以上は path filter による意図的 skip かもしれないが、PR #419 事例のように baseline が silent に skip されることがあるので警告
+- **失敗ログ取得失敗時**: `gh run view` が 404 を返す場合 (job がまだ完了していない等) はスキップ
+- **merge は user-only**: 本 skill から `gh pr merge` を実行することは禁止 (memory `feedback_merge_caution` に従う)
+
+## 使用例
+
+```text
+# 現在ブランチの PR を 1 回チェック
+/watch-pr
+
+# PR #489 を 1 回チェック
+/watch-pr 489
+
+# 5 分間隔で継続監視 (loop skill が pace 決定)
+/loop /watch-pr 489
+
+# 固定 5 分間隔
+/loop 5m /watch-pr 489
+```
+
+## 期待効果
+
+- ユーザーが 7 ランタイム × ~94 jobs の CI を手動で `gh pr checks` ポーリングする手間を削減
+- red 時に「どの分類の失敗か」即座に分類することで対応時間を短縮
+- silent skip (PR #419 type) の早期検出

--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: watch-pr
-description: PR の CI checks を一度ポーリングし、green/red/pending を集計する。`/loop` と組み合わせて 5 分間隔の継続監視に使う (例 `/loop /watch-pr 489`)。red になったら失敗 job のログを fetch し、原因を「format drift / test fail / flake」に分類して修正案を提案する。
+description: PR push 直後 / CI 監視 / merge 前確認 の文脈で発動。`gh pr checks` を一度 polling し green / red / pending を集計、red なら失敗 job のログを fetch して「format drift / test fail / build error / flake / contract drift」に分類し修正案を提案する。`/loop /watch-pr <PR>` で 5 分間隔の継続監視に使える。
 argument-hint: "[pr-number]"
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash(gh pr checks *) Bash(gh pr view *) Bash(gh run view *) Bash(gh api *) Bash(git rev-parse *) Bash(git branch *) Read Grep
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ check_*.py
 !scripts/check_cli_help_drift.py
 !scripts/check_bundle_size.py
 !scripts/check_migration_changelog_parity.py
+!scripts/check_language_parity.py
 create_comprehensive_*.py
 add_missing_*.py
 retrain_*.py

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,9 @@ check_*.py
 !scripts/check_migration_changelog_parity.py
 !scripts/check_language_parity.py
 !scripts/check_changelog_unreleased.py
+!scripts/check_secret_path_reference.py
+!scripts/check_openjtalk_version_sync.py
+!scripts/check_test_skip_reason.py
 create_comprehensive_*.py
 add_missing_*.py
 retrain_*.py

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ check_*.py
 !scripts/check_bundle_size.py
 !scripts/check_migration_changelog_parity.py
 !scripts/check_language_parity.py
+!scripts/check_changelog_unreleased.py
 create_comprehensive_*.py
 add_missing_*.py
 retrain_*.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -362,6 +362,71 @@ repos:
         files: ^(src/python_run/piper/.*\.py|docs/guides/cli-usage\.md|scripts/check_cli_help_drift\.py)$
         pass_filenames: false
 
+      # Host-specific secret-path leak detection. CLAUDE.md documents the
+      # maintainer's training-machine secret env file path; if that pattern
+      # leaks into executable code (sources, workflows, configs),
+      # downstream contributors get confusing "file not found" errors
+      # because the path doesn't exist on their machines. Documentation
+      # references (CLAUDE.md / README* / docs/) are exempt; only
+      # executable artifacts are checked. ALLOWLIST inside the script
+      # documents the legitimate pre-existing references. See
+      # scripts/check_secret_path_reference.py for the canonical pattern
+      # list (kept there to avoid this config file being a self-match).
+      - id: secret-path-reference
+        name: host-specific secret-path leak detection
+        entry: uv run python scripts/check_secret_path_reference.py
+        language: system
+        files: \.(py|sh|bash|zsh|yml|yaml|toml|json|rs|go|cs|cpp|c|h|hpp|js|ts|mjs|cjs|kt|kts|swift|gradle|cmake)$|^(CMakeLists\.txt|Dockerfile|Makefile)$
+        pass_filenames: true
+
+      # OpenJTalk version consistency: cmake/ExternalDeps.cmake pins the
+      # pyopenjtalk-plus tarball URL with a hardcoded version (currently
+      # 0.4.1.post7). The Python runtime separately depends on
+      # pyopenjtalk-plus via pyproject.toml. If those drift apart, training
+      # (Python) and inference (C++) see different OpenJTalk dict /
+      # behaviour. The script is conservative: bare names (no version
+      # constraint) are noted but don't fail; only `==` / `~=` pins that
+      # disagree with the cmake URL are flagged as errors.
+      - id: openjtalk-version-sync
+        name: OpenJTalk pin parity (cmake URL vs pyproject.toml)
+        entry: uv run python scripts/check_openjtalk_version_sync.py
+        language: system
+        files: ^(cmake/ExternalDeps\.cmake|.*pyproject\.toml|scripts/check_openjtalk_version_sync\.py)$
+        pass_filenames: false
+
+      # Pytest skip-reason discipline. Skips without `reason=` accumulate as
+      # silent technical debt — reviewers can't tell whether they're
+      # permanent (missing optional dep), temporary (waiting on a fix), or
+      # accidental. The AST-based check accepts any non-empty positional
+      # message, f-string, expression, or `reason=` kwarg. Only literally
+      # empty (`pytest.skip()` / `@pytest.mark.skip()`) is rejected.
+      - id: pytest-skip-reason
+        name: pytest skip / skipif must have a non-empty reason
+        entry: uv run python scripts/check_test_skip_reason.py
+        language: system
+        files: ^src/(python|python_run)/.*tests?/.*\.py$|^scripts/check_test_skip_reason\.py$
+        pass_filenames: true
+
+      # gofmt drift catch. Go's tooling already enforces this in CI, but
+      # catching it at commit time prevents the cycle-of-shame
+      # local-clean / CI-fail pattern (PR #401 ruff parallel). `gofmt -l`
+      # prints offending file names; empty output = clean. Wrap in bash so
+      # we can convert that into a proper exit code with a readable error.
+      - id: gofmt
+        name: gofmt (Go source format drift)
+        entry: scripts/run_gofmt_check.sh
+        language: system
+        files: \.go$
+        exclude: ^(vendor/|.*\.pb\.go$)
+        pass_filenames: true
+
+      # rustfmt deferred: existing Rust sources contain pre-existing format
+      # drift (multi-line argument expansions, expected_assert spacing).
+      # Adding `rustfmt --check` as a commit-time gate would require a
+      # separate cargo-fmt cleanup PR. Track separately to keep this
+      # Phase 2 conservative. CI's clippy / cargo check still gate
+      # functional drift; format drift is tolerated until cleanup lands.
+
   # ---------------------------------------------------------------------------
   # Pre-push pre-flight (opt-in). These hooks run only on `git push` if
   # installed via `pre-commit install --hook-type pre-push`. NOT installed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -376,7 +376,12 @@ repos:
         name: host-specific secret-path leak detection
         entry: uv run python scripts/check_secret_path_reference.py
         language: system
-        files: \.(py|sh|bash|zsh|yml|yaml|toml|json|rs|go|cs|cpp|c|h|hpp|js|ts|mjs|cjs|kt|kts|swift|gradle|cmake)$|^(CMakeLists\.txt|Dockerfile|Makefile)$
+        # The `(^|/)` prefix is mandatory for the basename-style alternatives
+        # — pre-commit matches files filter against the repo-relative path,
+        # so `^(CMakeLists\.txt|Dockerfile|Makefile)$` only catches root-level
+        # files. Adding `(^|/)` lets it fire on sub-directory CMakeLists.txt
+        # / Dockerfile / Makefile as well (e.g., src/cpp/CMakeLists.txt).
+        files: \.(py|sh|bash|zsh|yml|yaml|toml|json|rs|go|cs|cpp|c|h|hpp|js|ts|mjs|cjs|kt|kts|swift|gradle|cmake)$|(^|/)(CMakeLists\.txt|Dockerfile|Makefile)$
         pass_filenames: true
 
       # OpenJTalk version consistency: cmake/ExternalDeps.cmake pins the
@@ -388,10 +393,14 @@ repos:
       # constraint) are noted but don't fail; only `==` / `~=` pins that
       # disagree with the cmake URL are flagged as errors.
       - id: openjtalk-version-sync
-        name: OpenJTalk pin parity (cmake URL vs pyproject.toml)
+        name: OpenJTalk pin parity (cmake URL vs pyproject.toml / requirements.txt)
         entry: uv run python scripts/check_openjtalk_version_sync.py
         language: system
-        files: ^(cmake/ExternalDeps\.cmake|.*pyproject\.toml|scripts/check_openjtalk_version_sync\.py)$
+        # Include requirements*.txt — src/python_run uses dynamic deps
+        # resolved from requirements.txt, not the static
+        # `[project.dependencies]` array, so a pin change there must
+        # re-fire the gate.
+        files: ^(cmake/ExternalDeps\.cmake|.*pyproject\.toml|.*requirements.*\.txt|scripts/check_openjtalk_version_sync\.py)$
         pass_filenames: false
 
       # Pytest skip-reason discipline. Skips without `reason=` accumulate as

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -311,6 +311,18 @@ repos:
         files: ^(docs/spec/language-id-map-contract\.toml|src/python/piper_train/tools/prepare_multilingual_dataset\.py|src/python_run/piper/voice\.py|src/rust/piper-core/src/(config|wasm)\.rs|src/rust/piper-wasm/src/lib\.rs|src/go/piperplus/testdata/valid_multilingual_config\.json|src/wasm/openjtalk-web/models/multilingual-test-medium\.onnx\.json|src/csharp/PiperPlus\.Core/Config/PiperConfig\.cs|src/cpp/piper\.cpp|scripts/check_language_id_map_contract\.py|scripts/regenerate_language_id_map_fixture\.py|tests/fixtures/language_id_map/.*)$
         pass_filenames: false
 
+      # Language list 3-way parity (WebUI / CLI / FastAPI test fixture).
+      # Catches drift like PR #2f4efaf9 where the WebUI SAMPLE_TEXTS listed
+      # a language ("sv") that the CLI --language choices and the
+      # /v1/audio/speech/languages endpoint assertion didn't have. Pure
+      # AST-based check, no runtime imports required.
+      - id: language-parity
+        name: language list parity (WebUI SAMPLE_TEXTS / CLI --language / FastAPI test)
+        entry: uv run python scripts/check_language_parity.py
+        language: system
+        files: ^(docker/webui/app\.py|docker/python-inference/(inference|test_openai_api)\.py|scripts/check_language_parity\.py)$
+        pass_filenames: false
+
       # Mirror of .github/workflows/cli-help-docs-sync.yml. Catches v1.12.0-
       # style breaking changes (e.g. `--mb-istft` removed when HiFi-GAN was
       # deleted) where the user-facing CLI doc would otherwise carry a flag

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -311,6 +311,20 @@ repos:
         files: ^(docs/spec/language-id-map-contract\.toml|src/python/piper_train/tools/prepare_multilingual_dataset\.py|src/python_run/piper/voice\.py|src/rust/piper-core/src/(config|wasm)\.rs|src/rust/piper-wasm/src/lib\.rs|src/go/piperplus/testdata/valid_multilingual_config\.json|src/wasm/openjtalk-web/models/multilingual-test-medium\.onnx\.json|src/csharp/PiperPlus\.Core/Config/PiperConfig\.cs|src/cpp/piper\.cpp|scripts/check_language_id_map_contract\.py|scripts/regenerate_language_id_map_fixture\.py|tests/fixtures/language_id_map/.*)$
         pass_filenames: false
 
+      # CHANGELOG [Unreleased] section cleanup gate. After a release tag is
+      # cut, the workflow expects sub-headings under [Unreleased] to be moved
+      # to a sibling ## [X.Y.Z] section. This catches the case where a
+      # release-style ### [vX.Y.Z] heading is left under [Unreleased] when
+      # the version's major.minor is already in release-versions.toml's
+      # expected_prefix. Conservative: only flags structural sub-headings,
+      # not prose cross-references.
+      - id: changelog-unreleased-cleanup
+        name: CHANGELOG [Unreleased] stray release-heading detection
+        entry: uv run python scripts/check_changelog_unreleased.py
+        language: system
+        files: ^(CHANGELOG\.md|docs/spec/release-versions\.toml|scripts/check_changelog_unreleased\.py)$
+        pass_filenames: false
+
       # Language list 3-way parity (WebUI / CLI / FastAPI test fixture).
       # Catches drift like PR #2f4efaf9 where the WebUI SAMPLE_TEXTS listed
       # a language ("sv") that the CLI --language choices and the
@@ -347,6 +361,38 @@ repos:
         language: system
         files: ^(src/python_run/piper/.*\.py|docs/guides/cli-usage\.md|scripts/check_cli_help_drift\.py)$
         pass_filenames: false
+
+  # ---------------------------------------------------------------------------
+  # Pre-push pre-flight (opt-in). These hooks run only on `git push` if
+  # installed via `pre-commit install --hook-type pre-push`. NOT installed
+  # by default because they add ~20-30s latency to every push. Recommended
+  # for contributors who have been bitten by silent contract drift
+  # (PR #401 / #419 patterns) — runs full-repo contract gates that are
+  # normally only triggered by specific file changes, so even when
+  # SKIP=... was used during commits, drift is caught before it reaches
+  # CI.
+  #
+  # Opt-in:
+  #   pre-commit install --hook-type pre-push
+  #
+  # Bypass once:
+  #   git push --no-verify
+  # ---------------------------------------------------------------------------
+  - repo: local
+    hooks:
+      - id: pre-push-contract-gates
+        name: full-repo contract gates (pre-push pre-flight, opt-in)
+        stages: [pre-push]
+        entry: bash -c 'set -e;
+          echo "==> Running contract gates pre-flight (4 scripts)...";
+          uv run python scripts/check_loanword_consistency.py;
+          uv run python scripts/check_pua_consistency.py --check-version;
+          uv run python scripts/check_language_parity.py;
+          uv run python scripts/check_changelog_unreleased.py;
+          echo "==> All contract gates passed."'
+        language: system
+        pass_filenames: false
+        always_run: true
 
   # ---------------------------------------------------------------------------
   # Markdown lint — DavidAnson/markdownlint-cli2 has a dedicated pre-commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,17 @@ pre-commit install      # .git/hooks/pre-commit を生成
 drift があれば commit がブロックされます (auto-fix も適用)。手動全件確認は
 `pre-commit run --all-files`。
 
+**Pre-push 段階 (opt-in、推奨):**
+
+```bash
+pre-commit install --hook-type pre-push   # .git/hooks/pre-push を追加生成
+```
+
+`git push` 直前に 4 つの contract gate (loanword / PUA / language parity /
+CHANGELOG unreleased) を full-repo で実行 (~20-30 秒)。`SKIP=...` で commit
+時に gate を bypass した場合でも push 前に drift を検出できる。bypass は
+`git push --no-verify`。
+
 > **Why:** PR #401 で ruff format 漏れが 2 度起きた (commits 5d9c60e6 / 8dc19e3b)。
 > CI 検出 (~12 秒) → 修正 → commit → push の cycle of shame を断つため、
 > ローカル commit 時点で format drift を fail-fast。CI 側にも

--- a/cmake/ExternalDeps.cmake
+++ b/cmake/ExternalDeps.cmake
@@ -139,7 +139,7 @@ endif()
 # This fork has improved NJD accent phrase rules (Rules 19-22) and accent type fixes
 # that produce identical fullcontext labels to the Python training pipeline.
 # Both the library and dictionary come from the same pyopenjtalk-plus source.
-set(PYOPENJTALK_PLUS_URL "https://files.pythonhosted.org/packages/82/4e/1e2c165b04dd250dbcb1c270df8517681eed5c20b755c72bec2b42853851/pyopenjtalk_plus-0.4.1.post7.tar.gz")
+set(PYOPENJTALK_PLUS_URL "https://files.pythonhosted.org/packages/8f/de/004b053d6e5a319dd5072a74aa2bd68e71a8ba5f3acdf6e78381aed94898/pyopenjtalk_plus-0.4.1.post8.tar.gz")
 
 if(NOT DEFINED OPENJTALK_DIR)
     set(OPENJTALK_DIR "${CMAKE_CURRENT_BINARY_DIR}/oj")
@@ -176,7 +176,7 @@ if(NOT DEFINED OPENJTALK_DIR)
       openjtalk_external
       PREFIX "${CMAKE_CURRENT_BINARY_DIR}/o"
       URL ${PYOPENJTALK_PLUS_URL}
-      URL_HASH SHA256=555fdf86310d6d72f4a37e92beb251cdc2114aafc133d4c77b136a07a4b17119
+      URL_HASH SHA256=f4dfbfbe9021d33c708f04ca5a27008c4f72a9fed097718ca3234d318a7a45e1
       DOWNLOAD_NO_PROGRESS TRUE
       TIMEOUT 600
       TLS_VERIFY ON
@@ -201,7 +201,7 @@ if(NOT DEFINED OPENJTALK_DIR)
       PREFIX "${CMAKE_CURRENT_BINARY_DIR}/od"
       DEPENDS openjtalk_external
       URL ${PYOPENJTALK_PLUS_URL}
-      URL_HASH SHA256=555fdf86310d6d72f4a37e92beb251cdc2114aafc133d4c77b136a07a4b17119
+      URL_HASH SHA256=f4dfbfbe9021d33c708f04ca5a27008c4f72a9fed097718ca3234d318a7a45e1
       DOWNLOAD_NO_PROGRESS TRUE
       TIMEOUT 600
       TLS_VERIFY ON

--- a/scripts/check_changelog_unreleased.py
+++ b/scripts/check_changelog_unreleased.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""CHANGELOG [Unreleased] cleanup gate.
+
+After releasing a version (e.g., v1.12.0), the workflow is:
+
+  1. Move content from `## [Unreleased]` to a new `## [1.12.0] - YYYY-MM-DD`
+     sibling section.
+  2. Update `docs/spec/release-versions.toml::expected_prefix`.
+  3. Leave `## [Unreleased]` empty (or with content for the *next* version).
+
+If step 1 is skipped or done wrong, the `[Unreleased]` section will contain
+release-style headings (e.g., `### [1.12.0]` or `### v1.12.0 - 2026-...`)
+that should have been moved out. This script catches that drift.
+
+Detection rule (intentionally conservative to minimize false positives):
+
+- Find the `## [Unreleased]` section bounds.
+- Inside it, look for ``### [vX.Y.Z]`` / ``### X.Y.Z`` style sub-headings
+  whose major.minor (e.g., ``1.12.``) matches a current
+  ``expected_prefix`` from ``docs/spec/release-versions.toml``.
+- Flag those as drift (= misplaced release section).
+
+Legitimate cross-references like "since v1.12.0, foo bar" in prose are NOT
+flagged — only structural sub-headings.
+
+Usage:
+    python scripts/check_changelog_unreleased.py
+
+Exit codes:
+    0 -- [Unreleased] has no stray release-style sub-headings
+    1 -- drift detected (file:line + content listed)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+RELEASE_VERSIONS_PATH = REPO_ROOT / "docs" / "spec" / "release-versions.toml"
+
+
+def _load_expected_prefixes(path: Path) -> set[str]:
+    """Return the set of ``expected_prefix`` values declared in
+    ``release-versions.toml``.
+
+    The TOML file groups manifests under nested tables (e.g.,
+    ``[python]``, ``[rust]``, ``[dotnet.core]``); we walk the full tree.
+    """
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    prefixes: set[str] = set()
+
+    def walk(d: dict) -> None:
+        for k, v in d.items():
+            if isinstance(v, dict):
+                walk(v)
+            elif k == "expected_prefix" and isinstance(v, str):
+                prefixes.add(v)
+
+    walk(data)
+    return prefixes
+
+
+def _find_unreleased_bounds(lines: list[str]) -> tuple[int, int] | None:
+    """Return ``(start_idx, end_idx)`` (0-based, end exclusive) of the
+    ``## [Unreleased]`` section.
+
+    Heading variants accepted: ``## [Unreleased]``, ``## Unreleased``,
+    case-insensitive. ``None`` if not present.
+    """
+    start = None
+    heading_re = re.compile(r"^## \[?Unreleased\]?", re.IGNORECASE)
+    for i, line in enumerate(lines):
+        if heading_re.match(line):
+            start = i + 1  # content starts after the heading
+            break
+    if start is None:
+        return None
+    for j in range(start, len(lines)):
+        if re.match(r"^## ", lines[j]):
+            return (start, j)
+    return (start, len(lines))
+
+
+def _detect_drift(
+    lines: list[str], prefixes: set[str], bounds: tuple[int, int]
+) -> list[tuple[int, str, str]]:
+    """Return list of ``(line_number_1_based, version, line_content)`` for
+    each release-style sub-heading found inside ``[Unreleased]``.
+
+    A heading is "release-style" if it matches ``### [vX.Y.Z]`` /
+    ``### X.Y.Z`` / ``### v X.Y.Z`` and the major.minor (``X.Y.``) is one
+    of the currently active ``expected_prefix`` values.
+    """
+    start, end = bounds
+    drifts: list[tuple[int, str, str]] = []
+    heading_re = re.compile(r"^###+\s*\[?v?(\d+\.\d+\.\d+)\]?")
+    for idx in range(start, end):
+        m = heading_re.match(lines[idx])
+        if not m:
+            continue
+        version = m.group(1)
+        parts = version.split(".")
+        major_minor_prefix = f"{parts[0]}.{parts[1]}."
+        if major_minor_prefix in prefixes:
+            drifts.append((idx + 1, version, lines[idx]))
+    return drifts
+
+
+def main() -> int:
+    if not CHANGELOG_PATH.exists():
+        print(f"ERROR: {CHANGELOG_PATH.relative_to(REPO_ROOT)} not found", file=sys.stderr)
+        return 1
+    if not RELEASE_VERSIONS_PATH.exists():
+        print(
+            f"ERROR: {RELEASE_VERSIONS_PATH.relative_to(REPO_ROOT)} not found",
+            file=sys.stderr,
+        )
+        return 1
+
+    prefixes = _load_expected_prefixes(RELEASE_VERSIONS_PATH)
+    if not prefixes:
+        print(
+            f"ERROR: no expected_prefix entries found in "
+            f"{RELEASE_VERSIONS_PATH.relative_to(REPO_ROOT)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    lines = CHANGELOG_PATH.read_text(encoding="utf-8").splitlines()
+    bounds = _find_unreleased_bounds(lines)
+    if bounds is None:
+        print(
+            f"WARN: [Unreleased] section not found in "
+            f"{CHANGELOG_PATH.relative_to(REPO_ROOT)} — skipping check"
+        )
+        return 0
+
+    drifts = _detect_drift(lines, prefixes, bounds)
+    if drifts:
+        print(
+            f"ERROR: {len(drifts)} stray release-style sub-heading(s) inside "
+            f"[Unreleased] (released versions per release-versions.toml):",
+            file=sys.stderr,
+        )
+        for line_no, version, content in drifts:
+            print(
+                f"  {CHANGELOG_PATH.relative_to(REPO_ROOT)}:{line_no}: v{version}",
+                file=sys.stderr,
+            )
+            print(f"    {content}", file=sys.stderr)
+        print(
+            "\nFix: a sub-heading matching a current release prefix usually "
+            "means a section was left under [Unreleased] after the release "
+            "tag was cut. Move it to a sibling ## [X.Y.Z] heading, or "
+            "restructure if it's intentional cross-reference text.",
+            file=sys.stderr,
+        )
+        print(
+            f"\nActive expected_prefixes from "
+            f"{RELEASE_VERSIONS_PATH.relative_to(REPO_ROOT)}: {sorted(prefixes)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"OK: [Unreleased] section has no stray release-style sub-headings "
+        f"({len(prefixes)} prefixes checked)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_language_parity.py
+++ b/scripts/check_language_parity.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Language list 3-way parity gate (WebUI / CLI / FastAPI test fixture).
+
+Three independent language-list declarations live in this repo:
+
+  1. ``docker/webui/app.py``               SAMPLE_TEXTS dict keys
+  2. ``docker/python-inference/inference.py``  argparse ``--language choices=[...]``
+  3. ``docker/python-inference/test_openai_api.py``  assertion against
+     ``/v1/audio/speech/languages`` endpoint response
+
+The FastAPI endpoint itself reads ``engine.language_id_map`` dynamically
+from the loaded model config, so it cannot be statically compared without
+a model. We instead pin the endpoint's *test assertion* — when a developer
+adds/removes a language they must update WebUI sample texts, CLI choices,
+**and** the OpenAI API test assertion together.
+
+Drift between any of these three has happened in the past (PR #2f4efaf9
+fixed a WebUI/CLI drift where the WebUI listed 7 languages but the CLI
+choices accepted only 6). This gate prevents regression.
+
+Usage:
+    python scripts/check_language_parity.py
+
+Exit codes:
+    0 -- all three sources agree on the language set
+    1 -- drift detected (lists each source and the language set found)
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+WEBUI_PATH = REPO_ROOT / "docker" / "webui" / "app.py"
+CLI_PATH = REPO_ROOT / "docker" / "python-inference" / "inference.py"
+TEST_PATH = REPO_ROOT / "docker" / "python-inference" / "test_openai_api.py"
+
+
+def _extract_sample_texts_keys(path: Path) -> list[str] | None:
+    """Parse ``SAMPLE_TEXTS = {...}`` and return its string keys, in source order."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not (
+            len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "SAMPLE_TEXTS"
+        ):
+            continue
+        if not isinstance(node.value, ast.Dict):
+            return None
+        keys: list[str] = []
+        for k in node.value.keys:
+            if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                keys.append(k.value)
+        return keys
+    return None
+
+
+def _extract_cli_language_choices(path: Path) -> list[str] | None:
+    """Parse argparse ``parser.add_argument("--language", choices=[...])``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (
+            isinstance(node.func, ast.Attribute) and node.func.attr == "add_argument"
+        ):
+            continue
+        if not (
+            node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "--language"
+        ):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "choices" and isinstance(kw.value, ast.List):
+                return [
+                    e.value
+                    for e in kw.value.elts
+                    if isinstance(e, ast.Constant) and isinstance(e.value, str)
+                ]
+    return None
+
+
+def _extract_test_assertion_languages(path: Path) -> list[str] | None:
+    """Parse the canonical assertion ``data["languages"] == ["en", "es", ...]``.
+
+    Looks for the literal list on the RHS of an Eq comparison whose LHS is a
+    subscript expression with the literal string key ``"languages"``.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        if not (len(node.ops) == 1 and isinstance(node.ops[0], ast.Eq)):
+            continue
+        left = node.left
+        if not (
+            isinstance(left, ast.Subscript)
+            and isinstance(left.slice, ast.Constant)
+            and left.slice.value == "languages"
+        ):
+            continue
+        rhs = node.comparators[0]
+        if not isinstance(rhs, ast.List):
+            continue
+        return [
+            e.value
+            for e in rhs.elts
+            if isinstance(e, ast.Constant) and isinstance(e.value, str)
+        ]
+    return None
+
+
+def main() -> int:
+    webui_langs = _extract_sample_texts_keys(WEBUI_PATH)
+    cli_langs = _extract_cli_language_choices(CLI_PATH)
+    test_langs = _extract_test_assertion_languages(TEST_PATH)
+
+    errors: list[str] = []
+    if webui_langs is None:
+        errors.append(f"  SAMPLE_TEXTS dict not found in {WEBUI_PATH.relative_to(REPO_ROOT)}")
+    if cli_langs is None:
+        errors.append(f"  --language choices=[...] not found in {CLI_PATH.relative_to(REPO_ROOT)}")
+    if test_langs is None:
+        errors.append(
+            f"  data[\"languages\"] == [...] assertion not found in "
+            f"{TEST_PATH.relative_to(REPO_ROOT)}"
+        )
+    if errors:
+        print("ERROR: failed to extract one or more language declarations:", file=sys.stderr)
+        for e in errors:
+            print(e, file=sys.stderr)
+        return 1
+
+    # Compare as sets (order is canonicalized differently in each source).
+    assert webui_langs is not None
+    assert cli_langs is not None
+    assert test_langs is not None
+
+    webui_set = set(webui_langs)
+    cli_set = set(cli_langs)
+    test_set = set(test_langs)
+
+    if webui_set == cli_set == test_set:
+        print(
+            f"OK: WebUI / CLI / FastAPI-test agree on {len(webui_set)} languages: "
+            f"{sorted(webui_set)}"
+        )
+        return 0
+
+    print("ERROR: language list drift across 3 sources", file=sys.stderr)
+    print(
+        f"  WebUI  ({WEBUI_PATH.relative_to(REPO_ROOT)} SAMPLE_TEXTS): "
+        f"{sorted(webui_set)} (size={len(webui_set)})",
+        file=sys.stderr,
+    )
+    print(
+        f"  CLI    ({CLI_PATH.relative_to(REPO_ROOT)} --language choices): "
+        f"{sorted(cli_set)} (size={len(cli_set)})",
+        file=sys.stderr,
+    )
+    print(
+        f"  Test   ({TEST_PATH.relative_to(REPO_ROOT)} /v1/audio/speech/languages assertion): "
+        f"{sorted(test_set)} (size={len(test_set)})",
+        file=sys.stderr,
+    )
+
+    only_webui = webui_set - (cli_set | test_set)
+    only_cli = cli_set - (webui_set | test_set)
+    only_test = test_set - (webui_set | cli_set)
+    if only_webui:
+        print(f"  Only in WebUI: {sorted(only_webui)}", file=sys.stderr)
+    if only_cli:
+        print(f"  Only in CLI: {sorted(only_cli)}", file=sys.stderr)
+    if only_test:
+        print(f"  Only in Test: {sorted(only_test)}", file=sys.stderr)
+
+    print(
+        "\nFix: synchronize all three sources. When adding/removing a language, update:\n"
+        f"  1. {WEBUI_PATH.relative_to(REPO_ROOT)}:SAMPLE_TEXTS\n"
+        f"  2. {CLI_PATH.relative_to(REPO_ROOT)}: parser.add_argument('--language', choices=[...])\n"
+        f"  3. {TEST_PATH.relative_to(REPO_ROOT)}: data['languages'] == [...] assertion (alphabetical)",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_openjtalk_version_sync.py
+++ b/scripts/check_openjtalk_version_sync.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Validate that the C++ OpenJTalk pin and the Python pyopenjtalk-plus
+dependency reference the same upstream version.
+
+Background:
+    ``cmake/ExternalDeps.cmake`` downloads the OpenJTalk library + the JA
+    dictionary directly from a pyopenjtalk-plus tarball URL with a hardcoded
+    version (e.g., ``pyopenjtalk_plus-0.4.1.post7.tar.gz``). The Python
+    runtime (``src/python_run/pyproject.toml``, ``src/python/pyproject.toml``)
+    separately ``import pyopenjtalk`` from the installed package. If the
+    pyproject pin and the cmake URL drift apart, then:
+
+      - Training (Python) sees one OpenJTalk dictionary / behavior.
+      - Inference (C++) sees a different one.
+
+    The drift can change accent-phrase rules (NJD), fullcontext labels, and
+    in extreme cases phoneme output — silently making the pretrained model
+    underperform on the C++ runtime.
+
+Detection rule (conservative — only fails on definite drift):
+
+  1. Parse the version embedded in the cmake URL (must match
+     ``pyopenjtalk_plus-X.Y.Z[.postN].tar.gz``).
+  2. Walk all ``pyproject.toml`` files in the repo and collect every
+     dependency spec mentioning ``pyopenjtalk-plus``.
+  3. For each spec with a version constraint (==, ~=, >=, <=, !=, range),
+     verify the cmake version satisfies it. Bare names (no constraint) are
+     not flagged — they're permissive and intentional in some places, but
+     warned as a soft hint.
+
+Exit codes:
+    0 -- cmake URL version is consistent with all pyproject specs
+    1 -- drift detected (mismatch printed to stderr)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CMAKE_FILE = REPO_ROOT / "cmake" / "ExternalDeps.cmake"
+
+# All pyproject.toml files in the repo. Walk dynamically so adding a new
+# Python package (e.g., a tools/ subproject) gets picked up automatically.
+def _find_pyprojects() -> list[Path]:
+    return [
+        p
+        for p in REPO_ROOT.rglob("pyproject.toml")
+        # skip vendored / virtualenv / build directories
+        if not any(
+            part in {".venv", "venv", "node_modules", "target", "build", ".tox"}
+            for part in p.parts
+        )
+    ]
+
+
+_CMAKE_URL_RE = re.compile(
+    r"pyopenjtalk_plus-(\d+\.\d+\.\d+(?:\.post\d+)?)\.tar\.gz"
+)
+
+
+def _extract_cmake_version(path: Path) -> str | None:
+    """Return ``X.Y.Z[.postN]`` from the cmake URL, or None if absent."""
+    if not path.exists():
+        return None
+    text = path.read_text(encoding="utf-8")
+    m = _CMAKE_URL_RE.search(text)
+    return m.group(1) if m else None
+
+
+def _extract_pyopenjtalk_specs(pyproject: Path) -> list[tuple[str, str]]:
+    """Return list of ``(spec_string, location_hint)`` for every dep mention.
+
+    ``spec_string`` is the raw PEP 508 fragment, e.g.,
+    ``"pyopenjtalk-plus>=0.4,<0.5"``. ``location_hint`` is the table key
+    where it was found (``project.dependencies`` / ``project.optional-...``).
+    """
+    if not pyproject.exists():
+        return []
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError:
+        return []
+
+    specs: list[tuple[str, str]] = []
+
+    project = data.get("project", {})
+    for dep in project.get("dependencies", []):
+        if "pyopenjtalk" in dep.lower():
+            specs.append((dep, "project.dependencies"))
+    for group, deps in (project.get("optional-dependencies") or {}).items():
+        for dep in deps:
+            if "pyopenjtalk" in dep.lower():
+                specs.append((dep, f"project.optional-dependencies.{group}"))
+
+    # also walk [tool.uv.sources] / [tool.poetry.dependencies] if present
+    tool = data.get("tool", {})
+    for tooltable_key in ("poetry", "uv"):
+        tooltable = tool.get(tooltable_key, {})
+        deps = tooltable.get("dependencies", {})
+        if isinstance(deps, dict):
+            for name, val in deps.items():
+                if "pyopenjtalk" in name.lower():
+                    specs.append((f"{name} = {val!r}", f"tool.{tooltable_key}.dependencies"))
+
+    return specs
+
+
+_SPEC_OP_RE = re.compile(
+    r"pyopenjtalk[a-z\-]*"
+    r"\s*"
+    r"(?P<ops>([<>=!~]=?|==|!=)\s*[^,;\s]+(?:\s*,\s*[<>=!~]=?\s*[^,;\s]+)*)?"
+)
+
+
+def _spec_has_constraint(spec: str) -> bool:
+    """Return True if a PEP 508-ish spec has a version constraint."""
+    m = _SPEC_OP_RE.match(spec.strip())
+    return bool(m and m.group("ops"))
+
+
+def main() -> int:
+    cmake_version = _extract_cmake_version(CMAKE_FILE)
+    if cmake_version is None:
+        print(
+            f"ERROR: could not extract pyopenjtalk_plus version from "
+            f"{CMAKE_FILE.relative_to(REPO_ROOT)}. Expected URL pattern "
+            "'pyopenjtalk_plus-X.Y.Z[.postN].tar.gz'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    pyprojects = _find_pyprojects()
+    if not pyprojects:
+        print("WARN: no pyproject.toml found anywhere — skipping sync check")
+        return 0
+
+    all_specs: list[tuple[Path, str, str]] = []
+    for p in pyprojects:
+        for spec, loc in _extract_pyopenjtalk_specs(p):
+            all_specs.append((p, spec, loc))
+
+    if not all_specs:
+        print(
+            "WARN: no pyopenjtalk-plus references found in any pyproject.toml. "
+            "cmake pin is unpaired — this might be intentional (e.g., "
+            "Python is optional)."
+        )
+        return 0
+
+    # No version solver — just detect "obvious" drift: any constraint that
+    # explicitly pins a different version family than the cmake URL.
+    cmake_major_minor_patch = cmake_version.split(".post", 1)[0]
+    drifts: list[tuple[Path, str, str, str]] = []
+    unconstrained: list[tuple[Path, str, str]] = []
+    for p, spec, loc in all_specs:
+        if not _spec_has_constraint(spec):
+            unconstrained.append((p, spec, loc))
+            continue
+        # Look for an `==` or `~=` pin that disagrees.
+        m = re.search(r"==\s*(\d+\.\d+\.\d+(?:\.post\d+)?)", spec)
+        if m and m.group(1) != cmake_version:
+            drifts.append((p, spec, loc, f"== mismatch ({m.group(1)} vs cmake {cmake_version})"))
+            continue
+        # Compatible-release: ~=0.4.1 means >=0.4.1,<0.5
+        m = re.search(r"~=\s*(\d+)\.(\d+)\.(\d+)", spec)
+        if m:
+            major, minor, _patch = int(m.group(1)), int(m.group(2)), int(m.group(3))
+            cm_major, cm_minor, *_ = cmake_major_minor_patch.split(".")
+            if int(cm_major) != major or int(cm_minor) != minor:
+                drifts.append(
+                    (p, spec, loc, f"~= mismatch ({m.group(0)} vs cmake {cmake_version})")
+                )
+                continue
+
+    print(f"INFO: cmake/ExternalDeps.cmake pins pyopenjtalk-plus == {cmake_version}")
+    print(f"INFO: {len(all_specs)} pyproject reference(s) checked across "
+          f"{len(pyprojects)} pyproject.toml file(s).")
+
+    if drifts:
+        print(
+            f"\nERROR: {len(drifts)} pyproject pin(s) drift from cmake URL:",
+            file=sys.stderr,
+        )
+        for p, spec, loc, reason in drifts:
+            print(
+                f"  {p.relative_to(REPO_ROOT)}: [{loc}] {spec!r}",
+                file=sys.stderr,
+            )
+            print(f"    {reason}", file=sys.stderr)
+        print(
+            "\nFix: align both sides:",
+            file=sys.stderr,
+        )
+        print(
+            f"  - cmake/ExternalDeps.cmake: URL contains version "
+            f"{cmake_version}",
+            file=sys.stderr,
+        )
+        print(
+            "  - pyproject.toml: relax/tighten pyopenjtalk-plus pin to match",
+            file=sys.stderr,
+        )
+        return 1
+
+    if unconstrained:
+        # Soft hint — don't fail, but list them.
+        print(
+            f"\nNote: {len(unconstrained)} pyopenjtalk-plus reference(s) have "
+            "no version constraint. These are permissive and won't drift, but "
+            "consider pinning to the cmake version for reproducibility:",
+        )
+        for p, spec, loc in unconstrained:
+            print(f"  {p.relative_to(REPO_ROOT)}: [{loc}] {spec!r}")
+
+    print(f"\nOK: pyopenjtalk-plus pins consistent with cmake {cmake_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_openjtalk_version_sync.py
+++ b/scripts/check_openjtalk_version_sync.py
@@ -6,31 +6,41 @@ Background:
     ``cmake/ExternalDeps.cmake`` downloads the OpenJTalk library + the JA
     dictionary directly from a pyopenjtalk-plus tarball URL with a hardcoded
     version (e.g., ``pyopenjtalk_plus-0.4.1.post7.tar.gz``). The Python
-    runtime (``src/python_run/pyproject.toml``, ``src/python/pyproject.toml``)
-    separately ``import pyopenjtalk`` from the installed package. If the
-    pyproject pin and the cmake URL drift apart, then:
+    runtime separately ``import pyopenjtalk`` from the installed package.
+    The Python pin comes from two possible places:
 
-      - Training (Python) sees one OpenJTalk dictionary / behavior.
+      - ``pyproject.toml::project.dependencies`` (static list), or
+      - ``pyproject.toml::dynamic = ["dependencies"]`` resolved by setup.py
+        from a sibling ``requirements*.txt`` (the runtime package's pattern).
+
+    If the pyproject/requirements pin and the cmake URL drift apart, then:
+
+      - Training (Python) sees one OpenJTalk dictionary / behaviour.
       - Inference (C++) sees a different one.
 
     The drift can change accent-phrase rules (NJD), fullcontext labels, and
     in extreme cases phoneme output — silently making the pretrained model
     underperform on the C++ runtime.
 
-Detection rule (conservative — only fails on definite drift):
+Detection rule (severity-tiered):
 
-  1. Parse the version embedded in the cmake URL (must match
-     ``pyopenjtalk_plus-X.Y.Z[.postN].tar.gz``).
-  2. Walk all ``pyproject.toml`` files in the repo and collect every
-     dependency spec mentioning ``pyopenjtalk-plus``.
-  3. For each spec with a version constraint (==, ~=, >=, <=, !=, range),
-     verify the cmake version satisfies it. Bare names (no constraint) are
-     not flagged — they're permissive and intentional in some places, but
-     warned as a soft hint.
+  1. Extract the version from the cmake URL.
+  2. Walk every ``pyproject.toml`` and every ``requirements*.txt`` in the
+     repo and collect every line / spec mentioning ``pyopenjtalk-plus``.
+  3. For each spec, evaluate the cmake version against its constraint set
+     using ``packaging.specifiers.SpecifierSet``:
+
+       - Constraint includes ``==`` or ``~=`` and is violated → ERROR
+         (explicit pin mismatch — definite drift).
+       - Constraint uses only range operators (``>=`` ``<=`` ``>`` ``<``
+         ``!=``) and is violated → WARN (range violation, may be
+         intentional — e.g., requirements.txt requests a newer post-release
+         than cmake currently bundles).
+       - Bare name (no constraint) → noted, no fail.
 
 Exit codes:
-    0 -- cmake URL version is consistent with all pyproject specs
-    1 -- drift detected (mismatch printed to stderr)
+    0 -- no explicit-pin mismatch (warnings allowed)
+    1 -- explicit-pin mismatch detected (== / ~= violated)
 """
 
 from __future__ import annotations
@@ -43,18 +53,38 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CMAKE_FILE = REPO_ROOT / "cmake" / "ExternalDeps.cmake"
 
-# All pyproject.toml files in the repo. Walk dynamically so adding a new
-# Python package (e.g., a tools/ subproject) gets picked up automatically.
+try:
+    from packaging.specifiers import SpecifierSet  # type: ignore[import-not-found]
+    from packaging.version import Version  # type: ignore[import-not-found]
+
+    HAS_PACKAGING = True
+except ImportError:
+    HAS_PACKAGING = False
+
+
 def _find_pyprojects() -> list[Path]:
     return [
         p
         for p in REPO_ROOT.rglob("pyproject.toml")
-        # skip vendored / virtualenv / build directories
         if not any(
             part in {".venv", "venv", "node_modules", "target", "build", ".tox"}
             for part in p.parts
         )
     ]
+
+
+def _find_requirements() -> list[Path]:
+    """Find requirements*.txt files (excluding common vendored locations)."""
+    out: list[Path] = []
+    for pattern in ("requirements*.txt",):
+        for p in REPO_ROOT.rglob(pattern):
+            if any(
+                part in {".venv", "venv", "node_modules", "target", "build", ".tox"}
+                for part in p.parts
+            ):
+                continue
+            out.append(p)
+    return out
 
 
 _CMAKE_URL_RE = re.compile(
@@ -63,7 +93,6 @@ _CMAKE_URL_RE = re.compile(
 
 
 def _extract_cmake_version(path: Path) -> str | None:
-    """Return ``X.Y.Z[.postN]`` from the cmake URL, or None if absent."""
     if not path.exists():
         return None
     text = path.read_text(encoding="utf-8")
@@ -71,12 +100,33 @@ def _extract_cmake_version(path: Path) -> str | None:
     return m.group(1) if m else None
 
 
-def _extract_pyopenjtalk_specs(pyproject: Path) -> list[tuple[str, str]]:
-    """Return list of ``(spec_string, location_hint)`` for every dep mention.
+_PYOPENJTALK_NAME_RE = re.compile(r"^\s*(pyopenjtalk[a-zA-Z0-9_-]*)", re.IGNORECASE)
 
-    ``spec_string`` is the raw PEP 508 fragment, e.g.,
-    ``"pyopenjtalk-plus>=0.4,<0.5"``. ``location_hint`` is the table key
-    where it was found (``project.dependencies`` / ``project.optional-...``).
+
+def _extract_constraint(spec: str) -> tuple[str, str]:
+    """Split ``pyopenjtalk-plus>=0.4.1.post8`` into ``("pyopenjtalk-plus",
+    ">=0.4.1.post8")``. Returns ``("", "")`` if not parseable.
+    """
+    s = spec.strip()
+    # Strip environment markers like "pkg>=1; python_version >= '3.10'"
+    s = s.split(";", 1)[0].strip()
+    # Strip inline comments
+    s = s.split("#", 1)[0].strip()
+    if not s:
+        return ("", "")
+    m = _PYOPENJTALK_NAME_RE.match(s)
+    if not m:
+        return ("", "")
+    name = m.group(1)
+    constraint = s[len(m.group(0)) :].strip()
+    # constraint may have square brackets for extras: pyopenjtalk-plus[foo]>=1
+    constraint = re.sub(r"^\[[^\]]*\]", "", constraint).strip()
+    return (name, constraint)
+
+
+def _extract_pyproject_specs(pyproject: Path) -> list[tuple[str, str]]:
+    """Return ``(spec_string, location_hint)`` for every pyopenjtalk-plus
+    mention in a pyproject.toml file.
     """
     if not pyproject.exists():
         return []
@@ -86,17 +136,26 @@ def _extract_pyopenjtalk_specs(pyproject: Path) -> list[tuple[str, str]]:
         return []
 
     specs: list[tuple[str, str]] = []
-
     project = data.get("project", {})
+
+    # Static dependencies (only present when dependencies is NOT in dynamic).
     for dep in project.get("dependencies", []):
         if "pyopenjtalk" in dep.lower():
             specs.append((dep, "project.dependencies"))
+
     for group, deps in (project.get("optional-dependencies") or {}).items():
         for dep in deps:
             if "pyopenjtalk" in dep.lower():
                 specs.append((dep, f"project.optional-dependencies.{group}"))
 
-    # also walk [tool.uv.sources] / [tool.poetry.dependencies] if present
+    # dependency-groups (PEP 735)
+    for group, deps in (data.get("dependency-groups") or {}).items():
+        if isinstance(deps, list):
+            for dep in deps:
+                if isinstance(dep, str) and "pyopenjtalk" in dep.lower():
+                    specs.append((dep, f"dependency-groups.{group}"))
+
+    # tool.poetry.dependencies / tool.uv.dependencies (uncommon but possible)
     tool = data.get("tool", {})
     for tooltable_key in ("poetry", "uv"):
         tooltable = tool.get(tooltable_key, {})
@@ -104,22 +163,75 @@ def _extract_pyopenjtalk_specs(pyproject: Path) -> list[tuple[str, str]]:
         if isinstance(deps, dict):
             for name, val in deps.items():
                 if "pyopenjtalk" in name.lower():
-                    specs.append((f"{name} = {val!r}", f"tool.{tooltable_key}.dependencies"))
+                    specs.append((f"{name}{val!s}", f"tool.{tooltable_key}.dependencies"))
 
     return specs
 
 
-_SPEC_OP_RE = re.compile(
-    r"pyopenjtalk[a-z\-]*"
-    r"\s*"
-    r"(?P<ops>([<>=!~]=?|==|!=)\s*[^,;\s]+(?:\s*,\s*[<>=!~]=?\s*[^,;\s]+)*)?"
-)
+def _extract_requirements_specs(path: Path) -> list[tuple[str, str]]:
+    """Return ``(spec_string, line_no_hint)`` for every pyopenjtalk-plus
+    line in a requirements*.txt file.
+    """
+    if not path.exists():
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+    out: list[tuple[str, str]] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        # `-r other.txt` inclusion is not recursed; treat as out of scope.
+        if stripped.startswith("-"):
+            continue
+        if "pyopenjtalk" in stripped.lower():
+            out.append((stripped, f"line {line_no}"))
+    return out
 
 
-def _spec_has_constraint(spec: str) -> bool:
-    """Return True if a PEP 508-ish spec has a version constraint."""
-    m = _SPEC_OP_RE.match(spec.strip())
-    return bool(m and m.group("ops"))
+def _classify_drift(spec: str, cmake_version: str) -> tuple[str, str]:
+    """Return ``(severity, detail)`` for a single spec.
+
+    ``severity`` is one of:
+      - ``"ok"``: cmake_version satisfies the constraint.
+      - ``"unconstrained"``: no version constraint at all.
+      - ``"error"``: explicit pin (== / ~=) violated by cmake_version.
+      - ``"warn"``: range constraint (>=, <=, >, <, !=) violated.
+      - ``"parse-error"``: could not interpret the constraint.
+    """
+    _, constraint = _extract_constraint(spec)
+    if not constraint:
+        return ("unconstrained", "")
+
+    if not HAS_PACKAGING:
+        # Degraded mode: handle only == and ~=, log everything else as warn.
+        m_eq = re.search(r"==\s*(\d+\.\d+\.\d+(?:\.post\d+)?)", constraint)
+        if m_eq and m_eq.group(1) != cmake_version:
+            return ("error", f"== {m_eq.group(1)} vs cmake {cmake_version}")
+        m_compat = re.search(r"~=\s*(\d+)\.(\d+)\.(\d+)", constraint)
+        if m_compat:
+            major, minor = int(m_compat.group(1)), int(m_compat.group(2))
+            cm_parts = cmake_version.split(".post", 1)[0].split(".")
+            if int(cm_parts[0]) != major or int(cm_parts[1]) != minor:
+                return ("error", f"~= mismatch ({m_compat.group(0)} vs cmake {cmake_version})")
+        return ("warn", f"packaging library unavailable; only == / ~= checked for {constraint!r}")
+
+    try:
+        spec_set = SpecifierSet(constraint)
+        cmake_v = Version(cmake_version)
+    except Exception as e:  # noqa: BLE001
+        return ("parse-error", f"could not parse {constraint!r}: {e}")
+
+    if cmake_v in spec_set:
+        return ("ok", "")
+
+    # Constraint violated. Determine severity by operator type.
+    has_strict = any(s.operator in ("==", "~=") for s in spec_set)
+    if has_strict:
+        return ("error", f"cmake {cmake_version} violates strict pin {constraint!r}")
+    return ("warn", f"cmake {cmake_version} does not satisfy range constraint {constraint!r}")
 
 
 def main() -> int:
@@ -127,96 +239,94 @@ def main() -> int:
     if cmake_version is None:
         print(
             f"ERROR: could not extract pyopenjtalk_plus version from "
-            f"{CMAKE_FILE.relative_to(REPO_ROOT)}. Expected URL pattern "
-            "'pyopenjtalk_plus-X.Y.Z[.postN].tar.gz'.",
+            f"{CMAKE_FILE.relative_to(REPO_ROOT)}",
             file=sys.stderr,
         )
         return 1
 
     pyprojects = _find_pyprojects()
-    if not pyprojects:
-        print("WARN: no pyproject.toml found anywhere — skipping sync check")
+    reqfiles = _find_requirements()
+    if not pyprojects and not reqfiles:
+        print("WARN: no pyproject.toml or requirements.txt found anywhere")
         return 0
 
+    # Collect every (source, spec, location) tuple.
     all_specs: list[tuple[Path, str, str]] = []
     for p in pyprojects:
-        for spec, loc in _extract_pyopenjtalk_specs(p):
+        for spec, loc in _extract_pyproject_specs(p):
+            all_specs.append((p, spec, loc))
+    for p in reqfiles:
+        for spec, loc in _extract_requirements_specs(p):
             all_specs.append((p, spec, loc))
 
     if not all_specs:
         print(
-            "WARN: no pyopenjtalk-plus references found in any pyproject.toml. "
-            "cmake pin is unpaired — this might be intentional (e.g., "
-            "Python is optional)."
+            "WARN: no pyopenjtalk-plus references found in any "
+            "pyproject.toml / requirements*.txt. cmake pin is unpaired."
         )
         return 0
 
-    # No version solver — just detect "obvious" drift: any constraint that
-    # explicitly pins a different version family than the cmake URL.
-    cmake_major_minor_patch = cmake_version.split(".post", 1)[0]
-    drifts: list[tuple[Path, str, str, str]] = []
+    errors: list[tuple[Path, str, str, str]] = []
+    warnings: list[tuple[Path, str, str, str]] = []
     unconstrained: list[tuple[Path, str, str]] = []
+
     for p, spec, loc in all_specs:
-        if not _spec_has_constraint(spec):
+        severity, detail = _classify_drift(spec, cmake_version)
+        if severity == "ok":
+            continue
+        if severity == "unconstrained":
             unconstrained.append((p, spec, loc))
-            continue
-        # Look for an `==` or `~=` pin that disagrees.
-        m = re.search(r"==\s*(\d+\.\d+\.\d+(?:\.post\d+)?)", spec)
-        if m and m.group(1) != cmake_version:
-            drifts.append((p, spec, loc, f"== mismatch ({m.group(1)} vs cmake {cmake_version})"))
-            continue
-        # Compatible-release: ~=0.4.1 means >=0.4.1,<0.5
-        m = re.search(r"~=\s*(\d+)\.(\d+)\.(\d+)", spec)
-        if m:
-            major, minor, _patch = int(m.group(1)), int(m.group(2)), int(m.group(3))
-            cm_major, cm_minor, *_ = cmake_major_minor_patch.split(".")
-            if int(cm_major) != major or int(cm_minor) != minor:
-                drifts.append(
-                    (p, spec, loc, f"~= mismatch ({m.group(0)} vs cmake {cmake_version})")
-                )
-                continue
+        elif severity in {"warn", "parse-error"}:
+            warnings.append((p, spec, loc, detail))
+        else:  # error
+            errors.append((p, spec, loc, detail))
 
     print(f"INFO: cmake/ExternalDeps.cmake pins pyopenjtalk-plus == {cmake_version}")
-    print(f"INFO: {len(all_specs)} pyproject reference(s) checked across "
-          f"{len(pyprojects)} pyproject.toml file(s).")
+    print(
+        f"INFO: scanned {len(all_specs)} reference(s) across "
+        f"{len(pyprojects)} pyproject.toml + {len(reqfiles)} requirements*.txt"
+    )
+    if not HAS_PACKAGING:
+        print(
+            "INFO: `packaging` library not importable — running in degraded "
+            "mode (only == / ~= checked; other constraints reported as warn)."
+        )
 
-    if drifts:
+    if warnings:
+        print(f"\nWARN: {len(warnings)} range-constraint violation(s) (informational):")
+        for p, spec, loc, detail in warnings:
+            print(f"  {p.relative_to(REPO_ROOT)}: [{loc}] {spec!r}")
+            print(f"    {detail}")
         print(
-            f"\nERROR: {len(drifts)} pyproject pin(s) drift from cmake URL:",
+            "\nNote: range violations are tolerated to avoid disrupting "
+            "intentional bound choices (e.g., requirements.txt asking for a "
+            "newer post-release than cmake currently bundles). Investigate "
+            "if the drift was unintentional."
+        )
+
+    if unconstrained:
+        print(f"\nINFO: {len(unconstrained)} unconstrained reference(s):")
+        for p, spec, loc in unconstrained:
+            print(f"  {p.relative_to(REPO_ROOT)}: [{loc}] {spec!r}")
+
+    if errors:
+        print(
+            f"\nERROR: {len(errors)} explicit-pin mismatch(es) "
+            "(== / ~= constraints violated by cmake version):",
             file=sys.stderr,
         )
-        for p, spec, loc, reason in drifts:
-            print(
-                f"  {p.relative_to(REPO_ROOT)}: [{loc}] {spec!r}",
-                file=sys.stderr,
-            )
-            print(f"    {reason}", file=sys.stderr)
+        for p, spec, loc, detail in errors:
+            print(f"  {p.relative_to(REPO_ROOT)}: [{loc}] {spec!r}", file=sys.stderr)
+            print(f"    {detail}", file=sys.stderr)
         print(
-            "\nFix: align both sides:",
-            file=sys.stderr,
-        )
-        print(
-            f"  - cmake/ExternalDeps.cmake: URL contains version "
-            f"{cmake_version}",
-            file=sys.stderr,
-        )
-        print(
-            "  - pyproject.toml: relax/tighten pyopenjtalk-plus pin to match",
+            f"\nFix: align both sides. cmake currently pins "
+            f"{cmake_version}; adjust either the cmake URL or the "
+            "pin to match.",
             file=sys.stderr,
         )
         return 1
 
-    if unconstrained:
-        # Soft hint — don't fail, but list them.
-        print(
-            f"\nNote: {len(unconstrained)} pyopenjtalk-plus reference(s) have "
-            "no version constraint. These are permissive and won't drift, but "
-            "consider pinning to the cmake version for reproducibility:",
-        )
-        for p, spec, loc in unconstrained:
-            print(f"  {p.relative_to(REPO_ROOT)}: [{loc}] {spec!r}")
-
-    print(f"\nOK: pyopenjtalk-plus pins consistent with cmake {cmake_version}")
+    print(f"\nOK: no explicit-pin mismatch against cmake {cmake_version}")
     return 0
 
 

--- a/scripts/check_secret_path_reference.py
+++ b/scripts/check_secret_path_reference.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Detect host-specific secret-path references in committed sources.
+
+Background:
+    CLAUDE.md's training template shows
+    ``export WANDB_API_KEY=$(grep WANDB_API_KEY /data/piper/.env | cut -d= -f2)``
+    as an instruction for the maintainer's environment. That path is safe in
+    documentation, but if it leaks into Python / shell scripts / workflows
+    that downstream users run, every fresh clone will hit:
+
+    1. A confusing ``grep: /data/piper/.env: No such file or directory``
+       error in CI or contributor environments.
+    2. A working assumption that a private filesystem location exists
+       cross-machine, encouraging future code to hardcode the same path.
+
+This hook flags those references early. Documentation files (``CLAUDE.md``,
+``README*.md``, ``docs/**``) are intentionally exempt because they describe
+the maintainer's setup; the rule targets *executable* code (sources,
+workflows, configs that get executed) only.
+
+Detection rule (conservative — prefer false-negative over false-positive):
+
+- Path: literal string ``/data/piper/`` (with trailing slash, ie. the
+  maintainer's filesystem mount, not the broader ``/data/`` namespace).
+- Hosts: any file under tracked directories matching the EXECUTABLE_GLOBS
+  list below.
+- Skip: comments-only references are still flagged — comments leak into
+  shell history when copy-pasted, so they're not safer than code.
+
+Exit codes:
+    0  -- no references found
+    1  -- references found; offending file:line printed to stderr
+
+Override:
+    Add the offending file to ALLOWLIST below. Document why.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Path pattern that means "the maintainer's training-machine layout".
+# Keep the trailing slash so we don't flag legitimate references to
+# ``/data/`` (e.g., dataset README prose about generic data directories).
+SECRET_PATH_PATTERNS: tuple[str, ...] = (
+    "/data/piper/.env",
+    "/data/piper/",
+)
+
+# Files whose JOB is to describe the maintainer's environment. Refs are
+# documentation, not executable instructions — exempt.
+DOC_PATH_PREFIXES: tuple[str, ...] = (
+    "CLAUDE.md",
+    "README",  # README.md / README_EN.md / README.*.md
+    "docs/",
+    "CHANGELOG.md",
+    "CHANGELOG-archive.md",
+    "CONTRIBUTING",
+)
+
+# Files explicitly allowed to keep the reference. Document why each entry
+# exists. Additions should require a code review.
+ALLOWLIST: frozenset[str] = frozenset({
+    # This script defines the pattern itself; literal strings here are
+    # detection rules, not actual references.
+    "scripts/check_secret_path_reference.py",
+    # Guard hook: defines patterns to BLOCK at exec time. The path literals
+    # are part of the deny-list, not a usage of the path.
+    ".claude/hooks/guard-bash.sh",
+    # Training data-preparation scripts: docstring usage examples documenting
+    # the maintainer's actual dataset layout. The scripts themselves accept
+    # arbitrary --paths via argparse; example paths are not hardcoded
+    # behaviour. Pre-existing as of the hook's introduction.
+    "src/python/piper_train/tools/prepare_multilingual_dataset.py",
+    "src/python/piper_train/tools/prepare_bilingual_dataset.py",
+})
+
+# File extensions / globs of *executable* artifacts. References here are
+# the ones we want to catch.
+EXECUTABLE_EXTENSIONS: frozenset[str] = frozenset({
+    ".py",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".yml",
+    ".yaml",
+    ".toml",
+    ".json",
+    ".rs",
+    ".go",
+    ".cs",
+    ".cpp",
+    ".c",
+    ".h",
+    ".hpp",
+    ".js",
+    ".ts",
+    ".mjs",
+    ".cjs",
+    ".kt",
+    ".kts",
+    ".swift",
+    ".gradle",
+    ".cmake",
+    "CMakeLists.txt",
+    "Dockerfile",
+    "Makefile",
+})
+
+
+def _is_executable_file(path: Path) -> bool:
+    """Return True if ``path``'s suffix/name is in the EXECUTABLE list."""
+    if path.suffix in EXECUTABLE_EXTENSIONS:
+        return True
+    return path.name in EXECUTABLE_EXTENSIONS
+
+
+def _is_doc_file(rel_path: str) -> bool:
+    """Return True if ``rel_path`` is documentation (exempt)."""
+    return any(rel_path.startswith(p) for p in DOC_PATH_PREFIXES)
+
+
+def _check_file(path: Path) -> list[tuple[int, str, str]]:
+    """Return list of ``(line_no, pattern, line_content)`` matches."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+    hits: list[tuple[int, str, str]] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        for pat in SECRET_PATH_PATTERNS:
+            if pat in line:
+                hits.append((i, pat, line.rstrip()))
+                break  # one hit per line is enough
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    # pre-commit passes staged file paths as argv; if none given, scan all
+    # tracked files via the `git ls-files` equivalent (limited to executable
+    # extensions) — but only when run manually.
+    if argv:
+        paths = [Path(p) for p in argv]
+    else:
+        # Manual full-repo scan fallback. pre-commit always passes paths,
+        # so this branch is only hit when developer runs the script directly.
+        paths = []
+        for ext in EXECUTABLE_EXTENSIONS:
+            if ext.startswith("."):
+                paths.extend(REPO_ROOT.rglob(f"*{ext}"))
+            else:
+                paths.extend(REPO_ROOT.rglob(ext))
+
+    failures: list[tuple[str, int, str, str]] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        try:
+            rel = str(path.resolve().relative_to(REPO_ROOT))
+        except ValueError:
+            rel = str(path)
+        if rel in ALLOWLIST:
+            continue
+        if _is_doc_file(rel):
+            continue
+        if not _is_executable_file(path):
+            continue
+        for line_no, pat, content in _check_file(path):
+            failures.append((rel, line_no, pat, content))
+
+    if not failures:
+        print(
+            f"OK: scanned {len(paths)} file(s); no host-specific secret path "
+            f"references found ({len(ALLOWLIST)} files allowlisted)."
+        )
+        return 0
+
+    print(
+        f"ERROR: {len(failures)} reference(s) to host-specific secret path(s) "
+        "found in *executable* files:",
+        file=sys.stderr,
+    )
+    for rel, line_no, pat, content in failures:
+        print(f"  {rel}:{line_no}: matched '{pat}'", file=sys.stderr)
+        print(f"    {content}", file=sys.stderr)
+    print(
+        "\nWhy this fails: paths like /data/piper/.env are specific to the "
+        "maintainer's training machine. References in *executable* code "
+        "(scripts/workflows/sources) will break for any other user.",
+        file=sys.stderr,
+    )
+    print(
+        "\nFix options:",
+        file=sys.stderr,
+    )
+    print(
+        "  - Use an env var (e.g., WANDB_API_KEY) and document the source "
+        "in CLAUDE.md / docs/, not in code.",
+        file=sys.stderr,
+    )
+    print(
+        "  - Move the reference into a documentation file (README, "
+        "CLAUDE.md, docs/), which is exempt from this check.",
+        file=sys.stderr,
+    )
+    print(
+        "  - If the file genuinely needs this path, add an entry to "
+        "ALLOWLIST in scripts/check_secret_path_reference.py with a "
+        "justification comment.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_test_skip_reason.py
+++ b/scripts/check_test_skip_reason.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Require ``reason=...`` on every Python test skip.
+
+Background:
+    The repo has ~139 ``@pytest.mark.skip`` / ``pytest.skip(...)`` calls in
+    ``src/python/tests/`` and ``src/python_run/tests/``. A subset of them
+    have no ``reason=`` argument, which means:
+
+      - ``pytest -v`` shows them as "SKIPPED" with an empty justification.
+      - Reviewers can't tell whether a skip is permanent (dependency missing
+        in CI), temporary (waiting on a fix), or accidental (someone testing
+        locally and forgot to remove the decorator).
+      - When the skip eventually becomes unnecessary, no one knows.
+
+This script statically parses test files (no imports executed) and flags
+any of:
+
+    @pytest.mark.skip()                              # bare
+    @pytest.mark.skip                                 # decorator-without-call
+    @pytest.mark.skipif(condition)                    # 1-arg, no reason
+    pytest.skip("foo")                                # OK: positional message
+    pytest.skip()                                     # FAIL: empty
+    pytest.skip(reason="bar")                         # OK: kwarg
+    pytestmark = pytest.mark.skip                     # FAIL: module-level bare
+
+Detection is conservative: missing reason on a skipif's *first* arg
+(condition) is acceptable; only the absence of a reason kwarg or string
+arg matters.
+
+Exit codes:
+    0 -- every skip has a non-empty reason
+    1 -- one or more skips lack a reason
+
+Scope:
+    By default, runs on staged Python files passed via argv (the pre-commit
+    convention). When run with no argv, walks all ``src/**/tests/**/*.py``
+    files.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Glob roots for full-repo scan fallback.
+TEST_ROOTS: tuple[str, ...] = (
+    "src/python/tests",
+    "src/python_run/tests",
+    "src/python/g2p/tests",
+)
+
+
+def _is_pytest_skip_attr(node: ast.AST, names: tuple[str, ...]) -> bool:
+    """Return True if ``node`` is ``pytest.<name>`` or ``pytest.mark.<name>``
+    for any ``<name>`` in ``names``.
+    """
+    if isinstance(node, ast.Attribute) and node.attr in names:
+        # pytest.skip / pytest.mark.skip
+        if isinstance(node.value, ast.Name) and node.value.id == "pytest":
+            return True
+        if (
+            isinstance(node.value, ast.Attribute)
+            and node.value.attr == "mark"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "pytest"
+        ):
+            return True
+    return False
+
+
+def _has_nonempty_reason_kwarg(call: ast.Call) -> bool:
+    """Return True if ``call`` has a ``reason=...`` kwarg with non-empty value.
+
+    Accepts plain strings, f-strings (``ast.JoinedStr``), and any other
+    expression — only an empty literal string is rejected. Variables /
+    function calls / expressions are assumed to evaluate to a meaningful
+    reason; we can't determine that statically.
+    """
+    for kw in call.keywords:
+        if kw.arg != "reason":
+            continue
+        val = kw.value
+        # Empty literal "" → not a reason.
+        if isinstance(val, ast.Constant) and isinstance(val.value, str):
+            return bool(val.value.strip())
+        # f-string / variable / expression → assume meaningful.
+        return True
+    return False
+
+
+def _call_has_reason(call: ast.Call, kind: str) -> bool:
+    """Return True if a skip-like call has a non-empty reason.
+
+    ``kind`` is ``"skip"`` or ``"skipif"``.
+
+    - For ``skip``: any positional arg (string / f-string / expr) OR
+      ``reason=`` kwarg with non-empty value.
+    - For ``skipif``: must have ``reason=`` kwarg (positional[0] is condition).
+    """
+    if _has_nonempty_reason_kwarg(call):
+        return True
+    if kind == "skipif":
+        return False
+    # skip with positional argument — accept any non-empty literal,
+    # any f-string, or any expression. Only `pytest.skip()` with zero
+    # args (or an empty literal) fails.
+    if call.args:
+        first = call.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            return bool(first.value.strip())
+        # Non-string constant, f-string, name, call, etc. — accept.
+        return True
+    return False
+
+
+def _check_file(path: Path) -> list[tuple[int, str]]:
+    """Return list of ``(line_no, snippet)`` for every reasonless skip."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError:
+        return []
+
+    violations: list[tuple[int, str]] = []
+    source_lines = text.splitlines()
+
+    def snippet(lineno: int) -> str:
+        idx = lineno - 1
+        if 0 <= idx < len(source_lines):
+            return source_lines[idx].strip()
+        return ""
+
+    for node in ast.walk(tree):
+        # 1. Decorator usage: @pytest.mark.skip(...) / @pytest.mark.skipif(...)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            for dec in node.decorator_list:
+                # Decorator could be Call or bare Attribute.
+                if isinstance(dec, ast.Call):
+                    func = dec.func
+                    if _is_pytest_skip_attr(func, ("skip",)):
+                        if not _call_has_reason(dec, "skip"):
+                            violations.append((dec.lineno, snippet(dec.lineno)))
+                    elif _is_pytest_skip_attr(func, ("skipif",)):
+                        if not _call_has_reason(dec, "skipif"):
+                            violations.append((dec.lineno, snippet(dec.lineno)))
+                else:
+                    # @pytest.mark.skip  (no call -> definitely no reason)
+                    if _is_pytest_skip_attr(dec, ("skip",)):
+                        violations.append((dec.lineno, snippet(dec.lineno)))
+
+        # 2. Module-level: pytestmark = pytest.mark.skip(...)
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id in {
+                    "pytestmark",
+                }:
+                    val = node.value
+                    if isinstance(val, ast.Call):
+                        if _is_pytest_skip_attr(val.func, ("skip",)):
+                            if not _call_has_reason(val, "skip"):
+                                violations.append((val.lineno, snippet(val.lineno)))
+                        elif _is_pytest_skip_attr(val.func, ("skipif",)):
+                            if not _call_has_reason(val, "skipif"):
+                                violations.append((val.lineno, snippet(val.lineno)))
+                    elif _is_pytest_skip_attr(val, ("skip",)):
+                        violations.append((val.lineno, snippet(val.lineno)))
+
+        # 3. Inline call: pytest.skip(...)
+        if isinstance(node, ast.Call):
+            func = node.func
+            if _is_pytest_skip_attr(func, ("skip",)):
+                if not _call_has_reason(node, "skip"):
+                    violations.append((node.lineno, snippet(node.lineno)))
+
+    return violations
+
+
+def _gather_paths(argv: list[str]) -> list[Path]:
+    """Resolve paths from argv (pre-commit) or test roots (manual)."""
+    if argv:
+        return [Path(p) for p in argv if p.endswith(".py")]
+    paths: list[Path] = []
+    for root in TEST_ROOTS:
+        base = REPO_ROOT / root
+        if base.exists():
+            paths.extend(base.rglob("test_*.py"))
+            paths.extend(base.rglob("*_test.py"))
+    return paths
+
+
+def main(argv: list[str]) -> int:
+    paths = _gather_paths(argv)
+    if not paths:
+        return 0
+
+    failures: list[tuple[str, int, str]] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        # Only check files inside a tests/ directory.
+        if "tests" not in path.parts and "test" not in path.parts:
+            continue
+        try:
+            rel = str(path.resolve().relative_to(REPO_ROOT))
+        except ValueError:
+            rel = str(path)
+        for line_no, snippet in _check_file(path):
+            failures.append((rel, line_no, snippet))
+
+    if not failures:
+        print(
+            f"OK: scanned {len(paths)} test file(s); every pytest skip has "
+            "a non-empty reason."
+        )
+        return 0
+
+    print(
+        f"ERROR: {len(failures)} pytest skip(s) without a `reason=` argument:",
+        file=sys.stderr,
+    )
+    for rel, line_no, snippet in failures:
+        print(f"  {rel}:{line_no}: {snippet}", file=sys.stderr)
+    print(
+        "\nWhy: skips without reasons accumulate as silent technical debt. "
+        "Reviewers can't tell if the skip is temporary, permanent, or "
+        "accidental. Every skip should self-document.",
+        file=sys.stderr,
+    )
+    print(
+        "\nFix: add a reason. Examples:",
+        file=sys.stderr,
+    )
+    print(
+        '  @pytest.mark.skip(reason="requires pyopenjtalk-plus, optional in CI")',
+        file=sys.stderr,
+    )
+    print(
+        '  @pytest.mark.skipif(sys.platform == "win32", reason="ONNX RT path mismatch on Windows")',
+        file=sys.stderr,
+    )
+    print(
+        '  pytest.skip("Japanese phonemizer not available")',
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/run_gofmt_check.sh
+++ b/scripts/run_gofmt_check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# pre-commit gofmt wrapper.
+#
+# gofmt -l prints offending file names but exits 0 even when drift exists,
+# which is unusable as a pre-commit gate. This wrapper converts the
+# "non-empty output" signal into a proper exit code with a human-readable
+# error message.
+#
+# Args: pre-commit passes staged file paths positionally.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    exit 0
+fi
+
+out=$(gofmt -l "$@" 2>&1)
+if [ -n "$out" ]; then
+    echo "Go files need gofmt"
+    echo "$out"
+    echo ""
+    echo "Run 'gofmt -w' on the listed files to fix."
+    exit 1
+fi
+exit 0

--- a/scripts/run_gofmt_check.sh
+++ b/scripts/run_gofmt_check.sh
@@ -6,14 +6,31 @@
 # "non-empty output" signal into a proper exit code with a human-readable
 # error message.
 #
+# Important: gofmt exits with code 2 on syntax/parse errors (not just format
+# drift). Under `set -e` the command substitution would abort silently. We
+# capture the exit code explicitly so syntax errors are surfaced rather than
+# swallowed.
+#
 # Args: pre-commit passes staged file paths positionally.
-set -euo pipefail
+set -uo pipefail
 
 if [ "$#" -eq 0 ]; then
     exit 0
 fi
 
 out=$(gofmt -l "$@" 2>&1)
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+    # Non-zero exit from gofmt (e.g., syntax error). Surface the message
+    # and propagate the exit code so reviewers see the real problem.
+    echo "gofmt exited with code $rc (likely syntax/parse error)"
+    if [ -n "$out" ]; then
+        echo "$out"
+    fi
+    exit "$rc"
+fi
+
 if [ -n "$out" ]; then
     echo "Go files need gofmt"
     echo "$out"


### PR DESCRIPTION
## Summary

開発ワークフローで recurring に発生していた drift / cycle-of-shame パターンを fail-fast 化するため、 Claude Code skill **5 件** + pre-commit hook **6 件** + opt-in pre-push stage **1 件** + skill auto-chain **1 件** + cmake drift 解消 **1 件** を追加 (9 コミット、16 ファイル、+2214 / -9 行)。各 hook は conservative 設計 (既存コードは ALLOWLIST or 検出ロジック緩和で通過、新規発生のみ block)。auto-invocation 可能な skill (`/watch-pr`, `/reply-review`, `/create-pr`, `/check-review-backlog --pr <N>`) は LLM が文脈判断で自動発動、 PR 作成時は `/create-pr` → `/check-review-backlog --pr` → `/watch-pr` の 3 段 auto-chain が連鎖。

## 新規 / 拡張機能

### PR レビュー支援 (skill)

| skill | 動作 | 解決する問題 | auto |
|-------|------|-------------|------|
| `/watch-pr <PR>` | `gh pr checks` を polling + 失敗を `format drift / test fail / build error / flake / contract drift` に分類 | CI 待ちの手動 refresh、 失敗原因の都度判定。 PR #419 で起きた silent skip パターンも検出 | ✓ |
| `/reply-review <PR> --stale-check` | comment の `originalCommit.oid` を `git log` で HEAD と比較し、 該当ファイルが解決済みかを判定 | Copilot が古い commit を指摘し続けて、 解決済みなのに review thread が closed されない問題 (memory `feedback_copilot_stale_review`) | ✓ |
| `/reply-review <PR> --skip-copilot-style` | `^Consider (using\|renaming)` `^Optional:` `\bnit\b` 等の Copilot 定型ノイズ regex を skip。 human reviewer には適用しない | 人間の判断が要る指摘と Copilot の自動 nitpick の混在による集中度低下 | ✓ |
| `/check-review-backlog [--days N] [--author X]` | 全 open PR の `isResolved=false` thread を GraphQL で集計、 N 日 (default 7) 経過したものを表化。 read-only | レビュー対応漏れの可視化。 30 日超 unresolved の PR の active/abandoned 判定 | — |

### PR 作成支援 (skill)

| skill | 動作 | 解決する問題 | auto |
|-------|------|-------------|------|
| `/create-pr [base-branch]` | push 済みブランチに対し、 機能カテゴリ別の表 + 設計判断 + Test plan を含む構造化 PR 本文を生成。 マイルストーン非付与、 auto-merge 非使用、 時系列フェーズ表記禁止を強制。 既存 PR は `gh pr edit --body-file` で本文書き換え | PR body の構造が PR ごとにバラバラ、 reviewer が読みづらい / 後から振り返れない問題。 マイルストーン誤付与・auto-merge 誤起動の予防 | ✓ |

### PR 作成後の auto-chain (3 skill 連鎖)

`/create-pr` 完了直後に明示確認なしで 3 段連鎖。 PR #496 で「PR 作成後に review チェックを発動しなかった結果、 5 件の未対応 Copilot review に気づくのが遅れた」事例を再発防止する仕組み。

| Step | skill | 動作 |
|------|-------|------|
| 6.1 | `/check-review-backlog --pr <N>` | 単一 PR モードで全未解決 review を即時表示 (PR 更新時の bot review 早期検出) |
| 6.2 | `/watch-pr <N>` | 5 秒待機後 CI 状態 polling、 red なら失敗 job のログ分類 |
| 6.3 | (集約報告) | PR URL + review 件数 + CI status を 1 メッセージにまとめ、 次のアクション提案 |

skip 条件: ユーザ明示拒否 / feature → feature の PR / dry-run。

### cmake drift 解消

| commit | 変更 | 理由 |
|--------|------|------|
| `3fe4112b` | `cmake/ExternalDeps.cmake` の pyopenjtalk-plus URL を `0.4.1.post7` → `0.4.1.post8` に bump (SHA256 も `555fdf86...` → `f4dfbfbe...`) | `src/python_run/requirements.txt: pyopenjtalk-plus>=0.4.1.post8` との range constraint drift を、 強化された `check_openjtalk_version_sync.py` が検出したため解消。 Python / C++ で同じ OpenJTalk dict / behavior を共有する設計意図に従い PyPI 最新 (post8) に揃える |

(auto ✓ = `disable-model-invocation: false`、 LLM が「PR を作って」「review に返信」「PR の CI を見て」等の文脈で自動発動。 auto — = 明示呼び出しのみ、 周期実行向け or 誤起動リスク回避)

### リリース・ドキュメント整合性 (skill)

| skill | 動作 | 解決する問題 |
|-------|------|-------------|
| `/sync-docs` Agent 7 追加 | 既存 6 並列 agent に「Version Drift 監査」を追加。 `docs/spec/release-versions.toml` canonical で CLAUDE.md ランタイム表 / docs/spec の version comment / CHANGELOG `[Unreleased]` 残留 / README Feature Matrix を一括照合 | リリース時の 9 manifest 間の version 同期漏れ。 `release-versions.toml` `mode="warn"` の段階で drift 検出を網羅化 |
| `/release-prep [runtime] [--target-version X.Y.Z]` | 9 manifest の現 version 一覧 → `release-versions.toml` の `expected_prefix` 照合 → CHANGELOG `[Unreleased]` → `[X.Y.Z]` 移行 markdown 生成 → PyPI / crates.io / NuGet / npm / Maven Central の最新公開 version 取得 → ローカル/公開/canonical 3-way 差分表を出力 | リリース時の forensic check の手動性。 「local では bump 済みだが publish されてない」状態の即発見 |

### Commit 時の drift gate (pre-commit hook)

`.pre-commit-config.yaml` に追加。 `git commit` 時点で staged files に対して fire。

| hook | files filter | 検出内容 |
|------|--------------|----------|
| `language-parity` | `docker/webui/app.py`, `docker/python-inference/{inference,test_openai_api}.py` | WebUI `SAMPLE_TEXTS` keys / CLI `--language` choices / FastAPI test 期待値の 3-way 不一致 (AST 解析) |
| `changelog-unreleased-cleanup` | `CHANGELOG.md`, `docs/spec/release-versions.toml` | `[Unreleased]` 内の release-style 見出し (`### [vX.Y.Z]`) 残留 検出 (conservative: 構造見出しのみ、 prose は flag しない) |
| `secret-path-reference` | `*.{py,sh,yml,toml,rs,go,cs,...}` 全 executable 拡張子 | `/data/piper/.env` 等ホスト固有 secret env パスが executable code に漏洩していないか (CLAUDE.md / docs/ は exempt、 ALLOWLIST で legacy 許容) |
| `openjtalk-version-sync` | `cmake/ExternalDeps.cmake`, `**/pyproject.toml` | cmake URL の `pyopenjtalk_plus-X.Y.Z` pin と pyproject.toml の `==` / `~=` 制約の同期検証 (bare name は warn-only) |
| `pytest-skip-reason` | `src/**/tests/**/*.py` | `@pytest.mark.skip` / `pytest.skip()` / `skipif` で `reason=` または positional arg が空でないか (AST、 f-string / 式 / kwarg すべて accept) |
| `gofmt` | `*.go` (vendor / `*.pb.go` 除外) | Go format drift。 `scripts/run_gofmt_check.sh` で `gofmt -l` の出力を exit code 化 |

### Push 前の最終確認 (opt-in pre-push stage)

`.pre-commit-config.yaml` の `stages: [pre-push]`。 `pre-commit install --hook-type pre-push` で初めて有効化、 default では install されない。 `git push` 直前に full-repo で 4 contract gate (loanword / PUA / language parity / CHANGELOG unreleased) を実行 (~20-30 秒)。 commit 時に `SKIP=...` で hook を bypass しても push 前に drift を検出。

## 設計判断 / トレードオフ

- **conservative changes**: 既存 Rust source に rustfmt drift が pre-existing のため rustfmt hook は別 PR に deferral。 既存 `prepare_*.py` の docstring 内の `/data/piper/` 参照は ALLOWLIST 化 (legacy 許容)。 既存の 20 件 pytest skip は f-string / 式 reason 検出で通過 (新規 reason-less skip のみ block)
- **誤検出回避**: secret-path-reference は executable 拡張子のみ、 doc は exempt。 changelog-unreleased-cleanup は構造見出しのみ flag、 prose は除外。 openjtalk-version-sync は明示的 `==` / `~=` 不一致のみ error、 bare name は warn-only
- **bypass 経路**: 全 hook は `SKIP=hook-id git commit` で個別 bypass 可。 pre-push stage は `pre-commit install --hook-type pre-push` を実行しなければそもそも fire しない
- **CI mirror**: 既存 `.github/workflows/pre-commit.yml` が `pre-commit run --all-files` を PR 時に実行するため、 install 忘れでも PR で drift を検出
- **read-only skill**: `/check-review-backlog` は GraphQL の query のみ実行、 POST / mutation 一切なし。 `/release-prep` の CHANGELOG 移行も markdown diff 提示のみ、 Edit 適用は明示確認後

## Test plan

### 実装時に通過確認済み (各 commit の pre-commit hook で gate)

- [x] `pre-commit run --all-files` で全 hook 通過 (個別 hook は実装時に通過確認済み)
- [x] `git commit` 時の新規 hook fire を 9 commit 全件で確認 (`0daeefaf` `f9e33992` `40dc9fe4` `7d720eaa` `b7cd1d74` `27cc52f7` `b7e71c8a` `3fe4112b` `c204b55b`)
- [x] OpenJTalk pin sync gate: cmake bump 後 `uv run python scripts/check_openjtalk_version_sync.py` で `OK: no explicit-pin mismatch against cmake 0.4.1.post8` を確認 (range violation WARN は drift 解消で消滅)
- [x] secret-path-reference / language-parity / changelog-unreleased-cleanup / pytest-skip-reason / gofmt 各 hook 単体実行で Passed
- [x] PR #496 自身の `/check-review-backlog --pr 496` 単発モード: 5 thread が全件 resolved を確認
- [x] PR #496 自身の `/reply-review 496`: Copilot 5 件指摘に返信 + thread resolve 完了

### CI 側で要確認 (本 PR で初めて gate 化される項目)

- [x] cmake post8 bump 後の C++ build (Linux / macOS / Windows) が SHA256 mismatch / 構造変更で失敗しないこと — `cpp-tests / C++ Release & Debug × macos-latest / windows-latest / ubuntu-24.04` 全 6 組 + `cpp-coverage` + `test-cpp-unit-tests` + `test-cpp-inference` + iOS / macOS arm64 build が全件 pass
- [x] `.github/workflows/pre-commit.yml` で 6 新規 hook 全件が PR 時に通過 — `pre-commit run --all-files` job が pass
- [ ] pre-push opt-in stage: `pre-commit install --hook-type pre-push` 後の `git push` で 4 contract gate が 20-30 秒で完走 (ローカル検証のみ可、 副作用あり)

### skill chain の動作確認

- [ ] `/create-pr` フェーズ 6 auto chain: 別 PR で「PR を作って」要求から `/create-pr` → `/check-review-backlog --pr <N>` → `/watch-pr <N>` の 3 段連鎖が明示確認なしで発動 (本 PR 完了後に別 PR で要検証)
- [x] `/release-prep` core 動作: 9 manifest (VERSION=1.12.0 / Rust=0.4.0 / C# Core/Cli=0.3.0 / npm synthesis=0.6.0 / npm g2p=0.4.0 / Swift=1.13.0 / Swift G2P=1.14.0 / Kotlin=1.0.0) の version 抽出成功 + PyPI registry curl で `piper-plus 1.12.0` 取得確認 (local と in sync)
- [x] `/check-review-backlog` backlog 監視モード (引数なし): 全 4 open PR (#496/#386/#355/#222) を scan、 +4 GraphQL req で rate limit 4981→4977 (影響 0.08%、 5000/h limit に対し余裕大)、 全 PR で unresolved=0 を確認
- [ ] `/loop /check-review-backlog` で週次自動監視 (spec 正当性は確認済み、 定期実行系は本 PR で計測不可)

### Copilot レビュー対応検証 (commit `b7e71c8a` 関連)

- [x] `run_gofmt_check.sh`: `set -uo pipefail` + `rc=$?` の明示捕捉で gofmt exit 2 (syntax error) が silent abort しない
- [x] `check_openjtalk_version_sync.py`: `packaging.SpecifierSet` で `==` `~=` `>=` `<=` `>` `<` `!=` 全制約形式判定、 `requirements*.txt` も scan 対象に追加
- [x] `.pre-commit-config.yaml` files filter: `(^|/)(CMakeLists\.txt|Dockerfile|Makefile)$` で sub-directory の同名ファイルも検査対象 / `.*requirements.*\.txt` を openjtalk-version-sync filter に追加

## 参考

- canonical truth: `docs/spec/release-versions.toml` (`expected_prefix` per manifest)
- 関連 memory: `feedback_conservative_changes.md`, `feedback_merge_caution.md`, `feedback_copilot_stale_review.md`, `feedback_ci_cancelled_baseline.md`, `feedback_pr_body_over_comments.md`
- 関連 PR / issue: PR #419 (silent skip patterns), PR #401 (cycle-of-shame ruff drift)
