### PR TITLE
fix(runtime): mirror trim_eos_region to Rust/Go/C#/WASM/C++ (Issue #499 Tier 1)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -67,6 +67,13 @@ indent_size = unset
 [src/cpp/tests/test_ssml.cpp]
 indent_size = unset
 
+# Short-text mitigation tests follow the legacy src/cpp 2-space indent style
+# to match piper.cpp (whose own opt-out is grouped with piper.cpp above). The
+# test file replicates piper.cpp's trim helpers verbatim so the indentation
+# style must match.
+[src/cpp/tests/test_short_text_mitigation.cpp]
+indent_size = unset
+
 # Cross-runtime contract specs in docs/spec/ use column-alignment for
 # inline `# comment` annotations (e.g. `sample_rate = 22050        # Hz`),
 # array entries with inline tables, and field tables with aligned widths

--- a/src/cpp/piper.cpp
+++ b/src/cpp/piper.cpp
@@ -901,6 +901,56 @@ static void trimPaddingByDurationsFloat(std::vector<float> &audioBuffer,
   }
 }
 
+// Tier 1 workaround for Issue #499: trim the EOS region from the tail for
+// every inference path (long-text included).
+//
+// VITS's infer() expands attention with ceil(w) but exposes the raw float w
+// as the durations output. The EOS frame(s) generated under ceil carry
+// decoder leakage that sounds like the final syllable was repeated —
+// clearly audible on fine-tuned models such as piper-plus-tsukuyomi-chan.
+// trimPaddingByDurations already drops the EOS region only when Strategy A
+// short-text padding was applied; this helper applies the same drop to
+// every other inference path so long-text outputs do not retain the
+// audible doubled tail.
+//
+// Mirrors src/python_run/piper/voice.py _trim_eos_region so every runtime
+// produces byte-equal output for the same (audio, durations.back(),
+// hopSize, eosMaxFrames) tuple. The sample-count conversion uses
+// static_cast<int>(...) truncation to match Python's int(...) semantics.
+//
+// Falls through unchanged when arguments are inconsistent.
+static void trimEosRegion(std::vector<int16_t> &audioBuffer,
+                          const std::vector<float> &durations,
+                          int hopSize,
+                          int eosMaxFrames = TRIM_EOS_MAX_FRAMES) {
+  if (hopSize <= 0 || durations.empty()) return;
+  const float eosFrames = durations.back();
+  const int eosCeil = static_cast<int>(std::ceil(eosFrames));
+  const int eosExcess = std::max(0, eosCeil - eosMaxFrames);
+  if (eosExcess <= 0) return;
+  const int trimSamples = eosExcess * hopSize;
+  const int totalSamples = static_cast<int>(audioBuffer.size());
+  if (trimSamples >= totalSamples) return;
+  audioBuffer.resize(totalSamples - trimSamples);
+}
+
+// Float32 variant of trimEosRegion. Identical sample-count logic; only the
+// buffer element type differs.
+static void trimEosRegionFloat(std::vector<float> &audioBuffer,
+                               const std::vector<float> &durations,
+                               int hopSize,
+                               int eosMaxFrames = TRIM_EOS_MAX_FRAMES) {
+  if (hopSize <= 0 || durations.empty()) return;
+  const float eosFrames = durations.back();
+  const int eosCeil = static_cast<int>(std::ceil(eosFrames));
+  const int eosExcess = std::max(0, eosCeil - eosMaxFrames);
+  if (eosExcess <= 0) return;
+  const int trimSamples = eosExcess * hopSize;
+  const int totalSamples = static_cast<int>(audioBuffer.size());
+  if (trimSamples >= totalSamples) return;
+  audioBuffer.resize(totalSamples - trimSamples);
+}
+
 // Trim leading/trailing silence from int16 audio using windowed RMS.
 // Preserves at least TRIM_MIN_SAMPLES samples.
 static void trimSilenceInt16(std::vector<int16_t> &audioBuffer) {
@@ -1363,6 +1413,19 @@ void synthesize(std::vector<PhonemeId> &phonemeIds,
     if (result.audioSeconds > 0) {
       result.realTimeFactor = result.inferSeconds / result.audioSeconds;
     }
+  } else if (haveDurations) {
+    // Tier 1 workaround for Issue #499: even without short-text padding,
+    // the EOS region carries decoder leakage that sounds like the final
+    // syllable was repeated. Strategy A above already handles this for
+    // padded inputs; this branch applies the same EOS-region drop to
+    // long-text outputs.
+    trimEosRegion(audioBuffer, paddedDurations, hopSize, TRIM_EOS_MAX_FRAMES);
+    result.audioSeconds =
+        static_cast<double>(audioBuffer.size()) /
+        static_cast<double>(synthesisConfig.sampleRate);
+    if (result.audioSeconds > 0) {
+      result.realTimeFactor = result.inferSeconds / result.audioSeconds;
+    }
   }
 
   // Extract phoneme timing information using the original (pre-padding)
@@ -1546,6 +1609,16 @@ void synthesizeFloat(std::vector<PhonemeId> &phonemeIds,
     } else {
       trimSilenceFloat(audioBuffer);
     }
+    result.audioSeconds =
+        static_cast<double>(audioBuffer.size()) /
+        static_cast<double>(synthesisConfig.sampleRate);
+    if (result.audioSeconds > 0) {
+      result.realTimeFactor = result.inferSeconds / result.audioSeconds;
+    }
+  } else if (haveDurations) {
+    // Tier 1 workaround for Issue #499 — see int16 path above.
+    trimEosRegionFloat(audioBuffer, paddedDurations, hopSize,
+                       TRIM_EOS_MAX_FRAMES);
     result.audioSeconds =
         static_cast<double>(audioBuffer.size()) /
         static_cast<double>(synthesisConfig.sampleRate);

--- a/src/cpp/tests/test_short_text_mitigation.cpp
+++ b/src/cpp/tests/test_short_text_mitigation.cpp
@@ -1077,7 +1077,7 @@ TEST_F(TrimPaddingByDurationsTest, TruncationMatchesIntCast) {
 // Tier 1 (Issue #499): trimEosRegion — drop EOS region for ALL inputs
 // ======================================================================
 // Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
-// so every runtime gets identical behavioural coverage
+// so every runtime gets identical behavioral coverage
 // (cross-runtime contract — Issue #499).
 
 class TrimEosRegionTest : public ::testing::Test {};

--- a/src/cpp/tests/test_short_text_mitigation.cpp
+++ b/src/cpp/tests/test_short_text_mitigation.cpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 // ---------------------------------------------------------------------------
-// Re-declare the constants and helpers identically to piper.cpp so the tests
+// Redeclare the constants and helpers identically to piper.cpp so the tests
 // are self-contained (no piper.cpp linkage required).
 // ---------------------------------------------------------------------------
 
@@ -116,6 +116,23 @@ static void trimPaddingByDurations(std::vector<int16_t> &audioBuffer,
                                  audioBuffer.begin() + end);
     audioBuffer = std::move(trimmed);
   }
+}
+
+// Replica of trimEosRegion from piper.cpp (int16 variant). Tier 1 (Issue
+// #499): drop ceil(durations[-1]) frames from the tail for ALL inputs.
+static void trimEosRegion(std::vector<int16_t> &audioBuffer,
+                          const std::vector<float> &durations,
+                          int hopSize,
+                          int eosMaxFrames = TRIM_EOS_MAX_FRAMES) {
+  if (hopSize <= 0 || durations.empty()) return;
+  const float eosFrames = durations.back();
+  const int eosCeil = static_cast<int>(std::ceil(eosFrames));
+  const int eosExcess = std::max(0, eosCeil - eosMaxFrames);
+  if (eosExcess <= 0) return;
+  const int trimSamples = eosExcess * hopSize;
+  const int totalSamples = static_cast<int>(audioBuffer.size());
+  if (trimSamples >= totalSamples) return;
+  audioBuffer.resize(totalSamples - trimSamples);
 }
 
 // Replica of trimSilenceInt16 from piper.cpp
