### PR TITLE
fix(ci): bundle-size-gate に Android 3 ABI shared lib build を追加 (#494)

### DIFF
--- a/.github/workflows/bundle-size-gate.yml
+++ b/.github/workflows/bundle-size-gate.yml
@@ -37,9 +37,123 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Must stay aligned with release-shared-lib.yml's ONNXRUNTIME_VERSION and
+  # docs/reference/ort-versions.md — the prebuilt libpiper_plus.so depends on
+  # the same ORT major/minor that the runtime AAR will eventually ship with.
+  ONNXRUNTIME_VERSION: "1.20.0"
+
 jobs:
+  # Issue #494: the piper-plus-g2p AAR's JNI wrapper (libpiper_plus_g2p_jni.so)
+  # has libpiper_plus.so as an IMPORTED dependency under
+  # `android/piper-plus-g2p/src/main/jniLibs/<ABI>/`. Without this job, the
+  # gradle step below fails with "ninja: error: ... libpiper_plus.so missing"
+  # and the maven::piper-plus-g2p-android baseline is forever SKIP. We mirror
+  # release-shared-lib.yml's build-android job (3-ABI matrix, NDK r26c, 16 KB
+  # page-size alignment for 64-bit ABIs) so the AAR produced here matches the
+  # one Maven Central will ship.
+  build-android-shared-libs:
+    name: Build libpiper_plus.so (${{ matrix.abi }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [arm64-v8a, armeabi-v7a, x86_64]
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          submodules: true
+
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1.6.0
+        id: setup-ndk
+        with:
+          ndk-version: r26c
+
+      - name: Download ONNX Runtime Android
+        run: |
+          curl -L -o onnxruntime-android.aar \
+            "https://repo1.maven.org/maven2/com/microsoft/onnxruntime/onnxruntime-android/${ONNXRUNTIME_VERSION}/onnxruntime-android-${ONNXRUNTIME_VERSION}.aar"
+          unzip -q onnxruntime-android.aar -d onnxruntime-android
+          mkdir -p ort-android/lib ort-android/include
+          cp "onnxruntime-android/jni/${{ matrix.abi }}/libonnxruntime.so" ort-android/lib/
+          HEADER_DIR=$(find onnxruntime-android -name "onnxruntime_cxx_api.h" -exec dirname {} \; | head -1)
+          if [ -n "${HEADER_DIR}" ]; then
+            cp -R "${HEADER_DIR}/"* ort-android/include/
+          else
+            HEADER_DIR2=$(find onnxruntime-android -type d -name "headers" | head -1)
+            if [ -n "${HEADER_DIR2}" ]; then
+              cp -R "${HEADER_DIR2}/"* ort-android/include/
+            fi
+          fi
+          echo "ORT_ANDROID_DIR=${{ github.workspace }}/ort-android" >> "$GITHUB_ENV"
+          echo "ORT_ANDROID_LIB=${{ github.workspace }}/ort-android/lib/libonnxruntime.so" >> "$GITHUB_ENV"
+
+      - name: Configure CMake (Android)
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: |
+          # 16 KB page-size alignment for 64-bit ABIs (Pixel 8a / Android 15+).
+          # armeabi-v7a 32-bit kernels still use 4 KB pages — keep parity with
+          # release-shared-lib.yml / kotlin-g2p-ci.yml convention.
+          PAGE_ALIGN_FLAGS=""
+          if [ "${{ matrix.abi }}" != "armeabi-v7a" ]; then
+            PAGE_ALIGN_FLAGS="-Wl,-z,max-page-size=16384"
+          fi
+          CMAKE_EXTRA_FLAGS=""
+          if [ "${{ matrix.abi }}" = "armeabi-v7a" ]; then
+            CMAKE_EXTRA_FLAGS="-DANDROID_ARM_NEON=ON"
+          fi
+          cmake -B build-android \
+            -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DANDROID_ABI=${{ matrix.abi }} \
+            -DANDROID_PLATFORM=android-24 \
+            -DPIPER_PLUS_BUILD_SHARED=ON \
+            -DCMAKE_SHARED_LINKER_FLAGS="${PAGE_ALIGN_FLAGS}" \
+            -DCMAKE_EXE_LINKER_FLAGS="${PAGE_ALIGN_FLAGS}" \
+            -DONNXRUNTIME_DIR="${ORT_ANDROID_DIR}" \
+            -DONNXRUNTIME_LIB="${ORT_ANDROID_LIB}" \
+            -DONNXRUNTIME_INCLUDE_DIR="${ORT_ANDROID_DIR}/include" \
+            $CMAKE_EXTRA_FLAGS
+
+      - name: Build (Android)
+        run: cmake --build build-android --config Release -j$(nproc)
+
+      - name: Locate libpiper_plus.so
+        id: locate-so
+        run: |
+          set -euo pipefail
+          if [ -f build-android/libpiper_plus.so ]; then
+            SO_PATH="build-android/libpiper_plus.so"
+          elif [ -f build-android/lib/libpiper_plus.so ]; then
+            SO_PATH="build-android/lib/libpiper_plus.so"
+          else
+            echo "::error::libpiper_plus.so not found under build-android/"
+            find build-android -name "libpiper_plus.so" -print || true
+            exit 1
+          fi
+          echo "so-path=${SO_PATH}" >> "$GITHUB_OUTPUT"
+          echo "Resolved: ${SO_PATH}"
+
+      - name: Stage shared lib for downstream consumer
+        run: |
+          mkdir -p so-out
+          cp "${{ steps.locate-so.outputs.so-path }}" so-out/libpiper_plus.so
+
+      - name: Upload libpiper_plus.so artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: bundle-gate-libpiper_plus-${{ matrix.abi }}
+          path: so-out/libpiper_plus.so
+          retention-days: 1
+
   bundle-size:
     name: Measure + compare bundle sizes
+    needs: build-android-shared-libs
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     # Skip fork PRs — they cannot post sticky comments and would only emit
@@ -92,6 +206,34 @@ jobs:
         continue-on-error: true
         working-directory: src/rust
         run: cargo package -p piper-plus --no-verify --allow-dirty
+
+      # Issue #494: stage the prebuilt libpiper_plus.so produced by the
+      # build-android-shared-libs matrix into jniLibs/<ABI>/ so the JNI
+      # wrapper's CMakeLists.txt (IMPORTED target pointing at
+      # src/main/jniLibs/${ANDROID_ABI}/libpiper_plus.so) can link. All 3
+      # ABIs declared in android/piper-plus-g2p/build.gradle.kts
+      # (`abiFilters`) must be present or AGP's externalNativeBuild fails
+      # the first ABI to configure.
+      - name: Download Android shared libs (3 ABIs)
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: bundle-gate-libpiper_plus-*
+          path: android-shared-libs/
+
+      - name: Place libpiper_plus.so into jniLibs
+        run: |
+          set -euo pipefail
+          for abi in arm64-v8a armeabi-v7a x86_64; do
+            SRC="android-shared-libs/bundle-gate-libpiper_plus-${abi}/libpiper_plus.so"
+            DST_DIR="android/piper-plus-g2p/src/main/jniLibs/${abi}"
+            if [ ! -f "${SRC}" ]; then
+              echo "::error::expected artifact missing: ${SRC}"
+              exit 1
+            fi
+            mkdir -p "${DST_DIR}"
+            cp "${SRC}" "${DST_DIR}/libpiper_plus.so"
+            echo "staged ${DST_DIR}/libpiper_plus.so ($(stat -c%s "${DST_DIR}/libpiper_plus.so") bytes)"
+          done
 
       - name: gradle bundleRelease (piper-plus-g2p AAR)
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,8 @@ v1.12.0 で 5 ランタイム (Python/Rust/C#/Go/WASM) に展開した SSML / Vo
 
 - iOS / Linux / Windows / macOS / Android shared-lib リリースパイプラインを復旧 (Issue #377、v1.11.0 以降の停止)
   - `release` ジョブの `needs:` が `build-ios` 失敗で全 OS artifact のアップロードを止めていた
+- Bundle size gate: Android AAR ビルドが prebuilt `libpiper_plus.so` 欠如で永久 SKIP となっていた問題を修正 (Issue #494)
+  - `bundle-size-gate.yml` に `build-android-shared-libs` matrix job (arm64-v8a / armeabi-v7a / x86_64) を追加し、`release-shared-lib.yml` と同じ NDK r26c + ORT 1.20.0 + 16 KB page-align で `libpiper_plus.so` をビルド。bundle-size ジョブが artifact を `android/piper-plus-g2p/src/main/jniLibs/<ABI>/` に配置してから `assembleRelease` を実行することで `maven::piper-plus-g2p-android` の Observed サイズが取得可能に
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,7 @@ v1.12.0 で 5 ランタイム (Python/Rust/C#/Go/WASM) に展開した SSML / Vo
   - `release` ジョブの `needs:` が `build-ios` 失敗で全 OS artifact のアップロードを止めていた
 - Bundle size gate: Android AAR ビルドが prebuilt `libpiper_plus.so` 欠如で永久 SKIP となっていた問題を修正 (Issue #494)
   - `bundle-size-gate.yml` に `build-android-shared-libs` matrix job (arm64-v8a / armeabi-v7a / x86_64) を追加し、`release-shared-lib.yml` と同じ NDK r26c + ORT 1.20.0 + 16 KB page-align で `libpiper_plus.so` をビルド。bundle-size ジョブが artifact を `android/piper-plus-g2p/src/main/jniLibs/<ABI>/` に配置してから `assembleRelease` を実行することで `maven::piper-plus-g2p-android` の Observed サイズが取得可能に
+  - `scripts/check_ort_versions.py` の `TARGETS` に `bundle-size-gate.yml` を追加し、ORT バージョン drift gate の対象に統合 (Copilot review fix)
 
 ### Security
 

--- a/scripts/check_ort_versions.py
+++ b/scripts/check_ort_versions.py
@@ -22,6 +22,7 @@ Issue #383 follow-up で ORT 1.17.0 → 1.20.0 に上げた際、6 ファイル 
     * ``.github/workflows/kotlin-g2p-ci.yml`` (Kotlin G2P PR CI)
     * ``.github/workflows/build-piper.yml`` (Linux/macOS source build)
     * ``.github/workflows/_build-test-cpp.yml`` (Linux/macOS arm64/x86_64/Windows pre-built)
+    * ``.github/workflows/bundle-size-gate.yml`` (Android shared lib build for AAR size measure)
     * ``docker/cpp-dev/Dockerfile`` (CPU-only dev image; Issue #372)
 
 2. **Floor-check group** — canonical より低い floor pin は禁止 (Issue
@@ -75,6 +76,7 @@ TARGETS: list[Path] = [
     Path(".github/workflows/kotlin-g2p-ci.yml"),
     Path(".github/workflows/build-piper.yml"),
     Path(".github/workflows/_build-test-cpp.yml"),
+    Path(".github/workflows/bundle-size-gate.yml"),
     Path("docker/cpp-dev/Dockerfile"),
 ]
 


### PR DESCRIPTION
## Summary

- `bundle-size-gate.yml` の Android AAR ビルドが prebuilt `libpiper_plus.so` 欠如で永久 SKIP となり、`maven::piper-plus-g2p-android` baseline が永久に seed できない問題を修正 (Issue #494)
- 1 commit / 2 files / +144 lines (`.github/workflows/bundle-size-gate.yml` + `CHANGELOG.md`)
- 設計判断: bundle-size-gate **内部** で 3 ABI を build する Option A を採用 (release-shared-lib.yml の最新 artifact 利用 (Option B) はPR HEAD と shared lib の version drift があり整合性が保てない / maven 除外 (Option C) は AAR サイズ regression を盲点化するため)

## 新規 / 拡張機能

### CI / build 自動化 (`.github/workflows/bundle-size-gate.yml`)

| 機能 | 動作 | 解決する問題 |
|------|------|--------------|
| `build-android-shared-libs` matrix job | 3 ABI (`arm64-v8a` / `armeabi-v7a` / `x86_64`) を NDK r26c + ORT 1.20.0 で並列ビルドし、各 `libpiper_plus.so` を artifact `bundle-gate-libpiper_plus-<abi>` として upload (retention 1 日) | これまで JNI wrapper のリンクに必要な shared lib が無く `ninja: error: ... libpiper_plus.so missing` で fail していた |
| `bundle-size` job に `needs: build-android-shared-libs` 追加 | shared lib build が完了してから走る (matrix 失敗時は skip) | `assembleRelease` が依存する jniLibs/ が空の状態を排除 |
| `Download Android shared libs (3 ABIs)` step | `actions/download-artifact@v8.0.1` で 3 ABI 分の `.so` を pattern download | gradle externalNativeBuild は `abiFilters` の全 ABI を要求するため、 1 ABI でも欠けると最初の configure で失敗する |
| `Place libpiper_plus.so into jniLibs` step | `android/piper-plus-g2p/src/main/jniLibs/<abi>/` に配置、 size を log | CMakeLists.txt の IMPORTED `set_target_properties(... IMPORTED_LOCATION ".../jniLibs/${ANDROID_ABI}/libpiper_plus.so")` を満たす |
| `ONNXRUNTIME_VERSION: "1.20.0"` env 追加 | release-shared-lib.yml と同じ ORT major/minor を pin | shared lib と AAR が ship する ORT が divergence しないように同期 (`docs/reference/ort-versions.md` と整合) |

## 設計判断 / トレードオフ

- **Option A (in-workflow build) を採用、 Option B/C は不採用**: B (release-shared-lib.yml の artifact 利用) は PR HEAD と shared lib の SHA が乖離する可能性があり整合性を担保できない。 C (maven を gate から除外) は AAR サイズ regression を検知する責務が失われ、 最も重要な production AAR の盲点化につながる。 A は CI 時間 +5-8 分 (matrix 並列) のコストで、 release-shared-lib.yml と同一の build path を再現できる。
- **`release-shared-lib.yml` の build-android ジョブと意図的に重複**: reusable workflow への抽出は scope が広がるため保留。 NDK バージョン / ORT バージョン / 16 KB page-align フラグ / armeabi-v7a NEON フラグはすべて release-shared-lib.yml と同じ値を pin しており、 drift があれば bundle-size-gate / release-shared-lib どちらの CI でも検出可能。
- **`fail-fast: false` matrix**: 1 ABI が build 失敗しても他 2 ABI を続行。 全 ABI 失敗時のみ bundle-size ジョブが skip され (`needs` 連鎖)、 部分成功で false-green を作らない。
- **artifact retention 1 日**: shared lib は CI 中の一時 staging 用途のみ、 release artifact ではない。 storage コスト削減。
- **`continue-on-error: true` は gradle bundleRelease step に維持**: shared lib が揃った後でも gradle 側の transient failure (Sonatype repo down 等) で PR を red にしない bundle-size-gate の既存ポリシーを継続。

## Test plan

- [ ] PR 作成後、 `Bundle size gate` workflow run で `build-android-shared-libs (arm64-v8a)` / `(armeabi-v7a)` / `(x86_64)` の 3 ジョブが green になることを確認
- [ ] `bundle-size` ジョブの `Place libpiper_plus.so into jniLibs` step で 3 ABI 全部の staged byte size がログに出力されることを確認
- [ ] `gradle bundleRelease (piper-plus-g2p AAR)` step が green で `android/piper-plus-g2p/build/outputs/aar/piper-plus-g2p-release.aar` を生成することを確認
- [ ] sticky comment の `maven::piper-plus-g2p-android` 行が `SKIP` → `n/a` でなく実 byte 値 (約 数 MB) を表示することを確認
- [ ] merge 後、 dev で `workflow_dispatch` を走らせ、 別 PR で `uv run python scripts/check_bundle_size.py --update-baseline` を実行して `tests/fixtures/bundle-size-baseline.json` の `maven::piper-plus-g2p-android.size_bytes: null` を実値に置換 (follow-up PR)

## 参考

- Issue: #494
- 失敗 run (修正前): https://github.com/ayutaz/piper-plus/actions/runs/25918310666
- 関連 workflow: `.github/workflows/release-shared-lib.yml` (build-android ジョブを mirror)
- 関連 spec: `docs/reference/ort-versions.md` (ORT バージョン同期)
- 関連 CMakeLists: `android/piper-plus-g2p/src/main/cpp/CMakeLists.txt` (IMPORTED target の path 定義)
- 関連 build config: `android/piper-plus-g2p/build.gradle.kts` (3 ABI `abiFilters`)
