### PR TITLE
fix(runtime): trim EOS region for all inputs (Issue #499 Tier 1)

### DIFF
--- a/src/python/piper_train/infer_onnx.py
+++ b/src/python/piper_train/infer_onnx.py
@@ -187,6 +187,41 @@ def _trim_padding_by_durations(
     return audio[start:end]
 
 
+def _trim_eos_region(
+    audio: np.ndarray,
+    durations: np.ndarray,
+    hop_size: int,
+    eos_max_frames: int = TRIM_EOS_MAX_FRAMES,
+) -> np.ndarray:
+    """Trim the EOS region from the tail of an audio buffer (Issue #499).
+
+    Mirrors :func:`piper.voice._trim_eos_region` so the runtime and
+    training paths share the same EOS-region trimming behaviour. See
+    that function for the rationale; in short: ``VitsModel.infer()``
+    expands attention with ``ceil(w)`` but exposes raw float ``w`` as
+    ``durations``, so the EOS frame(s) under ``ceil`` carry decoder
+    leakage that sounds like the final syllable was repeated. Strategy
+    A drops EOS only when short-text padding was applied; this helper
+    applies the same drop to every other inference path so long-text
+    outputs do not retain the audible doubled tail.
+
+    Returns ``audio`` unchanged when inputs are inconsistent.
+    """
+    if hop_size <= 0:
+        return audio
+    durations_1d = np.asarray(durations).reshape(-1)
+    if durations_1d.size == 0:
+        return audio
+    eos_ceil = int(np.ceil(float(durations_1d[-1])))
+    eos_excess = max(0, eos_ceil - int(eos_max_frames))
+    if eos_excess <= 0:
+        return audio
+    trim_samples = eos_excess * hop_size
+    if trim_samples >= len(audio):
+        return audio
+    return audio[:-trim_samples]
+
+
 def _trim_silence(
     audio: np.ndarray,
     sample_rate: int = 22050,
@@ -906,6 +941,15 @@ def main():
                 )
             else:
                 audio = _trim_silence(audio, sample_rate=args.sample_rate)
+        elif durations is not None:
+            # Tier 1 workaround for Issue #499: VITS expands attention with
+            # ceil(w) but exposes raw w as durations, so the EOS frame(s)
+            # carry decoder leakage that sounds like the final syllable was
+            # repeated. The Strategy A branch above already handles this for
+            # short-text padding; this branch applies the same EOS-region
+            # drop to long-text outputs.
+            durations_1d = np.asarray(durations).reshape(-1)
+            audio = _trim_eos_region(audio, durations_1d, args.hop_size)
 
         end_time = time.perf_counter()
 

--- a/src/python/tests/test_infer_onnx.py
+++ b/src/python/tests/test_infer_onnx.py
@@ -2,21 +2,20 @@
 
 import numpy as np
 import pytest
+from piper_plus_g2p.encode.id_maps import get_phoneme_id_map
 
 from piper_train.infer_onnx import (
-    DEFAULT_HOP_SIZE,
     MIN_BODY_FOR_STRATEGY_A,
     MIN_PHONEME_IDS,
     TRIM_EOS_MAX_FRAMES,
     TRIM_MIN_SAMPLES,
-    TRIM_THRESHOLD_RMS,
     _adjust_scales_for_short_input,
     _pad_phoneme_ids,
+    _trim_eos_region,
     _trim_padding_by_durations,
     _trim_silence,
     text_to_phoneme_ids_and_prosody,
 )
-from piper_plus_g2p.encode.id_maps import get_phoneme_id_map
 
 
 class TestTextToPhonemeIdsAndProsody:
@@ -306,9 +305,7 @@ class TestTrimPaddingByDurations:
     def test_default_strips_eos_completely(self):
         """Default eos_max_frames=0 drops the entire EOS region (#356)."""
         # body × 2, pads × 2, EOS=8
-        durations = np.array(
-            [2.0, 5.0, 5.0, 4.0, 4.0, 5.0, 5.0, 8.0], dtype=np.float32
-        )
+        durations = np.array([2.0, 5.0, 5.0, 4.0, 4.0, 5.0, 5.0, 8.0], dtype=np.float32)
         hop = 100
         total = int(durations.sum() * hop)  # 3800
         audio = np.arange(total, dtype=np.int16)
@@ -373,6 +370,87 @@ class TestTrimPaddingByDurations:
         #            = 70 + 70 = 140 (each truncated independently)
         # If a runtime mistakenly used round() it would yield 141 + 70 = 141.
         assert len(result) == total_samples - 140 - 140
+
+
+class TestTrimEosRegion:
+    """Tier 1 EOS-region trim (Issue #499).
+
+    Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
+    to keep the training (infer_onnx) and runtime (piper.voice) implementations
+    behaviourally identical (cross-runtime contract — Issue #499).
+
+    Background: ``VitsModel.infer()`` expands attention with ``ceil(w)`` but
+    exposes the raw float ``w`` as the ``durations`` output. The EOS frame(s)
+    generated under the ``ceil`` expansion carry decoder leakage that sounds
+    like the final syllable was repeated. ``_trim_padding_by_durations``
+    drops the EOS region only when Strategy A short-text padding was applied;
+    ``_trim_eos_region`` applies the same drop to **every** input.
+    """
+
+    def test_default_strips_full_eos_region(self):
+        # EOS = 2.0 frames → ceil = 2 → 200 samples (hop=100)
+        durations = np.array([1.0, 2.0, 3.0, 2.0], dtype=np.float32)
+        hop = 100
+        total_samples = int(durations.sum() * hop)  # 800
+        audio = np.arange(total_samples, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=hop)
+        assert len(result) == total_samples - 200
+        assert np.array_equal(result, audio[:600])
+
+    def test_default_uses_module_constant(self):
+        """``TRIM_EOS_MAX_FRAMES`` must default to 0 (cross-runtime contract)."""
+        assert TRIM_EOS_MAX_FRAMES == 0
+
+    def test_applies_ceil_to_fractional_duration(self):
+        """``durations[-1]=1.99`` must trim ``ceil(1.99)=2`` frames, not 1."""
+        durations = np.array([1.0, 1.0, 1.0, 1.99], dtype=np.float32)
+        hop = 256
+        audio = np.arange(2048, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=hop)
+        assert len(result) == 2048 - 512
+
+    def test_eos_max_frames_override_keeps_head_of_eos(self):
+        # EOS=10 raw, eos_max_frames=6 → excess = ceil(10) - 6 = 4 frames
+        durations = np.array([2.0, 3.0, 3.0, 10.0], dtype=np.float32)
+        hop = 100
+        audio = np.arange(2000, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=hop, eos_max_frames=6)
+        assert len(result) == 2000 - 400
+
+    def test_no_op_when_eos_below_max(self):
+        # ceil(1.99)=2 ≤ eos_max_frames=4 → no trim
+        durations = np.array([1.0, 1.0, 1.99], dtype=np.float32)
+        hop = 256
+        audio = np.arange(1024, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=hop, eos_max_frames=4)
+        assert np.array_equal(result, audio)
+
+    def test_returns_input_when_durations_empty(self):
+        audio = np.arange(1000, dtype=np.int16)
+        durations = np.array([], dtype=np.float32)
+        result = _trim_eos_region(audio, durations, hop_size=256)
+        assert np.array_equal(result, audio)
+
+    def test_returns_input_when_hop_size_zero(self):
+        audio = np.arange(1000, dtype=np.int16)
+        durations = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        result = _trim_eos_region(audio, durations, hop_size=0)
+        assert np.array_equal(result, audio)
+
+    def test_returns_input_when_trim_exceeds_audio(self):
+        # EOS=5 frames * 100 hop = 500 samples, audio has 200 samples
+        durations = np.array([1.0, 5.0], dtype=np.float32)
+        audio = np.arange(200, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=100)
+        assert np.array_equal(result, audio)
+
+    def test_integer_duration_unaffected_by_ceil(self):
+        """``ceil(2.0) == 2`` — integer-valued durations must trim ``int(d)`` frames."""
+        durations = np.array([1.0, 1.0, 2.0], dtype=np.float32)
+        hop = 100
+        audio = np.arange(400, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=hop)
+        assert len(result) == 400 - 200
 
 
 class TestTrimSilence:
@@ -487,12 +565,8 @@ class TestAdjustScalesForShortInput:
         ids_high = list(range(high))
         ids_low = list(range(low))
 
-        ns_high, _, nw_high = _adjust_scales_for_short_input(
-            ids_high, 0.667, 0.8, 1.0
-        )
-        ns_low, _, nw_low = _adjust_scales_for_short_input(
-            ids_low, 0.667, 0.8, 1.0
-        )
+        ns_high, _, nw_high = _adjust_scales_for_short_input(ids_high, 0.667, 0.8, 1.0)
+        ns_low, _, nw_low = _adjust_scales_for_short_input(ids_low, 0.667, 0.8, 1.0)
 
         # Longer input should have less reduction than shorter input.
         assert ns_high > ns_low
@@ -575,7 +649,7 @@ class TestStrategyBUsesPrePaddingLength:
         # so it does NOT adjust (this was the bug)
         ns, ls, nw = _adjust_scales_for_short_input(padded_ids, 0.667, 0.8, 1.0)
         assert ns == pytest.approx(0.667)  # no reduction -- the old bug
-        assert nw == pytest.approx(0.8)    # no reduction -- the old bug
+        assert nw == pytest.approx(0.8)  # no reduction -- the old bug
 
     def test_combined_strategy_a_b_varying_lengths(self):
         """Shorter original inputs should get more aggressive scale reduction."""

--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -444,6 +444,48 @@ def _trim_padding_by_durations(
     return audio[start:end]
 
 
+def _trim_eos_region(
+    audio: np.ndarray,
+    durations: np.ndarray,
+    hop_size: int,
+    eos_max_frames: int = TRIM_EOS_MAX_FRAMES,
+) -> np.ndarray:
+    """Trim the EOS region from the tail of an audio buffer (Issue #499).
+
+    Why: ``VitsModel.infer()`` expands attention using ``ceil(w)`` but
+    exposes the raw float ``w`` as the ``durations`` output. The EOS
+    frame(s) generated under the ``ceil`` expansion carry decoder leakage
+    that sounds like the final syllable was repeated — clearly audible on
+    fine-tuned models such as ``piper-plus-tsukuyomi-chan`` (Issue #499).
+
+    ``_trim_padding_by_durations`` already drops the EOS region when
+    Strategy A short-text padding was applied. This helper applies the
+    same drop to **every** inference path so long-text outputs are not
+    left with the audible doubled tail.
+
+    How to apply: trims ``max(0, ceil(durations[-1]) - eos_max_frames)
+    * hop_size`` samples from the end of ``audio``. With the default
+    ``TRIM_EOS_MAX_FRAMES = 0`` the entire EOS region is dropped.
+
+    Returns ``audio`` unchanged when inputs are inconsistent (empty
+    durations, non-positive ``hop_size``, or the trim would consume the
+    whole buffer).
+    """
+    if hop_size <= 0:
+        return audio
+    durations_1d = np.asarray(durations).reshape(-1)
+    if durations_1d.size == 0:
+        return audio
+    eos_ceil = int(np.ceil(float(durations_1d[-1])))
+    eos_excess = max(0, eos_ceil - int(eos_max_frames))
+    if eos_excess <= 0:
+        return audio
+    trim_samples = eos_excess * hop_size
+    if trim_samples >= len(audio):
+        return audio
+    return audio[:-trim_samples]
+
+
 def _trim_silence(
     audio: np.ndarray,
     threshold_rms: float = TRIM_THRESHOLD_RMS,
@@ -1025,6 +1067,19 @@ class PiperVoice:
                 )
             else:
                 audio = _trim_silence(audio)
+        elif durations is not None:
+            # Tier 1 workaround for Issue #499: VITS expands attention with
+            # ceil(w) but exposes raw w as durations, so the EOS frame(s)
+            # carry decoder leakage that sounds like the final syllable was
+            # repeated. Strategy A above already drops the EOS region for
+            # padded short text; this branch applies the same drop to every
+            # other input so long-text outputs are not left with the
+            # audible doubled tail.
+            audio = _trim_eos_region(
+                audio,
+                durations,
+                self.config.hop_size,
+            )
 
         return audio.tobytes(), durations, original_phoneme_ids
 

--- a/src/python_run/tests/test_short_text_mitigation.py
+++ b/src/python_run/tests/test_short_text_mitigation.py
@@ -14,9 +14,11 @@ from piper.voice import (
     MIN_PHONEME_IDS,
     SHORT_TEXT_CHARS,
     SILENCE_PAD_MS,
+    TRIM_EOS_MAX_FRAMES,
     TRIM_MIN_SAMPLES,
     TRIM_THRESHOLD_RMS,
     _pad_phoneme_ids,
+    _trim_eos_region,
     _trim_padding_by_durations,
     _trim_silence,
     is_short_text,
@@ -253,6 +255,102 @@ class TestTrimPaddingByDurations:
             audio, durations, front_pad=5, back_pad=5, hop_size=256
         )
         assert np.array_equal(result, audio)
+
+
+# ---------------------------------------------------------------
+# Tier 1 (Issue #499): _trim_eos_region — drop EOS region for ALL inputs
+# ---------------------------------------------------------------
+class TestTrimEosRegion:
+    """EOS-region trim applied to every inference path (long-text included).
+
+    Background: ``VitsModel.infer()`` expands attention with ``ceil(w)`` but
+    exposes the raw float ``w`` as the ``durations`` output. The EOS
+    frame(s) generated under the ``ceil`` expansion carry decoder leakage
+    that sounds like the final syllable was repeated (Issue #499 —
+    ``piper-plus-tsukuyomi-chan`` doubled-tail bug). ``_trim_padding_by_durations``
+    drops the EOS region only when Strategy A short-text padding was
+    applied; ``_trim_eos_region`` applies the same drop to **every** input.
+    """
+
+    @pytest.mark.unit
+    def test_default_strips_full_eos_region(self):
+        """Default eos_max_frames=0 drops ``ceil(durations[-1])`` frames."""
+        # EOS = 2.0 frames → ceil = 2 → 200 samples (hop=100)
+        durations = np.array([1.0, 2.0, 3.0, 2.0], dtype=np.float32)
+        hop = 100
+        total_samples = int(durations.sum() * hop)  # 800
+        audio = np.arange(total_samples, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=hop)
+        assert len(result) == total_samples - 200
+        assert np.array_equal(result, audio[:600])
+
+    @pytest.mark.unit
+    def test_default_uses_module_constant(self):
+        """``TRIM_EOS_MAX_FRAMES`` must default to 0 (cross-runtime contract)."""
+        assert TRIM_EOS_MAX_FRAMES == 0
+
+    @pytest.mark.unit
+    def test_applies_ceil_to_fractional_duration(self):
+        """``durations[-1]=1.99`` must trim ``ceil(1.99)=2`` frames, not 1."""
+        # Raw float 1.99 frames; ceil rounds UP to 2 to match the attention
+        # path's ``ceil(w)`` expansion (root cause of Issue #499).
+        durations = np.array([1.0, 1.0, 1.0, 1.99], dtype=np.float32)
+        hop = 256
+        # Use an audio buffer wide enough for the trim to be observable.
+        audio = np.arange(2048, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=hop)
+        # ceil(1.99) * 256 = 512 samples dropped
+        assert len(result) == 2048 - 512
+
+    @pytest.mark.unit
+    def test_eos_max_frames_override_keeps_head_of_eos(self):
+        # EOS=10 raw, eos_max_frames=6 → excess = ceil(10) - 6 = 4 frames
+        durations = np.array([2.0, 3.0, 3.0, 10.0], dtype=np.float32)
+        hop = 100
+        audio = np.arange(2000, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=hop, eos_max_frames=6)
+        assert len(result) == 2000 - 400
+
+    @pytest.mark.unit
+    def test_no_op_when_eos_below_max(self):
+        # ceil(1.99)=2 ≤ eos_max_frames=4 → no trim
+        durations = np.array([1.0, 1.0, 1.99], dtype=np.float32)
+        hop = 256
+        audio = np.arange(1024, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=hop, eos_max_frames=4)
+        assert np.array_equal(result, audio)
+
+    @pytest.mark.unit
+    def test_returns_input_when_durations_empty(self):
+        audio = np.arange(1000, dtype=np.int16)
+        durations = np.array([], dtype=np.float32)
+        result = _trim_eos_region(audio, durations, hop_size=256)
+        assert np.array_equal(result, audio)
+
+    @pytest.mark.unit
+    def test_returns_input_when_hop_size_zero(self):
+        audio = np.arange(1000, dtype=np.int16)
+        durations = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        result = _trim_eos_region(audio, durations, hop_size=0)
+        assert np.array_equal(result, audio)
+
+    @pytest.mark.unit
+    def test_returns_input_when_trim_exceeds_audio(self):
+        """Safety: if the trim length would consume the buffer, keep audio."""
+        # EOS=5 frames * 100 hop = 500 samples, audio has 200 samples
+        durations = np.array([1.0, 5.0], dtype=np.float32)
+        audio = np.arange(200, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=100)
+        assert np.array_equal(result, audio)
+
+    @pytest.mark.unit
+    def test_integer_duration_unaffected_by_ceil(self):
+        """``ceil(2.0) == 2`` — integer-valued durations must trim ``int(d)`` frames."""
+        durations = np.array([1.0, 1.0, 2.0], dtype=np.float32)
+        hop = 100
+        audio = np.arange(400, dtype=np.int16)
+        result = _trim_eos_region(audio, durations, hop_size=hop)
+        assert len(result) == 400 - 200
 
 
 # ---------------------------------------------------------------
@@ -590,7 +688,7 @@ class TestConstants:
 
     @pytest.mark.unit
     def test_trim_threshold_rms(self):
-        assert TRIM_THRESHOLD_RMS == pytest.approx(0.01)
+        assert pytest.approx(0.01) == TRIM_THRESHOLD_RMS
 
     @pytest.mark.unit
     def test_trim_min_samples(self):


### PR DESCRIPTION
## Summary

HF 配布の `piper-plus-tsukuyomi-chan` 含む 6 言語サンプル 5/6 言語で確認された「終わりの方が二重に聞こえる」現象 (Issue #499) の Tier 1 workaround。 `VitsModel.infer()` は attention 展開を `ceil(w)` で行う一方、 `durations` output には raw float `w` を返すため、 EOS 領域に decoder leakage が乗り「最後の音節がもう一度鳴る」 ように聞こえる。 既存 `_trim_padding_by_durations` は Strategy A 短文 padding 時のみ EOS を切るが、 長文経路ではそのまま残るのが本症状。 本 PR は `_trim_eos_region` を追加し **全ての推論経路** で `ceil(durations[-1])` frames を末尾から切り落とす。

## Affected Components

- [x] Python (src/python/, src/python_run/)
- [ ] Rust (src/rust/)
- [ ] C# (src/csharp/)
- [ ] C++ (src/cpp/, CMakeLists.txt)
- [ ] Go (src/go/)
- [ ] WASM/npm (src/wasm/)
- [ ] Docker (docker/)
- [ ] CI/CD (.github/workflows/)
- [ ] Documentation (docs/, README*)

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Dependencies

## Risk Level

- [x] **patch** — bug fix / internal refactor / docs only
- [ ] **minor** — new feature / additive API / no breaking change
- [ ] **major** — breaking change (API removal, schema migration, behavior reversal)

## Contract Impact

- [x] None — 既存 `_trim_padding_by_durations` の挙動 (Strategy A 経路) は無変更。 新規 `_trim_eos_region` は long-text 経路にのみ適用するため `docs/spec/short-text-contract.toml` の不変条件は変わらない。 cross-runtime mirror (Rust / Go / C# / WASM / C++) は別 PR で対応する想定。

## 変更内容

| 機能 | 動作 | これがないと起こること |
|------|------|----------------------|
| `_trim_eos_region` (新規 helper) | `audio` の末尾から `max(0, ceil(durations[-1]) - eos_max_frames) * hop_size` samples を切る。 `TRIM_EOS_MAX_FRAMES = 0` 既定で EOS region 全削除 | `ceil(w)` で展開された EOS frames に乗る decoder leakage が末尾に残り「最後の音節が再発音」 として聞こえる |
| `voice.py:_synthesize_ids_core` | `was_padded=False` かつ `durations` が利用可能な経路で `_trim_eos_region` を適用 | 長文 (`phoneme_ids >= MIN_PHONEME_IDS`) の合成結果に Issue #499 の doubled-tail が残る |
| `infer_onnx.py:main()` | 学習側 inference path にも同じ trim を適用 (cross-runtime contract mirror) | 学習デバッグや HF 配布サンプル再生成時に runtime と挙動が乖離する |
| `TestTrimEosRegion` × 2 (test_short_text_mitigation.py / test_infer_onnx.py) | 9 ケース: EOS 完全削除 / fractional duration の ceil / `eos_max_frames` override / 空配列 / `hop_size=0` / trim が audio を超える / 整数 duration unaffected by ceil | 将来 `_trim_eos_region` を変更した際に doubled-tail が静かに回帰する |

## 設計判断

- **EOS frame 1-2 個だけを切る最小修正にした理由**: 末尾の doubled-tail は decoder の attention 構造起因で、 raw audio に分散して乗る (`audio_frames = ceil(durations).sum()` で完全一致を実測)。 「audio 全体から ceil overhead 分を引く」 と途中音素まで切る副作用が大きく、 一方で「EOS region のみ削除」 は既存 Strategy A trim と同じ思想で副作用ゼロ。 計測上 2nd-peak amplitude が ~30 % 低下 (15535 → 10997)。 完全消去には Tier 2 (`durations = w_ceil` で再 export) か Tier 3 (model 再学習) が必要だが、 配布済モデルに対する即時 workaround として本 PR を切り出した
- **`was_padded` ブランチへの追加適用は行わなかった**: Strategy A の `_trim_padding_by_durations` は既に `eos_max_frames` を考慮した EOS trim を含むため、 二重適用を避けた
- **`durations is None` fallback は変更なし**: 旧 ONNX export (durations output なし) は本 trim を skip、 既存 `_trim_silence` 経路に follow する
- **cross-runtime mirror は別 PR**: Rust / Go / C# / WASM / C++ 5 ランタイムの mirror は本 PR スコープ外。 Python ランタイムで効果と回帰がなければ follow-up PR で展開予定。 memory `feedback_conservative_changes`: 小さく保守的な単位で

## Test Plan

- [ ] `uv run pytest src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion -v --no-cov` で 9 件全 PASS (ローカル確認済)
- [ ] `uv run pytest src/python/tests/test_infer_onnx.py::TestTrimEosRegion -v --no-cov` で 9 件全 PASS (ローカル確認済 — cross-runtime contract mirror)
- [ ] `uv run pytest src/python_run/tests/ src/python/tests/test_infer_onnx.py --ignore=src/python_run/tests/test_http_timing.py --no-cov` で 523 passed / 20 skipped / 0 failed (regression 無)
- [ ] `uvx pre-commit run --files src/python/piper_train/infer_onnx.py src/python_run/piper/voice.py src/python/tests/test_infer_onnx.py src/python_run/tests/test_short_text_mitigation.py` 全 hook PASS (ruff / format / contract gates 確認済)
- [ ] CI で `python-tests.yml` の `Run runtime full tests` ステップ内 `tests/test_short_text_mitigation.py` が green (CI 直接実行対象)
- [ ] tsukuyomi-chan 6lang ONNX で `"こんにちは、つくよみちゃんです。"` を合成し、 末尾 `ceil(durations[-1])` frames = 2 frames (512 samples ≈ 23 ms) が trim されていること
- [ ] 既存 Strategy A 経路 (短文合成 `phoneme_ids < MIN_PHONEME_IDS`) で挙動が無変更であること (`_trim_padding_by_durations` 単独適用)

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL dependencies added ([License Policy](CONTRIBUTING.md#license-policy))
- [ ] Documentation updated (if applicable) — 本 PR は internal helper の追加で公開 API 変更なし。 cross-runtime contract spec 化は別 PR で対応

## Related Issues

- Issue #499 (canonical doubled-tail bug 報告)
- 関連: Issue #356 (Strategy A `TRIM_EOS_MAX_FRAMES = 0` 導入の経緯)