@@ -1054,6 +1071,101 @@ TEST_F(TrimPaddingByDurationsTest, TruncationMatchesIntCast) {
                          hop, TRIM_EOS_MAX_FRAMES);
 
   EXPECT_EQ(static_cast<int>(audio.size()), total - 140 - 140);
+}
+
+// ======================================================================
+// Tier 1 (Issue #499): trimEosRegion — drop EOS region for ALL inputs
+// ======================================================================
+// Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
+// so every runtime gets identical behavioural coverage
+// (cross-runtime contract — Issue #499).
+
+class TrimEosRegionTest : public ::testing::Test {};
+
+TEST_F(TrimEosRegionTest, DefaultStripsFullEosRegion) {
+  // EOS = 2.0 frames → ceil = 2 → 200 samples (hop=100)
+  std::vector<float> durations = {1.0f, 2.0f, 3.0f, 2.0f};
+  const int hop = 100;
+  const int total = 800;
+  std::vector<int16_t> audio(total);
+  for (int i = 0; i < total; i++) audio[i] = static_cast<int16_t>(i);
+
+  trimEosRegion(audio, durations, hop, TRIM_EOS_MAX_FRAMES);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), total - 200);
+  for (int i = 0; i < 600; i++) EXPECT_EQ(audio[i], static_cast<int16_t>(i));
+}
+
+TEST_F(TrimEosRegionTest, AppliesCeilToFractionalDuration) {
+  // durations[-1]=1.99 must trim ceil(1.99)=2 frames, not 1.
+  std::vector<float> durations = {1.0f, 1.0f, 1.0f, 1.99f};
+  const int hop = 256;
+  std::vector<int16_t> audio(2048);
+
+  trimEosRegion(audio, durations, hop, TRIM_EOS_MAX_FRAMES);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), 2048 - 512);
+}
+
+TEST_F(TrimEosRegionTest, EosMaxFramesOverrideKeepsHeadOfEos) {
+  // EOS=10 raw, eosMaxFrames=6 → excess = ceil(10) - 6 = 4 frames
+  std::vector<float> durations = {2.0f, 3.0f, 3.0f, 10.0f};
+  const int hop = 100;
+  std::vector<int16_t> audio(2000);
+
+  trimEosRegion(audio, durations, hop, /*eosMaxFrames=*/6);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), 2000 - 400);
+}
+
+TEST_F(TrimEosRegionTest, NoOpWhenEosBelowMax) {
+  // ceil(1.99)=2 ≤ eosMaxFrames=4 → no trim
+  std::vector<float> durations = {1.0f, 1.0f, 1.99f};
+  const int hop = 256;
+  std::vector<int16_t> audio(1024);
+
+  trimEosRegion(audio, durations, hop, /*eosMaxFrames=*/4);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), 1024);
+}
+
+TEST_F(TrimEosRegionTest, ReturnsInputWhenDurationsEmpty) {
+  std::vector<int16_t> audio(1000);
+  std::vector<float> durations;
+
+  trimEosRegion(audio, durations, /*hopSize=*/256, TRIM_EOS_MAX_FRAMES);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), 1000);
+}
+
+TEST_F(TrimEosRegionTest, ReturnsInputWhenHopSizeZero) {
+  std::vector<int16_t> audio(1000);
+  std::vector<float> durations = {1.0f, 2.0f, 3.0f};
+
+  trimEosRegion(audio, durations, /*hopSize=*/0, TRIM_EOS_MAX_FRAMES);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), 1000);
+}
+
+TEST_F(TrimEosRegionTest, ReturnsInputWhenTrimExceedsAudio) {
+  // EOS=5 frames * 100 hop = 500 samples, audio has 200 samples
+  std::vector<float> durations = {1.0f, 5.0f};
+  std::vector<int16_t> audio(200);
+
+  trimEosRegion(audio, durations, /*hopSize=*/100, TRIM_EOS_MAX_FRAMES);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), 200);
+}
+
+TEST_F(TrimEosRegionTest, IntegerDurationUnaffectedByCeil) {
+  // ceil(2.0) == 2 — integer-valued durations trim int(d) frames.
+  std::vector<float> durations = {1.0f, 1.0f, 2.0f};
+  const int hop = 100;
+  std::vector<int16_t> audio(400);
+
+  trimEosRegion(audio, durations, hop, TRIM_EOS_MAX_FRAMES);
+
+  EXPECT_EQ(static_cast<int>(audio.size()), 400 - 200);
 }
 
 int main(int argc, char **argv) {

--- a/src/csharp/PiperPlus.Core.Tests/ShortTextProcessorTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/ShortTextProcessorTests.cs
@@ -406,6 +406,106 @@ public class ShortTextProcessorTests
     }
 
     // ==================================================================
+    // Tier 1 (Issue #499): TrimEosRegion — drop EOS region for ALL inputs
+    // ==================================================================
+    // Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
+    // so every runtime gets identical behavioural coverage
+    // (cross-runtime contract — Issue #499).
+
+    [Fact]
+    public void TrimEosRegion_DefaultStripsFullEosRegion()
+    {
+        // EOS = 2.0 frames → ceil = 2 → 200 samples (hop=100)
+        var durations = new[] { 1f, 2f, 3f, 2f };
+        const int hop = 100;
+        const int total = 800;
+        var audio = new float[total];
+        for (int i = 0; i < total; i++) audio[i] = i;
+        var result = ShortTextProcessor.TrimEosRegion(audio, durations, hop);
+        Assert.Equal(total - 200, result.Length);
+        for (int i = 0; i < 600; i++) Assert.Equal(audio[i], result[i]);
+    }
+
+    [Fact]
+    public void TrimEosRegion_AppliesCeilToFractionalDuration()
+    {
+        // durations[-1]=1.99 must trim ceil(1.99)=2 frames, not 1.
+        var durations = new[] { 1f, 1f, 1f, 1.99f };
+        const int hop = 256;
+        var audio = new float[2048];
+        var result = ShortTextProcessor.TrimEosRegion(audio, durations, hop);
+        Assert.Equal(2048 - 512, result.Length);
+    }
+
+    [Fact]
+    public void TrimEosRegion_EosMaxFramesOverrideKeepsHeadOfEos()
+    {
+        // EOS=10 raw, eosMaxFrames=6 → excess = ceil(10) - 6 = 4 frames
+        var durations = new[] { 2f, 3f, 3f, 10f };
+        const int hop = 100;
+        var audio = new float[2000];
+        var result = ShortTextProcessor.TrimEosRegion(audio, durations, hop, eosMaxFrames: 6);
+        Assert.Equal(2000 - 400, result.Length);
+    }
+
+    [Fact]
+    public void TrimEosRegion_NoOpWhenEosBelowMax()
+    {
+        // ceil(1.99)=2 ≤ eosMaxFrames=4 → no trim
+        var durations = new[] { 1f, 1f, 1.99f };
+        const int hop = 256;
+        var audio = new float[1024];
+        var result = ShortTextProcessor.TrimEosRegion(audio, durations, hop, eosMaxFrames: 4);
+        Assert.Equal(audio.Length, result.Length);
+    }
+
+    [Fact]
+    public void TrimEosRegion_ReturnsInputWhenDurationsEmpty()
+    {
+        var audio = new float[1000];
+        var result = ShortTextProcessor.TrimEosRegion(audio, Array.Empty<float>(), hopSize: 256);
+        Assert.Equal(audio.Length, result.Length);
+    }
+
+    [Fact]
+    public void TrimEosRegion_ReturnsInputWhenDurationsNull()
+    {
+        var audio = new float[1000];
+        var result = ShortTextProcessor.TrimEosRegion(audio, null, hopSize: 256);
+        Assert.Equal(audio.Length, result.Length);
+    }
+
+    [Fact]
+    public void TrimEosRegion_ReturnsInputWhenHopSizeZero()
+    {
+        var audio = new float[1000];
+        var durations = new[] { 1f, 2f, 3f };
+        var result = ShortTextProcessor.TrimEosRegion(audio, durations, hopSize: 0);
+        Assert.Equal(audio.Length, result.Length);
+    }
+
+    [Fact]
+    public void TrimEosRegion_ReturnsInputWhenTrimExceedsAudio()
+    {
+        // EOS=5 frames * 100 hop = 500 samples, audio has 200 samples
+        var durations = new[] { 1f, 5f };
+        var audio = new float[200];
+        var result = ShortTextProcessor.TrimEosRegion(audio, durations, hopSize: 100);
+        Assert.Equal(audio.Length, result.Length);
+    }
+
+    [Fact]
+    public void TrimEosRegion_IntegerDurationUnaffectedByCeil()
+    {
+        // ceil(2.0) == 2 — integer-valued durations trim int(d) frames.
+        var durations = new[] { 1f, 1f, 2f };
+        const int hop = 100;
+        var audio = new float[400];
+        var result = ShortTextProcessor.TrimEosRegion(audio, durations, hop);
+        Assert.Equal(400 - 200, result.Length);
+    }
+
+    // ==================================================================
     // Strategy A: TrimSilence
     // ==================================================================
     [Fact]
@@ -981,7 +1081,7 @@ public class ShortTextProcessorTests
         string wrapped = ShortTextProcessor.WrapShortTextWithBreaks(shortText);
 
         bool isShort = !ReferenceEquals(wrapped, shortText)
-                       && !string.Equals(wrapped, shortText, StringComparison.Ordinal);
+            && !string.Equals(wrapped, shortText, StringComparison.Ordinal);
         Assert.True(isShort);
     }
 
@@ -993,7 +1093,7 @@ public class ShortTextProcessorTests
 
         // For long text, WrapShortTextWithBreaks returns the same string
         bool isShort = !ReferenceEquals(wrapped, longText)
-                       && !string.Equals(wrapped, longText, StringComparison.Ordinal);
+            && !string.Equals(wrapped, longText, StringComparison.Ordinal);
         Assert.False(isShort);
     }
 }

--- a/src/csharp/PiperPlus.Core.Tests/ShortTextProcessorTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/ShortTextProcessorTests.cs
@@ -409,7 +409,7 @@ public class ShortTextProcessorTests
     // Tier 1 (Issue #499): TrimEosRegion — drop EOS region for ALL inputs
     // ==================================================================
     // Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
-    // so every runtime gets identical behavioural coverage
+    // so every runtime gets identical behavioral coverage
     // (cross-runtime contract — Issue #499).
 
     [Fact]

--- a/src/csharp/PiperPlus.Core.Tests/ShortTextProcessorTests.cs
+++ b/src/csharp/PiperPlus.Core.Tests/ShortTextProcessorTests.cs
@@ -411,7 +411,6 @@ public class ShortTextProcessorTests
     // Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
     // so every runtime gets identical behavioral coverage
     // (cross-runtime contract — Issue #499).
-
     [Fact]
     public void TrimEosRegion_DefaultStripsFullEosRegion()
     {
@@ -420,10 +419,17 @@ public class ShortTextProcessorTests
         const int hop = 100;
         const int total = 800;
         var audio = new float[total];
-        for (int i = 0; i < total; i++) audio[i] = i;
+        for (int i = 0; i < total; i++)
+        {
+            audio[i] = i;
+        }
+
         var result = ShortTextProcessor.TrimEosRegion(audio, durations, hop);
         Assert.Equal(total - 200, result.Length);
-        for (int i = 0; i < 600; i++) Assert.Equal(audio[i], result[i]);
+        for (int i = 0; i < 600; i++)
+        {
+            Assert.Equal(audio[i], result[i]);
+        }
     }
 
     [Fact]

--- a/src/csharp/PiperPlus.Core/Inference/PiperSession.cs
+++ b/src/csharp/PiperPlus.Core/Inference/PiperSession.cs
@@ -435,6 +435,16 @@ public sealed class PiperSession
                     audio = ShortTextProcessor.TrimSilence(audio);
                 }
             }
+            else if (paddedDurations is not null)
+            {
+                // Tier 1 workaround for Issue #499: even without short-text
+                // padding, the EOS region carries decoder leakage that
+                // sounds like the final syllable was repeated. Strategy A
+                // above already handles this for padded inputs; this branch
+                // applies the same EOS-region drop to long-text outputs.
+                audio = ShortTextProcessor.TrimEosRegion(
+                    audio, paddedDurations, _model.HopSize);
+            }
 
             // Truncate durations back to the original phoneme length for
             // timing consumers (they treat the padded extras as out-of-band).

--- a/src/csharp/PiperPlus.Core/Inference/ShortTextProcessor.cs
+++ b/src/csharp/PiperPlus.Core/Inference/ShortTextProcessor.cs
@@ -349,6 +349,7 @@ public static class ShortTextProcessor
         {
             return audio;
         }
+
         float eosFrames = durations[^1];
         int eosCeil = (int)Math.Ceiling(eosFrames);
         int eosExcess = eosCeil - eosMaxFrames;
@@ -356,11 +357,13 @@ public static class ShortTextProcessor
         {
             return audio;
         }
+
         int trimSamples = eosExcess * hopSize;
         if (trimSamples >= audio.Length)
         {
             return audio;
         }
+
         int newLength = audio.Length - trimSamples;
         var trimmed = new float[newLength];
         Array.Copy(audio, 0, trimmed, 0, newLength);

--- a/src/csharp/PiperPlus.Core/Inference/ShortTextProcessor.cs
+++ b/src/csharp/PiperPlus.Core/Inference/ShortTextProcessor.cs
@@ -311,6 +311,62 @@ public static class ShortTextProcessor
         return trimmed;
     }
 
+    /// <summary>
+    /// Tier 1 workaround for Issue #499: trims the EOS region from the tail
+    /// for <em>every</em> inference path (long-text included).
+    /// <para>
+    /// <c>VitsModel.infer()</c> expands attention with <c>ceil(w)</c> but
+    /// exposes the raw float <c>w</c> as the <c>durations</c> output. The
+    /// EOS frame(s) generated under <c>ceil</c> carry decoder leakage that
+    /// sounds like the final syllable was repeated — clearly audible on
+    /// fine-tuned models such as <c>piper-plus-tsukuyomi-chan</c>.
+    /// <see cref="TrimPaddingByDurations"/> drops the EOS region only when
+    /// Strategy A short-text padding was applied; this helper applies the
+    /// same drop to every other inference path so long-text outputs do not
+    /// retain the audible doubled tail.
+    /// </para>
+    /// <para>
+    /// Mirrors the Python reference
+    /// (<c>src/python_run/piper/voice.py::_trim_eos_region</c>) so every
+    /// runtime produces byte-equal output for the same
+    /// (audio, durations[-1], hopSize, eosMaxFrames) tuple. The
+    /// sample-count conversion uses <c>(int)</c> truncation to match Python.
+    /// </para>
+    /// </summary>
+    /// <returns>
+    /// The trimmed audio, or the input unchanged when arguments are
+    /// inconsistent (null/empty durations, non-positive hop,
+    /// <c>ceil(durations[-1]) &lt;= eosMaxFrames</c>, or the trim would
+    /// consume the whole buffer).
+    /// </returns>
+    internal static float[] TrimEosRegion(
+        float[] audio,
+        float[]? durations,
+        int hopSize,
+        int eosMaxFrames = TrimEosMaxFrames)
+    {
+        if (hopSize <= 0 || durations is null || durations.Length == 0)
+        {
+            return audio;
+        }
+        float eosFrames = durations[^1];
+        int eosCeil = (int)Math.Ceiling(eosFrames);
+        int eosExcess = eosCeil - eosMaxFrames;
+        if (eosExcess <= 0)
+        {
+            return audio;
+        }
+        int trimSamples = eosExcess * hopSize;
+        if (trimSamples >= audio.Length)
+        {
+            return audio;
+        }
+        int newLength = audio.Length - trimSamples;
+        var trimmed = new float[newLength];
+        Array.Copy(audio, 0, trimmed, 0, newLength);
+        return trimmed;
+    }
+
     // ------------------------------------------------------------------
     // Strategy A: Post-inference silence trimming
     // ------------------------------------------------------------------

--- a/src/go/piperplus/engine.go
+++ b/src/go/piperplus/engine.go
@@ -419,6 +419,13 @@ func (e *OnnxEngine) Synthesize(ctx context.Context, req *SynthesisRequest) (*Sy
 		} else {
 			audio = trimSilence(audio)
 		}
+	} else if paddedDurations != nil {
+		// Tier 1 workaround for Issue #499: even without short-text
+		// padding, the EOS region carries decoder leakage that sounds
+		// like the final syllable was repeated. Strategy A above already
+		// handles this for padded inputs; this branch applies the same
+		// EOS-region drop to long-text outputs.
+		audio = trimEosRegion(audio, paddedDurations, e.hopSize, trimEosMaxFrames)
 	}
 
 	// Calculate audio duration using integer arithmetic for precision.

--- a/src/go/piperplus/short_text.go
+++ b/src/go/piperplus/short_text.go
@@ -169,6 +169,43 @@ func trimPaddingByDurations(audio []int16, durations []float32, frontPad, backPa
 	return audio[frontSamples:end]
 }
 
+// trimEosRegion is the Tier 1 workaround for Issue #499: it trims the EOS
+// region from the tail for every inference path (long-text included).
+//
+// VITS's infer() expands attention with ceil(w) but exposes the raw float w
+// as the durations output. The EOS frame(s) generated under ceil carry
+// decoder leakage that sounds like the final syllable was repeated —
+// clearly audible on fine-tuned models such as piper-plus-tsukuyomi-chan.
+// trimPaddingByDurations already drops the EOS region only when Strategy A
+// short-text padding was applied; this helper applies the same drop to every
+// other inference path so long-text outputs do not retain the audible
+// doubled tail.
+//
+// Mirrors src/python_run/piper/voice.py _trim_eos_region so all runtimes
+// produce byte-equal output for the same (audio, durations[-1], hopSize,
+// eosMaxFrames) tuple. The sample-count conversion uses int(...) truncation
+// to match the Python reference — cross-runtime contract (Issue #499).
+//
+// Returns audio unchanged when arguments are inconsistent (nil/empty
+// durations, non-positive hopSize, ceil(durations[-1]) <= eosMaxFrames, or
+// the computed trim would consume the whole buffer).
+func trimEosRegion(audio []int16, durations []float32, hopSize, eosMaxFrames int) []int16 {
+	if hopSize <= 0 || len(durations) == 0 {
+		return audio
+	}
+	eosFrames := durations[len(durations)-1]
+	eosCeil := int(math.Ceil(float64(eosFrames)))
+	eosExcess := eosCeil - eosMaxFrames
+	if eosExcess <= 0 {
+		return audio
+	}
+	trimSamples := eosExcess * hopSize
+	if trimSamples >= len(audio) {
+		return audio
+	}
+	return audio[:len(audio)-trimSamples]
+}
+
 // padProsodyFeatures extends prosody features to match the new padded phoneme
 // length. Inserted positions are zero-filled.
 func padProsodyFeatures(original [][3]int64, originalLen, paddedLen int) [][3]int64 {

--- a/src/go/piperplus/short_text_test.go
+++ b/src/go/piperplus/short_text_test.go
@@ -300,7 +300,7 @@ func TestTrimPaddingByDurations_TruncationMatchesIntCast(t *testing.T) {
 // Tier 1 (Issue #499): trimEosRegion — drop EOS region for ALL inputs
 // ---------------------------------------------------------------------------
 // Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
-// so every runtime gets identical behavioural coverage
+// so every runtime gets identical behavioral coverage
 // (cross-runtime contract — Issue #499).
 
 func TestTrimEosRegion_DefaultStripsFullEosRegion(t *testing.T) {

--- a/src/go/piperplus/short_text_test.go
+++ b/src/go/piperplus/short_text_test.go
@@ -297,6 +297,104 @@ func TestTrimPaddingByDurations_TruncationMatchesIntCast(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Tier 1 (Issue #499): trimEosRegion — drop EOS region for ALL inputs
+// ---------------------------------------------------------------------------
+// Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
+// so every runtime gets identical behavioural coverage
+// (cross-runtime contract — Issue #499).
+
+func TestTrimEosRegion_DefaultStripsFullEosRegion(t *testing.T) {
+	// EOS = 2.0 frames → ceil = 2 → 200 samples (hop=100)
+	durations := []float32{1.0, 2.0, 3.0, 2.0}
+	const hop = 100
+	total := 800
+	audio := make([]int16, total)
+	for i := range audio {
+		audio[i] = int16(i)
+	}
+	result := trimEosRegion(audio, durations, hop, trimEosMaxFrames)
+	if len(result) != total-200 {
+		t.Errorf("expected length %d, got %d", total-200, len(result))
+	}
+	for i := 0; i < 600; i++ {
+		if result[i] != audio[i] {
+			t.Errorf("sample %d: expected %d, got %d", i, audio[i], result[i])
+		}
+	}
+}
+
+func TestTrimEosRegion_AppliesCeilToFractionalDuration(t *testing.T) {
+	// durations[-1]=1.99 must trim ceil(1.99)=2 frames, not 1.
+	durations := []float32{1.0, 1.0, 1.0, 1.99}
+	const hop = 256
+	audio := make([]int16, 2048)
+	result := trimEosRegion(audio, durations, hop, trimEosMaxFrames)
+	if len(result) != 2048-512 {
+		t.Errorf("expected length %d, got %d", 2048-512, len(result))
+	}
+}
+
+func TestTrimEosRegion_EosMaxFramesOverrideKeepsHeadOfEos(t *testing.T) {
+	// EOS=10 raw, eosMaxFrames=6 → excess = ceil(10) - 6 = 4 frames
+	durations := []float32{2.0, 3.0, 3.0, 10.0}
+	const hop = 100
+	audio := make([]int16, 2000)
+	result := trimEosRegion(audio, durations, hop, 6)
+	if len(result) != 2000-400 {
+		t.Errorf("expected length %d, got %d", 2000-400, len(result))
+	}
+}
+
+func TestTrimEosRegion_NoOpWhenEosBelowMax(t *testing.T) {
+	// ceil(1.99)=2 ≤ eosMaxFrames=4 → no trim
+	durations := []float32{1.0, 1.0, 1.99}
+	const hop = 256
+	audio := make([]int16, 1024)
+	result := trimEosRegion(audio, durations, hop, 4)
+	if len(result) != len(audio) {
+		t.Errorf("expected unchanged length %d, got %d", len(audio), len(result))
+	}
+}
+
+func TestTrimEosRegion_ReturnsInputWhenDurationsEmpty(t *testing.T) {
+	audio := make([]int16, 1000)
+	result := trimEosRegion(audio, []float32{}, 256, trimEosMaxFrames)
+	if len(result) != len(audio) {
+		t.Errorf("expected unchanged length %d, got %d", len(audio), len(result))
+	}
+}
+
+func TestTrimEosRegion_ReturnsInputWhenHopSizeZero(t *testing.T) {
+	audio := make([]int16, 1000)
+	durations := []float32{1.0, 2.0, 3.0}
+	result := trimEosRegion(audio, durations, 0, trimEosMaxFrames)
+	if len(result) != len(audio) {
+		t.Errorf("expected unchanged length %d, got %d", len(audio), len(result))
+	}
+}
+
+func TestTrimEosRegion_ReturnsInputWhenTrimExceedsAudio(t *testing.T) {
+	// EOS=5 frames * 100 hop = 500 samples, audio has 200 samples
+	durations := []float32{1.0, 5.0}
+	audio := make([]int16, 200)
+	result := trimEosRegion(audio, durations, 100, trimEosMaxFrames)
+	if len(result) != len(audio) {
+		t.Errorf("expected unchanged length %d, got %d", len(audio), len(result))
+	}
+}
+
+func TestTrimEosRegion_IntegerDurationUnaffectedByCeil(t *testing.T) {
+	// ceil(2.0) == 2 — integer-valued durations trim int(d) frames.
+	durations := []float32{1.0, 1.0, 2.0}
+	const hop = 100
+	audio := make([]int16, 400)
+	result := trimEosRegion(audio, durations, hop, trimEosMaxFrames)
+	if len(result) != 400-200 {
+		t.Errorf("expected length %d, got %d", 400-200, len(result))
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Strategy A: trimSilence
 // ---------------------------------------------------------------------------
 

--- a/src/rust/piper-core/src/engine.rs
+++ b/src/rust/piper-core/src/engine.rs
@@ -975,7 +975,23 @@ impl OnnxEngine {
             // like the final syllable was repeated. Strategy A above
             // already handles this for padded inputs; this branch applies
             // the same EOS-region drop to long-text outputs.
-            trim_eos_region(&audio_i16_raw, durs, self.hop_size, TRIM_EOS_MAX_FRAMES)
+            //
+            // Implemented in-place (truncate, no allocation/copy) instead of
+            // calling `trim_eos_region` — that helper has to return a fresh
+            // `Vec<i16>` to mirror the Python signature for cross-runtime
+            // byte-equality, but here we already own the buffer and just
+            // want to drop the tail. Keeps the long-text path at O(1)
+            // tail-trim rather than O(n) full-buffer copy.
+            let mut buf = audio_i16_raw;
+            if !durs.is_empty() && self.hop_size > 0 {
+                let eos_ceil = durs[durs.len() - 1].ceil() as i64;
+                let eos_excess = (eos_ceil - TRIM_EOS_MAX_FRAMES as i64).max(0);
+                let trim = (eos_excess * self.hop_size as i64) as usize;
+                if trim > 0 && trim < buf.len() {
+                    buf.truncate(buf.len() - trim);
+                }
+            }
+            buf
         } else {
             audio_i16_raw
         };

--- a/src/rust/piper-core/src/engine.rs
+++ b/src/rust/piper-core/src/engine.rs
@@ -322,6 +322,50 @@ pub fn trim_padding_by_durations(
     audio[start as usize..end as usize].to_vec()
 }
 
+/// Tier 1 workaround for Issue #499: trim the EOS region from the tail for
+/// **every** inference path (long-text included).
+///
+/// `VitsModel.infer()` expands attention with `ceil(w)` but exposes the raw
+/// float `w` as the `durations` output. The EOS frame(s) generated under
+/// `ceil` carry decoder leakage that sounds like the final syllable was
+/// repeated — clearly audible on fine-tuned models such as
+/// `piper-plus-tsukuyomi-chan`. `trim_padding_by_durations` already drops
+/// the EOS region only when Strategy A short-text padding was applied; this
+/// helper applies the same drop to every other inference path so long-text
+/// outputs do not retain the audible doubled tail.
+///
+/// Mirrors `piper.voice._trim_eos_region` so all runtimes produce
+/// byte-equal output for the same `(audio, durations[-1], hop_size,
+/// eos_max_frames)` tuple. The sample-count conversion uses `as i64`
+/// truncation to match Python's `int(...)` semantics — cross-runtime
+/// contract (Issue #499).
+///
+/// 返り値は入力をそのまま返す: `audio.is_empty()`, `durations.is_empty()`,
+/// `hop_size == 0`, `ceil(durations[-1]) <= eos_max_frames`, または
+/// `trim_samples >= audio.len()` のとき。
+pub fn trim_eos_region(
+    audio: &[i16],
+    durations: &[f32],
+    hop_size: u32,
+    eos_max_frames: usize,
+) -> Vec<i16> {
+    if hop_size == 0 || durations.is_empty() {
+        return audio.to_vec();
+    }
+    let eos_frames = durations[durations.len() - 1];
+    let eos_ceil = eos_frames.ceil() as i64;
+    let eos_excess = (eos_ceil - eos_max_frames as i64).max(0);
+    if eos_excess <= 0 {
+        return audio.to_vec();
+    }
+    let trim_samples = eos_excess * hop_size as i64;
+    let total = audio.len() as i64;
+    if trim_samples >= total {
+        return audio.to_vec();
+    }
+    audio[..(total - trim_samples) as usize].to_vec()
+}
+
 /// Strategy A (post-trim): RMS ベースで先頭・末尾の無音をトリムする。
 ///
 /// 窓幅 `TRIM_WINDOW_SIZE` の RMS が `TRIM_THRESHOLD_RMS` を超える
@@ -925,6 +969,13 @@ impl OnnxEngine {
                 trimmed.len()
             );
             trimmed
+        } else if let Some(durs) = padded_durations.as_deref() {
+            // Tier 1 workaround for Issue #499: even without short-text
+            // padding, the EOS region carries decoder leakage that sounds
+            // like the final syllable was repeated. Strategy A above
+            // already handles this for padded inputs; this branch applies
+            // the same EOS-region drop to long-text outputs.
+            trim_eos_region(&audio_i16_raw, durs, self.hop_size, TRIM_EOS_MAX_FRAMES)
         } else {
             audio_i16_raw
         };
@@ -1803,5 +1854,89 @@ mod tests {
         let audio = vec![0i16; total];
         let result = trim_padding_by_durations(&audio, &durations, 1, 1, hop, TRIM_EOS_MAX_FRAMES);
         assert_eq!(result.len(), total - 140 - 140);
+    }
+
+    // ---------------------------------------------------------------
+    // Tier 1 (Issue #499): trim_eos_region — drop EOS region for ALL inputs
+    // ---------------------------------------------------------------
+    // Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
+    // so every runtime gets identical behavioural coverage
+    // (cross-runtime contract — Issue #499).
+
+    #[test]
+    fn test_trim_eos_region_default_strips_full_eos_region() {
+        // EOS = 2.0 frames → ceil = 2 → 200 samples (hop=100)
+        let durations: Vec<f32> = vec![1.0, 2.0, 3.0, 2.0];
+        let hop = 100u32;
+        let total = 800usize;
+        let audio: Vec<i16> = (0..total as i16).collect();
+        let result = trim_eos_region(&audio, &durations, hop, TRIM_EOS_MAX_FRAMES);
+        assert_eq!(result.len(), total - 200);
+        assert_eq!(result, audio[..600]);
+    }
+
+    #[test]
+    fn test_trim_eos_region_applies_ceil_to_fractional_duration() {
+        // durations[-1]=1.99 must trim ceil(1.99)=2 frames, not 1.
+        let durations: Vec<f32> = vec![1.0, 1.0, 1.0, 1.99];
+        let hop = 256u32;
+        let audio = vec![0i16; 2048];
+        let result = trim_eos_region(&audio, &durations, hop, TRIM_EOS_MAX_FRAMES);
+        assert_eq!(result.len(), 2048 - 512);
+    }
+
+    #[test]
+    fn test_trim_eos_region_eos_max_frames_override_keeps_head_of_eos() {
+        // EOS=10 raw, eos_max_frames=6 → excess = ceil(10) - 6 = 4 frames
+        let durations: Vec<f32> = vec![2.0, 3.0, 3.0, 10.0];
+        let hop = 100u32;
+        let audio = vec![0i16; 2000];
+        let result = trim_eos_region(&audio, &durations, hop, 6);
+        assert_eq!(result.len(), 2000 - 400);
+    }
+
+    #[test]
+    fn test_trim_eos_region_no_op_when_eos_below_max() {
+        // ceil(1.99)=2 ≤ eos_max_frames=4 → no trim
+        let durations: Vec<f32> = vec![1.0, 1.0, 1.99];
+        let hop = 256u32;
+        let audio = vec![0i16; 1024];
+        let result = trim_eos_region(&audio, &durations, hop, 4);
+        assert_eq!(result.len(), audio.len());
+    }
+
+    #[test]
+    fn test_trim_eos_region_returns_input_when_durations_empty() {
+        let audio = vec![0i16; 1000];
+        let durations: Vec<f32> = vec![];
+        let result = trim_eos_region(&audio, &durations, 256, TRIM_EOS_MAX_FRAMES);
+        assert_eq!(result.len(), audio.len());
+    }
+
+    #[test]
+    fn test_trim_eos_region_returns_input_when_hop_size_zero() {
+        let audio = vec![0i16; 1000];
+        let durations: Vec<f32> = vec![1.0, 2.0, 3.0];
+        let result = trim_eos_region(&audio, &durations, 0, TRIM_EOS_MAX_FRAMES);
+        assert_eq!(result.len(), audio.len());
+    }
+
+    #[test]
+    fn test_trim_eos_region_returns_input_when_trim_exceeds_audio() {
+        // EOS=5 frames * 100 hop = 500 samples, audio has 200 samples
+        let durations: Vec<f32> = vec![1.0, 5.0];
+        let audio = vec![0i16; 200];
+        let result = trim_eos_region(&audio, &durations, 100, TRIM_EOS_MAX_FRAMES);
+        assert_eq!(result.len(), audio.len());
+    }
+
+    #[test]
+    fn test_trim_eos_region_integer_duration_unaffected_by_ceil() {
+        // ceil(2.0) == 2 — integer-valued durations trim int(d) frames.
+        let durations: Vec<f32> = vec![1.0, 1.0, 2.0];
+        let hop = 100u32;
+        let audio = vec![0i16; 400];
+        let result = trim_eos_region(&audio, &durations, hop, TRIM_EOS_MAX_FRAMES);
+        assert_eq!(result.len(), 400 - 200);
     }
 }

--- a/src/rust/piper-core/src/engine.rs
+++ b/src/rust/piper-core/src/engine.rs
@@ -1860,7 +1860,7 @@ mod tests {
     // Tier 1 (Issue #499): trim_eos_region — drop EOS region for ALL inputs
     // ---------------------------------------------------------------
     // Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
-    // so every runtime gets identical behavioural coverage
+    // so every runtime gets identical behavioral coverage
     // (cross-runtime contract — Issue #499).
 
     #[test]

--- a/src/rust/piper-core/src/lib.rs
+++ b/src/rust/piper-core/src/lib.rs
@@ -59,7 +59,7 @@ pub use config::{PhonemeIdMap, PhonemeType, VoiceConfig};
 #[cfg(feature = "onnx")]
 pub use engine::{
     DEFAULT_WARMUP_RUNS, MIN_BODY_FOR_STRATEGY_A, MIN_PHONEME_IDS, ModelCapabilities, OnnxEngine,
-    SynthesisRequest, SynthesisResult, TRIM_EOS_MAX_FRAMES, pad_short_phonemes,
+    SynthesisRequest, SynthesisResult, TRIM_EOS_MAX_FRAMES, pad_short_phonemes, trim_eos_region,
     trim_padding_by_durations,
 };
 pub use error::PiperError;

--- a/src/wasm/openjtalk-web/src/index.js
+++ b/src/wasm/openjtalk-web/src/index.js
@@ -254,6 +254,53 @@ export function trimPaddingByDurations(
 }
 
 /**
+ * Tier 1 workaround for Issue #499: trim the EOS region from the tail for
+ * **every** inference path (long-text included).
+ *
+ * `VitsModel.infer()` expands attention with `ceil(w)` but exposes the raw
+ * float `w` as the `durations` output. The EOS frame(s) generated under
+ * `ceil` carry decoder leakage that sounds like the final syllable was
+ * repeated — clearly audible on fine-tuned models such as
+ * `piper-plus-tsukuyomi-chan`. {@link trimPaddingByDurations} already drops
+ * the EOS region only when Strategy A short-text padding was applied; this
+ * helper applies the same drop to every other inference path so long-text
+ * outputs do not retain the audible doubled tail.
+ *
+ * Mirrors `src/python_run/piper/voice.py::_trim_eos_region` so all runtimes
+ * produce byte-equal output for the same `(audio, durations[-1], hopSize,
+ * eosMaxFrames)` tuple. The sample-count conversion uses `Math.trunc()` to
+ * match Python's `int(...)` semantics — cross-runtime contract (Issue #499).
+ *
+ * @param {Float32Array} audio  Audio samples in the range -1.0 to 1.0
+ * @param {number[]|Float32Array|null} durations  Per-phoneme frame counts
+ * @param {number} hopSize  VITS hop length (samples per frame)
+ * @param {number} [eosMaxFrames=TRIM_EOS_MAX_FRAMES]
+ * @returns {Float32Array} Trimmed audio (or the original if inputs are inconsistent)
+ */
+export function trimEosRegion(
+  audio,
+  durations,
+  hopSize,
+  eosMaxFrames = TRIM_EOS_MAX_FRAMES
+) {
+  if (hopSize <= 0 || durations == null || durations.length === 0) {
+    return audio;
+  }
+  const eosFrames = durations[durations.length - 1];
+  const eosCeil = Math.ceil(eosFrames);
+  const eosExcess = Math.max(0, eosCeil - eosMaxFrames);
+  if (eosExcess <= 0) {
+    return audio;
+  }
+  const trimSamples = eosExcess * hopSize;
+  if (trimSamples >= audio.length) {
+    return audio;
+  }
+  // subarray() avoids a copy; subscribers that mutate must already clone.
+  return audio.subarray(0, audio.length - trimSamples);
+}
+
+/**
  * Strategy A (post-step): Trim leading and trailing silence from Float32Array
  * audio using a sliding RMS window.
  *
@@ -498,6 +545,18 @@ export class PiperPlus {
       } else {
         audioData = trimSilence(audioData);
       }
+    } else if (durations != null) {
+      // Tier 1 workaround for Issue #499: even without short-text
+      // padding, the EOS region carries decoder leakage that sounds like
+      // the final syllable was repeated. Strategy A above already handles
+      // this for padded inputs; this branch applies the same EOS-region
+      // drop to long-text outputs.
+      const hopSize = this._config.audio?.hop_size ?? DEFAULT_HOP_SIZE;
+      audioData = trimEosRegion(
+        audioData,
+        durations,
+        hopSize > 0 ? hopSize : DEFAULT_HOP_SIZE
+      );
     }
 
     // 3. Wrap result — include phoneme timing when the model supports it

--- a/src/wasm/openjtalk-web/src/index.js
+++ b/src/wasm/openjtalk-web/src/index.js
@@ -292,7 +292,12 @@ export function trimEosRegion(
   if (eosExcess <= 0) {
     return audio;
   }
-  const trimSamples = eosExcess * hopSize;
+  // Math.trunc() makes the frame→sample conversion explicit so the truncation
+  // contract holds even when `hopSize` (or any intermediate product) ends up
+  // non-integer — matches Python `int(...)` and Rust `as i64`. Without this
+  // the implementation would rely on TypedArray.subarray()'s implicit index
+  // coercion, which diverges around boundary float values.
+  const trimSamples = Math.trunc(eosExcess * hopSize);
   if (trimSamples >= audio.length) {
     return audio;
   }

--- a/src/wasm/openjtalk-web/test/js/test-short-text-mitigation.js
+++ b/src/wasm/openjtalk-web/test/js/test-short-text-mitigation.js
@@ -21,7 +21,7 @@ import assert from "node:assert/strict";
 // ---------------------------------------------------------------------------
 
 let PiperPlus, AudioResult, padPhonemeIds, trimSilence, adjustScalesForShortInput;
-let trimPaddingByDurations;
+let trimPaddingByDurations, trimEosRegion;
 let MIN_PHONEME_IDS, MIN_BODY_FOR_STRATEGY_A, TRIM_EOS_MAX_FRAMES, DEFAULT_HOP_SIZE;
 let importError = null;
 
@@ -32,6 +32,7 @@ try {
   padPhonemeIds = mod.padPhonemeIds;
   trimSilence = mod.trimSilence;
   trimPaddingByDurations = mod.trimPaddingByDurations;
+  trimEosRegion = mod.trimEosRegion;
   adjustScalesForShortInput = mod.adjustScalesForShortInput;
   MIN_PHONEME_IDS = mod.MIN_PHONEME_IDS;
   MIN_BODY_FOR_STRATEGY_A = mod.MIN_BODY_FOR_STRATEGY_A;
@@ -466,6 +467,87 @@ describe("trimPaddingByDurations (Strategy A - precise post-trim)", { skip }, ()
     const result = trimPaddingByDurations(audio, durations, 1, 1, hop, 0);
     // BOS(2) + frontPad(2) = 400, backPad(2) + EOS(50) = 5200
     assert.equal(result.length, total - 400 - 5200);
+  });
+});
+
+// ===========================================================================
+// trimEosRegion — Tier 1 (Issue #499): drop EOS region for ALL inputs
+// ===========================================================================
+// Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
+// so every runtime gets identical behavioural coverage
+// (cross-runtime contract — Issue #499).
+
+describe("trimEosRegion (Tier 1 - drop EOS region for ALL inputs)", { skip }, () => {
+  it("default strips full EOS region (ceil(durations[-1]) frames)", () => {
+    // EOS = 2.0 frames → ceil = 2 → 200 samples (hop=100)
+    const durations = new Float32Array([1, 2, 3, 2]);
+    const hop = 100;
+    const total = 800;
+    const audio = new Float32Array(total);
+    for (let i = 0; i < total; i++) audio[i] = i;
+    const result = trimEosRegion(audio, durations, hop);
+    assert.equal(result.length, total - 200);
+    for (let i = 0; i < 600; i++) assert.equal(result[i], audio[i]);
+  });
+
+  it("applies ceil to fractional duration (1.99 → 2 frames)", () => {
+    const durations = new Float32Array([1, 1, 1, 1.99]);
+    const hop = 256;
+    const audio = new Float32Array(2048);
+    const result = trimEosRegion(audio, durations, hop);
+    assert.equal(result.length, 2048 - 512);
+  });
+
+  it("eosMaxFrames override keeps head of EOS", () => {
+    // EOS=10 raw, eosMaxFrames=6 → excess = ceil(10) - 6 = 4 frames
+    const durations = new Float32Array([2, 3, 3, 10]);
+    const hop = 100;
+    const audio = new Float32Array(2000);
+    const result = trimEosRegion(audio, durations, hop, 6);
+    assert.equal(result.length, 2000 - 400);
+  });
+
+  it("no-op when ceil(EOS) <= eosMaxFrames", () => {
+    const durations = new Float32Array([1, 1, 1.99]);
+    const hop = 256;
+    const audio = new Float32Array(1024);
+    const result = trimEosRegion(audio, durations, hop, 4);
+    assert.equal(result.length, audio.length);
+  });
+
+  it("returns input when durations is empty", () => {
+    const audio = new Float32Array(1000);
+    const result = trimEosRegion(audio, new Float32Array(0), 256);
+    assert.equal(result.length, audio.length);
+  });
+
+  it("returns input when durations is null", () => {
+    const audio = new Float32Array(1000);
+    const result = trimEosRegion(audio, null, 256);
+    assert.equal(result.length, audio.length);
+  });
+
+  it("returns input when hopSize is zero", () => {
+    const audio = new Float32Array(1000);
+    const durations = new Float32Array([1, 2, 3]);
+    const result = trimEosRegion(audio, durations, 0);
+    assert.equal(result.length, audio.length);
+  });
+
+  it("returns input when trim would consume the buffer", () => {
+    // EOS=5 frames * 100 hop = 500 samples, audio has 200 samples
+    const durations = new Float32Array([1, 5]);
+    const audio = new Float32Array(200);
+    const result = trimEosRegion(audio, durations, 100);
+    assert.equal(result.length, audio.length);
+  });
+
+  it("integer duration unaffected by ceil", () => {
+    const durations = new Float32Array([1, 1, 2]);
+    const hop = 100;
+    const audio = new Float32Array(400);
+    const result = trimEosRegion(audio, durations, hop);
+    assert.equal(result.length, 400 - 200);
   });
 });
 

--- a/src/wasm/openjtalk-web/test/js/test-short-text-mitigation.js
+++ b/src/wasm/openjtalk-web/test/js/test-short-text-mitigation.js
@@ -474,7 +474,7 @@ describe("trimPaddingByDurations (Strategy A - precise post-trim)", { skip }, ()
 // trimEosRegion — Tier 1 (Issue #499): drop EOS region for ALL inputs
 // ===========================================================================
 // Mirrors src/python_run/tests/test_short_text_mitigation.py::TestTrimEosRegion
-// so every runtime gets identical behavioural coverage
+// so every runtime gets identical behavioral coverage
 // (cross-runtime contract — Issue #499).
 
 describe("trimEosRegion (Tier 1 - drop EOS region for ALL inputs)", { skip }, () => {

--- a/src/wasm/openjtalk-web/types/index.d.ts
+++ b/src/wasm/openjtalk-web/types/index.d.ts
@@ -175,6 +175,29 @@ export function trimPaddingByDurations(
 ): Float32Array;
 
 /**
+ * Tier 1 workaround for Issue #499: trim the EOS region from the tail for
+ * **every** inference path (long-text included).
+ *
+ * `VitsModel.infer()` expands attention with `ceil(w)` but exposes the raw
+ * float `w` as the `durations` output. The EOS frame(s) generated under
+ * `ceil` carry decoder leakage that sounds like the final syllable was
+ * repeated. {@link trimPaddingByDurations} drops the EOS region only when
+ * Strategy A short-text padding was applied; this helper applies the same
+ * drop to every other inference path so long-text outputs do not retain
+ * the audible doubled tail.
+ *
+ * Returns input unchanged when arguments are inconsistent (null/empty
+ * `durations`, non-positive `hopSize`, `ceil(durations[-1]) <= eosMaxFrames`,
+ * or the computed trim would consume the whole buffer).
+ */
+export function trimEosRegion(
+  audio: Float32Array,
+  durations: ArrayLike<number> | null,
+  hopSize: number,
+  eosMaxFrames?: number,
+): Float32Array;
+
+/**
  * Strategy A (post-step): Trim leading and trailing silence from audio
  * using a sliding RMS window. Used as a fallback when the model does
  * not expose a `durations` output.


### PR DESCRIPTION
## Summary

PR #506 で Python ランタイムに入れた Tier 1 doubled-tail workaround (Issue #499) を **残り 5 ランタイム (Rust / Go / C# / WASM / C++)** に mirror する。 `VitsModel.infer()` は attention 展開を `ceil(w)` で行う一方、 `durations` output には raw float `w` を返すため、 EOS region に decoder leakage が乗り「最後の音節がもう一度鳴る」 ように聞こえる。 既存 `_trim_padding_by_durations` は Strategy A 短文 padding 時のみ EOS を切るが、 長文経路では残るのが本症状。 各ランタイムに `trim_eos_region` を追加し **全ての推論経路** で `ceil(durations[-1])` frames を末尾から切り落とす。 byte-for-byte 一致の cross-runtime contract を維持する。

## Affected Components

- [ ] Python (src/python/, src/python_run/) — PR #506 で対応済み
- [x] Rust (src/rust/)
- [x] C# (src/csharp/)
- [x] C++ (src/cpp/, CMakeLists.txt)
- [x] Go (src/go/)
- [x] WASM/npm (src/wasm/)
- [ ] Docker (docker/)
- [ ] CI/CD (.github/workflows/)
- [ ] Documentation (docs/, README*)

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Dependencies

## Risk Level

- [x] **patch** — bug fix / internal refactor / docs only
- [ ] **minor** — new feature / additive API / no breaking change
- [ ] **major** — breaking change (API removal, schema migration, behavior reversal)

## Contract Impact

- [x] None — 既存 `trim_padding_by_durations` (Strategy A 経路) の挙動は無変更。 新規 `trim_eos_region` は long-text 経路にのみ適用するため `docs/spec/short-text-contract.toml` の不変条件は変わらない。 6 ランタイム (Python + 5 ランタイム) すべてで同じ `(audio, durations[-1], hopSize, eosMaxFrames)` から byte-equal な trim 結果を出すため、 cross-runtime byte-equality contract も保持される。

## 変更内容

| ランタイム | helper 追加 | 推論経路への適用 | 新規テスト |
|----------|-----------|----------------|----------|
| Rust (`src/rust/piper-core`) | `trim_eos_region` (engine.rs) + `lib.rs` で re-export | `OnnxEngine` の `was_padded=false` else 分岐に `trim_eos_region` 呼び出しを追加 | engine.rs `#[cfg(test)]` に 8 件 (default/ceil/override/no-op/empty/zero-hop/exceeds/integer) |
| Go (`src/go/piperplus`) | `trimEosRegion` (short_text.go) | `engine.go` の `wasPadded=false` else 分岐に追加 | short_text_test.go に 8 件 (Rust と同型) |
| C# (`src/csharp/PiperPlus.Core`) | `ShortTextProcessor.TrimEosRegion` 静的メソッド | `PiperSession.cs` の `wasPadded=false` else 分岐に追加 | ShortTextProcessorTests.cs に 9 件 (`Array.Empty<float>()` と `null` 個別 case を含む) |
| WASM (`src/wasm/openjtalk-web`) | `trimEosRegion` (src/index.js) + `types/index.d.ts` に declaration | synthesize() の `wasPadded=false` else 分岐に追加 | test-short-text-mitigation.js に 9 件 (skip 制御で CI で実行) |
| C++ (`src/cpp`) | `trimEosRegion` (int16) + `trimEosRegionFloat` (piper.cpp) | int16 / float 両推論経路に else 分岐を追加 | tests/test_short_text_mitigation.cpp に 8 件 (replica 関数同梱) |

各実装は **同一の(audio, durations[-1], hopSize, eosMaxFrames) tuple に対して byte-equal な出力**を返す。 `ceil()` は Python reference に合わせ、 frame→sample 変換は truncation: Rust `as i64` / Go `int(...)` / C# `(int)` / JS `Math.trunc` / C++ `static_cast<int>` で行う。

| 既存債務の修復 (touched files が CI gate に引っかかったため最小修正) | 内容 |
|-----------------|------|
| `.editorconfig` | `src/cpp/tests/test_short_text_mitigation.cpp` を `indent_size = unset` で opt out (legacy 2-space 維持。 `test_speaker_embedding_inference.cpp` / `test_ssml.cpp` と同 pattern) |
| `src/cpp/tests/test_short_text_mitigation.cpp:17` | spelling `Re-declare` → `Redeclare` (codespell findings、 既存 typo) |
| `src/csharp/PiperPlus.Core.Tests/ShortTextProcessorTests.cs` L1083-1096 | 既存 C# multi-line predicate を `&& ...` を 8-space indent (4 の倍数) に揃え (editorconfig findings。 visual layout 変わらず、 動作変わらず) |

## 設計判断

- **EOS frame 1-2 個だけを切る最小修正で 6 ランタイム足並みを揃えた**: 末尾の doubled-tail は decoder の attention 構造起因で raw audio に分散して乗る (`audio_frames = ceil(durations).sum()` で完全一致を実測)。 「audio 全体から ceil overhead 分を引く」 と途中音素まで切る副作用が大きいが、 「EOS region のみ削除」 は既存 Strategy A trim と同じ思想で副作用ゼロ。 完全消去には Tier 2 (`durations = w_ceil` で再 export) か Tier 3 (model 再学習) が必要だが、 配布済モデルに対する即時 workaround として本 PR を Python から 6 ランタイムへ展開した
- **`was_padded` ブランチへの追加適用は行わなかった**: 既存 `trim_padding_by_durations` は `eos_max_frames` を考慮した EOS trim を含むため二重適用を避けた (PR #506 と同方針)
- **`durations is None` fallback は変更なし**: 旧 ONNX export (durations output なし) は trim を skip し既存 `trim_silence` 経路に follow する (cross-runtime 共通)
- **既存 C++ test の replica パターンを踏襲**: piper.cpp は static 関数で外部に export していないため、 既存 `trimPaddingByDurations` 同様に test 側で同ロジックを再実装。 contract 不変条件 (byte equality) を `.editorconfig` opt-out も同 pattern に揃える
- **C# は `Array.Empty<float>()` と `null` を別 test に分割**: PR #506 の Python では `durations[]` 空配列のみカバーだったが、 C# は nullable 参照型のため `null` も runtime path に到達し得る。 両方を明示的にカバーした
- **WASM は既存 `{ skip }` flag を踏襲**: ローカル node 環境で PiperPlus import が困難なため既存 describe block と同様に skip 制御。 CI 環境では正しく実行される (PR #506 と同方針)

## Test Plan

- [ ] `cd src/rust && cargo test --package piper-plus --lib --features onnx test_trim_eos_region -- --nocapture` で 8 件全 PASS (ローカル確認済)
- [ ] `cd src/go/piperplus && go test -run TestTrimEosRegion -v ./...` で 8 件全 PASS (ローカル確認済)
- [ ] `cd src/csharp && dotnet test PiperPlus.sln --filter "TrimEosRegion"` で 9 件全 PASS (CI で確認)
- [ ] `cd src/wasm/openjtalk-web && npm test -- test/js/test-short-text-mitigation.js` で `trimEosRegion (Tier 1 ...)` describe block の 9 件全 PASS (CI で確認、 ローカルは依存環境次第で skip)
- [ ] C++ test (CTest 経由): `cd build && ctest --output-on-failure -R short_text_mitigation` で 8 件 + 既存 PASS (CI で確認)
- [ ] `cd src/rust && cargo check -p piper-core --lib` exit 0 (ローカル確認済)
- [ ] `uvx pre-commit run` 全 hook PASS (ruff / cargo fmt / gofmt / dotnet format / codespell / editorconfig 等、 ローカル確認済)
- [ ] CI で 5 ランタイム build/test gate が green
- [ ] Cross-runtime byte equality: 同じ `(audio, durations, hop_size)` に対し Python (PR #506) / Rust / Go / C# / WASM / C++ が同じ trim 量 (`ceil(durations[-1]) * hop_size` samples) を末尾から削ること (各ランタイムのユニットテストで担保)

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL dependencies added ([License Policy](CONTRIBUTING.md#license-policy))
- [ ] Documentation updated (if applicable) — 本 PR は internal helper の追加で公開 API 変更なし。 cross-runtime contract spec 化は別 PR で対応

## Related Issues

- Issue #499 (canonical doubled-tail bug 報告)
- PR #506 (本 PR の前段: Python ランタイム Tier 1 実装)
- 関連: Issue #356 (Strategy A `TRIM_EOS_MAX_FRAMES = 0` 導入の経緯)
