### PR TITLE
docs(tickets): CI 拡張プラン Top 10 を個別実装チケット 10 本に分解

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,16 @@ piper-plus ドキュメント。利用ガイド・各ランタイム連携・仕
 - [Spec INDEX](spec/README.md) — `.toml` 契約 (PUA / phoneme-timing / SSML / 推論入力など、CI gate 対応)
 - [Reference INDEX](reference/README.md) — `.md` 設計書 (Kotlin/Swift G2P / iOS shared-lib / ZH-EN ランタイム展開 / Model 解決 等)
 
+## Proposals (ロードマップ / 議論起点)
+
+- [CI/CD 拡張プラン (2026-05)](proposals/ci-expansion-2026-05.md) — Unlimited CI 前提の網羅調査 + 真に追加する価値があるトップ 10 + 3 ヶ月ロードマップ
+- [CI/CD 拡張プラン — マイルストーン詳細](proposals/ci-expansion-milestones.md) — Top 10 を M1-M3 + M4 + M-Stretch に分解、 各 M に目的 / 成功基準 / タスク / 依存 / リスク / 工数を明記
+
+## Tickets (実装単位の個別チケット)
+
+- [Tickets INDEX](tickets/README.md) — CI/CD 拡張プラン マイルストーンを実装者が一人で着手できるレベルまで分解した 10 チケット + 5 phase overview (M1-M4 + M-Stretch) / マイルストーン↔チケット相互マップ / 依存グラフ
+- Phase overview: [M1 Defensive Foundations](tickets/M1-overview.md) / [M2 Audio Quality Moat](tickets/M2-overview.md) / [M3 ABI & Ecosystem Hardening](tickets/M3-overview.md) / [M4 Informational Tier](tickets/M4-overview.md) / [M-Stretch Strategic Bets](tickets/M-Stretch-overview.md)
+
 ## Migration
 
 - [v1.11 → v1.12](migration/v1.11-to-v1.12.md) — HiFi-GAN/Flask/HTS-voice 削除など

--- a/docs/proposals/ci-expansion-2026-05.md
+++ b/docs/proposals/ci-expansion-2026-05.md
@@ -1,0 +1,325 @@
+# CI/CD 拡張プラン (Unlimited CI 前提の網羅調査)
+
+**作成日**: 2026-05-18
+**前提条件**: 「CI 時間とマシンが無制限」(OSS public repo として GitHub Actions は実質無料、 concurrent slot のみ制限)
+**目的**: piper-plus の **OSS としての品質** と **開発イテレーション速度** の向上
+**調査体制**: 30 エージェント並列調査 (現状監査 10 + 領域別ギャップ分析 10 + 前向き提案 10)
+
+> このドキュメントは「ロードマップ提案」であり、 実装決定ではない。 各項目は採用判断の議論起点として扱う。
+
+---
+
+## 目次
+
+- [0. エグゼクティブサマリ](#0-エグゼクティブサマリ)
+- [1. 現状診断](#1-現状診断)
+- [2. 領域別ギャップ](#2-領域別ギャップ)
+- [3. 前向き提案 (横断テーマ)](#3-前向き提案-横断テーマ)
+- [4. 批判的観点 — なぜ追加しないが default か](#4-批判的観点--なぜ追加しないが-default-か)
+- [5. 真に追加する価値があるトップ 10](#5-真に追加する価値があるトップ-10)
+- [6. 3 ヶ月実装ロードマップ](#6-3-ヶ月実装ロードマップ)
+- [7. 留保事項](#7-留保事項)
+
+---
+
+## 0. エグゼクティブサマリ
+
+piper-plus は **93 workflow + 100+ pre-commit hook + 20 skill + 19 contract spec.toml** で構成された **第二級コードベース化した CI 基盤** を持つ、極めて成熟したプロジェクト。 「Unlimited CI」を額面通り受け取って網羅的に追加すると **メンテナンス税が逆に開発速度を毀損** する。
+
+結論: **「追加すべきでない」を default として、 既存で構造的に検出不可能な領域に絞ってトップ 10 を選定**。 具体的には以下 3 軸:
+
+1. **音声品質の user-visible regression** (現状は RTF / メモリ / バイナリサイズの gate のみで、 PESQ / UTMOS / WER が空白)
+2. **7 ランタイム間の差分テスト深化** (現状は phoneme timing と fixture byte 一致のみで、 audio output / ORT input tensor / SSML AST / speaker embedding が空白)
+3. **既存 gate の構造欠陥修復** (PR #419 で発覚した「cancelled silent skip」、 contributor onboarding 障壁)
+
+---
+
+## 1. 現状診断
+
+### 1.1 全体規模
+
+- **93 workflow** (PR trigger: 78%, push: 63%, schedule: 10%, release: 2%)
+- **schedule cron 9 本のうち 6 本が月曜 UTC 朝に集中** → GitHub Actions outage 時の SPOF
+- **paths filter 70% 適用** (差分 CI が機能している)
+- **self-hosted / large runner ゼロ** (全 GitHub-hosted)
+
+### 1.2 既存 gate のカバレッジ
+
+| 領域 | 既存 | 評価 |
+|------|------|------|
+| Format / Lint | ruff / cargo-fmt / gofmt / golangci-lint / dotnet-format / mypy / pyright / clang-tidy / markdownlint / codespell / hadolint / actionlint | **過剰なほど厚い** |
+| Cross-runtime parity | 13 workflow (PUA / loanword / ORT / version / CLI / lang-id / timing / SSML / text-splitter / voice-catalog / migration / ABI / API-diff) | **業界トップクラス** |
+| 性能・品質 | RTF (6 runtime × 3 length) / memory / bundle size / mutation / fuzz smoke / parity-hub | **良好だが audio 品質と cross-runtime audio diff が空白** |
+| セキュリティ | CodeQL / secret-scan / SBOM / Trivy / cosign / dependency-review / license / security-audit / action-pin | **SLSA L2-3 ハイブリッド相当、 OpenSSF Scorecard 7-8 推定** |
+| Release / publish | PyPI / npm / crates / NuGet / Maven / HF Hub / GHCR / GitHub Releases、 全て SLSA provenance attestation 済 | **強い。 nightly / canary が空白** |
+
+### 1.3 既存 CI の健康状態 (直近 1000 run / ~36h)
+
+- success **92.0%** / cancelled **5.8%** / failure **1.9%**
+- 真の test bug は 19 件、 ほぼ全部 issue-499 ブランチ作業中の差分
+- cancelled 58 件のうち **49 件が 5 PR に集中** (force-push churn) — 単一ブランチで 33 件
+- ARM64 (QEMU) と Docker レーンが平均 25-37 分で支配的、 重量級 4 レーン (ARM64×2 + Docker×2 + rust-tests) が CI 経過時間の大半
+
+### 1.4 構造的弱点 (PR #419 教訓)
+
+Multi-Runtime RTF / Memory regression / CodeQL の baseline 検証が **cancelled で silently skip** された履歴あり。 「validation green に見えるが実は何も verify されていない」リスクが現存。
+
+---
+
+## 2. 領域別ギャップ
+
+### 2.1 各ランタイム ROI トップ提案
+
+| Runtime | 即実装の最優先 | 理由 |
+|---------|---------------|------|
+| **Python** | (1) argparse snapshot, (2) import-time bench, (3) pip-audit, (4) wheel install smoke, (5) ORT version matrix 1.17-1.20, (6) Py 3.13t free-threading | 低コスト × 高 ROI が 6 個積み上がる |
+| **Rust** | (1) `cargo-deny check all` gate、 (2) MSRV + stable + beta matrix、 (3) **cargo-semver-checks**、 (4) cargo-criterion 連続 bench | semver 違反は publish 後修正不可 |
+| **C#** | (1) **NativeAOT publish smoke**、 (2) **NuGet 公開後 install smoke (matrix 6 cell)**、 (3) dotnet-format CI gate、 (4) Trim warning 0 gate、 (5) net8 / net9 / net10 multi-TFM matrix | LTS 用途と AOT は将来 mobile 配信の前提条件 |
+| **Go** | (1) golangci `errorlint / revive / gocyclo` を warn → error 昇格、 (2) **go test -fuzz** を phonemize / ssml に、 (3) `go mod tidy -diff` drift gate、 (4) golden file drift detection | Go 1.18+ ネイティブ fuzz が piper-plus #346 / #499 系 drift に直結 |
+| **JS / WASM** | (1) **Playwright Browser matrix** (Chrome / FF / WebKit)、 (2) Node 20 / 22 / 24 matrix、 (3) **Deno + Bun smoke**、 (4) **dist tarball install smoke**、 (5) heap snapshot leak、 (6) 3-bundler integration、 (7) TS API diff | npm 0.6.0 publish 事故 (data 漏れ) は publish 後でないと検出不可 |
+| **C++ / C API** | (1) **TSan dedicated job**、 (2) **libFuzzer for C API**、 (3) **OSS-Fuzz 申請** (Google 無料インフラ)、 (4) gcov + Codecov、 (5) ABI baseline を libabigail abidiff に拡張、 (6) compiler matrix (gcc 11-14 / clang 16-19 / MSVC) | C API は外部入力点、 ABI 境界 crash 検出力最大 |
+| **Mobile** | (1) **Android emulator matrix API 24-35** + Firebase Test Lab、 (2) iOS Simulator UI test、 (3) **JNI ABI compat check**、 (4) Privacy manifest validation、 (5) ARM64 simulator (M1+)、 (6) R8 / ProGuard 最適化検証 | 顧客報告 bug の温床、 unlimited CI なら network of devices で網羅可能 |
+
+### 2.2 音声品質 (現状空白の最重要領域)
+
+**Tier 1 (PR gate 候補)**:
+
+1. **Cross-runtime audio byte parity** (SHA256 + RMSE 閾値 + chromaprint fingerprint)
+2. **PESQ / STOI 自動評価** (つくよみちゃん 50 文 fixture × 6 言語)
+3. **ASR-based WER** (Whisper-large-v3 で書き起こし → WER < 15%、 G2P regression を実音声で検出)
+4. **Voice cloning identity verification** (reference WAV ↔ 合成 WAV の ECAPA-TDNN embedding cosine ≥ 0.7)
+5. **Streaming vs batch 出力一致** (v1.12.0 breaking の core contract)
+
+**Tier 2 (nightly)**: UTMOS / pitch contour / long-form / SSML タイミング / silence padding A/B/C 品質。
+
+### 2.3 ONNX / モデル
+
+1. **ONNX checker + shape inference clean pass** (低コスト・最優先)
+2. ORT version matrix (1.16-1.20) で output MAE 検証
+3. ONNX op coverage report (ORT mobile / WebGPU EP の supported op list と diff)
+4. Tensor shape regression
+5. **Speaker embedding L2 norm + cosine 一致 (全 6 runtime)**
+6. HF artifact attestation (SHA256 pin と CLI auto-DL 検証)
+
+### 2.4 学習パイプライン
+
+**CPU で即着手** (低コスト・高 ROI):
+
+- ONNX export E2E (tiny ckpt → export → inference → audio sanity)
+- dataset 前処理 golden (`prepare_multilingual_dataset.py`)
+- checkpoint loading regression
+- VAD energy threshold (~25x 高速化変更後の品質 pinning)
+- **HiFi-GAN ckpt 明示エラー regression** (v1.12.0 migration 契約保証)
+- Phoneme ID consistency (PUA contract 連動)
+
+**GPU runner 確保後**: training smoke (1 epoch tiny) / resume lossless / mixed precision drift。
+
+---
+
+## 3. 前向き提案 (横断テーマ)
+
+### 3.1 Sanitizer 拡張
+
+**実装順**:
+
+1. C++ ASan + UBSan を PR gate に昇格 (既存 workflow_dispatch only を `pull_request` に昇格)
+2. Rust `-Z sanitizer=address` pure crate のみ
+3. Python `pytest-leaks` + tracemalloc growth gate
+4. C# dotMemory Unit
+5. WASM heap snapshot (Playwright + CDP `HeapProfiler`)
+6. C++ TSan / Valgrind nightly
+7. iOS / Android leak nightly
+8. Rust miri nightly
+
+**Suppression 一元管理**: `tools/sanitizer/` 配下に集約、 ORT 既知 leak は `ort-known-leaks.md` で justification 必須化。
+
+**CI minutes**: ~20,400 min/月 (public repo 無料、 macOS billing も 10x で実質無料)。
+
+### 3.2 Cross-runtime differential testing
+
+新規 workflow `runtime-parity-deep.yml` に 7 項目を集約:
+
+1. **Golden phoneme IDs** (Python canonical, byte 一致、 ZH-EN 混在 / SSML break / PUA / N バリアント網羅)
+2. **Golden ONNX inputs** (`--dump-ort-inputs` flag を 7 runtime 全実装、 npz 比較)
+3. **Golden audio** (SNR ≥ 60 dB / mel-spec MSE ≤ 1e-3、 浮動小数差を許容)
+4. Streaming vs batch parity (各 runtime 内 self-consistency)
+5. **SSML parse tree parity** (Rust canonical の AST JSON 化、 byte 一致)
+6. Speaker embedding parity (cosine ≥ 0.9995)
+7. Phoneme timing 7 ランタイム拡張 (Swift / Kotlin G2P 追加)
+
+設計詳細は本ドキュメント末尾の関連 spec 候補 (`docs/spec/runtime-parity-deep-contract.toml` を将来作成) を参照。
+
+### 3.3 Property-based & Fuzzing 拡張
+
+**継続価値 Top 5**:
+
+1. **OSS-Fuzz 連携** (c_api / SSML / G2P、 Google 無料計算インフラ、 申請 1-2 週間)
+2. **Differential fuzzing: text_splitter 7 ランタイム** (#346 / #499 系 drift の構造的再発防止)
+3. **Differential fuzzing: Python ↔ Rust G2P** (loanword / PUA 10 mirror 同期は byte gate 済みだが出力等価性未検証)
+4. Python hypothesis を SSML / 8 言語 G2P / dict loader / PUA / timing / voice catalog に全展開
+5. Rust proptest: streaming.rs 状態機械
+
+**Mutation testing 拡張**: Go (gremlins) / JS (Stryker) / C++ (mull)。週次。
+
+### 3.4 Real-device CI farm
+
+**5 本柱**:
+
+| 領域 | サービス | 用途 | コスト |
+|---|---|---|---|
+| Android 実機 | Firebase Test Lab | API 24-35 + Pixel / Samsung / Xiaomi 物理デバイス | OSS 5 device-hour/day 無料 |
+| iOS 実機 | BrowserStack App Live OSS plan + Xcode Cloud | iPhone 15/16, iPad、 iOS 17/18/26 並走 | BS OSS = 5 並列無制限分; XC Cloud = 25h/month 無料 |
+| ブラウザ | BrowserStack Live OSS + Playwright + GitHub Actions | Safari iOS、 Samsung Internet、 WeChat WebView 等 | OSS plan 無料 |
+| Apple Silicon | GitHub Actions `macos-14` / `macos-15` (M1) + Xcode Cloud | M1 native runner は GA free | 無料 |
+| Linux ARM | GitHub Actions `ubuntu-22.04-arm` + 自前 Raspberry Pi 5 self-hosted | Pi / Jetson の native build | 電気代のみ |
+
+**実コスト ≈ ¥200/月 (電気代のみ)**。
+
+**検出できる典型 bug** (GH Actions x86_64 では発見不能): iOS 18 WebKit SAB block, Android x86 emulator SIGBUS, M3 Pro Metal MPSGraph assertion, Windows ARM WoW64 遅延, Pi Zero 2W NEON fp16 fallback, Samsung Internet autoplay policy, WeChat WebView WASM SIMD trap。
+
+### 3.5 Continuous performance dashboard
+
+**Platform 選定**: **Bencher (primary) + GitHub Pages (secondary)**
+
+- Codspeed は Rust / Python / Node のみで 7 ランタイム未対応のため不採用
+- Datadog はエンタープライズ機能豊富だが OSS では費用構造が見合わない
+- Bencher は OSS 無料 + multi-language adapter + statistical boundary 検出 + sticky PR comment
+
+**継続収集すべき指標 (追加)**:
+
+- インストール後 cold-start (process spawn → ready) 時間
+- First-token latency (streaming で最初の音声 chunk 到達)
+- Per-language MOS / PESQ / STOI を nightly で
+- Bundle compressed sizes (gzip / br / zstd 3 種類)
+- WASM compile time
+- Import time / module load
+- CI workflow duration (meta-metric)
+
+### 3.6 Supply-chain hardening (推奨ロードマップ 6 週)
+
+| Week | 実施 | Scorecard 予想 |
+|------|------|----------------|
+| 1 | **OpenSSF Scorecard CI 化** + branch protection audit + **typosquatting 防衛** (PyPI / npm scope 予約) | 7.5 → 8.5 |
+| 2-3 | Sigstore Rekor verification + Action SHA drift 監視 (revoked / force-pushed 検出) | 8.5 → 9.0 |
+| 3-4 | Distroless / Chainguard 移行 (python-inference / webui / wyoming) | 9.0 |
+| 5-6 | SLSA Build L3 公式 generator (`slsa-framework/slsa-github-generator`) 移行 | 9.0 → 9.3 |
+| 7+ | OSS-Fuzz 申請 → reproducible spot check (Rust / Go binary 限定) | — |
+
+### 3.7 Docs / i18n / CHANGELOG
+
+**Tier S (即効性高、 ROI 圧倒)**:
+
+1. CHANGELOG keep-a-changelog 形式 validator + breaking-change → migration cross-ref 強制
+2. **README.md ⇔ README-ja.md 構造一致 gate** (heading tree AST 比較)
+3. 7 ランタイム CLI help auto-extract → `docs/reference/cli-help/<runtime>.txt` を auto-commit
+
+**Tier A (中期)**: spec contract toml ⇔ implementation 同期 gate / mkdocs-material 統合配信 / code example execution test (multi-runtime doctest)。
+
+### 3.8 PR preview & nightly canary
+
+**実装順**:
+
+1. GHCR + WASM preview (secret 不要・最小リスク)
+2. TestPyPI nightly (yank 容易)
+3. HF Space preview (cost 中、 環境 isolation 設計後)
+4. crates.io / Maven は週次に格下げ (immutability リスク)
+5. telemetry / auto-yank (opt-in 設計と community RFC 必須)
+
+**Secret 漏洩リスク回避**: fork PR は `pull_request_target` で **必ず** `actions/checkout` の `ref: head.sha` + workflow file は base branch のものを使う (Dependabot vulnerability pattern 回避)。HF / Docker token は GitHub Environments `pr-preview-fork` で manual approval gate。
+
+### 3.9 CI observability
+
+**ROI トップ 3**:
+
+1. **CI flake / cancel / skip dashboard** (`/watch-ci-patterns` skill の data layer 化、 PR #419 silent skip 再発防止)
+2. **Test result aggregation** (7 runtime の test を統合表示、 `/check-cross-runtime` と接続)
+3. **Build artifact size trend** (bundle-size-gate を dashboard 化)
+
+**Datadog / Trunk / BuildPulse は不採用** (vendor lock-in、 自前 aggregator + GitHub Pages が piper-plus 文化に合う)。
+
+---
+
+## 4. 批判的観点 — なぜ「追加しない」が default か
+
+piper-plus は既に 93 workflow + 100+ pre-commit hook を持ち、 **CI 基盤自体が second-order codebase** になっている。 新規追加を議論する前に、 以下の cost を直視すべき。
+
+- **メンテナンス税の指数化**: workflow 1 つ ≒ 月 1h (action 版上げ / flaky 調査 / log 読解)。93 本なら 93h/月 = エンジニア 0.6 FTE 相当を「CI 守り」に費やしている計算。 **新規追加は既存削除とペアが原則**。
+- **signal-to-noise の閾値割れ**: PR #419 で「cancelled が silently skip され baseline 検証が事実上 no-op」が起きた。 検査が多いほど誰も log を読まなくなり、 green / red の意味が空洞化する。 Hypothesis nightly や fuzzer のような確率的検査は特に「flake = 無視」が常態化する。
+- **queue contention**: OSS public で minute 無制限でも、 concurrent runner 数は実用上シリアル化される。 Linux runner だけで 60+ ジョブ並ぶ PR では、 人間が結果を待つ tail latency が 30 分を超える。 これは contributor 体験を直接劣化させる。
+- **"CI as a moat" 誤謬**: 18+ contract gate を通すための前提知識 (PUA contract、 loanword sync、 ORT pin、 ruff version 6 箇所同期) は初回 contributor には事実上 unlearnable で、 PR が merge されない原因になる。 Gate を増やすほど「メンテナ以外は PR を出せない」プロジェクトに収束する。
+- **breaking change の真のコスト**: v1.11 → v1.12 で発生したのは CI でなく **migration doc / runtime parity** の問題。 CI で防げた割合は限定的で、 追加 gate の限界効用は逓減している。
+
+**結論**: **「追加すべきでない」が baseline**。 以下のトップ 10 は「既存と排他的でない / 既存 gate では構造的に検出不可能 / user-visible damage を防ぐ」の 3 条件を満たすもののみ。
+
+---
+
+## 5. 真に追加する価値があるトップ 10
+
+| # | 項目 | ROI | 難易度 | 検出 bug カテゴリ |
+|---|------|-----|--------|------------------|
+| 1 | **音声品質 MOS proxy gate** (PESQ / STOI / ViSQOL、 golden 10 sample) | 高 | 中 | 音声品質回帰 (user-visible 最致命) |
+| 2 | **Cross-runtime audio byte-parity diff** (7 runtime × 3 model の waveform hash) | 高 | 中 | 計算順序差 / FP16 drift / decoder 差 |
+| 3 | **Migration guide lint** (CHANGELOG breaking 節 ↔ `docs/migration/` cross-ref 強制) | 高 | 低 | doc drift / migration 欠落 |
+| 4 | **Public ABI snapshot** (C API / Swift / Kotlin の JSON snapshot 化、 非互換変更で fail) | 高 | 中 | semver 違反 / silent ABI break |
+| 5 | **First-PR fast lane** (新規 contributor の PR は contract gate を warning に降格、 コア lint のみ blocker。 merge 前に手動で full gate) | 高 | 低 | 新規 contributor 離脱 (斜め視点) |
+| 6 | Loanword / PUA "未来仕様" forward-compat fuzz (`schema_version: 99` のランダム未来フィールドを 7 ランタイムに食わせ panic / exception しないこと) | 中 | 中 | forward-compat regression |
+| 7 | **Model card / license 自動付与** (HF release 生成の ONNX 同梱物に LibriTTS-R / AISHELL-3 / CML-TTS の attribution を build 時 injection) | 中 | 低 | license 不備 (斜め視点、 法務リスク) |
+| 8 | **Typosquatting / supply-chain 監視** (PyPI / npm / crates / NuGet / Maven の "piper-pIus" / "piper_plus_g2p" 類似名を週次 scan、 issue 起票) | 中 | 低 | supply chain (斜め視点) |
+| 9 | Phoneme timing temporal monotonicity property test (Hypothesis で 1000 ケース、 ただし **PR ブロックせず informational** に留め signal noise を避ける) | 中 | 中 | timing 計算 bug |
+| 10 | **Cancelled / skipped baseline alarm** (PR #419 再発防止: required check が cancelled で終わった場合、 merge button を block する gating job を 1 つだけ追加) | 高 | 低 | CI 構造欠陥 (既存 gate の盲点) |
+
+**斜め視点採用**: #5 (onboarding) / #7 (license attribution の audio asset への自動付与) / #8 (typosquatting 監視、 ecosystem 認知の防衛側)。Carbon footprint は piper-plus が training を手動運用しているため CI で測る価値が薄く不採用。Issue auto-labeling は GitHub 標準で十分なため不採用。
+
+---
+
+## 6. 3 ヶ月実装ロードマップ
+
+### Month 1 (defensive, ROI 即時回収)
+
+`#10 cancelled baseline alarm` → `#3 migration lint` → `#5 first-PR fast lane` の 3 本。
+
+いずれも難易度低、 既存 gate の構造欠陥 / contributor onboarding / breaking change discipline を底上げし、 新規メンテナンス税が最小。
+
+### Month 2 (audio quality moat)
+
+`#1 MOS proxy gate` を 10 golden sample + ViSQOL で導入し、 並行して `#2 cross-runtime byte-parity` の waveform hash diff を 3 model に絞って試験投入。
+
+MOS gate は最初 4 週間 informational で false positive 率を測り、 安定したら blocker 化。
+
+### Month 3 (ABI / ecosystem hardening)
+
+`#4 public ABI snapshot` を C / Swift / Kotlin の 3 面で運用開始、 `#7 license attribution` を `release-shared-lib.yml` に組込、 `#8 typosquatting 週次 scan` を schedule 化、 `#6 / #9` forward-compat fuzz と timing property test は **informational tier** で追加し signal noise の蓄積を回避する。
+
+### 運用ルール (重要)
+
+各月末に **「追加 workflow と同数の既存 workflow を削除候補としてレビュー」** する maintenance budget rule を運用ルールとして固定化することを強く推奨する (net flat policy)。
+
+---
+
+## 7. 留保事項
+
+- **GPU runner**: training smoke / WER (Whisper) / UTMOS は GPU 必要。 self-hosted (RTX 3090 / 中古 V100) を Tailscale で繋げば月 ¥3000 程度の電気代で実現可能。
+- **Carbon footprint estimation**: training を手動運用しているため CI で測る価値が薄く不採用。
+- **Issue auto-labeling**: GitHub 標準で十分。
+- **Reproducible builds 完全実施**: Python wheel / NuGet の timestamp embed のため ROI 低、 Rust binary + Go binary の 2 つに絞り informational のみ。
+- **OSS-Fuzz**: 審査 1-2 週間、 採択されれば 24/7 fuzz + 自動 Issue 起票 + bug bounty 対象で最大 ROI。
+- **完全 hermetic build (Bazel / Nix への全面移行)**: 工数 200+ 時間、 ROI なし。 既存 GitHub Actions の OIDC + pinned runner image で「実用上 hermetic」と判定。
+- **install-time cosign 強制 (失敗で install block)**: ユーザビリティ毀損、 verify は opt-in ドキュメント止まりが妥当。
+
+---
+
+## 関連ドキュメント
+
+- [`docs/spec/README.md`](../spec/README.md) — 既存 contract spec の一覧 (19 toml)
+- [`docs/reference/README.md`](../reference/README.md) — 既存設計書の一覧
+- [`docs/migration/v1.11-to-v1.12.md`](../migration/v1.11-to-v1.12.md) — breaking change 事例
+- [`.claude/README.md`](../../.claude/README.md) — 既存 skill / hook / pre-commit gate
+- [`CLAUDE.md`](../../CLAUDE.md) — プロジェクト概要
+
+## 調査体制 (備考)
+
+本ドキュメントは 30 並列エージェントによる以下の調査結果を統合したもの:
+
+- **Wave 1 (現状監査、 10 agents)**: workflow 全 93 本のトリガー集計 / pre-commit 全 hook の分類 / 7 ランタイム test カバレッジ / 性能・品質 gate / セキュリティ gate / parity gate / CI 健康レポート / release 自動化 / skill 自動化 / OS × version matrix
+- **Wave 2 (領域別ギャップ、 10 agents)**: Python / Rust / C# / Go / JS-WASM / C++ / Mobile / Audio quality / ONNX-quantization / Training pipeline
+- **Wave 3 (前向き提案、 10 agents)**: Sanitizer 拡張 / Cross-runtime differential / Property-fuzzing / Real-device farm / Performance dashboard / Supply-chain hardening / Docs-i18n-CHANGELOG / PR preview-canary / CI observability / 最終 synthesizer (批判的レビュー + Top 10 選定)

--- a/docs/proposals/ci-expansion-milestones.md
+++ b/docs/proposals/ci-expansion-milestones.md
@@ -1,0 +1,259 @@
+# CI/CD 拡張プラン — マイルストーン詳細
+
+**親ドキュメント**: [ci-expansion-2026-05.md](./ci-expansion-2026-05.md)
+**個別チケット**: [../tickets/README.md](../tickets/README.md) — 各 M.X を実装者が一人で着手できるレベルまで具体化した 10 チケット
+**作成日**: 2026-05-18
+**対象期間**: Month 1-3 (本ドキュメント) + Stretch (Month 4+)
+
+> このドキュメントは [ci-expansion-2026-05.md](./ci-expansion-2026-05.md) の **Top 10 項目** を実装単位のマイルストーンに分解したもの。 GitHub Milestone / Project board と紐づけできる粒度で、 各 M に **目的 / 成功基準 / タスク / 依存 / リスク / 関連ファイル** を明記する。 各 M.X の詳細実装チケット (エージェントチーム配置 / Unit/E2E テスト / Reinvention / Handoff まで) は [../tickets/](../tickets/README.md) を参照。
+
+---
+
+## 全体マップ
+
+| Milestone | テーマ | 期間 | 含まれる Top 10 項目 | 主要成果物 |
+|-----------|--------|------|---------------------|------------|
+| **M1: Defensive Foundations** | 既存 gate 構造欠陥修復 + onboarding | Month 1 (4 週) | #10 #3 #5 | cancelled baseline alarm / migration lint / first-PR fast lane |
+| **M2: Audio Quality Moat** | user-visible 品質 regression 検出 | Month 2 (4 週) | #1 #2 | MOS proxy gate (informational → blocker) / cross-runtime audio byte parity |
+| **M3: ABI & Ecosystem Hardening** | semver 違反 / 法務 / supply chain | Month 3 (4 週) | #4 #7 #8 | Public ABI snapshot / license auto-injection / typosquatting weekly scan |
+| **M4: Informational Tier** (任意、 並走可) | flaky 検査の signal noise 隔離 | Month 3 並走 | #6 #9 | forward-compat fuzz / timing monotonicity property test (どちらも non-blocker) |
+| **M-Stretch: Strategic Bets** | unlimited CI を本気で活かすなら | Month 4+ | (Top 10 外、 親 doc §3 参照) | OSS-Fuzz / Bencher dashboard / real-device farm |
+
+各 M 末尾に **「追加 workflow と同数の既存 workflow を削除候補としてレビュー」** する maintenance budget rule を運用ルールとして固定化 (親 doc §6 net flat policy)。
+
+---
+
+## M1: Defensive Foundations
+
+**期間**: Month 1 (4 週)
+**狙い**: 既存 gate の構造欠陥を修復し、 新規 contributor の onboarding 障壁を下げる。 新規メンテナンス税を最小化するため難易度低のみで構成。
+
+### M1.1 — Cancelled / skipped baseline alarm (Top 10 #10)
+
+**実装チケット**: [M1-1-cancelled-baseline-alarm.md](../tickets/M1-1-cancelled-baseline-alarm.md)
+
+| 項目 | 内容 |
+|------|------|
+| 目的 | PR #419 再発防止: required check が cancelled で終わった場合に merge を block する |
+| 成功基準 | (a) `required_status_check_gate.yml` workflow が存在、 (b) Multi-Runtime RTF / Memory regression / CodeQL の baseline 検証が cancelled なら fail、 (c) dev branch protection に new check を required 化 |
+| タスク | (1) cancelled / skipped を success として扱う既存 workflow を棚卸し、 (2) gate workflow 作成 (`gh api` で run conclusion を集計)、 (3) branch protection を `gh api` で更新、 (4) `feedback_ci_cancelled_baseline.md` を memory に記載済みなのを確認 |
+| 依存 | なし |
+| リスク | concurrency group との競合で本物の supersede cancel まで block する可能性 — `head_sha == latest commit` 条件で再 trigger を待つ仕組みを併設 |
+| ROI / 難易度 | 高 / 低 |
+| 関連ファイル | `.github/workflows/multi-runtime-rtf.yml`, `memory-regression.yml`, `codeql.yml`、 新規 `required_status_check_gate.yml` |
+| 想定工数 | 1-2 PR (~8h) |
+
+### M1.2 — Migration guide lint (Top 10 #3)
+
+**実装チケット**: [M1-2-migration-guide-lint.md](../tickets/M1-2-migration-guide-lint.md)
+
+| 項目 | 内容 |
+|------|------|
+| 目的 | `CHANGELOG.md` の `[Unreleased] > Breaking` 節と `docs/migration/v*.md` の cross-ref を強制 |
+| 成功基準 | (a) `migration-guide-lint.yml` workflow が PR で breaking entry を検出した場合、 対応する migration doc の存在 + anchor link を assert、 (b) `migration-changelog-parity.yml` の延長として動作 |
+| タスク | (1) keep-a-changelog parser script (`scripts/check_migration_xref.py`)、 (2) breaking entry に migration anchor link を強制する正規表現、 (3) `migration-changelog-parity.yml` を拡張 or 新規 workflow |
+| 依存 | なし (既存の `migration-changelog-parity.yml` を継承) |
+| リスク | breaking change の粒度が一律ではなく、 docs を必須化すると過剰 friction の懸念 — 「breaking」label 付き PR のみ enforce する設計 |
+| ROI / 難易度 | 高 / 低 |
+| 関連ファイル | `.github/workflows/migration-changelog-parity.yml`、 `CHANGELOG.md`、 `docs/migration/` |
+| 想定工数 | 1 PR (~6h) |
+
+### M1.3 — First-PR fast lane (Top 10 #5)
+
+**実装チケット**: [M1-3-first-pr-fast-lane.md](../tickets/M1-3-first-pr-fast-lane.md)
+
+| 項目 | 内容 |
+|------|------|
+| 目的 | 新規 contributor の PR は contract gate を warning に降格、 コア lint のみ blocker。 merge 前に maintainer が手動で full gate trigger |
+| 成功基準 | (a) `first-pr-fast-lane.yml` で `github.event.pull_request.author_association in ['FIRST_TIME_CONTRIBUTOR', 'NONE', 'FIRST_TIMER']` なら contract gate を `continue-on-error: true` 化、 (b) maintainer が `/run-full-gate` label を付与すると blocker 化 |
+| タスク | (1) author_association 判定 logic、 (2) contract gate 18 本に conditional 化、 (3) `CONTRIBUTING.md` に fast lane 説明追加、 (4) maintainer-only label workflow |
+| 依存 | M1.1 (gate concept) |
+| リスク | full gate を maintainer が忘れて merge する事故 — `merge` API で `required_status_check_gate.yml` を一律 require にして maintainer も bypass 不可にする |
+| ROI / 難易度 | 高 / 低 |
+| 関連ファイル | `.github/workflows/parity-hub.yml`, `pua-consistency.yml`, `zh-en-loanword-sync.yml`、 新規 `first-pr-fast-lane.yml`、 `CONTRIBUTING.md` |
+| 想定工数 | 2 PR (~12h) |
+
+**M1 完了基準**: 3 PR が merge され、 `required_status_check_gate.yml` が dev branch protection に組み込まれていること。
+
+---
+
+## M2: Audio Quality Moat
+
+**期間**: Month 2 (4 週)
+**狙い**: piper-plus 最大の盲点である「合成音声 user-visible regression」を 2 軸で塞ぐ。
+**設計方針**: 最初の 4 週間は **informational tier** (non-blocking) で false positive 率を観測し、 安定後に blocker 化する。 一気に gate 化しない。
+
+### M2.1 — Audio MOS proxy gate (Top 10 #1)
+
+**実装チケット**: [M2-1-audio-mos-proxy.md](../tickets/M2-1-audio-mos-proxy.md)
+
+| 項目 | 内容 |
+|------|------|
+| 目的 | PESQ / STOI / ViSQOL で golden sample 10 個に対し PR ごとに走らせ、 閾値割れで fail |
+| 成功基準 | (a) `audio-mos-proxy.yml` workflow が tsukuyomi 50 文 × 6 言語の MOS proxy を計算、 (b) baseline JSON (`tests/fixtures/audio-mos-baseline.json`) と比較し threshold 内、 (c) 4 週間 informational 後に blocker 昇格 |
+| タスク | (1) golden sample 選定 (短文 / 長文 / SSML / ZH-EN 混在 / PUA 含む)、 (2) PESQ-WB / STOI / UTMOS22 score 計算 script (`scripts/audio_quality_metrics.py`)、 (3) baseline 生成 + commit、 (4) workflow 構築、 (5) PR comment 自動投稿 (sticky comment、 `feedback_pr_body_over_comments` 準拠) |
+| 依存 | M1.1 (cancelled silent skip 防止が前提) |
+| リスク | UTMOS は PyTorch dependency が重い (~3GB) — Whisper / wav2vec2 representation 抽出に絞り、 軽量化を優先。 GPU は使わず CPU で完結 (~10 min / run、 unlimited CI 前提なので可) |
+| ROI / 難易度 | 高 / 中 |
+| 関連ファイル | `tools/benchmark/` (既存 MOS script の CI 化)、 `tests/fixtures/audio-mos-baseline.json` 新規、 `.github/workflows/audio-mos-proxy.yml` 新規 |
+| 想定工数 | 3-4 PR (~30h) |
+
+### M2.2 — Cross-runtime audio byte parity (Top 10 #2)
+
+**実装チケット**: [M2-2-cross-runtime-audio-parity.md](../tickets/M2-2-cross-runtime-audio-parity.md)
+
+| 項目 | 内容 |
+|------|------|
+| 目的 | 7 runtime × 3 model で同一入力 → 合成音声 WAV の SHA256 / RMSE / chromaprint fingerprint 比較 |
+| 成功基準 | (a) `runtime-parity-deep.yml` の subset として `parity-audio` job が動作、 (b) SNR ≥ 60 dB / mel-spec MSE ≤ 1e-3 を満たす、 (c) 失敗時に diff spectrogram PNG を artifact upload |
+| タスク | (1) 各 runtime に `--dump-wav` 経路を実装 or 既存 CLI 活用、 (2) fixture text 選定 (M2.1 と共有可)、 (3) chromaprint / mel-spec MSE 計算 script、 (4) workflow 構築、 (5) 浮動小数 / ORT provider 差を許容する閾値設計 |
+| 依存 | M1.1 / M2.1 (fixture 共有) |
+| リスク | ORT provider × OS で浮動小数差が大きく、 閾値設定の試行錯誤が必要 — 最初 1 model に絞り、 安定後 3 model に拡大 |
+| ROI / 難易度 | 高 / 中 |
+| 関連ファイル | `tests/parity/fixtures/golden_audio_corpus.txt` 新規、 `scripts/audio_parity.py` 新規、 `.github/workflows/runtime-parity-deep.yml` 新規 |
+| 想定工数 | 4-5 PR (~40h) |
+
+**M2 完了基準**: 2 workflow が dev で稼働、 4 週間 informational で false positive 率 < 5% を観測。 安定後 blocker 化の判断は M3 開始時に再評価。
+
+---
+
+## M3: ABI & Ecosystem Hardening
+
+**期間**: Month 3 (4 週)
+**狙い**: semver 違反 / 法務リスク / supply chain 攻撃の 3 軸を塞ぐ。 メンテナンス税は低いが OSS としての信頼性に直結。
+
+### M3.1 — Public ABI snapshot (Top 10 #4)
+
+**実装チケット**: [M3-1-public-abi-snapshot.md](../tickets/M3-1-public-abi-snapshot.md)
+
+| 項目 | 内容 |
+|------|------|
+| 目的 | C API / Swift / Kotlin の public signature を JSON snapshot 化、 非互換変更で fail |
+| 成功基準 | (a) `public-abi-snapshot.yml` が 3 ターゲット (C / Swift / Kotlin) で signature を抽出、 (b) `tests/fixtures/public-abi/{c,swift,kotlin}.json` と diff、 (c) breaking 削除 / 型変更で fail、 追加のみは pass |
+| タスク | (1) C: `nm -D libpiper_plus.so \| grep ' T '` + `abi-dumper` で struct layout、 (2) Swift: `swift package describe --type json` + symbol graph、 (3) Kotlin: `binary-compatibility-validator` plugin、 (4) baseline JSON commit、 (5) workflow 構築 |
+| 依存 | なし (既存 `cpp-abi-check.yml` `public-api-diff.yml` を継承拡張) |
+| リスク | xcframework / AAR の release artifact が PR ごとに生成されないと diff 不可能 — 軽量 build-only path を追加 |
+| ROI / 難易度 | 高 / 中 |
+| 関連ファイル | `.github/workflows/cpp-abi-check.yml`, `public-api-diff.yml`、 新規 `.github/workflows/public-abi-snapshot.yml`、 `tests/fixtures/public-abi/` |
+| 想定工数 | 3 PR (~25h) |
+
+### M3.2 — Model card / license auto-injection (Top 10 #7)
+
+**実装チケット**: [M3-2-license-auto-injection.md](../tickets/M3-2-license-auto-injection.md)
+
+| 項目 | 内容 |
+|------|------|
+| 目的 | HF release で生成される ONNX 同梱物に LibriTTS-R / AISHELL-3 / CML-TTS / MOE-Speech の attribution を build 時 injection |
+| 成功基準 | (a) `release-shared-lib.yml` / `deploy-huggingface.yml` の publish 直前で `MODEL_CARD.md` + `LICENSE_ATTRIBUTIONS.md` を auto-generate、 (b) 6 言語のデータセット出典・ライセンス・話者数を表組み、 (c) HF Hub 上の readme.md template に注入 |
+| タスク | (1) `scripts/generate_model_card.py` (CLAUDE.md のデータセット表から抽出)、 (2) `LICENSE_ATTRIBUTIONS.md` template (各 dataset の license + URL + commit hash)、 (3) `release-shared-lib.yml` 末尾に hook、 (4) HF Hub upload 時に metadata 注入 |
+| 依存 | なし |
+| リスク | データセットの license は時間経過で変わる可能性 — `data-sources.yml` を canonical source として upstream 変更を quarterly review |
+| ROI / 難易度 | 中 / 低 |
+| 関連ファイル | `CLAUDE.md` (データセット表)、 `release-shared-lib.yml`, `deploy-huggingface.yml`、 新規 `scripts/generate_model_card.py`、 `data-sources.yml` 新規 |
+| 想定工数 | 2 PR (~15h) |
+
+### M3.3 — Typosquatting weekly scan (Top 10 #8)
+
+**実装チケット**: [M3-3-typosquatting-watch.md](../tickets/M3-3-typosquatting-watch.md)
+
+| 項目 | 内容 |
+|------|------|
+| 目的 | PyPI / npm / crates / NuGet / Maven の "piper-pIus" / "piper_plus_g2p" / "piperplus" 類似名を週次 scan、 issue 起票 |
+| 成功基準 | (a) `typosquatting-watch.yml` が schedule で 5 registry を polling、 (b) Levenshtein distance ≤ 2 の package を検出、 (c) 新規検出で Issue auto-create (label `security:typosquatting`) |
+| タスク | (1) `scripts/check_typosquatting.py` (registry API 経由)、 (2) 既知 false positive 除外リスト (`tests/fixtures/typosquatting-allowlist.json`)、 (3) workflow 構築、 (4) namespace 予約: PyPI `piper_plus` / `piperplus` を placeholder publish (README に「本物はこちら」)、 npm `@piper-plus/*` scope を保護 |
+| 依存 | なし |
+| リスク | registry API rate limit — 週次 schedule で抑制、 backoff retry を実装。 placeholder publish は OSS audience に誤解を与えないよう README を明確に |
+| ROI / 難易度 | 中 / 低 |
+| 関連ファイル | 新規 `.github/workflows/typosquatting-watch.yml`、 `scripts/check_typosquatting.py`、 `tests/fixtures/typosquatting-allowlist.json` |
+| 想定工数 | 2 PR (~12h) |
+
+**M3 完了基準**: 3 workflow が稼働、 ABI snapshot baseline が commit 済、 model card auto-injection が次回 HF release で動作確認できること。
+
+---
+
+## M4: Informational Tier (任意、 M3 と並走可)
+
+**狙い**: 確率的 / flaky な検査を **PR ブロックせず informational tier** に隔離。 signal noise 蓄積を回避しつつ trend 監視を可能に。
+
+### M4.1 — Loanword / PUA forward-compat fuzz (Top 10 #6)
+
+**実装チケット**: [M4-1-loanword-pua-forward-compat.md](../tickets/M4-1-loanword-pua-forward-compat.md)
+
+`schema_version: 99` のランダム未来フィールドを 7 ランタイムに食わせ、 panic / exception しないことを保証。 `feedback_data_asset_distribution.md` の延長で `forward-compat` を CI 化。
+
+- 成功基準: 既存 loanword / PUA workflow に `--fuzz-future-schema` job 追加、 `continue-on-error: true`
+- 工数: 1-2 PR (~10h)
+- 関連: `zh-en-loanword-sync.yml`, `pua-consistency.yml`
+
+### M4.2 — Phoneme timing monotonicity property test (Top 10 #9)
+
+**実装チケット**: [M4-2-timing-monotonicity-property.md](../tickets/M4-2-timing-monotonicity-property.md)
+
+任意入力で `start ≤ end` かつ累積単調なことを Hypothesis で 1000 ケース。 **PR ブロックせず informational** に留める。
+
+- 成功基準: `timing-parity.yml` に property test job 追加、 `continue-on-error: true`、 失敗履歴を gh-pages にダッシュボード化
+- 工数: 1 PR (~8h)
+- 関連: `timing-parity.yml`, `src/python_run/piper/timing.py`
+
+**運用ルール**: informational tier の workflow が **3 ヶ月連続で 1 度も signal を出さなかった場合、 削除候補**。 net flat policy の一環。
+
+---
+
+## M-Stretch: Strategic Bets (Month 4+ 候補)
+
+**Overview チケット**: [M-Stretch-overview.md](../tickets/M-Stretch-overview.md) — S1-S8 候補 (OSS-Fuzz / Bencher / Real-device / SLSA L3 / Distroless / Sanitizer / cross-runtime differential / PR preview) の各々を昇格判定基準とあわせて整理。
+
+Top 10 外の領域で、 unlimited CI を本気で活かすなら検討に値するもの。 親 doc §3 から抜粋。 各々独立した別 milestone として議論可能:
+
+| 候補 | 親 doc §参照 | 期待効果 | 主な障壁 |
+|------|-------------|---------|---------|
+| OSS-Fuzz 申請 | §3.3 / §3.6 | 24/7 fuzz + 自動 Issue + bug bounty 対象 | 申請 1-2 週間 + harness 整備 |
+| Bencher dashboard 導入 | §3.5 | 7 runtime 横断 perf trend / sticky PR comment | 既存 gh-pages baseline からの移行 |
+| Real-device farm | §3.4 | iOS / Android / WebKit の発見不能 bug 検出 | サービス契約 (BS / Firebase) の OSS plan 申請 |
+| SLSA Build L3 公式 generator 移行 | §3.6 | OpenSSF Scorecard 9.3+ | 5 registry × 2 PR の作業量 |
+| Distroless / Chainguard 移行 | §3.6 | container image attack surface 削減 | Dockerfile 7 個の段階的書き換え |
+| Sanitizer 拡張 (全 7 runtime) | §3.1 | C++ / Rust UB / leak の網羅 | suppression file の継続メンテ |
+| Cross-runtime differential testing 完全版 | §3.2 | 7 項目全部 (golden phoneme / ORT input / SSML AST 等) | 各 runtime に `--dump-*` flag 実装 |
+| PR preview + nightly canary | §3.8 | contributor 体験向上 / regression 早期発見 | secret 漏洩リスク設計 |
+
+---
+
+## マイルストーン横断の運用ルール
+
+### 採用判断 checklist (各 M 開始時)
+
+- [ ] 親 doc §4 の批判的観点を再確認 (「追加しない」が default)
+- [ ] 含まれる項目が「既存と排他的でない / 既存 gate では構造的に検出不可能 / user-visible damage を防ぐ」の 3 条件のいずれかを満たすか
+- [ ] 同月内に削除候補となる既存 workflow があるか (net flat policy)
+- [ ] 想定工数が 4 週 / 1 maintainer の容量を超えないか
+
+### 完了判定 checklist (各 M 終了時)
+
+- [ ] 含まれる workflow が dev で 1 週間 green を維持
+- [ ] false positive 率 < 5% (informational tier は除く)
+- [ ] PR / Issue で contributor から friction 報告がないか
+- [ ] 削除候補レビュー実施済み (net flat policy)
+- [ ] 親 doc / 関連 spec toml の更新
+
+### 中止判定 (各 M 内で blocker 発生時)
+
+- false positive 率が 20% を超えた場合 → 当該 milestone item を informational tier に降格
+- 工数が見積もりの 2 倍を超えた場合 → scope を半減して再見積もり
+- contributor friction 報告が 3 件以上出た場合 → 設計再検討
+
+---
+
+## 関連ドキュメント
+
+- [ci-expansion-2026-05.md](./ci-expansion-2026-05.md) — 親調査レポート (30 エージェント統合)
+- [`docs/spec/README.md`](../spec/README.md) — 既存 contract spec 一覧
+- [`docs/migration/v1.11-to-v1.12.md`](../migration/v1.11-to-v1.12.md) — breaking change 事例
+- [`.claude/README.md`](../../.claude/README.md) — 既存 skill / hook / pre-commit gate
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — Contribution guidelines (M1.3 で更新予定)
+
+## 変更履歴
+
+| 日付 | 変更 | 関連 PR |
+|------|------|---------|
+| 2026-05-18 | 初版作成 (30 エージェント調査結果より Top 10 を M1-M3 + M4 + M-Stretch に分解) | — |
+| 2026-05-18 | 個別実装チケット 10 本 + 5 overview を [../tickets/](../tickets/README.md) に追加 (4 エージェント並列執筆 / 計 5314 行)、 各 M.X セクションに backlink 追加 | — |

--- a/docs/tickets/M-Stretch-overview.md
+++ b/docs/tickets/M-Stretch-overview.md
@@ -1,0 +1,326 @@
+# M-Stretch: Strategic Bets — Phase Overview
+
+**親マイルストーン**: [ci-expansion-milestones.md §M-Stretch](../proposals/ci-expansion-milestones.md#m-stretch-strategic-bets-month-4-候補)
+**親調査**: [ci-expansion-2026-05.md §3](../proposals/ci-expansion-2026-05.md)
+**期間**: Month 4 以降 (M1-M4 完了後の判定で各候補を個別 milestone として起動)
+**作成日**: 2026-05-18
+**ステータス**: 候補出し段階 (個別チケットなし)
+
+---
+
+## フェーズの狙い
+
+Top 10 外で **unlimited CI を本気で活かすなら検討に値する候補** を 8 件列挙。 親調査 §4 の批判的観点 (「追加しない」が default) を再適用した上で、 工数 / 申請プロセス / dependency が重く Top 10 から外れたが、 中長期で piper-plus エコシステムに大きな価値を生む候補のみを残した。
+
+各候補は **独立した別 milestone** として議論可能で、 本 phase overview はあくまで「候補一覧と判断基準」を提示する。 個別チケットは作らず、 昇格判定後に M5 / M6 等として再ドキュメント化する。
+
+---
+
+## 候補一覧
+
+各候補について以下を記載:
+
+- **目的 / 期待効果**: 何を達成し、 ユーザー / メンテナにどう便益するか
+- **主な障壁**: 申請プロセス / 工数 / dependency
+- **依存**: どの M を完了している必要があるか
+- **概略の実装方針**: workflow ファイル名候補、 想定アーキテクチャ
+- **一から設計するなら**: 200-300 字の reinvention
+- **個別チケット化する判断基準**: どんな状況になったら正式 milestone に昇格させるか
+
+---
+
+### S1. OSS-Fuzz 申請
+
+**目的 / 期待効果**: Google の無料 fuzz インフラ (OSS-Fuzz) に piper-plus の C API / SSML parser / G2P を harness 登録し、 24/7 fuzz + 自動 Issue 起票 + Google bug bounty 対象化。 親調査 §3.3 で「採択されれば 24/7 fuzz + 自動 Issue 起票 + bug bounty 対象で最大 ROI」と評価された候補。 M4.1 の forward-compat fuzz の延長として位置付け可能。
+
+**主な障壁**:
+
+- OSS-Fuzz 審査プロセス 1-2 週間 (project metadata.yaml 提出 + maintainer email verification)
+- libFuzzer 互換 harness の整備 (C API は比較的容易、 Rust は `cargo-fuzz` 経由、 Python は `atheris` 経由で別 harness 必要)
+- corpus seed の整備と、 OSS-Fuzz と GitHub Issue の双方向同期設定
+
+**依存**: M4.1 (forward-compat fuzz の harness を libFuzzer 互換に書き換え可能な構造で実装済みであること)
+
+**概略の実装方針**:
+
+- `oss-fuzz/projects/piper-plus/` を OSS-Fuzz 本体 repo に提出 (PR ベース)
+- `fuzz/` 配下に harness を 3 種類追加 (`fuzz_c_api.cc`, `fuzz_ssml_rust.rs`, `fuzz_g2p_python.py`)
+- `.github/workflows/oss-fuzz-build-check.yml` で OSS-Fuzz 公式の `build_fuzzers` action を CI 化、 push 時に harness 壊れていないか検証
+- corpus は `tests/fixtures/fuzz_corpus/` に commit、 OSS-Fuzz 側と sync
+
+**一から設計するなら**: OSS-Fuzz への提出は「外部インフラへの依存追加」というコストがあるが、 piper-plus 規模なら自前 fuzz farm 構築コスト (CI runner + Slack 通知 + Issue auto-create) と比較して圧倒的に安い。 ただし harness 3 種類を 1 度に出すのは reviewer の負荷が高く、 まず C API harness 1 本で申請、 採択後に SSML / G2P を順次追加する段階的アプローチが reviewer experience として最良。 corpus seed は piper-plus 既存 fixture (zh_en_loanword / pua / golden audio fixture) から minimal subset を選定し、 Bloom filter で coverage を上げる戦略を取る。
+
+**個別チケット化する判断基準**:
+
+- M4.1 forward-compat fuzz が完了し、 真の bug を 1 件以上検出した時点
+- piper-plus の C API binary が安定し ABI break が 3 ヶ月以上発生していない時点
+- メンテナ 1 名が OSS-Fuzz 通知 (Issue auto-create) を確実に対応できる体制が整った時点
+
+---
+
+### S2. Bencher dashboard 導入
+
+**目的 / 期待効果**: 7 ランタイム横断の perf trend を 1 つの dashboard に集約、 PR ごとの sticky comment で regression を可視化、 statistical boundary 検出で「true regression vs noise」を自動判定。 親調査 §3.5 で「Bencher (primary) + GitHub Pages (secondary)」が選定済。 M4 informational tier の dashboard を Bencher に統合可能。
+
+**主な障壁**:
+
+- Bencher project セットアップ + API token 管理
+- 既存 gh-pages baseline (`docs/ci-dashboard/data/*.jsonl` 形式) からの移行作業
+- 7 ランタイム × N benchmark の adapter 実装 (Bencher は Rust criterion / Python pytest-benchmark / Node.js / Go test -bench / C# BenchmarkDotNet の公式 adapter あり、 C++ Google Benchmark も対応、 Swift / Kotlin は custom adapter 必要)
+
+**依存**: M2 (audio quality moat) の MOS proxy gate が安定後、 trend 表示の data source として活用可能。 M4 (informational tier) の dashboard data を Bencher schema に統一する前提作業を完了していること。
+
+**概略の実装方針**:
+
+- Bencher OSS plan に project 登録 (`piper-plus` namespace)
+- `.github/workflows/bencher-publish.yml` を新規追加、 PR / push / schedule 全てで perf data を upload
+- `BENCHER_API_TOKEN` を GitHub secret に追加 (OIDC 連携も検討)
+- 既存 `multi-runtime-rtf.yml` / `memory-regression.yml` / `bundle-size-gate.yml` の output を Bencher BMF 形式に変換
+- Bencher の `bencher run --threshold` でこれまでの informational signal を統合 alerting 化
+
+**一から設計するなら**: 既存 gh-pages 自前 dashboard は維持コストが累積する設計で、 JSON schema / HTML template / publish workflow の 3 重メンテが必要。 Bencher に移行することで JSON schema は Bencher 標準、 HTML は Bencher が hosting、 publish は `bencher run` 1 コマンドに集約され、 piper-plus 側の責務は「BMF 形式に変換」だけになる。 ただし Bencher の OSS plan が将来制限される (storage quota / retention period) リスクがあり、 contingency として「Bencher API で全 raw data を定期 backup → gh-pages に保管」を併用する 2-tier 構成が望ましい。 Bencher は primary、 gh-pages は cold archive、 という役割分担で運用する。
+
+**個別チケット化する判断基準**:
+
+- M4 の dashboard data が 1 ヶ月以上 (~30 data point) 蓄積された時点
+- 既存 gh-pages dashboard のメンテに月 5h 以上かかっていることが定量的に確認できた時点
+- Bencher の OSS plan policy が安定し、 storage quota が piper-plus の data 量 (現状推定 < 100MB) で十分なことを確認できた時点
+
+---
+
+### S3. Real-device farm
+
+**目的 / 期待効果**: iOS 実機 / Android 実機 / Safari WebKit / Samsung Internet / WeChat WebView 等、 GitHub Actions x86_64 では発見不能な platform-specific bug を CI で検出。 親調査 §3.4 で「iOS 18 WebKit SAB block, Android x86 emulator SIGBUS, M3 Pro Metal MPSGraph assertion, Pi Zero 2W NEON fp16 fallback, Samsung Internet autoplay policy, WeChat WebView WASM SIMD trap」が具体例として列挙された領域。
+
+**主な障壁**:
+
+- Firebase Test Lab (Android 実機 OSS plan) / BrowserStack App Live OSS / Xcode Cloud の各 OSS plan 申請プロセス (それぞれ 1-3 週間)
+- 各 service の API integration 工数 (Firebase は `gcloud firebase test android run`、 BrowserStack は REST API、 Xcode Cloud は workflow YAML)
+- 実機固有 flake への suppression メンテ (typical real-device farm の最大コスト要因)
+
+**依存**: M3 (ABI hardening) の public ABI snapshot が安定し、 mobile binary が ABI 安定保証された後でないと実機 test の意味が薄い
+
+**概略の実装方針**:
+
+- `.github/workflows/real-device-android.yml`: Firebase Test Lab で API 24-35 + Pixel / Samsung / Xiaomi
+- `.github/workflows/real-device-ios.yml`: Xcode Cloud workflow + BrowserStack App Live で iPhone 15/16, iPad, iOS 17/18/26
+- `.github/workflows/real-device-browser.yml`: BrowserStack Live + Playwright で Safari iOS, Samsung Internet, WeChat
+- service credential は GitHub Environments `real-device-farm` で保護、 fork PR からは access 不可
+- 実コスト ≈ ¥200/月 (Raspberry Pi 5 self-hosted の電気代のみ、 親調査 §3.4 参照)
+
+**一から設計するなら**: real-device farm は「3 service × N device」の組み合わせ爆発を抑えるのが設計の中心。 piper-plus は audio output の検証が中心で、 device-specific bug は (a) audio device permission, (b) WASM SIMD instruction support, (c) NEON fp16 fallback の 3 軸に集約される。 ゼロから設計するなら、 これら 3 軸を representative device 1 台ずつ (= 3 device 合計) で daily 検査する minimum coverage を目標とし、 親調査 §3.4 のフル matrix は month-end nightly schedule で隔離する。 PR ごとに real-device を回すと feedback loop が長くなり contributor friction を生むため、 PR では emulator (既存) のみ、 schedule で real-device、 という分離が望ましい。
+
+**個別チケット化する判断基準**:
+
+- M3.1 (Public ABI snapshot) で iOS Swift / Kotlin Android の ABI が 3 ヶ月以上安定維持できた時点
+- ユーザーから real-device 固有 bug 報告が 3 件以上累積し、 個別調査コストが累計 10h を超えた時点
+- 各 OSS plan service の申請プロセスを並列 1 名で 2 週間で完了できる体制が整った時点
+
+---
+
+### S4. SLSA Build L3 公式 generator 移行
+
+**目的 / 期待効果**: 現状 SLSA L2-3 ハイブリッド相当の release 自動化を、 `slsa-framework/slsa-github-generator` 公式 generator に移行することで **SLSA Build L3 正式準拠 + OpenSSF Scorecard 9.3+** を達成。 親調査 §3.6 で「Week 5-6: SLSA Build L3 公式 generator 移行」と planning 済。
+
+**主な障壁**:
+
+- 5 registry (PyPI / npm / crates.io / NuGet / Maven Central) × 2 PR 程度の作業量
+- `slsa-github-generator` の generic generator + container generator + go generator 等の selection
+- 既存 cosign 署名 / SBOM 生成との整合性確保 (重複 attestation を避ける)
+
+**依存**: なし (独立に進められる)
+
+**概略の実装方針**:
+
+- 各 publish workflow (`publish-pypi.yml`, `publish-npm.yml`, `publish-crates.yml`, `publish-nuget.yml`, `publish-maven.yml`) に `slsa-framework/slsa-github-generator` の reusable workflow を呼び出すよう書き換え
+- 既存 OIDC token 発行経路を維持しつつ、 provenance attestation を Sigstore Rekor に publish
+- `release-shared-lib.yml` (C API binary) は generic_generator で対応
+- OpenSSF Scorecard の `Signed-Releases` check が 9-10 点になることを確認
+
+**一から設計するなら**: SLSA L3 は「ephemeral build environment + non-falsifiable provenance + isolated build」の 3 条件を満たす必要があり、 GitHub Actions の reusable workflow を介すれば自動的に L3 相当が達成できる。 ゼロから設計するなら自前 publish workflow をすべて捨てて `slsa-framework/slsa-github-generator` のテンプレートに差し替えるのが最短だが、 piper-plus は publish workflow に micro-customization (HF Hub upload, model card 自動注入 等) が多く、 一括移行は破壊的。 段階的に PyPI → npm → crates → NuGet → Maven の順 (依存規模が小さい順) で 5 PR 個別に移行する。 各 PR で破壊変更が起きないよう staging publish (TestPyPI 等) で sanity check するチェーンを設計する。
+
+**個別チケット化する判断基準**:
+
+- M3 完了後、 publish workflow に新規 customization を加える PR が 1 ヶ月以上ない (= 安定期に入った) 時点
+- OpenSSF Scorecard score が 8.5 を下回るような new dependency / supply chain regression が起きた時点
+- SLSA L3 準拠が政府 / enterprise 顧客の調達要件になったケースが報告された時点
+
+---
+
+### S5. Distroless / Chainguard 移行
+
+**目的 / 期待効果**: `docker/python-inference/Dockerfile`, `docker/webui/Dockerfile`, `docker/wyoming/Dockerfile` 等の container image を distroless (Google) または Chainguard image に移行することで、 attack surface を ~90% 削減 (shell / package manager / system utility を image から除外)。 親調査 §3.6 で「Week 3-4: Distroless / Chainguard 移行」と planning 済。
+
+**主な障壁**:
+
+- piper-plus の Docker image は 7 個 (python-inference, webui, wyoming, csharp-cli, rust-cli, go-cli, c-api) で段階的書き換え必要
+- distroless image は debugging が困難 (sh が無い) で troubleshooting 経験の習得コスト
+- Python 系は `gcr.io/distroless/python3` が available だが ONNX Runtime の glibc 依存と非互換の可能性
+
+**依存**: なし (独立に進められる) だが、 M2 / M3 完了後の方が image 仕様変更が少なく安定して移行できる
+
+**概略の実装方針**:
+
+- multi-stage build を全 Dockerfile に統一適用: builder stage で deps install + binary build、 runtime stage は distroless
+- `cgr.dev/chainguard/python:latest` または `gcr.io/distroless/python3-debian12` を base に選定
+- 既存 `.github/workflows/docker-build.yml` の trivy scan + cosign 署名は維持
+- 移行順序: webui (Gradio で軽量) → wyoming → python-inference (ONNX 依存で最も検証コスト高)
+
+**一から設計するなら**: distroless 移行の本質は「build-time deps と runtime deps の厳密分離」であり、 Dockerfile を書き換えるだけでなく piper-plus の Python wheel / native dependency 構造を見直す機会でもある。 ゼロから設計するなら、 全 Docker image を `chainguard/<lang>` で統一し、 Chainguard Enterprise の vulnerability tracking と組み合わせる方が長期コスト最適だが、 Chainguard Enterprise は有料。 OSS では `cgr.dev/chainguard/*:latest-dev` で十分。 ただし `:latest-dev` は内容が頻繁に変わるため SHA pin が必須で、 Dependabot 連携を Dockerfile FROM 行で有効化する設計を併せて入れる。
+
+**個別チケット化する判断基準**:
+
+- M3.3 (Typosquatting watch) が安定し、 supply chain 監視体制が整った時点
+- container image の CVE 報告が 1 件以上発生し、 base image 更新の必要性が顕在化した時点
+- Docker Hub の rate limit や image pull cost が問題化した時点 (Chainguard は無料 image を提供)
+
+---
+
+### S6. Sanitizer 拡張 (全 7 runtime)
+
+**目的 / 期待効果**: C++ ASan / UBSan / TSan、 Rust miri / `-Z sanitizer=address`、 Python `pytest-leaks` + tracemalloc growth、 C# dotMemory Unit、 WASM heap snapshot、 iOS / Android leak nightly を網羅的に有効化することで、 UB / leak / race condition を CI で構造的に検出。 親調査 §3.1 で詳細実装順が定義済。
+
+**主な障壁**:
+
+- ORT 既知 leak の suppression file 維持コスト (各 sanitizer ごとに別 file)
+- C++ TSan は false positive が多く、 真の race condition 抽出に試行錯誤
+- Rust miri は std collections の internal で false alarm を出すケースあり
+- CI 実時間が ~20,400 min/月 (親調査 §3.1) で public repo 無料だが concurrent slot は消費
+
+**依存**: M1.1 (cancelled silent skip 防止) が前提。 sanitizer job が timeout で cancelled になると silent skip リスクが高い
+
+**概略の実装方針**:
+
+- `tools/sanitizer/` ディレクトリに 8 種類の suppression file を集約 (ASan / UBSan / TSan / LSan / miri / dotMemory / heap-snapshot / leak-nightly)
+- `ort-known-leaks.md` で ORT 既知 leak の justification を一元管理
+- 段階的有効化: PR gate (C++ ASan + UBSan) → nightly (Rust sanitizer, Python pytest-leaks) → weekly (TSan, Valgrind, miri) → monthly (iOS / Android leak)
+- 各 sanitizer の output を統一 JSON 形式に変換 (`sanitizer-report-schema.json` 新規) してダッシュボード化
+
+**一から設計するなら**: sanitizer は「false positive 率」と「真の bug 検出率」のトレードオフが各 sanitizer で大きく異なる。 ASan / UBSan は false positive 低く blocker 化可能、 TSan / miri は false positive 高く informational 維持が妥当、 Python pytest-leaks は ORT の C++ leak と区別困難。 ゼロから設計するなら、 各 sanitizer を「tier 化」して PR blocker (ASan/UBSan) / nightly informational (TSan/miri) / weekly research (Valgrind) の 3 段階に明示分類し、 各 tier の昇格基準 (false positive < 5% で 1 ヶ月以上維持) を spec.toml で公式化する。 これにより「sanitizer を有効化するだけで開発が止まる」という典型的失敗パターンを回避できる。
+
+**個別チケット化する判断基準**:
+
+- M4 informational tier の運用が 3 ヶ月以上安定し、 false positive 管理プロセスが確立した時点
+- C++ / Rust の UB / memory bug 報告が 1 件以上発生し、 sanitizer の ROI が定量化できた時点
+- メンテナ 1 名が sanitizer suppression file の maintenance に月 5h 以下を維持できる見通しが立った時点
+
+---
+
+### S7. Cross-runtime differential testing 完全版
+
+**目的 / 期待効果**: 親調査 §3.2 で列挙された 7 項目 (golden phoneme IDs / golden ONNX inputs / golden audio / streaming vs batch parity / SSML parse tree parity / speaker embedding parity / phoneme timing 7 runtime 拡張) を **新規 workflow `runtime-parity-deep.yml` に集約** して網羅実施。 M4.2 timing monotonicity property test の invariant DSL 化も本 phase でカバー。
+
+**主な障壁**:
+
+- 各ランタイムに `--dump-ort-inputs`, `--dump-ssml-ast`, `--dump-wav`, `--dump-embedding` の 4 種類 dump CLI flag を追加する工数 (7 runtime × 4 flag = 28 cell)
+- 浮動小数差を許容する閾値設計 (各ランタイムの ORT provider × OS で drift パターンが異なる)
+- 既存 13 parity workflow との重複整理 (PUA / loanword / ORT / version / CLI / lang-id / timing / SSML / text-splitter / voice-catalog / migration / ABI / API-diff)
+
+**依存**: M2.2 (Cross-runtime audio byte parity) が安定後、 残り 6 項目を順次追加していく
+
+**概略の実装方針**:
+
+- 新規 `docs/spec/runtime-parity-deep-contract.toml` で 7 項目の検査 spec を統合管理
+- 新規 `.github/workflows/runtime-parity-deep.yml` で 7 job (各項目 1 job) を matrix 化
+- 各ランタイムに dump CLI flag を追加 (既存実装で対応していれば flag 名統一のみ)
+- 既存 `parity-hub.yml` / `timing-parity.yml` / `ssml-parity.yml` 等は subset として継続、 deep workflow が superset
+
+**一から設計するなら**: piper-plus の既存 13 parity workflow は時系列で incremental に増えた結果、 各 workflow が独自の fixture / 閾値 / report format を持ち、 cross-runtime regression を全体俯瞰できる単一ダッシュボードが存在しない。 ゼロから設計するなら、 全 13 workflow を `runtime-parity-deep.yml` に統合し、 各検査項目を 1 つの `[parity.<category>]` セクションで管理する monolith approach が長期的に最適。 ただし統合は大規模 refactoring で破壊リスクが高いため、 M-Stretch §S7 として独立 milestone 化し、 並走で旧 workflow を deprecate していく 3-6 ヶ月計画を取る。
+
+**個別チケット化する判断基準**:
+
+- M2.2 (Cross-runtime audio byte parity) が 3 ヶ月以上 stable 維持された時点
+- 既存 13 parity workflow のメンテコストが月 10h を超えた時点 (統合 ROI が顕在化)
+- 真の cross-runtime drift bug が 3 件以上発生し、 各 workflow が個別に検出した重複の整理が必要になった時点
+
+---
+
+### S8. PR preview + nightly canary
+
+**目的 / 期待効果**: PR ごとに preview build (GHCR container / WASM / TestPyPI) を publish して reviewer / contributor が live で動作確認可能にする。 nightly canary で release 前に early adopter community が新機能を試せる体制を構築。 親調査 §3.8 で「Secret 漏洩リスク回避」を重点設計として列挙済。
+
+**主な障壁**:
+
+- fork PR からの secret 漏洩リスク (典型的 Dependabot vulnerability pattern)
+- HF Space preview のコスト (CPU runtime / storage)
+- crates.io / Maven の immutability 制約 (一度 publish したら yank しかできない、 versioning に注意)
+- telemetry / auto-yank は community RFC 必須
+
+**依存**: M1 (defensive foundations) 完了で gateway workflow による fail-closed 化が前提。 M3.3 (typosquatting watch) で supply chain 監視が機能していること
+
+**概略の実装方針**:
+
+- 段階 1: GHCR + WASM preview (secret 不要・最小リスク)
+- 段階 2: TestPyPI nightly (yank 容易)
+- 段階 3: HF Space preview (cost 中、 環境 isolation 設計後)
+- 段階 4: crates.io / Maven は週次 canary に格下げ (immutability リスク)
+- 段階 5: telemetry / auto-yank (opt-in 設計と community RFC 必須)
+- fork PR は `pull_request_target` + `actions/checkout` の `ref: head.sha` + workflow file は base branch のものを使う安全 pattern (親調査 §3.8 参照)
+- HF / Docker token は GitHub Environments `pr-preview-fork` で manual approval gate
+
+**一から設計するなら**: PR preview の本質は「reviewer に live artifact を渡す」だけでなく、 contributor が自分の PR を別 cli installer で試せる self-service feedback loop を作ること。 ゼロから設計するなら、 preview artifact は OSS 標準命名 (`piper-plus-pr-<number>-<sha>`) で統一し、 PR description に installer 1-line command (`pip install piper-plus --index-url ...` 等) を自動 append する PR comment bot を併設するのが UX 最良。 これにより contributor は CI green を待たずに自分の build を `pip install` できる。 ただし fork PR からの secret 漏洩を完全排除する設計 (`pull_request_target` 制約) が前提で、 1 度でも漏洩すると repo 全体の signing key が compromise されるため、 設計レビューを M1 完了の maintainer 2 名以上で実施する必要がある。
+
+**個別チケット化する判断基準**:
+
+- M3 完了後、 publish 経路の security 監査 (OpenSSF Scorecard 9.0+) が達成された時点
+- contributor PR が月 5 件以上に達し、 「PR の動作確認のためのローカル build」が contributor friction として顕在化した時点
+- HF Hub / Docker Hub の OSS plan が piper-plus の preview cost (推定 月数 GB storage + 数千 pull) を吸収できる確認が取れた時点
+
+---
+
+## マイルストーン昇格判定の共通フレームワーク
+
+各候補が個別 milestone (M5 / M6 / ...) に昇格するかは、 以下の共通フレームワークで判定する。
+
+### 判定タイミング
+
+- M1-M4 完了後 (Month 4 序盤) に 1 度目のレビュー
+- 以降、 quarterly (3 ヶ月ごと) に再評価
+- 緊急昇格 (例: real-device 固有 bug 報告 / supply chain attack 発生) は ad-hoc に判定可
+
+### 判定 checklist
+
+各候補について以下を満たすかを確認:
+
+- [ ] 親 doc §4 の批判的観点 (「追加しない」が default) を再適用したか
+- [ ] 「既存と排他的でない / 既存 gate では構造的に検出不可能 / user-visible damage を防ぐ」の 3 条件のいずれかを満たすか
+- [ ] 該当する判断基準 (各 S 節末尾) を全て満たしたか
+- [ ] net flat policy: 削除候補とセットになっているか (新規 workflow 追加と同数の削除候補を同時に提示)
+- [ ] contributor friction の累積監視: PR comment / Issue で friction 報告が 3 件以下に収まっているか
+
+### net flat policy の徹底
+
+M-Stretch 候補は M1-M4 と比較して **追加 workflow 数が多い** 傾向 (S2 Bencher は 1-2 workflow だが S6 Sanitizer 拡張は 8 種類)。 net flat policy を厳格に適用しないと、 piper-plus の CI 基盤が second-order codebase 化を加速する。
+
+各候補の昇格 PR では:
+
+- 同期間 (1 milestone = 4 週間) に削除候補となる workflow / pre-commit hook / skill を **同数以上** 特定
+- 削除候補が見つからない場合は **候補そのものを informational tier に降格** または **延期**
+- 削除実施は milestone 完了の必須条件 (4 週間以内に削除しない場合は milestone 未完了扱い)
+
+### contributor friction の累積監視
+
+PR comment / Issue でのフィードバックを `feedback` ラベル付きで集計し、 quarterly review で:
+
+- 「CI が遅すぎる」「contract gate が多すぎる」等の friction 報告が 3 件以上 → 該当 milestone を rollback 検討
+- 「初回 PR で何を pass すればいいか分からない」報告 → M1.3 first-PR fast lane の拡張で対応
+- 「sanitizer が flake で merge できない」報告 → S6 sanitizer 拡張を informational に降格
+
+---
+
+## 関連リンク
+
+- [親マイルストーン: §M-Stretch](../proposals/ci-expansion-milestones.md#m-stretch-strategic-bets-month-4-候補)
+- [親調査: §3 前向き提案 (横断テーマ)](../proposals/ci-expansion-2026-05.md)
+- [親調査: §4 批判的観点](../proposals/ci-expansion-2026-05.md)
+- [M1 overview](./M1-overview.md)
+- [M4 overview](./M4-overview.md) (informational tier との連携)
+- [`docs/spec/README.md`](../spec/README.md) (S7 で参照する既存 contract spec 一覧)
+- [`.claude/README.md`](../../.claude/README.md) (既存 skill / hook / pre-commit gate)
+- [CLAUDE.md](../../CLAUDE.md) (プロジェクト概要)
+
+## 変更履歴
+
+| 日付 | 変更 | 関連 |
+|------|------|------|
+| 2026-05-18 | 初版作成 (Top 10 外 8 候補を S1-S8 として整理、 共通フレームワーク追加) | M4 overview と同時作成 |

--- a/docs/tickets/M1-1-cancelled-baseline-alarm.md
+++ b/docs/tickets/M1-1-cancelled-baseline-alarm.md
@@ -1,0 +1,308 @@
+# [M1.1] Cancelled / skipped baseline alarm
+
+**親マイルストーン**: [M1 Defensive Foundations](./M1-overview.md)
+**親調査**: [ci-expansion-2026-05.md §Top 10 #10](../proposals/ci-expansion-2026-05.md#5-真に追加する価値があるトップ-10)
+**Top 10 内番号**: #10
+**ステータス**: 未着手
+**想定工数**: 1-2 PR (~8h)
+**優先度**: 高
+**作成日**: 2026-05-18
+
+---
+
+## 1. タスクの目的とゴール
+
+- **目的**: PR #419 で発覚した「required check が `cancelled` で終わると GitHub UI 上は灰色チェックとなり、 baseline 検証が silently skip されたまま merge できてしまう」事故の再発防止。 cancelled / skipped を明示的 fail に変換する gateway workflow を新設し、 dev branch protection に組込む。
+- **ゴール (Definition of Done)**:
+  - [ ] 新規 workflow `required_status_check_gate.yml` が dev で稼働している
+  - [ ] gateway は Multi-Runtime RTF / Memory regression / CodeQL を含む 5 本以上の baseline workflow の conclusion を `gh api` で集計し、 1 本でも cancelled / skipped で終わったら fail する
+  - [ ] dev branch protection に `required_status_check_gate` が required check として追加されている (`gh api repos/:owner/:repo/branches/dev/protection` で確認可能)
+  - [ ] supersede cancel (force-push churn) は誤検出しない: `head_sha == latest commit` 条件で再 trigger を待つ
+  - [ ] `docs/reference/branch-protection-history.md` (新規) に変更前後のスナップショットを記録
+
+---
+
+## 2. 実装する内容の詳細
+
+### 背景
+
+`feedback_ci_cancelled_baseline.md` で記録されている通り、 GitHub Actions の `cancelled` 状態は UI 上で灰色チェックとなり、 PR 作成者・レビュアーともに「次の push で走るだろう」とスルーする心理が働く。 PR #419 では codespell が 9 typo を誤検出する状態のまま baseline が崩壊し、 数日間気付かれなかった。 これは GitHub branch protection 自体が「required check が `success` で終わったか」のみ判定し、 `cancelled` / `skipped` を pass 扱いするため発生する **fail-open 設計の欠陥**。
+
+`gh run list --json conclusion --jq '.[] | select(.conclusion=="cancelled")'` で過去 24h の cancelled 集計を取れるが、 これを習慣化するのは現実的でなく、 構造的に塞ぐ必要がある。
+
+### アーキテクチャ概要
+
+「**hub-and-spoke gateway**」パターン。 既存 baseline workflow (spoke) は触らず、 新規 gateway workflow (hub) が PR の最新コミットに対する全 spoke の conclusion を `gh api` で集計、 cancelled / skipped が 1 本でもあれば fail する。
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant GHA as GitHub Actions
+    participant Spokes as baseline workflows<br/>(RTF / Memory / CodeQL ...)
+    participant Gate as required_status_check_gate.yml
+    participant BP as dev branch protection
+    Dev->>GHA: push commit X
+    GHA->>Spokes: trigger 5+ spoke workflows
+    GHA->>Gate: trigger gateway (after spokes)
+    Spokes-->>Gate: conclusions: success / failure / cancelled / skipped
+    Gate->>Gate: collect via gh api (filter head_sha == X)
+    alt all spokes success
+        Gate-->>BP: gateway → success
+        BP-->>Dev: merge allowed
+    else any spoke cancelled/skipped/failure
+        Gate-->>BP: gateway → failure (with diagnostic comment)
+        BP-->>Dev: merge blocked
+    end
+```
+
+ポイント: spoke workflow 側は触らない。 gateway 側で完結する設計により、 既存 18+ contract gate の責務分離を壊さない。
+
+### 具体的な変更内容
+
+- 新規: `.github/workflows/required_status_check_gate.yml`
+  - trigger: `pull_request` (types: opened, synchronize, reopened) + `workflow_run` (workflows: [Multi-Runtime RTF, Memory Regression, CodeQL Analysis, ...], types: completed)
+  - 監視対象 baseline workflow list を `MONITORED_WORKFLOWS` 環境変数で定義
+  - `gh api` で head_sha の最新 run conclusion を取得し fail-open 経路 (cancelled / skipped) を fail に変換
+  - 失敗時は PR に sticky comment で「どの spoke が cancelled だったか」を表示
+- 新規: `scripts/check_required_gate.py`
+  - workflow conclusion 集計ロジックの主要部 (テスト可能化のため Python script に分離)
+  - `gh` CLI を subprocess で叩く形ではなく `requests` + `GITHUB_TOKEN` で REST 直接呼び出し (rate-limit / retry を制御)
+- 新規: `tests/scripts/test_check_required_gate.py`
+  - pytest で 6 シナリオ (全 success / 1 cancelled / 1 skipped / 1 failure / supersede cancel / head_sha mismatch) をテスト
+- 新規: `docs/reference/branch-protection-history.md`
+  - dev branch protection の変更履歴を `gh api ... | jq` の snapshot 形式で記録
+- 改修: `.github/workflows/parity-hub.yml` 等の baseline 系 (任意、 scope 内)
+  - `concurrency.cancel-in-progress: false` 化を検討するワークフローを M1 内で **list up のみ**、 変更は別 PR (scope 肥大回避)
+- 更新: `memory/feedback_ci_cancelled_baseline.md` に「M1.1 で gateway 化」を追記
+
+### 設定 / API 例
+
+`required_status_check_gate.yml` (主要部):
+
+```yaml
+name: Required Status Check Gate
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows:
+      - Multi-Runtime RTF
+      - Memory Regression
+      - CodeQL Analysis
+      - Parity Hub
+      - PUA Consistency
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@<pinned-sha>
+      - name: Resolve head_sha
+        id: head
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Aggregate spoke conclusions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.head.outputs.sha }}
+        run: |
+          uv run python scripts/check_required_gate.py \
+            --head-sha "$HEAD_SHA" \
+            --monitored Multi-Runtime\ RTF,Memory\ Regression,CodeQL\ Analysis,Parity\ Hub,PUA\ Consistency \
+            --on-cancelled fail \
+            --on-skipped fail \
+            --post-pr-comment "${{ github.event.pull_request.number }}"
+```
+
+`scripts/check_required_gate.py` (擬似コード):
+
+```python
+def main(head_sha: str, monitored: list[str], on_cancelled: str, on_skipped: str) -> int:
+    runs = gh_get(f"/repos/{REPO}/actions/runs?head_sha={head_sha}&per_page=100")
+    by_workflow = {r["name"]: r for r in runs["workflow_runs"] if r["name"] in monitored}
+
+    missing = [w for w in monitored if w not in by_workflow]
+    bad = [(w, r["conclusion"]) for w, r in by_workflow.items()
+           if r["conclusion"] in ("cancelled", "skipped", "failure", "timed_out")]
+
+    # supersede cancel guard: if a newer commit exists, defer (return 0 with deferred status)
+    if is_superseded(head_sha):
+        post_comment(f"gateway deferred: HEAD moved past {head_sha[:7]}")
+        return 0
+
+    if missing or bad:
+        post_comment(format_diagnostic(missing, bad))
+        return 1
+    return 0
+```
+
+---
+
+## 3. エージェントチームの役割と人数
+
+| ロール | 人数 | 担当範囲 |
+|--------|------|---------|
+| GitHub Actions specialist | 1 | `required_status_check_gate.yml` 設計と `workflow_run` trigger の挙動検証、 `gh api` rate-limit / retry の安全設計 |
+| Python script author | 1 | `scripts/check_required_gate.py` 実装、 pytest テスト、 supersede cancel 判定の edge case |
+| Branch protection operator | 1 | `gh api repos/.../branches/dev/protection` で gateway を required に追加、 変更前後 snapshot の docs 記録、 dev branch への影響確認 |
+| Docs writer | 1 | `docs/reference/branch-protection-history.md` 新規作成、 `feedback_ci_cancelled_baseline.md` への追記、 `CONTRIBUTING.md` への一言追加 (M1.3 へ引き継ぎ) |
+| QA reviewer | 1 | 実際の dev PR で force-push churn / paths filter skip / concurrency cancel の 3 シナリオを再現テスト、 false positive を観測 |
+
+合計 5 名規模。 個人 maintainer 1 名で兼務する場合はロール単位で commit を分け、 PR review で他 maintainer に各ロールの観点でレビュー依頼する。
+
+---
+
+## 4. 提供範囲とテスト項目
+
+### 提供範囲 (Scope)
+
+**IN-SCOPE**:
+
+- gateway workflow 1 本 + Python script 1 本 + pytest 6 ケース
+- dev branch protection への追加
+- 監視対象 baseline workflow 5 本 (Multi-Runtime RTF / Memory Regression / CodeQL / Parity Hub / PUA Consistency) を初期セットとして登録
+- supersede cancel の正しい defer 挙動
+- 失敗時 PR sticky comment
+
+**OUT-OF-SCOPE**:
+
+- 既存 baseline workflow 自身の改修 (concurrency / paths filter の見直しは別 PR)
+- main branch protection への適用 (dev で 2 週間安定後に検討)
+- 6 本目以降の baseline workflow 追加 (M2 / M3 で必要に応じ拡張)
+- 失敗 baseline の自動 re-run (人力 retry が現状で十分、 過剰自動化を避ける)
+
+### Unit テスト (シナリオレベル)
+
+- **全 spoke success**: 5 本全て conclusion=success → gateway exit 0
+- **1 spoke cancelled**: Multi-Runtime RTF だけ cancelled、 他 success → gateway exit 1、 PR comment に「Multi-Runtime RTF was cancelled」記載
+- **1 spoke skipped**: CodeQL だけ skipped (paths filter で skip) → gateway exit 1
+- **1 spoke failure**: Memory Regression failure → gateway exit 1 (failure も明示的 fail として扱うが、 元から protection が catch しているので冗長 OK)
+- **supersede cancel**: head_sha が古い + 新しい commit が存在 → gateway exit 0 (defer)、 PR comment は「gateway deferred」
+- **head_sha mismatch**: API から取れた run の head_sha が指定と不一致 → 該当 run を無視して missing 扱い
+- fixture: `tests/scripts/fixtures/gh_runs_*.json` (`gh api` レスポンスの mock)
+
+### E2E / 統合テスト
+
+- **実 PR シナリオ A**: dev に小さな typo 修正 PR を出し、 force-push を 3 回行い concurrency cancel を誘発 → gateway が「supersede」と判定して block しないこと
+- **実 PR シナリオ B**: paths filter で CodeQL が skipped となる PR (docs-only 変更) → gateway が skipped を fail に変換、 maintainer が `/run-full-gate` label (M1.3) または re-run で解消できること (M1.3 完成前は手動 dispatch で対応)
+- **実 PR シナリオ C**: Multi-Runtime RTF が flaky で cancelled となる状況 → gateway が fail、 maintainer が re-run、 success 後に gateway も success に転じること
+- **実 PR シナリオ D (リグレッション)**: PR #419 と同じ codespell baseline cancel 状態を再現し、 gateway が block すること
+
+### 手動検証項目
+
+- dev branch protection を変更後、 元の protection rule を `git diff` 同等で確認できるか (`docs/reference/branch-protection-history.md` の YAML diff で目視確認)
+- gateway 自身が cancelled になった場合の挙動 (gateway が自分を監視するループは作らない、 別途 schedule で sanity check)
+- `actions/checkout` 等の pinned SHA が gateway workflow にも適用されているか (action-pin-check workflow が PR 時に拾うこと)
+
+---
+
+## 5. 懸念事項とレビュー観点
+
+### 懸念事項 (Risks)
+
+1. **`workflow_run` trigger の non-blocking 性**: `workflow_run` で起動される workflow は元の PR の status check として表示されない場合がある (GitHub の制約)。 → `pull_request` trigger を併用し、 PR の最新 commit に対して periodic に再評価する fallback 経路を持つ。
+2. **`gh api` rate limit**: 大量 PR が並ぶと REST API limit (5000 req/h) に近づく可能性。 → workflow ごとに 1 回しか叩かないよう head_sha でキャッシュ、 retry with exponential backoff。
+3. **supersede cancel 誤検出による block**: force-push 直後に古い commit の gateway が「cancelled」と判定すると新 commit の gateway も同じく block する可能性。 → `is_superseded(head_sha)` で「`gh api` で取れる branch の最新 sha と比較」して defer。
+4. **gateway 自身の cancelled**: gateway も `cancelled` 状態に陥り、 protection から見て「pass」扱いされる可能性 (自己参照問題)。 → gateway の workflow には `concurrency.cancel-in-progress: false` を設定し、 cancel されにくくする。 加えて schedule (毎日 UTC 09:00) で sanity check job を別ファイルに分離。
+5. **branch protection の操作ミス**: 既存 required check を誤って外す事故。 → `gh api ... PATCH` ではなく `gh api ... GET` で current snapshot を取り、 `jq` で `+ [{context: "required_status_check_gate"}]` 形式で additive に追加。 変更前後 diff を `docs/reference/branch-protection-history.md` に必ず commit してから protection を実適用。
+
+### レビュー観点 (Review checklist)
+
+- [ ] gateway workflow が `pull_request` と `workflow_run` の両 trigger を持ち、 head_sha 解決が両分岐で正しい
+- [ ] supersede cancel (force-push churn) は誤って block しない (fixture テスト + 実 PR で確認)
+- [ ] `gh api` 呼び出しは 5000 req/h limit を考慮した backoff / cache を実装
+- [ ] gateway 自身が cancelled になった場合の二重 fail-open 経路を塞いでいる (`concurrency.cancel-in-progress: false`)
+- [ ] dev branch protection の変更が additive (既存 required check を破壊しない)、 snapshot を `docs/reference/branch-protection-history.md` に commit
+- [ ] PR sticky comment は `feedback_pr_body_over_comments.md` に従い、 新規コメント追記でなく既存 comment 更新を優先
+- [ ] PR body は `pull_request_template.md` の section 構造に従う (`## Test Plan` 大文字 P、 `## Risk Level` 1 つだけ check)
+- [ ] PR title / merge に M1 等のマイルストーン番号を含めない (`feedback_pr_no_milestones`)
+- [ ] `gh pr merge --auto` 禁止、 ユーザ最終確認後に merge (`feedback_merge_caution`)
+- [ ] GitHub Actions は `@v<major>` sliding tag 禁止、 SHA pin (`feedback_pin_actions_sha`)
+- [ ] 監視対象 baseline workflow list を将来追加する手順が `CONTRIBUTING.md` に書かれている
+- [ ] backward compat: 既存 PR の status check 状態を破壊せず、 新規 gateway は additive
+
+---
+
+## 6. 一から作り直すとしたら (Reinvention thought experiment)
+
+現状の制約 (GitHub branch protection が `cancelled` を pass 扱いする) を取り払って piper-plus の CI 構造をゼロから設計するなら、 **single gateway workflow が全 spoke を支配** する hub-and-spoke 構造の最終形が望ましい。 つまり protection rule に登録するのは `merge-gateway.yml` ただ 1 本だけで、 内部で 93 workflow の conclusion を集計し、 merge 可否を `gh api ... CHECK_RUNS` API で擬似的に統合判定する。 これなら個別 workflow の rename / 統廃合に protection rule が追従不要になる。
+
+別 layer での実装も検討した:
+
+- **GitHub Apps (custom merge bot)**: bors / Mergify と同等。 PR への merge command を gating する。 ただし piper-plus のような小規模 OSS では bot 運用コストが gateway workflow 1 本より重く、 secret 管理も増える。 不採用。
+- **Custom merge queue**: GitHub Merge Queue は cancelled の扱いが GitHub native の protection に従うため、 同じ問題が発生する。 不採用。
+- **CODEOWNERS で「baseline 系 file 変更時に追加レビュアー強制」**: CI 結果ではなく PR 著者数の問題にすり替わるため、 baseline collapse の根本対策にならない。 不採用。
+- **`pre-receive` hook で server-side 拒否**: GitHub managed では unavailable。 GHE Server なら可能だが piper-plus は github.com を使うため不可。
+
+採用しなかった代案として最も真剣に検討したのは「**Dependabot 風の `auto-merge` を gateway 経由でしか許可しない設定**」だが、 piper-plus は `gh pr merge --auto` を memory feedback で明示禁止しているため、 そもそも auto-merge は使わない方針。 gateway workflow + manual merge の組み合わせがチーム文化と最も整合する。
+
+「ゼロから」設計の単純化を優先するなら、 ext tool 不要・ Python だけ・ ~50 行で済む `check_required_gate.py` + workflow 1 本という今回の構成が現実解。
+
+---
+
+## 7. 後続タスクへの連絡事項 (Handoff)
+
+- **M1.3 への連絡**: 本 gateway workflow が dev で稼働後、 M1.3 の `/run-full-gate` label workflow は gateway の監視対象 list を「first-PR 時は warning に降格」する logic に絡む。 `scripts/check_required_gate.py` に `--first-pr-soft-fail` フラグを追加する余地を残しておく。
+- **M2 への連絡**: M2.1 (audio MOS proxy) / M2.2 (cross-runtime audio parity) の workflow は最初 4 週間 informational tier で運用する。 gateway の `MONITORED_WORKFLOWS` には **追加しない** こと (informational なので block してはならない)。 blocker 昇格 (M3 開始時に判断) のタイミングで gateway list に追加する。
+- **`docs/reference/branch-protection-history.md`** を新規作成。 以降 M1.3 / M2 / M3 でも protection 変更がある場合は同 file に追記する単一 source of truth とする。
+- **既知 TODO / フォローアップ候補**:
+  - `concurrency.cancel-in-progress: false` を baseline 系 workflow にも適用する別 PR (Issue 化)
+  - main branch protection への適用 (dev で 2 週間安定後)
+  - gateway の `MONITORED_WORKFLOWS` を YAML config file に外出し (workflow 内 env だと list が肥大化する)
+  - schedule cron で gateway 自身の sanity check (毎日 09:00 UTC、 gateway が `cancelled` だった場合に Issue 自動起票)
+- **net flat policy 宿題**: 本 PR で 1 workflow + 1 script + 1 docs file を新規追加。 同期間に削除候補として `older-action-pin-check.yml` (重複疑い) を評価する Issue を起票。
+
+---
+
+## 8. 関連ファイル
+
+### 既存ファイル (改修対象)
+
+- `.github/workflows/parity-hub.yml` (改修対象候補、 scope 内では trigger 条件確認のみ、 内容変更は別 PR)
+- `.github/workflows/multi-runtime-rtf.yml` (監視対象、 内容は触らない)
+- `.github/workflows/memory-regression.yml` (監視対象、 内容は触らない)
+- `.github/workflows/codeql.yml` (監視対象、 内容は触らない)
+- `.github/workflows/pua-consistency.yml` (監視対象、 内容は触らない)
+
+### 新規作成ファイル
+
+- `.github/workflows/required_status_check_gate.yml`
+- `scripts/check_required_gate.py`
+- `tests/scripts/test_check_required_gate.py`
+- `tests/scripts/fixtures/gh_runs_all_success.json`
+- `tests/scripts/fixtures/gh_runs_cancelled.json`
+- `tests/scripts/fixtures/gh_runs_skipped.json`
+- `tests/scripts/fixtures/gh_runs_failure.json`
+- `tests/scripts/fixtures/gh_runs_supersede.json`
+- `tests/scripts/fixtures/gh_runs_head_sha_mismatch.json`
+- `docs/reference/branch-protection-history.md`
+
+### 仕様 toml / docs
+
+- 仕様 toml は新規作成しない (gateway は spec.toml 化する必要がない統合 logic)
+- `CONTRIBUTING.md` に「baseline cancelled は gateway で block される」一文を追加 (M1.3 で詳細化)
+
+---
+
+## 9. 参照
+
+- [親マイルストーン §M1.1](../proposals/ci-expansion-milestones.md#m11--cancelled--skipped-baseline-alarm-top-10-10)
+- [親調査 §Top 10 #10](../proposals/ci-expansion-2026-05.md#5-真に追加する価値があるトップ-10)
+- [親調査 §1.4 構造的弱点 (PR #419 教訓)](../proposals/ci-expansion-2026-05.md#14-構造的弱点-pr-419-教訓)
+- [feedback memory: feedback_ci_cancelled_baseline.md](../../.claude/memory/) — PR #419 詳細
+- [feedback memory: feedback_pr_no_milestones.md](../../.claude/memory/) — PR title 規約
+- [feedback memory: feedback_merge_caution.md](../../.claude/memory/) — merge 前ユーザー確認
+- [feedback memory: feedback_pin_actions_sha.md](../../.claude/memory/) — Actions SHA pin
+- [feedback memory: feedback_pr_body_over_comments.md](../../.claude/memory/) — PR body 更新方針
+- 関連 PR: #419 (codespell baseline 崩壊事例)、 #447 / #448 (parity gate 導入)

--- a/docs/tickets/M1-2-migration-guide-lint.md
+++ b/docs/tickets/M1-2-migration-guide-lint.md
@@ -1,0 +1,307 @@
+# [M1.2] Migration guide lint
+
+**親マイルストーン**: [M1 Defensive Foundations](./M1-overview.md)
+**親調査**: [ci-expansion-2026-05.md §Top 10 #3](../proposals/ci-expansion-2026-05.md#5-真に追加する価値があるトップ-10)
+**Top 10 内番号**: #3
+**ステータス**: 未着手
+**想定工数**: 1 PR (~6h)
+**優先度**: 高
+**作成日**: 2026-05-18
+
+---
+
+## 1. タスクの目的とゴール
+
+- **目的**: `CHANGELOG.md` の `[Unreleased] > Breaking` 節と `docs/migration/v*.md` の cross-ref を構造的に強制する。 v1.11 → v1.12 で発生した「migration doc が後追いで作成される」問題を再発させない。
+- **ゴール (Definition of Done)**:
+  - [ ] 新規 workflow `migration-guide-lint.yml` (または既存 `migration-changelog-parity.yml` 拡張) が PR で `[Unreleased] > Breaking` entry を検出
+  - [ ] 検出時、 対応する `docs/migration/v<X>-to-v<Y>.md` の存在と `[Unreleased] > Breaking` から該当 migration anchor へのリンク存在を assert
+  - [ ] keep-a-changelog parser `scripts/check_migration_xref.py` (新規) が CHANGELOG を AST 化し、 missing anchor / 404 link を fail として報告
+  - [ ] PR label `breaking` 付き or `[Unreleased] > Breaking` 節に entry がある場合のみ enforce、 patch / minor PR は skip
+  - [ ] pre-commit hook (`migration-guide-lint`) として CI 前にローカルで検出可能
+
+---
+
+## 2. 実装する内容の詳細
+
+### 背景
+
+v1.12.0 で `Generator` 削除 + `phonemize()` 戻り値型変更という 2 件の breaking change を導入したが、 `docs/migration/v1.11-to-v1.12.md` は **breaking commit より後に作成** された。 親調査 §4 「breaking change の真のコスト」で指摘されている通り、 これは CI で防げる drift で、 「CHANGELOG breaking 記述 ↔ migration doc」の双方向リンクを強制すれば構造的に塞げる。
+
+既存の `migration-changelog-parity.yml` は CHANGELOG と migration doc の **存在対応** のみチェックしており、 内容の **anchor link cross-ref** は未検査。 本 ticket でこの穴を埋める。
+
+### アーキテクチャ概要
+
+keep-a-changelog 準拠の AST parser を `scripts/check_migration_xref.py` に実装し、 以下 3 段階で検証する。
+
+```mermaid
+flowchart TD
+    A[PR diff includes CHANGELOG.md] --> B{Has [Unreleased] > Breaking entries?}
+    B -- No --> C[Skip - PASS]
+    B -- Yes --> D[Parse CHANGELOG to AST]
+    D --> E[Extract anchor links in Breaking entries]
+    E --> F{All anchors resolve<br/>to docs/migration/v*.md?}
+    F -- No --> G[FAIL: list missing anchors]
+    F -- Yes --> H{Migration doc has<br/>matching anchor heading?}
+    H -- No --> I[FAIL: doc missing heading]
+    H -- Yes --> J[PASS]
+```
+
+### 具体的な変更内容
+
+- 新規: `scripts/check_migration_xref.py`
+  - keep-a-changelog parser (regex ベースで `## [version] - YYYY-MM-DD` / `### Breaking` 階層を読む、 既存 `scripts/check_changelog_unreleased.py` を継承)
+  - 各 breaking entry から markdown link `[text](docs/migration/v<X>-to-v<Y>.md#anchor)` を抽出
+  - 該当 file の存在チェック + heading anchor (`## anchor-name` を kebab-case 化) のチェック
+  - exit 0 / 1 + 人間可読 diagnostic
+- 改修 or 新規: `.github/workflows/migration-guide-lint.yml`
+  - 既存 `migration-changelog-parity.yml` を拡張する選択肢もあるが、 責務分離のため **新規 workflow を推奨**
+  - trigger: `pull_request` for `paths: [CHANGELOG.md, docs/migration/**]`
+  - condition: `contains(github.event.pull_request.labels.*.name, 'breaking')` または CHANGELOG diff に `### Breaking` 追加検出
+- 改修: `.pre-commit-config.yaml`
+  - hook `migration-guide-lint` を追加 (local hook、 Python script を呼ぶ)
+  - stage: `commit` (CHANGELOG または `docs/migration/` 変更時のみ)
+- 改修: `CHANGELOG.md` の `[Unreleased]` template
+  - `### Breaking` entry 記入時の link 規約をコメントで明示
+  - 例: `- foo bar が削除されました ([移行ガイド](docs/migration/v1.12-to-v1.13.md#foo-bar-removal))`
+- 新規: `tests/scripts/test_check_migration_xref.py`
+  - 6-8 シナリオの pytest
+- 改修: `docs/migration/README.md` (存在しなければ新規)
+  - migration doc の規約 (heading anchor 命名規則、 `## v<X>-to-v<Y>` セクション必須 等) を明文化
+
+### 設定 / API 例
+
+`scripts/check_migration_xref.py` の擬似コード:
+
+```python
+import re
+import pathlib
+import sys
+
+ANCHOR_LINK_RE = re.compile(r"\[([^\]]+)\]\((docs/migration/v[\d\.]+-to-v[\d\.]+\.md)(#[a-z0-9-]+)?\)")
+
+def parse_changelog(path: pathlib.Path) -> dict:
+    """keep-a-changelog AST を構築。 returns {version: {section: [entries]}}"""
+    # 既存 scripts/check_changelog_unreleased.py から共通化
+    ...
+
+def slugify(heading: str) -> str:
+    """GitHub markdown anchor slug 規約 (kebab-case, ascii alpha+num+hyphen)"""
+    s = heading.lower()
+    s = re.sub(r"[^\w\s-]", "", s)
+    return re.sub(r"[\s_]+", "-", s).strip("-")
+
+def main() -> int:
+    changelog = parse_changelog(pathlib.Path("CHANGELOG.md"))
+    breaking_entries = changelog.get("Unreleased", {}).get("Breaking", [])
+
+    if not breaking_entries:
+        print("No [Unreleased] > Breaking entries; skip.")
+        return 0
+
+    errors = []
+    for entry in breaking_entries:
+        links = ANCHOR_LINK_RE.findall(entry["raw"])
+        if not links:
+            errors.append(f"Breaking entry missing migration link: {entry['raw'][:80]}")
+            continue
+        for _text, doc_path, anchor in links:
+            p = pathlib.Path(doc_path)
+            if not p.exists():
+                errors.append(f"Migration doc not found: {doc_path}")
+                continue
+            if anchor:
+                headings = {slugify(h) for h in extract_headings(p)}
+                if anchor.lstrip("#") not in headings:
+                    errors.append(f"Anchor not found in {doc_path}: {anchor}")
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+`.github/workflows/migration-guide-lint.yml`:
+
+```yaml
+name: Migration Guide Lint
+on:
+  pull_request:
+    paths:
+      - CHANGELOG.md
+      - docs/migration/**
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@<pinned-sha>
+      - uses: astral-sh/setup-uv@<pinned-sha>
+      - name: Check migration cross-ref
+        run: |
+          uv run python scripts/check_migration_xref.py
+```
+
+---
+
+## 3. エージェントチームの役割と人数
+
+| ロール | 人数 | 担当範囲 |
+|--------|------|---------|
+| Python script author | 1 | `scripts/check_migration_xref.py` 実装、 既存 `check_changelog_unreleased.py` の AST 部を共通化、 pytest 6-8 ケース |
+| GitHub Actions author | 1 | `migration-guide-lint.yml` workflow 設計、 `paths` filter と label conditional の組合せ、 既存 `migration-changelog-parity.yml` との分担明確化 |
+| Docs writer | 1 | `docs/migration/README.md` 規約整備、 `CHANGELOG.md` の `[Unreleased]` template にコメント追記、 CONTRIBUTING.md へ一文追加 |
+| Reviewer | 1 | 既存 migration doc (v1.11-to-v1.12.md) を script でテストし retroactive な fail / pass を確認、 false positive を観測 |
+
+合計 4 名規模。
+
+---
+
+## 4. 提供範囲とテスト項目
+
+### 提供範囲 (Scope)
+
+**IN-SCOPE**:
+
+- CHANGELOG.md `[Unreleased] > Breaking` 節のリンク強制
+- `docs/migration/v<X>-to-v<Y>.md` 存在 + heading anchor 一致
+- pre-commit hook + CI workflow の二重化
+- 既存 v1.11-to-v1.12.md に retroactive 適用 (drift 検出のテスト)
+
+**OUT-OF-SCOPE**:
+
+- リリース済み version (v1.12.0 等) の遡及修正 (現状 release notes は HF Hub / GitHub Releases に手動で書いているため、 retroactive 修正は別 task)
+- 8 言語翻訳された migration doc の同期検査 (i18n 軸、 親調査 §3.7 で別途扱う)
+- CHANGELOG entry の意味的妥当性検査 (「これは本当に breaking か」は人間判断)
+- non-Markdown ドキュメント (mkdocs / RST 等) への拡張 (piper-plus は Markdown 統一)
+
+### Unit テスト (シナリオレベル)
+
+- **fixture 1: 完全形 (PASS)**: CHANGELOG に `### Breaking` + link `[移行ガイド](docs/migration/v1.12-to-v1.13.md#foo-removal)`、 migration doc に `## foo-removal` heading → exit 0
+- **fixture 2: link 欠落 (FAIL)**: `### Breaking` entry が plain text のみ → exit 1、 "missing migration link"
+- **fixture 3: file 不存在 (FAIL)**: link 先 `docs/migration/v9.9-to-v10.0.md` が存在しない → exit 1、 "Migration doc not found"
+- **fixture 4: anchor mismatch (FAIL)**: link `#foo-removal` だが doc に `## bar-removal` のみ → exit 1、 "Anchor not found"
+- **fixture 5: anchor なし (PASS, lenient)**: link が `docs/migration/v1.12-to-v1.13.md` のみで anchor なし → exit 0 (anchor 省略は許可、 一般的な migration overview link として正当)
+- **fixture 6: [Unreleased] に Breaking なし (PASS)**: `### Added` のみ → exit 0 (skip)
+- **fixture 7: 既存 v1.11-to-v1.12.md retroactive (regression test)**: 実 CHANGELOG を入力にして fail/pass のどちらが返るかを記録、 期待値を retroactive に追加してテスト
+- **fixture 8: kebab-case 異体字 (PASS)**: heading に全角数字 / 日本語が混じる場合の slug 化挙動を pinning
+
+fixture path: `tests/scripts/fixtures/migration_xref/{changelog_*.md, doc_*.md}` (組み合わせで 8 シナリオ)
+
+### E2E / 統合テスト
+
+- **実 PR シナリオ A**: `CHANGELOG.md` に `### Breaking` + 正しい link を追加した PR → workflow PASS
+- **実 PR シナリオ B**: `### Breaking` を追加したが link を忘れた PR → workflow FAIL、 PR check に diagnostic 表示
+- **実 PR シナリオ C**: docs 変更のみ (CHANGELOG なし) PR → paths filter で skip、 余計に走らない
+- **実 PR シナリオ D**: `breaking` label を後付けで付与した PR → re-run でラベル condition が再評価される
+
+### 手動検証項目
+
+- 既存 `docs/migration/v1.11-to-v1.12.md` を入力にした場合、 retroactive に PASS/FAIL のどちらが期待値か確認 (既存 CHANGELOG にリンクが書かれていない場合は **FAIL を期待値として fixture 化** し、 修正 PR を別途切る)
+- `pre-commit run migration-guide-lint --all-files` でローカル実行確認
+- `breaking` label の付与/除去で PR 上の check が再評価されるか確認 (GitHub の挙動上は label change で workflow が re-trigger される)
+
+---
+
+## 5. 懸念事項とレビュー観点
+
+### 懸念事項 (Risks)
+
+1. **breaking change の粒度が一律でない**: 「内部実装の breaking」と「user-facing breaking」が CHANGELOG で混在する可能性。 → `### Breaking` 節は user-facing 限定とし、 内部実装変更は `### Changed` に分類するルールを `docs/migration/README.md` に明記。
+2. **anchor slug 規約の不安定性**: GitHub Markdown の slug 化は仕様文書化されていない部分があり、 emoji / 全角 / 連続ハイフン等で差異が出る。 → `slugify()` は GitHub 互換を目指すが、 fixture テストで pinning し drift が出たら slug を手動指定する逃げ道を用意。
+3. **false positive: 過剰 friction**: 全 PR で breaking 検査を走らせると軽微な内部変更でも fail する可能性。 → `breaking` label or CHANGELOG diff の `### Breaking` 追加検出のみで enforce、 patch PR は skip。
+4. **migration doc の heading 命名規則と既存 doc の drift**: 既存 v1.11-to-v1.12.md が新規規約に合わない場合、 retroactive 修正が必要。 → 規約は緩く設定し、 既存 doc は別 PR で順次対応 (本 PR の scope 外)。
+5. **CHANGELOG parser の脆さ**: 既存 `check_changelog_unreleased.py` の regex parser を流用するが、 keep-a-changelog 仕様外の書式 (絵文字 / 表組み 等) で誤動作する可能性。 → AST 化を欲張らず、 「`### Breaking` 行直下 ~50 行」を簡素に走査する保守的 parser に留める。
+
+### レビュー観点 (Review checklist)
+
+- [ ] `scripts/check_migration_xref.py` が既存 `check_changelog_unreleased.py` と AST 共通化されており、 二重実装になっていない
+- [ ] `### Breaking` 検出は CHANGELOG diff 増分のみで動作し、 既存 `### Breaking` 節に手を加えない PR では skip される (false positive 防止)
+- [ ] `breaking` label と CHANGELOG diff の OR 条件が workflow conditional で正しく組まれている
+- [ ] anchor slug 化が GitHub 互換、 fixture pinning が網羅的
+- [ ] `docs/migration/README.md` に migration doc 命名規則 (`v<X>-to-v<Y>.md`) と heading 規約が明記
+- [ ] `CHANGELOG.md` の `[Unreleased]` template にコメントで link 規約を追記
+- [ ] pre-commit hook が CHANGELOG / docs/migration 変更時のみ走る (`files: ^(CHANGELOG\.md|docs/migration/)`)
+- [ ]既存 migration doc (v1.11-to-v1.12.md) に対する retroactive 結果を明示
+- [ ] PR body は pull_request_template の section 構造 (Test Plan 大文字、 Risk Level 1 つ)
+- [ ] PR title に M1 等のマイルストーン番号を含めない
+- [ ] GitHub Actions は SHA pin
+- [ ] backward compat: 既存 PR の `CHANGELOG.md` 編集を破壊しない
+
+---
+
+## 6. 一から作り直すとしたら (Reinvention thought experiment)
+
+ゼロから設計するなら、 そもそも **CHANGELOG の手書き運用を廃止**し、 conventional commits → release-please / changesets で CHANGELOG を auto-generate する pipeline が理想。 breaking change は commit footer `BREAKING CHANGE:` で機械的に拾え、 migration doc は PR template の checkbox + GitHub Issue forms で必須化できる。 これなら「`### Breaking` 節が書かれていない breaking」を作る余地がそもそも存在しない。
+
+採用しなかった代案:
+
+- **release-please 全面導入**: piper-plus は 7 ランタイム × 複数 publish target (PyPI/npm/crates/NuGet/Maven/HF) で release 戦略が複雑、 release-please 単独で全 target を管理するのは現状非現実的。 段階移行が必要だが scope 過大。
+- **changesets (Atlassian)**: monorepo 想定の tool で piper-plus の構造 (Cargo workspace + Python flat + Go module + C# solution + npm) と相性が悪い。 不採用。
+- **GitHub Issue forms + bot による migration doc 自動生成**: doc を bot に書かせると低品質になりがち、 例文 + frontmatter テンプレ手書きが現実的。
+- **branch protection で `docs/migration/` 変更を CODEOWNERS で必須 review**: file 変更を要求するのは強いが、 「breaking が CHANGELOG にあるのに docs/migration/ 変更がない」cross-ref は protection rule で表現不能。 やはり CI lint が現実解。
+
+別 layer での実装も検討した: GitHub Apps で merge command を gating する案 (e.g. `/migration-docs-ok` で maintainer override) も考えたが、 lint workflow に bypass label (`skip-migration-lint`) を 1 つ用意すれば十分で、 GitHub Apps 化は overengineering。
+
+**結論**: 6h 規模で得られる ROI を考えると、 既存 keep-a-changelog parser を継承した軽量 lint script + 1 workflow + pre-commit hook の組合せが最も合理的。 release-please 全面導入は M-Stretch (Month 4+) に候補として残す。
+
+---
+
+## 7. 後続タスクへの連絡事項 (Handoff)
+
+- **M1.3 への連絡**: first-PR fast lane では本 lint も警告に降格対象とするか? → **対象とする**。 初回 contributor は migration doc の規約を知らないため、 warning に留め、 maintainer が `/run-full-gate` label で blocker 化する。 M1.3 で `migration-guide-lint.yml` の conditional に `author_association` 判定を組込む。
+- **M2 / M3 への連絡**: M2 (audio MOS proxy) / M3.1 (Public ABI snapshot) は breaking change を伴う可能性が高い。 これら作業時には `### Breaking` + `docs/migration/v*.md` の cross-ref を必ず書く運用を `docs/migration/README.md` で徹底。
+- **既存 v1.11-to-v1.12.md への retroactive 適用**: 本 PR の script で fail する場合、 別 PR で `docs/migration/v1.11-to-v1.12.md` の heading 構造を新規約に合わせる修正を行う (Issue 化、 本 PR の scope 外)。
+- **release-please 移行調査** Issue: M-Stretch 候補として登録、 7 ランタイム release 戦略と整合する形を Month 4+ で検討。
+- **net flat policy 宿題**: 本 PR で 1 workflow + 1 script + 1 docs file 追加。 削除候補として既存 `migration-changelog-parity.yml` を **本 PR で吸収統合** することも検討 (責務分離の観点で別 workflow のままにする方が望ましいので、 単なる削除でなく統合可否を検討する Issue を起票)。
+
+---
+
+## 8. 関連ファイル
+
+### 既存ファイル (改修対象)
+
+- `CHANGELOG.md` (template コメント追記、 既存 entry の retroactive 修正は別 PR)
+- `.github/workflows/migration-changelog-parity.yml` (本 PR では触らない、 統合可否は別 Issue)
+- `.pre-commit-config.yaml` (local hook 追加)
+- `scripts/check_changelog_unreleased.py` (AST 部の共通化対象)
+- `docs/migration/v1.11-to-v1.12.md` (retroactive テスト対象、 必要なら別 PR で修正)
+- `CONTRIBUTING.md` (一文追記、 M1.3 で詳細化)
+
+### 新規作成ファイル
+
+- `.github/workflows/migration-guide-lint.yml`
+- `scripts/check_migration_xref.py`
+- `tests/scripts/test_check_migration_xref.py`
+- `tests/scripts/fixtures/migration_xref/changelog_pass.md`
+- `tests/scripts/fixtures/migration_xref/changelog_missing_link.md`
+- `tests/scripts/fixtures/migration_xref/changelog_no_breaking.md`
+- `tests/scripts/fixtures/migration_xref/doc_pass.md`
+- `tests/scripts/fixtures/migration_xref/doc_missing_anchor.md`
+- `docs/migration/README.md` (規約整備)
+
+### 仕様 toml / docs
+
+- 専用 spec.toml は不要 (lint logic が小規模、 toml 化のコストが上回る)
+- `docs/migration/README.md` を canonical reference として運用
+
+---
+
+## 9. 参照
+
+- [親マイルストーン §M1.2](../proposals/ci-expansion-milestones.md#m12--migration-guide-lint-top-10-3)
+- [親調査 §Top 10 #3](../proposals/ci-expansion-2026-05.md#5-真に追加する価値があるトップ-10)
+- [親調査 §3.7 Docs / i18n / CHANGELOG](../proposals/ci-expansion-2026-05.md#37-docs--i18n--changelog)
+- [親調査 §4 "breaking change の真のコスト"](../proposals/ci-expansion-2026-05.md#4-批判的観点--なぜ追加しないが-default-か)
+- [docs/migration/v1.11-to-v1.12.md](../migration/v1.11-to-v1.12.md) — breaking change の参考事例
+- [keep-a-changelog 1.1.0 仕様](https://keepachangelog.com/en/1.1.0/)
+- 関連 PR / Issue: v1.12.0 リリース系 PR (`PR #507` 等)

--- a/docs/tickets/M1-3-first-pr-fast-lane.md
+++ b/docs/tickets/M1-3-first-pr-fast-lane.md
@@ -1,0 +1,367 @@
+# [M1.3] First-PR fast lane
+
+**親マイルストーン**: [M1 Defensive Foundations](./M1-overview.md)
+**親調査**: [ci-expansion-2026-05.md §Top 10 #5](../proposals/ci-expansion-2026-05.md#5-真に追加する価値があるトップ-10)
+**Top 10 内番号**: #5
+**ステータス**: 未着手
+**想定工数**: 2 PR (~12h)
+**優先度**: 高
+**作成日**: 2026-05-18
+
+---
+
+## 1. タスクの目的とゴール
+
+- **目的**: 新規 contributor が 18+ contract gate (PUA / loanword / ORT pin / ruff version 6 箇所同期 等) で躓いて離脱する onboarding 障壁を緩和。 初回 PR は contract gate を warning に降格、 コア lint のみ blocker 化。 maintainer が `/run-full-gate` label を付与すると blocker に昇格。
+- **ゴール (Definition of Done)**:
+  - [ ] 新規 workflow `first-pr-fast-lane.yml` が `author_association ∈ {FIRST_TIME_CONTRIBUTOR, NONE, FIRST_TIMER}` を判定
+  - [ ] 該当 PR では contract gate 18 本を `continue-on-error: true` 化、 コア lint (ruff / 各言語 formatter) のみ blocker
+  - [ ] maintainer が `run-full-gate` label を付与すると、 contract gate が即時 blocker に昇格して再実行
+  - [ ] `CONTRIBUTING.md` に fast lane 説明と「初回 PR で何が緩和されるか」を追加
+  - [ ] M1.1 の `required_status_check_gate.yml` が「first-PR でも cancelled は許さない」原則を維持 (gateway は maintainer も bypass 不可)
+  - [ ] 4 週間運用後に「first-PR で merge された PR 数 / その後 maintainer による follow-up 修正 PR 数」を計測する script (`scripts/first_pr_health.py`) を schedule で稼働
+
+---
+
+## 2. 実装する内容の詳細
+
+### 背景
+
+親調査 §4 で「**Gate を増やすほどメンテナ以外は PR を出せないプロジェクトに収束する**」と指摘されている通り、 piper-plus は 18+ contract gate (PUA contract、 loanword sync、 ORT pin、 ruff version 6 箇所同期 等) を merge 要件とするため、 初回 contributor が事実上 PR を merge できない構造になっている。 これは「**CI as a moat 誤謬**」(CI を堀として contributor を排除する逆説) の典型例。
+
+一方、 PR #419 で露呈した cancelled silent skip の教訓から、 「merge gate は paranoid に、 contributor は寛容に」という非対称設計が望ましい (M1 overview の reinvention 節参照)。 M1.3 はこの非対称性を contract gate 軸で実現する。
+
+具体的には:
+
+- **初回 PR (author_association = FIRST_TIME_CONTRIBUTOR / NONE / FIRST_TIMER)**:
+  - 18+ contract gate は warning に降格 (`continue-on-error: true`)
+  - コア lint (ruff format / cargo fmt / gofmt / dotnet-format / clang-tidy) は blocker のまま
+  - `required_status_check_gate.yml` (M1.1) は blocker のまま (cancelled silent skip は許さない)
+- **maintainer が `run-full-gate` label を付与**:
+  - 全 contract gate が blocker に昇格、 re-run trigger
+  - merge 前に最終チェック
+- **2 回目以降の contributor**:
+  - 通常通り、 全 contract gate が blocker
+
+### アーキテクチャ概要
+
+```mermaid
+flowchart TD
+    A[PR opened/sync] --> B{author_association?}
+    B -- COLLABORATOR/MEMBER/<br/>CONTRIBUTOR/OWNER --> C[Normal mode:<br/>all gates blocker]
+    B -- FIRST_TIME_CONTRIBUTOR/<br/>NONE/FIRST_TIMER --> D[Fast lane:<br/>contract gates → warning]
+    D --> E{Label 'run-full-gate'?}
+    E -- Yes --> C
+    E -- No --> F[Core lint only blocker<br/>+ M1.1 gateway blocker]
+    C --> G[Merge if all required green]
+    F --> H{Maintainer ready to merge?}
+    H -- Yes --> I[Manual /run-full-gate label]
+    I --> C
+    H -- No --> F
+```
+
+ポイント:
+
+- 既存 contract gate 18 本は **触らずに済ませる**。 conditional 化 logic は新規 workflow `first-pr-fast-lane.yml` で集中管理し、 個別 gate に `if:` 条件を散布しない。
+- 具体的には、 fast-lane workflow が「PR の状態を観測し、 PR の status check API で contract gate の結果を `neutral` (= passing 扱い) に書き換える」approach を使う。 これにより GitHub branch protection rule からは pass に見えるが、 maintainer の UI 上は warning として残る。
+
+### 具体的な変更内容
+
+- 新規: `.github/workflows/first-pr-fast-lane.yml`
+  - trigger: `pull_request` (opened, synchronize, reopened, labeled, unlabeled), `pull_request_target` 不使用 (fork PR の secret 漏洩リスク回避、 親調査 §3.8 参照)
+  - author_association 判定 + label 判定
+  - fast lane 該当時は GitHub Checks API で contract gate の結果を `neutral` に書き換え、 branch protection の required check を pass 扱い化
+  - 失敗 contract gate は PR comment で「これは warning、 maintainer が `/run-full-gate` label を付ければ blocker 化」と説明
+- 新規: `scripts/first_pr_fast_lane.py`
+  - author_association / label 評価ロジック
+  - contract gate result の neutral 書き換え (GitHub Checks API)
+  - PR sticky comment 生成 (`feedback_pr_body_over_comments` 準拠で既存 comment update)
+- 新規: `scripts/first_pr_health.py`
+  - 週次 schedule で「first-PR で merge された PR 数 / その後 maintainer による follow-up 修正 PR 数」を集計
+  - 結果を `docs/reference/first-pr-metrics.md` に追記 (4 週間運用後の効果測定用)
+- 改修: `CONTRIBUTING.md`
+  - fast lane 説明節を新設
+  - 初回 contributor 向けの「PR を出すまでに最低限何が必要か」「contract gate で warning が出ても気にしない」一覧
+  - maintainer 向け「初回 PR を merge する前に `run-full-gate` label を必ず付与」運用ルール
+- 改修: `.github/labels.yml` (存在しなければ新規)
+  - `run-full-gate` label 追加 (color: 紅、 description: "Promote contract gates to blocker for first-PR")
+- 改修: `.github/workflows/required_status_check_gate.yml` (M1.1 で作成済み)
+  - first-PR でも gateway は blocker 維持 (cancelled silent skip 防止)
+  - ただし「contract gate が neutral だった場合は spoke として success と扱う」logic 追加
+- 新規: `tests/scripts/test_first_pr_fast_lane.py`
+  - pytest で 8 シナリオ
+
+### 設定 / API 例
+
+`first-pr-fast-lane.yml`:
+
+```yaml
+name: First-PR Fast Lane
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      fast_lane: ${{ steps.eval.outputs.fast_lane }}
+    steps:
+      - uses: actions/checkout@<pinned-sha>
+      - id: eval
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          uv run python scripts/first_pr_fast_lane.py evaluate \
+            --pr "$PR_NUMBER" \
+            --author-association "$AUTHOR_ASSOC" \
+            --labels "$LABELS"
+
+  neutralize:
+    needs: evaluate
+    if: needs.evaluate.outputs.fast_lane == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Neutralize contract gate checks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          uv run python scripts/first_pr_fast_lane.py neutralize \
+            --pr "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --gates "PUA Consistency,ZH-EN Loanword Sync Gate,Runtime Parity Hub,..."
+```
+
+`scripts/first_pr_fast_lane.py` (擬似コード):
+
+```python
+FAST_LANE_ASSOCIATIONS = {"FIRST_TIME_CONTRIBUTOR", "NONE", "FIRST_TIMER"}
+CONTRACT_GATES = [
+    "PUA Consistency",
+    "ZH-EN Loanword Sync Gate",
+    "Runtime Parity Hub",
+    "ORT Version Sync",
+    "ruff version sync",
+    # ... 18 total
+]
+
+def evaluate(pr: int, author_association: str, labels: str) -> bool:
+    if "run-full-gate" in labels.split(","):
+        return False
+    return author_association in FAST_LANE_ASSOCIATIONS
+
+def neutralize(pr: int, head_sha: str, gates: list[str]) -> None:
+    """contract gate の check_run conclusion を 'neutral' に書き換え、
+    branch protection の required check を pass 扱いに。
+    元の failure は PR comment で「warning として記録」を明示。"""
+    for gate in gates:
+        check = find_check_run(head_sha, gate)
+        if check and check["conclusion"] == "failure":
+            update_check_run(check["id"], conclusion="neutral",
+                             output={"summary": f"[fast-lane] {gate} downgraded to warning"})
+    post_sticky_comment(pr, build_fast_lane_explanation(gates))
+```
+
+`CONTRIBUTING.md` 追加節 (抜粋):
+
+```markdown
+## 初回 PR (First-PR Fast Lane)
+
+piper-plus は 18+ contract gate を持ちますが、 **初回 PR ではこれらを warning に降格** します。
+初回 contributor が以下を満たせば merge できます:
+
+- ruff / cargo fmt / gofmt / dotnet-format / clang-tidy 等の **コア lint pass**
+- `required_status_check_gate` pass (cancelled run がない)
+- maintainer review 通過
+
+contract gate (PUA / loanword / ORT pin / ruff version 6 箇所同期 等) は
+warning として記録され、 maintainer が merge 前に `run-full-gate` label を
+付与して再評価します。 つまり初回 contributor は contract gate の知識なしに
+PR を出せます。
+```
+
+---
+
+## 3. エージェントチームの役割と人数
+
+| ロール | 人数 | 担当範囲 |
+|--------|------|---------|
+| GitHub Actions specialist | 1 | `first-pr-fast-lane.yml` 設計、 `pull_request` events と label trigger の組合せ、 fork PR security |
+| Python script author | 1 | `scripts/first_pr_fast_lane.py` + `scripts/first_pr_health.py` 実装、 GitHub Checks API の neutral 書き換えロジック、 pytest 8 ケース |
+| Branch protection operator | 1 | M1.1 の gateway を継承拡張、 protection rule に label-conditional 要素を追加 (or label workflow で擬似実現)、 dev branch 変更履歴 docs 記録 |
+| Docs writer | 1 | `CONTRIBUTING.md` の fast lane 節、 初回 contributor 向け FAQ、 maintainer 向け「run-full-gate label 必須」運用書 |
+| QA / UX reviewer | 1 | 実際に test account から fork PR を出し、 fast lane 経路を end-to-end で再現テスト、 contract gate が warning に正しく降格するか、 maintainer のラベル付与で blocker 化するか確認 |
+| Metrics analyst | 1 | `first_pr_health.py` で 4 週間後の効果測定 (first-PR merge 数 / follow-up 修正 PR 数 / 離脱率)、 親 milestone doc に結果記載 |
+
+合計 6 名規模 (個人 maintainer 兼務時はロール単位で commit 分割)。
+
+---
+
+## 4. 提供範囲とテスト項目
+
+### 提供範囲 (Scope)
+
+**IN-SCOPE**:
+
+- `first-pr-fast-lane.yml` workflow + `scripts/first_pr_fast_lane.py`
+- 初期対象 contract gate 18 本のリスト化 (workflow 内 env variable)
+- `run-full-gate` label 定義と maintainer 運用書
+- `CONTRIBUTING.md` 更新
+- 4 週間後の効果測定用 `first_pr_health.py` (schedule weekly)
+- M1.1 gateway との整合 (gateway は first-PR でも blocker 維持)
+
+**OUT-OF-SCOPE**:
+
+- 個別 contract gate 自身の `if:` conditional 化 (集中管理で済むため触らない)
+- 「初回 contributor が悪意ある PR を出す」リスクへの対応 (review process で人間判断、 CI で防がない)
+- 2 回目以降の contributor への特別扱い (`CONTRIBUTOR` association は通常モード)
+- fork PR から secret 必要な job を実行する仕組み (`pull_request_target` は使わない)
+- core lint 自身の「初回 PR では緩める」設計 (core lint は brand new contributor でも pass 可能なレベル、 緩めない)
+
+### Unit テスト (シナリオレベル)
+
+- **fixture 1: first-time, no label (PASS, fast-lane)**: author_association=FIRST_TIME_CONTRIBUTOR, labels=[] → fast_lane=true、 contract gate neutralize 実行
+- **fixture 2: first-time + run-full-gate label (NOT fast-lane)**: author_association=FIRST_TIME_CONTRIBUTOR, labels=[run-full-gate] → fast_lane=false、 通常モード
+- **fixture 3: existing contributor (NOT fast-lane)**: author_association=CONTRIBUTOR, labels=[] → fast_lane=false
+- **fixture 4: NONE association (PASS, fast-lane)**: author_association=NONE → fast_lane=true (anonymous の fork PR)
+- **fixture 5: FIRST_TIMER (PASS, fast-lane)**: author_association=FIRST_TIMER → fast_lane=true
+- **fixture 6: COLLABORATOR (NOT fast-lane)**: author_association=COLLABORATOR → fast_lane=false
+- **fixture 7: neutralize idempotency**: 既に neutral な check に対して再実行しても safe (副作用なし)
+- **fixture 8: gateway 整合**: M1.1 gateway の `MONITORED_WORKFLOWS` に first-PR で neutral 化された gate が含まれる場合、 gateway は neutral を success と扱う
+
+fixture: `tests/scripts/fixtures/first_pr/{event_*.json, check_runs_*.json}`
+
+### E2E / 統合テスト
+
+- **実 PR シナリオ A**: 別アカウントから fork PR を出し、 PUA / loanword fixture を意図的に壊した PR で fast lane が動作するか確認。 contract gate は warning、 core lint と gateway は pass で merge 可能であること
+- **実 PR シナリオ B**: maintainer が上記 PR に `run-full-gate` label を付与 → contract gate が即時 blocker 化、 PR が merge できなくなること
+- **実 PR シナリオ C**: maintainer が PR を直接 push (collaborator association) → fast lane 不適用、 通常モードで全 gate blocker
+- **実 PR シナリオ D**: M1.1 gateway が cancelled になった状況で fast lane PR → gateway は blocker 維持で merge 不可 (cancelled silent skip 防止)
+
+### 手動検証項目
+
+- 実 fork account で「初回 PR は何分くらいで CI 通過するか」を計測 (UX 評価)
+- `run-full-gate` label を付与後、 contract gate が即時 re-run trigger されるか確認 (GitHub の label event 挙動)
+- `CONTRIBUTING.md` を読んだ初心者 (内部の非 piper 開発者にレビュー依頼) が 30 分以内に PR を出せるか dogfood
+
+---
+
+## 5. 懸念事項とレビュー観点
+
+### 懸念事項 (Risks)
+
+1. **maintainer が `run-full-gate` 付与を忘れて merge する事故**: 初回 PR がそのまま contract gate を bypass して merge されると、 PUA / loanword fixture が壊れたまま dev に入る可能性。 → CONTRIBUTING.md の maintainer 運用書で必須化 + `feedback_merge_caution` (gh pr merge --auto 禁止、 ユーザー最終確認必須) と整合させる + M1.1 gateway の logic に「first-PR は label 必須」を埋める可能性も検討 (ただし maintainer 自身を block する強い制約のため初版では運用ルールで担保)
+2. **Checks API による neutral 書き換えが GitHub 仕様変更で動かなくなる**: GitHub Checks API は documented だが behavior change の可能性。 → API 呼び出しに version pinning + 失敗時は fast lane を諦めて通常モード fallback (fail-open でなく fail-safe)
+3. **悪意ある初回 contributor の supply chain 攻撃**: 初回 PR で PUA fixture を改ざんし、 fast lane で warning に隠れる可能性。 → fixture 変更を含む PR は CODEOWNERS で必須 review (既存) + `data-fixture-change` label を auto-add する workflow を別途検討 (本 PR scope 外、 Issue 化)
+4. **2 回目の PR で contract gate が突然 blocker 化して contributor が驚く**: author_association が初回 → 2 回目で `FIRST_TIME_CONTRIBUTOR` → `CONTRIBUTOR` に変わる挙動を周知不足。 → CONTRIBUTING.md の fast lane 節に明記、 PR sticky comment で「次回 PR から通常モードになります」を表示
+5. **fork PR の secret 露出**: `pull_request_target` を使うと fork からも secret アクセス可能になり Dependabot vulnerability pattern を踏む。 → `pull_request` のみ使用、 secret は最小限 (`GITHUB_TOKEN` の checks:write のみ)
+6. **fast lane で merge された PR の後追い修正コスト**: contract gate を bypass した結果、 後で別 PR で fix する必要が生じる。 → `first_pr_health.py` で「first-PR merge 後の follow-up 修正 PR 数」を計測、 5% 以上なら設計見直し
+
+### レビュー観点 (Review checklist)
+
+- [ ] author_association 判定が 3 値 (FIRST_TIME_CONTRIBUTOR / NONE / FIRST_TIMER) を網羅、 COLLABORATOR / MEMBER は除外
+- [ ] `run-full-gate` label trigger で fast lane が解除される (label event で workflow re-run)
+- [ ] GitHub Checks API で neutral 書き換えが idempotent (二重実行で副作用なし)
+- [ ] `pull_request_target` 不使用、 fork PR から secret 露出経路がない
+- [ ] M1.1 gateway は first-PR でも blocker 維持 (cancelled silent skip 防止)
+- [ ] CONTRIBUTING.md に fast lane 節 + maintainer 必須運用 (`run-full-gate` 付与) が明記
+- [ ] `feedback_merge_caution` (auto merge 禁止、 ユーザー確認必須) と整合
+- [ ] PR body は `pull_request_template.md` の section 構造、 `## Test Plan` 大文字 P、 `## Risk Level` 1 つ
+- [ ] PR title に M1 等のマイルストーン番号を含めない
+- [ ] GitHub Actions の SHA pin
+- [ ] sticky comment は既存 comment update (新規追記しない)
+- [ ] `first_pr_health.py` schedule が weekly で過剰負荷にならない
+- [ ] backward compat: 既存 PR の挙動を破壊しない (`author_association = CONTRIBUTOR` 以上は通常モード継続)
+
+---
+
+## 6. 一から作り直すとしたら (Reinvention thought experiment)
+
+ゼロから設計するなら、 **contract gate そのものを 18 本も持たない**選択が最も radical な解。 親調査 §4 で指摘される「CI as a moat 誤謬」を逆手に取り、 contract gate を「人間レビューで補える soft requirement」と「機械でないと catch できない hard requirement」に二分する。 後者だけを CI で gate 化し (例: ABI break / PUA fixture byte mismatch)、 前者は pre-commit hook で fast feedback + PR review checklist で人間判断する。 これなら初回 contributor の onboarding 障壁を構造的に下げられる。
+
+別 layer での実装も検討した:
+
+- **GitHub Apps + Mergify でラベル / role ベースのルール DSL**: Mergify は強力だが piper-plus 規模では外部依存追加のコストが上回る。 また maintainer feedback `gh pr merge --auto` 禁止と整合せず不採用。
+- **CODEOWNERS で contract spec 変更を maintainer 必須レビュー化**: 初回 contributor が spec.toml を一切触らない PR (例: docs typo) も既存 protection で 18 gate 通す必要がある。 CODEOWNERS では「PUA fixture を触らない PR」を pass させるロジックは表現不可。 不採用。
+- **GitHub Merge Queue**: queue で各 PR を順次評価できるが、 contract gate 自体は同じ。 onboarding 課題に効かない。 不採用。
+- **CLA bot / DCO sign-off**: legal 観点で別軸、 ROI ない。 不採用。
+- **「contract gate を pre-commit のみで運用、 CI からは外す」**: pre-commit を初回 contributor が install していないと検出できず、 dev branch に drift が入る。 構造的に弱い。 不採用。
+
+採用しなかった代案で最も真剣に検討したのは「**bot による fixture 自動修正 PR**」(初回 PR で PUA / loanword fixture drift があれば bot が修正 commit を auto-push)。 これなら contributor が contract gate を意識せずに済む。 ただし fixture 自動修正は「悪意ある change を含む PR」で攻撃面を増やすため、 fast lane の neutral 書き換え (= 警告に降格、 maintainer が最終判断) が現実的な落としどころ。
+
+**結論**: 12h 規模で得られる ROI として、 既存 18 gate を触らずに集中管理 workflow 1 本 + script で fast lane を実現する設計が最適。 contract gate 18 本の整理 (二分) は M-Stretch (Month 4+) 候補として残す。
+
+---
+
+## 7. 後続タスクへの連絡事項 (Handoff)
+
+- **M1.1 への連絡**: 本 PR で `required_status_check_gate.yml` の logic に「first-PR で neutral 化された check は success と扱う」分岐を追加する。 M1.1 完成後でないと本 PR は merge できない (依存)。 M1.1 PR と本 PR は順序付け必須。
+- **M1.2 への連絡**: migration guide lint も first-PR では warning に降格する対象。 M1.2 の `migration-guide-lint.yml` を `CONTRACT_GATES` env list に追加。
+- **M2 / M3 への連絡**: M2 (audio MOS proxy) / M3 (Public ABI snapshot) の新規 workflow も「first-PR では warning」と「`run-full-gate` で blocker 昇格」に従う必要がある。 新 workflow 追加時は `first-pr-fast-lane.yml` の `CONTRACT_GATES` list に追加する運用を `CONTRIBUTING.md` の maintainer 節に記載。
+- **既知 TODO / フォローアップ Issue 候補**:
+  - 4 週間運用後の効果測定レビュー Issue (`first_pr_health.py` の結果を親 milestone doc に追記)
+  - `data-fixture-change` label auto-add workflow (悪意ある fixture 改ざん対策)
+  - contract gate 18 本の整理 (soft / hard 二分) を M-Stretch 候補として Issue 化
+  - `run-full-gate` 以外のラベル (例: `run-mos-gate` / `run-abi-gate`) の規約を M2 / M3 で追加する際の命名統一指針を本 PR で確立
+- **net flat policy 宿題**: 本 PR で 2 workflow (`first-pr-fast-lane.yml` + label workflow) + 2 script + 1 labels.yml 追加。 削除候補として、 重複疑い workflow を M1 期間中に list up 完了させる。
+
+---
+
+## 8. 関連ファイル
+
+### 既存ファイル (改修対象)
+
+- `.github/workflows/required_status_check_gate.yml` (M1.1 で作成、 本 PR で neutral 認識 logic 追加)
+- `.github/workflows/parity-hub.yml` (触らない、 `CONTRACT_GATES` list に登録のみ)
+- `.github/workflows/pua-consistency.yml` (触らない、 list に登録のみ)
+- `.github/workflows/zh-en-loanword-sync.yml` (触らない、 list に登録のみ)
+- `CONTRIBUTING.md` (fast lane 節新設、 maintainer 運用書追加)
+- `.github/labels.yml` (存在しなければ新規、 `run-full-gate` label 定義)
+
+### 新規作成ファイル
+
+- `.github/workflows/first-pr-fast-lane.yml`
+- `scripts/first_pr_fast_lane.py`
+- `scripts/first_pr_health.py`
+- `tests/scripts/test_first_pr_fast_lane.py`
+- `tests/scripts/fixtures/first_pr/event_first_time.json`
+- `tests/scripts/fixtures/first_pr/event_with_label.json`
+- `tests/scripts/fixtures/first_pr/event_contributor.json`
+- `tests/scripts/fixtures/first_pr/event_none.json`
+- `tests/scripts/fixtures/first_pr/event_collaborator.json`
+- `tests/scripts/fixtures/first_pr/check_runs_18_gates.json`
+- `docs/reference/first-pr-metrics.md` (4 週後計測結果用)
+
+### 仕様 toml / docs
+
+- 専用 spec.toml は不要 (集中管理 logic は workflow + script で完結)
+- `CONTRIBUTING.md` を canonical reference として運用 (maintainer / contributor 両視点を 1 doc に集約)
+
+---
+
+## 9. 参照
+
+- [親マイルストーン §M1.3](../proposals/ci-expansion-milestones.md#m13--first-pr-fast-lane-top-10-5)
+- [親調査 §Top 10 #5](../proposals/ci-expansion-2026-05.md#5-真に追加する価値があるトップ-10)
+- [親調査 §4 "CI as a moat" 誤謬](../proposals/ci-expansion-2026-05.md#4-批判的観点--なぜ追加しないが-default-か)
+- [親調査 §3.8 PR preview & nightly canary (fork PR security)](../proposals/ci-expansion-2026-05.md#38-pr-preview--nightly-canary)
+- [feedback memory: feedback_merge_caution.md](../../.claude/memory/) — auto merge 禁止
+- [feedback memory: feedback_pr_body_over_comments.md](../../.claude/memory/) — sticky comment 更新方針
+- [feedback memory: feedback_pin_actions_sha.md](../../.claude/memory/) — Actions SHA pin
+- [feedback memory: feedback_ci_matrix_no_reduction.md](../../.claude/memory/) — OSS public CI 無制限前提
+- [feedback memory: feedback_pr_body_validate_sections.md](../../.claude/memory/) — PR body section 規約
+- [GitHub: author_association values](https://docs.github.com/en/rest/issues/comments#about-the-author-association)
+- [GitHub: Checks API conclusion=neutral](https://docs.github.com/en/rest/checks/runs)
+- 関連 PR / Issue: M1.1 PR (依存)、 PR #419 (cancelled silent skip 教訓)

--- a/docs/tickets/M1-overview.md
+++ b/docs/tickets/M1-overview.md
@@ -1,0 +1,80 @@
+# M1: Defensive Foundations — Phase Overview
+
+**親マイルストーン**: [ci-expansion-milestones.md §M1](../proposals/ci-expansion-milestones.md#m1-defensive-foundations)
+**親調査**: [ci-expansion-2026-05.md](../proposals/ci-expansion-2026-05.md)
+**期間**: Month 1 (4 週)
+**作成日**: 2026-05-18
+**ステータス**: 未着手
+
+---
+
+## フェーズの狙い
+
+piper-plus は既に 93 workflow + 100+ pre-commit hook を持つが、 **構造的弱点が 2 つ顕在化** している。
+
+1. **既存 gate の盲点**: PR #419 で発覚した「required check が `cancelled` で終了した場合に GitHub UI 上は灰色チェックとなり、 baseline 検証が silently skip されたまま merge できてしまう」事故。 検査が多いほど log が読まれず、 green / red の意味が空洞化する。
+2. **contributor onboarding 障壁**: 18+ contract gate (PUA / loanword / ORT pin / ruff version 6 箇所同期 等) を全て pass しないと merge できない構造のため、 初回 contributor は事実上 PR を出せず、 メンテナのみが寄与する閉鎖プロジェクトに収束しつつある。
+
+M1 はこの 2 課題を「**merge gate の信頼性軸**」で同時に修復する。 加えて breaking change discipline (CHANGELOG ↔ migration doc の cross-ref) を底上げし、 M2 以降の audio quality moat / ABI hardening の前提条件を整える。 構成要素は全て **難易度 "低"** に限定し、 新規メンテナンス税を最小化する。
+
+---
+
+## 含まれるチケット
+
+| ID | タイトル | Top 10 # | 想定工数 | 優先度 |
+|----|---------|----------|---------|--------|
+| [M1.1](./M1-1-cancelled-baseline-alarm.md) | Cancelled / skipped baseline alarm | #10 | 1-2 PR (~8h) | 高 |
+| [M1.2](./M1-2-migration-guide-lint.md) | Migration guide lint | #3 | 1 PR (~6h) | 高 |
+| [M1.3](./M1-3-first-pr-fast-lane.md) | First-PR fast lane | #5 | 2 PR (~12h) | 高 |
+
+合計想定工数: 4-5 PR / ~26h (4 週で 1 maintainer 容量に収まる)。
+
+---
+
+## 一から設計し直すとしたら (Phase-level reinvention)
+
+### 1. アーキテクチャ: branch protection と CI gate の分離をやり直すなら?
+
+現在は **GitHub branch protection の required check list** と **93 workflow の job name** が一対多で対応しており、 各 workflow が独自に「skip / fail / cancel」を返す。 PR #419 はこの設計のうち「protection が check 名で集合判定するが、 cancel 状態が pass 扱いされる」点に起因する。 ゼロから設計するなら、 **single gateway workflow** (`merge-gateway.yml`) を required にし、 その内部で各 workflow の conclusion を `gh api` で集計、 cancelled / skipped を明示 fail に変換する hub-and-spoke 構造が望ましい。 こうすれば protection rule は 1 行で済み、 個別 workflow の rename / 統廃合に追従しなくて済む。 M1.1 はこの方向へ第一歩を踏み出すが、 protection list の全面置き換えは scope 外とし、 補助 gate として始める。
+
+### 2. 設計: "cancelled silent skip" と "first-PR friction" の同一 phase 統合の妥当性
+
+両者は表面的には別軸 (前者は CI 構造欠陥、 後者は UX) に見えるが、 共通根は **「required check のセット設計が contributor / maintainer / CI 三者で食い違っている」** ことにある。 cancelled が silent skip するのは「maintainer は protection list を信用しているのに CI 側が pass 扱いを返す」ズレ、 first-PR friction は「全 contract gate が均一に required」という雑な protection 設計のズレ。 両者を同一 phase で扱うのは、 **protection rule を再設計する機会を 1 度だけ作る** ことで重複作業を減らすため。 M1.1 で gateway を作り、 M1.3 で gateway 内に「first-PR conditional softening」logic を埋め込めば、 protection list を 2 度書き換える事故を避けられる。
+
+### 3. 実装: 既存 workflow 93 本がある中で、 新規追加すべきか既存改修すべきか
+
+判断軸は **「変更の影響半径 × 既存 workflow の責務凝集度」**。
+
+- 既存 workflow に新 logic を埋め込む選択 → 影響半径小だが、 例えば `parity-hub.yml` に「first-PR なら soft fail」を埋めると `parity-hub.yml` が「parity 検査 + contributor 判定」の 2 責務を持つ。 後で fast-lane を変更するたびに parity-hub に手を入れることになり、 凝集度が崩れる。
+- 新規 workflow 追加 → 責務分離は綺麗だが、 93 → 95 への増加分は将来「同数削除」の対象としてレビューする必要がある (net flat policy)。
+
+M1 の 3 タスクは全て **「新規 workflow 追加 + 既存 workflow は触らない (またはトリガー条件のみ追加)」** に倒す。 理由は (a) 既存 18+ contract gate は spec.toml と pre-commit hook で構造的に堅牢化されており触ると壊れる、 (b) M1 期間内で削除候補 2 本以上を特定する宿題を「M1 完了基準」に組み込み net flat を担保する。
+
+### 4. 思考プロセス: PR #419 のような silent skip 事故を未然に防ぐとしたら
+
+CI 検出で塞ぐのは事後対応であり、 根本的には **branch protection 設計時点の "fail-closed" 原則** を徹底する。 GitHub Actions の `cancelled` を「中立」とせず「明示的 fail」と読み替えるのが本来の安全設計。 これを protection rule で表現する手段は現状存在しない (GitHub の制約) ため、 piper-plus 側で gateway workflow を 1 枚噛ませることで fail-closed 化する。 これは「Postel の法則 (受信側は寛容に、 送信側は厳格に)」の反対側、 **"merge gate は paranoid に、 contributor は寛容に"** という非対称設計であり、 OSS の特性 (悪意ある PR と善意の初回 contributor が混在する) に最適化されたパターン。 別案として「protection rule を一切信用せず、 mergeable 状態を `pre-receive` hook (= GitHub では unavailable) で再判定する」も検討したが、 GitHub の制約上不可能で却下。
+
+---
+
+## 後続フェーズへの連絡事項
+
+- **M2 (Audio Quality Moat) は M1.1 を前提とする**: informational tier の workflow (audio MOS proxy / cross-runtime audio parity) を追加する前に、 silent skip 経路を塞いでおく必要がある。 そうでないと「informational だから cancelled でも気にしない」が常態化し、 4 週後の blocker 昇格判断材料 (false positive 率) が取れない。
+- **M1.3 で導入する `/run-full-gate` label workflow パターンは M2 / M3 でも再利用可能**: maintainer が informational tier を手動 promote する標準パスとして使える。 ラベル名規約 (`run-full-gate` / `run-mos-gate` / `run-abi-gate` 等) を M1.3 で確立する。
+- **net flat policy の宿題**: M1 で 3 workflow 追加するため、 同期間に **3 本の workflow を削除候補としてレビュー** する。 候補 (M1 期間中に評価):
+  - `older-action-pin-check.yml` (現在 `pin-action-sha-check.yml` と重複の疑い、 要確認)
+  - `legacy-bilingual-*.yml` 系 (v2/v3/v4 アーカイブ移行後の残骸)
+  - schedule cron が月曜朝に集中している 6 本のうち、 informational 系で deprecate 可能なもの
+- **branch protection の dev branch 変更履歴**: M1.1 完了時に `required_status_check_gate` を required に追加。 M1.3 完了時にも protection に新 check が増える可能性あり。 変更前後の `gh api repos/:owner/:repo/branches/dev/protection` のスナップショットを `docs/reference/branch-protection-history.md` に追記する運用を M1.1 で定義する。
+
+---
+
+## 関連リンク
+
+- [M1.1: Cancelled / skipped baseline alarm](./M1-1-cancelled-baseline-alarm.md)
+- [M1.2: Migration guide lint](./M1-2-migration-guide-lint.md)
+- [M1.3: First-PR fast lane](./M1-3-first-pr-fast-lane.md)
+- [親マイルストーン: ci-expansion-milestones.md §M1](../proposals/ci-expansion-milestones.md#m1-defensive-foundations)
+- [親調査: ci-expansion-2026-05.md](../proposals/ci-expansion-2026-05.md)
+- [feedback memory: feedback_ci_cancelled_baseline.md](../../.claude/memory/) (PR #419 教訓)
+- [feedback memory: feedback_pr_body_validate_sections.md](../../.claude/memory/) (PR body 構造)
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) (M1.3 で更新予定)

--- a/docs/tickets/M2-1-audio-mos-proxy.md
+++ b/docs/tickets/M2-1-audio-mos-proxy.md
@@ -1,0 +1,424 @@
+# [M2.1] Audio MOS proxy gate (PESQ / STOI / UTMOS / Whisper WER)
+
+**親マイルストーン**: [M2 Audio Quality Moat](./M2-overview.md)
+**親調査**: [ci-expansion-2026-05.md §Top 10 #1](../proposals/ci-expansion-2026-05.md)
+**Top 10 内番号**: #1
+**ステータス**: 未着手
+**前提チケット**: [M1.1 Cancelled baseline alarm](./M1-1-cancelled-baseline-alarm.md)
+**想定工数**: 3-4 PR (~30h)
+**優先度**: 高
+**informational 期間**: 4 週間 (M2 開始 〜 M3 開始時に blocker 昇格判定)
+**作成日**: 2026-05-18
+
+---
+
+## 1. タスクの目的とゴール
+
+### 目的
+
+piper-plus が現状検出できていない「合成音声そのものの user-visible regression」 を、 PR ごとに golden corpus に対する **PESQ-WB / STOI / UTMOS proxy / Whisper WER** の 4 指標で自動評価する gate を導入する。 最初の 4 週間は informational tier (non-blocking) で false positive 率を観測し、 安定後 blocker 化する。
+
+### ゴール (DoD)
+
+- [ ] `.github/workflows/audio-mos-proxy.yml` workflow が PR / push (dev) で trigger され green
+- [ ] つくよみちゃん 6lang-v2 model (`/data/piper/output-tsukuyomi-finetune-6lang-v2/`) または等価な軽量 model に対し、 6 言語 × 5 サンプル = 30 golden text で合成 → 4 指標計算が CPU で 15 分以内に完了
+- [ ] `tests/fixtures/audio-mos-baseline.json` に baseline 値を commit、 PR ごとに diff を取り **informational tier** で sticky comment 投稿
+- [ ] `scripts/audio_quality_metrics.py` が **Bencher Adapter 互換 JSON** を吐き、 M-Stretch (Bencher 移行) で再利用可能
+- [ ] 4 週間 informational 運用後、 maintainer が blocker 昇格判定を実施 (M2-overview.md §「informational → blocker 昇格判定基準」 の 3 条件)
+- [ ] CI artifact として spectrogram PNG / metrics.json / 合成 WAV を upload、 90 日 retention
+
+---
+
+## 2. 実装する内容の詳細
+
+### 背景
+
+`tools/benchmark/compute_metrics.py` には既に UTMOS 計算機能が存在し、 MOS survey フォーム生成と PESQ / STOI スクリプト群も `tools/benchmark/` 配下にある。 ただし **CI に組み込まれていない** ため、 PR 単位の regression 検出には使えていない。 これを `.github/workflows/audio-mos-proxy.yml` に昇格させ、 baseline JSON と diff を取る gate にする。
+
+既存の `multi-runtime-rtf.yml` / `memory-regression.yml` は RTF / memory の baseline JSON + diff の pattern を確立済み (`tests/fixtures/multi-runtime-rtf-baseline.json` / `tests/fixtures/memory-baseline.json`)。 これと同じ schema を踏襲する。
+
+### アーキテクチャ概要
+
+```mermaid
+flowchart TD
+    Trigger[PR / push trigger] --> Setup[Setup: uv run python 3.11 + PyTorch CPU]
+    Setup --> Cache[restore cache: utmos22 weights / Whisper-base.en]
+    Cache --> Corpus[Load golden corpus: tests/fixtures/audio-corpus/]
+    Corpus --> Synth[Synthesize 30 samples: piper-plus Python CLI]
+    Synth --> Metrics[Compute 4 metrics: scripts/audio_quality_metrics.py]
+    Metrics --> Baseline[Diff vs tests/fixtures/audio-mos-baseline.json]
+    Baseline --> Report{informational tier}
+    Report -->|sticky comment| PR[PR conversation]
+    Report -->|artifact upload| Artifact[spectrogram / metrics / WAV]
+    Report -->|fail informational| Always[continue-on-error: true]
+```
+
+### 具体的な変更内容 (file path 単位)
+
+| 変更 | パス | 種別 |
+|------|------|------|
+| 新規 corpus directory | `tests/fixtures/audio-corpus/{ja,en,zh,es,fr,pt}/` | 新規 (各言語 5 text、 計 30 file) |
+| 新規 corpus metadata | `tests/fixtures/audio-corpus/manifest.json` | 新規 (各 text の category / expected duration / source) |
+| 新規 baseline JSON | `tests/fixtures/audio-mos-baseline.json` | 新規 (4 指標 × 30 sample = 120 entries) |
+| 新規スクリプト | `scripts/audio_quality_metrics.py` | 新規 (PESQ / STOI / UTMOS / WER 計算 + Bencher JSON 出力) |
+| 既存スクリプト流用 | `tools/benchmark/compute_metrics.py` | 引用のみ (UTMOS 計算ロジックを再利用) |
+| 新規 workflow | `.github/workflows/audio-mos-proxy.yml` | 新規 |
+| sticky comment | `.github/workflows/audio-mos-proxy.yml` 内 step | `marocchino/sticky-pull-request-comment` action 使用 |
+| 既存 CI 拡張 | `.github/workflows/required_status_check_gate.yml` (M1.1) | 4 週後 blocker 昇格時に追記 |
+
+### 設定例
+
+```yaml
+# .github/workflows/audio-mos-proxy.yml (抜粋)
+name: Audio MOS Proxy
+on:
+  pull_request:
+    paths:
+      - 'src/python_run/**'
+      - 'src/python/piper_train/**'
+      - 'tests/fixtures/audio-corpus/**'
+      - 'tests/fixtures/audio-mos-baseline.json'
+      - 'scripts/audio_quality_metrics.py'
+      - '.github/workflows/audio-mos-proxy.yml'
+  push:
+    branches: [dev]
+
+jobs:
+  mos-proxy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    continue-on-error: true  # informational tier (4 週間)
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+      - name: Cache UTMOS / Whisper weights
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/torch/hub
+            ~/.cache/whisper
+          key: utmos-whisper-${{ hashFiles('scripts/audio_quality_metrics.py') }}
+      - name: Download golden model
+        run: |
+          uv run python -c "from huggingface_hub import snapshot_download; \
+            snapshot_download('ayousanz/piper-plus-tsukuyomi-chan', \
+            local_dir='models/tsukuyomi-6lang-v2')"
+      - name: Synthesize golden corpus
+        run: |
+          uv run python scripts/audio_quality_metrics.py \
+            --mode synthesize \
+            --model models/tsukuyomi-6lang-v2/model.onnx \
+            --corpus tests/fixtures/audio-corpus \
+            --output /tmp/synthesized/
+      - name: Compute metrics
+        run: |
+          uv run python scripts/audio_quality_metrics.py \
+            --mode compute \
+            --synthesized /tmp/synthesized/ \
+            --reference tests/fixtures/audio-corpus/reference/ \
+            --output /tmp/metrics.json \
+            --bencher-json /tmp/bencher.json
+      - name: Diff vs baseline
+        id: diff
+        run: |
+          uv run python scripts/audio_quality_metrics.py \
+            --mode diff \
+            --metrics /tmp/metrics.json \
+            --baseline tests/fixtures/audio-mos-baseline.json \
+            --threshold-pesq 0.15 \
+            --threshold-stoi 0.02 \
+            --threshold-utmos 0.10 \
+            --threshold-wer 0.05 \
+            --output /tmp/diff.md
+      - name: Post sticky comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: audio-mos-proxy
+          path: /tmp/diff.md
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: audio-mos-${{ github.run_id }}
+          path: |
+            /tmp/synthesized/
+            /tmp/metrics.json
+            /tmp/bencher.json
+            /tmp/diff.md
+          retention-days: 90
+```
+
+### Golden sample 選定基準
+
+総計 **6 言語 × 5 カテゴリ × 1 sample = 30 text** を fixture として commit。 各言語あたり 5 text 構成は以下の通り。
+
+| カテゴリ | 説明 | 例 (ja) | 評価対象 |
+|---------|------|---------|---------|
+| **短文** (< 20 chars) | 1 sentence、 句読点最小 | 「こんにちは」 | silence padding A/B/C / EOS trim regression |
+| **長文** (50-100 chars) | 複文、 中間 prosody 検証 | 「桜の咲く季節になりました。今日は天気もよく、 散歩日和です。」 | streaming vs batch parity / prosody |
+| **SSML** | `<break>` / `<prosody rate>` 含む | `<speak>こんにちは<break time="500ms"/>世界</speak>` | SSML parser / silence insertion |
+| **ZH-EN 混在** (zh のみ) | acronym / loanword | 「我用 USB 充电」 | zh_en_loanword.json sync, MultilingualPhonemizer |
+| **PUA / 多 codepoint phoneme** | `ɔɪ` / `œ̃` / `ɐ̃` / `ɨ` / `ɫ` 等 | (各言語の難所音素) | PUA contract regression |
+
+ja / en / zh / es / fr / pt の 6 言語で網羅。 SSML / ZH-EN 混在の該当しない言語では「韻律変化が顕著な文」 / 「数値読み」 等で代替。 corpus は git に plain text + manifest.json でコミット、 reference WAV は別途 HF Hub (`ayousanz/piper-plus-audio-corpus`) に置く (LFS 肥大化回避)。
+
+### 採用する 4 指標
+
+| 指標 | ライブラリ | 計算量 | 用途 | informational 閾値 |
+|------|----------|--------|------|---------|
+| **PESQ-WB** | `pesq` (Python pip、 ITU-T P.862.2 wrapper) | 1 file ~50ms | telecom 系 MOS proxy、 reference / degraded 比較 | Δ ≥ 0.15 (4.5 scale) |
+| **STOI** | `pystoi` | 1 file ~30ms | speech intelligibility 0-1 | Δ ≥ 0.02 |
+| **UTMOS22** | `utmos` または `tools/benchmark/compute_metrics.py` の既存実装 | 1 file ~500ms (PyTorch CPU) | TTS 専用 SSL ベース MOS proxy | Δ ≥ 0.10 |
+| **Whisper WER** | `openai-whisper` (base.en + base.multilingual) | 1 file ~3s (CPU) | G2P regression を実音声で検出 (transcribe → WER) | Δ ≥ 0.05 (5% point) |
+
+採用しない指標:
+
+- **ViSQOL**: Google C++、 Python wrapper 不安定、 Apache 2.0 だが build 困難で CI に組込みづらい
+- **Mel Cepstral Distortion (MCD)**: 計算は軽いが TTS 評価との相関が UTMOS より弱い
+- **DNSMOS**: ノイズ除去用途設計で TTS 不適合
+
+reference audio (oracle) は M2.1 開始時点での `dev` HEAD で同 model を使って 1 回合成し、 これを `tests/fixtures/audio-corpus/reference/` に commit (LFS は HF Hub)。 baseline JSON はこの reference を基準として PESQ / STOI を計算する。 UTMOS / WER は reference-free 指標なので絶対値での閾値設定 (UTMOS ≥ 3.5 / WER ≤ 15%) も可。
+
+### Baseline JSON schema
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-18T00:00:00Z",
+  "model": {
+    "name": "tsukuyomi-6lang-v2",
+    "path": "models/tsukuyomi-6lang-v2/model.onnx",
+    "sha256": "abc123...",
+    "config_sha256": "def456..."
+  },
+  "reference_corpus": {
+    "manifest": "tests/fixtures/audio-corpus/manifest.json",
+    "manifest_sha256": "789ghi..."
+  },
+  "samples": [
+    {
+      "id": "ja-short-001",
+      "language": "ja",
+      "category": "short",
+      "text": "こんにちは",
+      "metrics": {
+        "pesq_wb": 4.21,
+        "stoi": 0.953,
+        "utmos22": 3.84,
+        "wer": 0.0
+      }
+    }
+  ]
+}
+```
+
+### Sticky comment 設計
+
+`feedback_pr_body_over_comments.md` (PR 本文書き換え) は **PR 説明文** の話で、 sticky comment による automated bot 投稿は 1 個に集約される限り conflict しない (`marocchino/sticky-pull-request-comment` は header で同一 comment を update する)。 表示例:
+
+```markdown
+## Audio MOS Proxy (informational tier)
+
+| Sample | PESQ-WB | STOI | UTMOS | WER |
+|--------|---------|------|-------|-----|
+| ja-short-001 | 4.21 (=) | 0.953 (=) | 3.84 (=) | 0.00 (=) |
+| ja-long-001 | 4.05 (-0.18 !) | 0.921 (=) | 3.72 (=) | 0.02 (=) |
+| ...
+
+[regression] ja-long-001: PESQ-WB dropped by 0.18 (threshold 0.15). Inspect [spectrogram artifact](link).
+```
+
+---
+
+## 3. エージェントチームの役割と人数
+
+| ロール | 人数 | 担当範囲 |
+|--------|------|---------|
+| **audio quality engineer (lead)** | 1 | golden corpus 選定 / 4 指標実装 / 閾値設計 / baseline JSON 生成 |
+| **Python runtime integration** | 1 | `scripts/audio_quality_metrics.py` の Python CLI 統合 / Whisper / UTMOS / PESQ wrapper |
+| **MLOps / CI engineer** | 1 | `.github/workflows/audio-mos-proxy.yml` / sticky comment / artifact / cache 設計 |
+| **docs writer** | 1 | corpus manifest 記述 / informational tier 運用ガイド / 4 週後判定手順 docs |
+| **reviewer (maintainer)** | 1 | 4 週後 blocker 昇格判定 / false positive 率レビュー / threshold 調整承認 |
+
+合計 **5 名規模** (1 名で兼任可能、 並列なら 3 名で 4 週完遂)。 audio quality engineer は信号処理に明るい者を想定 (PESQ / STOI / UTMOS の数学的性質を理解)。
+
+---
+
+## 4. 提供範囲とテスト項目
+
+### 提供範囲
+
+**IN-SCOPE**:
+
+- 6 言語 × 5 カテゴリ = 30 golden text fixture
+- 4 指標 (PESQ-WB / STOI / UTMOS22 / Whisper WER) の自動計算
+- baseline JSON + diff + threshold 判定
+- sticky comment 自動投稿
+- spectrogram PNG / metrics / WAV の artifact upload (90 日)
+- **informational tier 4 週間運用**
+- Bencher 互換 JSON 出力 (M-Stretch 連携用)
+
+**OUT-OF-SCOPE** (M2 期間内では実装しない):
+
+- GPU runner での UTMOS / Whisper-large 推論 (CPU の base model で十分)
+- ViSQOL / DNSMOS / MCD 等の追加指標 (Bencher dashboard 移行後に検討)
+- 7 ランタイム横断の MOS 計測 (M2.2 で audio byte parity を取り、 そこから派生検討)
+- voice cloning (reference audio → 合成) の MOS 計測 (M-Stretch で voice identity 検証と統合)
+- リアルタイム listening test の crowdsource 連携 (`tools/benchmark/generate_mos_survey.py` の CI 化は M-Stretch)
+
+### Unit テスト
+
+| テスト | 対象 | 検証内容 |
+|--------|------|---------|
+| `tests/unit/test_audio_quality_metrics.py::test_pesq_known_pair` | `scripts/audio_quality_metrics.py` | 同一 WAV を ref / deg にして PESQ ≈ 4.5 が返る |
+| `test_pesq_known_distortion` | 同上 | 既知 distortion (Gaussian noise) で PESQ が baseline より低い |
+| `test_stoi_clean_vs_noisy` | 同上 | clean WAV STOI > noisy WAV STOI |
+| `test_utmos_deterministic_seed` | 同上 | seed 固定で UTMOS 出力が ±0.001 内で一致 |
+| `test_whisper_wer_known_text` | 同上 | LibriSpeech sample で既知 WER 範囲に収まる |
+| `test_bencher_json_schema` | 同上 | 出力 JSON が Bencher Adapter spec に合致 |
+| `test_sticky_comment_markdown` | diff レンダラ | regression / no-change / improvement の 3 種類が表組みで出る |
+| `test_baseline_diff_threshold` | diff ロジック | threshold 超過で `[regression]` tag が立つ |
+
+### E2E / 統合テスト
+
+| テスト | 内容 |
+|--------|------|
+| **happy path** | baseline JSON と一致する model で workflow を流し、 全 sample が pass する |
+| **regression detection** | baseline と異なる model (FP32 → FP16 強制 / decoder 差し替え) で workflow を流し、 少なくとも 1 sample が regression 検出される |
+| **CI timeout** | 30 sample × 4 指標が CPU で 15 分以内に完了 (Ubuntu Linux runner) |
+| **artifact retention** | run 完了後に spectrogram / metrics / WAV が artifact として 90 日 retain |
+| **sticky comment update** | 同一 PR で push を重ねた際、 新規 comment が増えずに既存 comment が update される |
+| **branch protection** | informational tier で `continue-on-error: true` のため fail しても merge button 緑 |
+| **blocker 昇格 dry-run** | `continue-on-error: false` に切替えると、 真の regression が merge を block することを確認 |
+
+### 手動検証項目
+
+- [ ] 4 週間中、 weekly で `audio-mos-proxy.yml` の run history を maintainer がレビュー
+- [ ] regression flagged な PR について spectrogram PNG を目視で確認 (実際の劣化か / false positive か判定)
+- [ ] false positive 率 < 5% であるか集計 (M3 開始時)
+- [ ] CI 経過時間が PR 全体の tail latency を 5 分以上延長していないか集計
+- [ ] sticky comment が contributor を混乱させていないか (Issue / PR comment で friction 報告がないか)
+- [ ] UTMOS / Whisper の cache hit 率 (cold cache 時に CI が timeout しないか)
+- [ ] 4 週後の blocker 昇格判定書面を `docs/proposals/ci-expansion-milestones.md` に追記
+
+---
+
+## 5. 懸念事項とレビュー観点
+
+### 懸念事項
+
+1. **UTMOS の PyTorch dependency が ~3GB** — cache hit すれば数十 MB の delta だが、 cold cache の初回 run で artifact download に 3 分かかる懸念。 `actions/cache@v4` で hash 安定化必須
+2. **Whisper の言語別精度差** — ja / zh は en に比べて WER が natural に高い (15-20% 程度)。 言語別に閾値を分ける必要あり、 一律 5% point では fail multi
+3. **CPU 推論時間の不安定性** — GitHub-hosted runner の CPU は noisy neighbor の影響を受け、 30 sample × 4 指標 の実行時間が ±20% ばらつく。 timeout は 25 分の余裕を持たせる
+4. **浮動小数差 / ORT provider 差** — Linux x86_64 と macOS arm64 で同一 model を動かしても PESQ が ±0.05 程度ずれる。 baseline は **Linux ubuntu-latest 固定** で生成し、 OS matrix は M2.2 で扱う
+5. **TTS 用途における PESQ / STOI の妥当性疑問** — 元々 telecom speech 用設計のため絶対値の意味は弱い。 ただし「baseline からの相対差」 用途では useful
+6. **informational tier 中の signal 過多** — 4 週で 100 PR あれば数十回の MOS proxy report が sticky で蓄積、 contributor がノイズと感じる可能性。 `header: audio-mos-proxy` で 1 comment に集約必須
+7. **golden model 自体の variance** — 同一 model でも seed (noise_scale 0.667) の影響あり。 baseline 生成時に seed 固定 + 5 run の median を採用
+8. **reference WAV の HF Hub 依存** — HF Hub down 時に CI fail。 fallback として GitHub Release artifact に mirror を置く
+9. **license 観点** — Whisper の cache 配布、 UTMOS pretrained weight の license (CC-BY-4.0) を `LICENSE_ATTRIBUTIONS.md` に記載 (M3.2 で auto-injection 候補)
+10. **4 週後 blocker 化判定の owner 不明確** — M2-overview.md で maintainer に指定したが、 個人依存にしないため judge criteria を data-driven (3 条件) で固定化
+
+### レビュー観点 checklist
+
+- [ ] golden corpus 30 text は ja / en / zh / es / fr / pt の 6 言語を均等にカバーしているか
+- [ ] 5 カテゴリ (短文 / 長文 / SSML / ZH-EN 混在 / PUA) は各言語で意味のある選択か (該当無しの言語は代替を justify)
+- [ ] reference WAV の生成手順が再現可能か (seed / model hash / `noise_scale` 等を manifest に記載)
+- [ ] baseline JSON の schema が future field 追加に forward-compat か (`schema_version` フィールド存在)
+- [ ] 4 指標の threshold は経験則ではなく **「人間が regression と感じる cluster」** に裏付けあるか (informational 期間中に実測)
+- [ ] sticky comment header が固定で、 PR が長期化しても 1 comment に集約されるか
+- [ ] CI timeout は 25 分で十分か (UTMOS cold cache 時のマージン含む)
+- [ ] artifact retention 90 日は cost / debug 容易性のバランス上適切か
+- [ ] `continue-on-error: true` が明示されているか (informational tier)
+- [ ] M3 開始時の blocker 昇格判定手順が docs に明記されているか
+- [ ] Bencher JSON 出力 schema が M-Stretch で再利用可能か
+- [ ] OS は Linux ubuntu-latest 固定で、 macOS / Windows での variance 確認は M2.2 / M-Stretch に分離されているか
+- [ ] Whisper / UTMOS の license attribution が `LICENSE_ATTRIBUTIONS.md` に記載されているか (M3.2 連携)
+- [ ] 「`feedback_csharp_path_join` のように Path.Combine 禁止」 のような cross-runtime 規約に違反していないか (本チケットは Python のみ)
+- [ ] PUA category の text が `pua.json` と sync 済みか (`/check-pua` skill 通過)
+
+---
+
+## 6. 一から作り直すとしたら
+
+CI gate ではなく **「signal 集積基盤 + 週次レビュー」** にする alternative を真剣に検討した。 具体的には以下の設計:
+
+- 各 PR で MOS proxy 計算は実行するが、 sticky comment ではなく `audio-mos-proxy-results` という別 branch に commit
+- 週 1 で GitHub Action が `audio-mos-proxy-results` を集計し、 `docs/quality/weekly-report.md` を auto-update
+- regression 検出は **trend** ベース (4 週移動平均からの逸脱) で行い、 個別 PR ではなく週次 PR で issue 化
+
+これは contributor friction が小さく、 Bencher dashboard 化 (M-Stretch) と親和性が高い。 ただし「**merge 前の regression 防止**」 という本来目的は満たさないため、 M2 期間中は採用しない。 informational tier 4 週 + blocker 化の二段階で「PR gate として動かしつつ false positive 率を低く保つ」 ことを優先する。
+
+baseline をモノレポ commit するか別 LFS / artifact ストアにするかも検討した。 **text manifest は git にコミット、 reference WAV は HF Hub にホスト** が結論。 baseline JSON (~30 KB) は git commit、 reference WAV (~5 MB × 30 = 150 MB) は git LFS 課金 / clone 遅延を避けるため HF Hub。 HF Hub down リスクは GitHub Release artifact mirror で塞ぐ。
+
+---
+
+## 7. 後続タスクへの連絡事項
+
+### M2.2 への引き継ぎ
+
+- 本チケットで作成する `tests/fixtures/audio-corpus/` は **M2.2 と共有**。 M2.2 では同 corpus を 7 ランタイムで合成し byte 比較する
+- `scripts/audio_quality_metrics.py` の `--mode synthesize` step は Python CLI 経由なので、 M2.2 で他 runtime CLI を追加する際の pattern として参照
+
+### M3.2 (license auto-injection) への引き継ぎ
+
+- UTMOS weights (CC-BY-4.0) / Whisper model (MIT) の attribution を `LICENSE_ATTRIBUTIONS.md` に記載
+- `data-sources.yml` に「audio-corpus reference WAV の出典 model hash」 を明記する欄を追加 (M3.2 で `scripts/generate_model_card.py` が読む)
+
+### M-Stretch (Bencher dashboard) への引き継ぎ
+
+- `scripts/audio_quality_metrics.py` の `--bencher-json` 出力は Bencher Adapter `json` 形式に従う
+- Bencher 移行時は `.github/workflows/audio-mos-proxy.yml` の sticky comment 部分を Bencher CLI (`bencher run`) に置換するだけで完了する想定
+
+### 4 週間後の blocker 昇格判定タイミング
+
+- M2 開始から 4 週後 (= M3 開始時) に maintainer が以下を実施:
+  1. 4 週分の `audio-mos-proxy.yml` run history を `gh api` で収集
+  2. fail run を「真の regression」 / 「false positive」 に分類
+  3. M2-overview.md §「informational → blocker 昇格判定基準」 の 3 条件 (true positive ≥ 1 / FP < 5% / tail latency 延長 < 5 分) を判定
+  4. 判定結果を `docs/proposals/ci-expansion-milestones.md` に追記し M3 開始通知 PR に含める
+- 昇格しない場合は **informational 継続** または **M-Stretch (Bencher dashboard) 移行** の二択を maintainer が選択
+
+---
+
+## 8. 関連ファイル
+
+### 新規作成
+
+- `.github/workflows/audio-mos-proxy.yml`
+- `scripts/audio_quality_metrics.py`
+- `tests/fixtures/audio-corpus/{ja,en,zh,es,fr,pt}/*.txt` (30 file)
+- `tests/fixtures/audio-corpus/manifest.json`
+- `tests/fixtures/audio-corpus/reference/` (HF Hub にホスト、 git には manifest のみ)
+- `tests/fixtures/audio-mos-baseline.json`
+- `tests/unit/test_audio_quality_metrics.py`
+- `docs/spec/audio-mos-contract.toml` (任意、 4 指標 / threshold の正式仕様化)
+
+### 既存変更
+
+- `tools/benchmark/compute_metrics.py` — UTMOS 計算ロジックを `scripts/audio_quality_metrics.py` に流用 (片寄り解消)
+- `CHANGELOG.md` — `[Unreleased]` に `### Added` で entry 追加
+- `.gitattributes` — corpus 関連 path の LFS 設定 (reference WAV を git LFS 経由にする場合)
+
+### 参照のみ
+
+- `.github/workflows/multi-runtime-rtf.yml` — baseline JSON + diff pattern の参考
+- `.github/workflows/memory-regression.yml` — sticky comment pattern の参考
+- `tests/fixtures/multi-runtime-rtf-baseline.json` — schema の参考
+- `CLAUDE.md` — 6 言語データセット表 (model card 生成の元ネタ)
+
+---
+
+## 9. 参照
+
+- [M2 phase overview](./M2-overview.md)
+- [親調査 §2.2 音声品質](../proposals/ci-expansion-2026-05.md)
+- [親調査 §5 Top 10 #1](../proposals/ci-expansion-2026-05.md)
+- [親マイルストーン §M2.1](../proposals/ci-expansion-milestones.md#m21--audio-mos-proxy-gate-top-10-1)
+- [M1.1 cancelled baseline alarm (前提)](./M1-1-cancelled-baseline-alarm.md)
+- [M2.2 cross-runtime audio parity (後続)](./M2-2-cross-runtime-audio-parity.md)
+- [`docs/benchmark-mos.md`](../benchmark-mos.md) — 既存 MOS benchmark 運用 docs (CI 化前の手動運用)
+- ITU-T P.862.2 (PESQ-WB) standard
+- Andersen et al. (2010) — STOI 原論文
+- Saeki et al. (2022) — UTMOS22 原論文

--- a/docs/tickets/M2-2-cross-runtime-audio-parity.md
+++ b/docs/tickets/M2-2-cross-runtime-audio-parity.md
@@ -1,0 +1,526 @@
+# [M2.2] Cross-runtime audio byte parity (7 runtime × 3 model)
+
+**親マイルストーン**: [M2 Audio Quality Moat](./M2-overview.md)
+**親調査**: [ci-expansion-2026-05.md §Top 10 #2](../proposals/ci-expansion-2026-05.md)
+**Top 10 内番号**: #2
+**ステータス**: 未着手
+**前提チケット**: [M1.1 Cancelled baseline alarm](./M1-1-cancelled-baseline-alarm.md) / [M2.1 Audio MOS proxy gate](./M2-1-audio-mos-proxy.md)
+**想定工数**: 4-5 PR (~40h)
+**優先度**: 高
+**informational 期間**: 4 週間 (M2 開始 〜 M3 開始時に blocker 昇格判定)
+**作成日**: 2026-05-18
+
+---
+
+## 1. タスクの目的とゴール
+
+### 目的
+
+piper-plus は 7 ランタイム (Python / Rust / C# / Go / JS-WASM / C++ / iOS-Swift+Android-Kotlin G2P) を持つが、 **「同一 model + 同一 phoneme IDs → 同一 audio」 が runtime 横断で保証されているか** は現状未検証。 既存 parity gate は phoneme IDs / timing / fixture byte 一致までで、 **decoder 出力 (合成 WAV)** のレイヤは抜け落ちている。 これを SHA256 / RMSE / chromaprint fingerprint / mel-spectrogram MSE の **階層化** で検証し、 runtime drift を gate 化する。
+
+### ゴール (DoD)
+
+- [ ] `.github/workflows/runtime-parity-deep.yml` workflow が PR / push (dev) で trigger され green
+- [ ] **6 runtime (Python / Rust / C# / Go / JS-WASM / C++)** × **3 model** (multilingual-test-medium / tsukuyomi-6lang-v2 / 6lang-mb-istft-base) で同一入力 → 合成 WAV 比較を実行 (iOS Swift / Android Kotlin は G2P のみで decoder 推論未対応のため除外)
+- [ ] 階層化判定: SHA256 一致 → RMSE → chromaprint similarity → mel-spec MSE の順に評価、 全ての runtime pair で **SNR ≥ 60 dB かつ mel-spec MSE ≤ 1e-3** を満たす
+- [ ] 失敗時に **diff spectrogram PNG** (reference vs degraded を上下並べた図) を CI artifact として upload
+- [ ] 各 runtime に `--dump-wav <path>` flag を追加 (既存 CLI 経路から WAV を確実に取り出す)
+- [ ] 4 週間 informational 運用後、 blocker 昇格判定 (M3 開始時)
+- [ ] golden corpus は M2.1 と **共有** (`tests/fixtures/audio-corpus/`)
+
+---
+
+## 2. 実装する内容の詳細
+
+### 背景
+
+piper-plus は既に以下の cross-runtime parity gate を持つが、 audio output に関しては空白:
+
+| 既存 gate | 検証層 | workflow |
+|----------|-------|---------|
+| Phoneme timing parity | timing JSON byte 一致 | `timing-parity.yml` |
+| SSML AST parity (検討中) | parse tree 比較 | (未実装) |
+| Phoneme IDs parity | 各 runtime fixture 内 | runtime 個別 test |
+| PUA / loanword sync | JSON byte 一致 | `pua-consistency.yml`, `zh-en-loanword-sync.yml` |
+| Multi-runtime RTF | 速度ベンチ | `multi-runtime-rtf.yml` |
+
+このうち **「decoder 出力 (合成 WAV)」 のレイヤが構造的に空白**。 phoneme IDs まで一致していても、 各 runtime の ORT session 設定 / FP16 量子化扱い / iSTFT 実装差 / output normalize / silence trim 実装差で audio が divergent する可能性がある。 これは PR #320 (MB-iSTFT decoder 置換) や PR #499 (EOS trim) のような decoder / 後処理 PR で特に発火しやすい。
+
+### アーキテクチャ概要
+
+```mermaid
+flowchart TD
+    Corpus[tests/fixtures/audio-corpus/ M2.1 共有] --> Python[Python CLI --dump-wav]
+    Corpus --> Rust[Rust CLI --dump-wav]
+    Corpus --> CSharp[C# CLI --dump-wav]
+    Corpus --> Go[Go CLI --dump-wav]
+    Corpus --> WASM[Node.js + WASM --dump-wav]
+    Corpus --> Cpp[C++ CLI --dump-wav]
+    Python & Rust & CSharp & Go & WASM & Cpp --> Compare[scripts/audio_parity.py]
+    Compare --> SHA256{SHA256 一致?}
+    SHA256 -->|yes| Pass[pass tier 1]
+    SHA256 -->|no| RMSE[RMSE 計算]
+    RMSE --> Chroma[chromaprint similarity]
+    Chroma --> MelMSE[mel-spec MSE / SNR]
+    MelMSE --> Threshold{SNR ≥ 60 dB AND<br/>mel-MSE ≤ 1e-3?}
+    Threshold -->|yes| Pass2[pass tier 2-4]
+    Threshold -->|no| Fail[fail + diff spectrogram PNG]
+    Fail --> Artifact[upload artifact]
+```
+
+### 具体的な変更内容 (file path 単位)
+
+| 変更 | パス | 種別 |
+|------|------|------|
+| 新規 corpus (M2.1 共有) | `tests/fixtures/audio-corpus/` | M2.1 で既に作成済を流用 |
+| 新規 baseline JSON | `tests/fixtures/audio-parity-baseline.json` | 新規 (runtime × sample の reference hash + mel-spec) |
+| 新規 比較 script | `scripts/audio_parity.py` | 新規 (SHA256 / RMSE / chromaprint / mel-spec MSE / 階層判定 / spectrogram PNG 出力) |
+| 新規 workflow | `.github/workflows/runtime-parity-deep.yml` | 新規 (jobs: `parity-audio` を含む。 将来 `parity-ort-inputs` / `parity-ssml-ast` 拡張枠) |
+| Python CLI 変更 | `src/python_run/piper/__main__.py` | `--dump-wav <path>` flag 追加 (既存の `--output-file` で代用可なら不要) |
+| Rust CLI 変更 | `src/rust/piper-cli/src/main.rs` | `--dump-wav <path>` flag 追加 |
+| C# CLI 変更 | `src/csharp/PiperPlus.Cli/Program.cs` | `--dump-wav <path>` flag 追加 |
+| Go CLI 変更 | `src/go/cmd/piper-plus/main.go` | `--dump-wav <path>` flag 追加 |
+| WASM CLI 変更 | `src/wasm/openjtalk-web/scripts/cli-dump.js` | 新規 Node.js entry (既存 CLI が存在しなければ作る) |
+| C++ CLI 変更 | `src/cpp/piper_plus_cli.cpp` | `--dump-wav <path>` flag 追加 |
+| 新規 spec toml | `docs/spec/audio-parity-contract.toml` | 階層判定の閾値仕様 (SHA256 / RMSE / chromaprint / mel-spec MSE / SNR) |
+| 既存 CI 拡張 | `.github/workflows/required_status_check_gate.yml` | 4 週後 blocker 昇格時に追記 |
+
+### 設定例
+
+```yaml
+# .github/workflows/runtime-parity-deep.yml (parity-audio job 抜粋)
+name: Runtime Parity Deep
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/fixtures/audio-corpus/**'
+      - 'tests/fixtures/audio-parity-baseline.json'
+      - 'scripts/audio_parity.py'
+      - 'docs/spec/audio-parity-contract.toml'
+  push:
+    branches: [dev]
+
+jobs:
+  parity-audio:
+    strategy:
+      fail-fast: false
+      matrix:
+        model:
+          - multilingual-test-medium
+          - tsukuyomi-6lang-v2
+          - 6lang-mb-istft-base
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    continue-on-error: true  # informational tier (4 週間)
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download model
+        run: |
+          uv run python scripts/download_model.py --model ${{ matrix.model }}
+      - name: Synthesize with all 6 runtimes
+        run: |
+          uv run python scripts/audio_parity.py \
+            --mode synthesize \
+            --model ${{ matrix.model }} \
+            --corpus tests/fixtures/audio-corpus \
+            --runtimes python rust csharp go wasm cpp \
+            --output /tmp/audio-parity/${{ matrix.model }}/
+      - name: Compute pairwise parity
+        id: parity
+        run: |
+          uv run python scripts/audio_parity.py \
+            --mode compare \
+            --input-dir /tmp/audio-parity/${{ matrix.model }}/ \
+            --baseline tests/fixtures/audio-parity-baseline.json \
+            --contract docs/spec/audio-parity-contract.toml \
+            --output-json /tmp/parity-${{ matrix.model }}.json \
+            --output-md /tmp/parity-${{ matrix.model }}.md \
+            --output-spectrogram-dir /tmp/spectrograms/${{ matrix.model }}/
+      - name: Post sticky comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: audio-parity-${{ matrix.model }}
+          path: /tmp/parity-${{ matrix.model }}.md
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: audio-parity-${{ matrix.model }}-${{ github.run_id }}
+          path: |
+            /tmp/audio-parity/${{ matrix.model }}/
+            /tmp/parity-${{ matrix.model }}.json
+            /tmp/spectrograms/${{ matrix.model }}/
+          retention-days: 90
+```
+
+### 階層化判定設計
+
+```python
+# scripts/audio_parity.py の判定ロジック (擬似コード)
+def compare_pair(ref_wav: Path, target_wav: Path) -> ParityResult:
+    # Tier 1: SHA256 (実現すれば理想だが ORT provider 差で稀)
+    if sha256(ref_wav) == sha256(target_wav):
+        return ParityResult(tier=1, status="exact")
+
+    # Tier 2: 浮動小数差を許容する RMSE
+    ref_audio, sr = load_wav(ref_wav)
+    tgt_audio, _ = load_wav(target_wav)
+    if len(ref_audio) != len(tgt_audio):
+        # 長さ違いは silence padding / EOS trim 差
+        # 短い方に揃えて比較、 長さ差自体も metric として記録
+        n = min(len(ref_audio), len(tgt_audio))
+        ref_audio, tgt_audio = ref_audio[:n], tgt_audio[:n]
+    rmse = np.sqrt(np.mean((ref_audio - tgt_audio) ** 2))
+    snr = 20 * np.log10(rms(ref_audio) / (rmse + 1e-12))
+
+    # Tier 3: chromaprint fingerprint (perceptual similarity)
+    chroma_sim = chromaprint_similarity(ref_audio, tgt_audio, sr)
+
+    # Tier 4: mel-spectrogram MSE
+    ref_mel = mel_spectrogram(ref_audio, sr)
+    tgt_mel = mel_spectrogram(tgt_audio, sr)
+    mel_mse = np.mean((ref_mel - tgt_mel) ** 2)
+
+    # 判定: spec toml の閾値で判断
+    if snr >= 60.0 and mel_mse <= 1e-3 and chroma_sim >= 0.95:
+        return ParityResult(tier=2, status="equivalent", snr=snr, mel_mse=mel_mse, chroma=chroma_sim)
+    else:
+        return ParityResult(tier=4, status="divergent", snr=snr, mel_mse=mel_mse, chroma=chroma_sim,
+                            spectrogram_path=save_diff_spectrogram(ref_audio, tgt_audio, sr))
+```
+
+### `audio-parity-contract.toml` (新規 spec)
+
+```toml
+# docs/spec/audio-parity-contract.toml
+schema_version = 1
+canonical_runtime = "python"  # baseline 生成基準
+
+[thresholds]
+# Tier 1: bit-exact (informational only、 実用閾値ではない)
+require_sha256_match = false
+
+# Tier 2: SNR-based numerical equivalence
+snr_db_min = 60.0
+length_diff_samples_max = 256  # EOS trim 差を許容
+
+# Tier 3: perceptual similarity
+chromaprint_similarity_min = 0.95
+
+# Tier 4: spectral similarity
+mel_spec_mse_max = 1e-3
+mel_n_fft = 2048
+mel_hop_length = 512
+mel_n_mels = 80
+
+[matrix]
+runtimes = ["python", "rust", "csharp", "go", "wasm", "cpp"]
+models = ["multilingual-test-medium", "tsukuyomi-6lang-v2", "6lang-mb-istft-base"]
+languages = ["ja", "en", "zh", "es", "fr", "pt"]
+
+[allowlist]
+# 既知の divergence (一時許容、 issue link 必須)
+# 例: WASM の SIMD 未対応環境で FP16 経路が softmax 順序差で発火
+# [[allowlist.entry]]
+# runtime_a = "python"
+# runtime_b = "wasm"
+# sample_id = "ja-long-001"
+# reason = "WASM SIMD off, softmax order diff"
+# issue = "https://github.com/ayutaz/piper-plus/issues/XYZ"
+# expires = "2026-08-01"
+```
+
+### 7 runtime × 3 model のマトリクス設計
+
+実際には **6 runtime** (Python / Rust / C# / Go / JS-WASM / C++) × 3 model = 18 cell。 iOS-Swift と Android-Kotlin は **G2P のみ** (decoder 推論はホスト OS の ONNX Runtime API 経由でユーザー側実装) なので decoder 比較対象外。 G2P parity は別 workflow (将来 `parity-g2p` job として `runtime-parity-deep.yml` 内で並走) でカバー。
+
+3 model の選定理由:
+
+- **multilingual-test-medium**: `test/models/` 配下、 50 epoch FT、 軽量、 CI 用 (~30 MB)
+- **tsukuyomi-6lang-v2**: HiFi-GAN decoder の代表、 production reference (~50 MB)
+- **6lang-mb-istft-base**: MB-iSTFT decoder の代表、 PR #320 で導入された軽量 decoder の regression 検出に必須 (~50 MB)
+
+3 model 含めることで HiFi-GAN ⇔ MB-iSTFT の 2 つの decoder family を網羅。 各 model は CI 開始時に HF Hub からキャッシュ前提で download。 cold cache 時 download ~3 min × 3 = 9 min を timeout 40 分に含める。
+
+### 浮動小数許容閾値 (SNR ≥ 60 dB / mel-MSE ≤ 1e-3) の根拠
+
+- **SNR ≥ 60 dB**: 16-bit PCM の量子化ノイズが約 96 dB SNR、 これより 36 dB 余裕がある領域で「人間の聴覚 threshold 以下の差」 とみなせる。 ORT provider 差 / FP16 ⇔ FP32 演算順序差は通常 SNR 70-80 dB 程度の差に収まる
+- **mel-spec MSE ≤ 1e-3**: 80-mel × 100-frame で各 bin が [-1, 1] 程度の値域。 MSE 1e-3 ≒ RMS 0.032 で、 人間の知覚閾値 (10-15% spectral difference) より十分小さい
+- **chromaprint similarity ≥ 0.95**: AcoustID の経験則として 0.95 以上は「同一楽曲」 判定圏内。 TTS の同一文だと 0.97-0.99 が普通、 0.95 でも regression 危険レベル
+
+これらの値は **informational 4 週間中に実測** して微調整する。 親 doc §5 で「最初 1 model に絞り、 安定後 3 model に拡大」 とあるが、 本チケットでは **最初から 3 model を informational tier で並走** し、 4 週後の blocker 化判定時に問題のあった model だけを除外する case-by-case 戦略を採用する。
+
+### Diff spectrogram PNG 生成
+
+`scripts/audio_parity.py` が divergent と判定したケースで以下の PNG を生成し artifact upload:
+
+```python
+# 擬似コード
+fig, axes = plt.subplots(3, 1, figsize=(12, 8))
+plot_spectrogram(axes[0], ref_audio, title="Reference (Python canonical)")
+plot_spectrogram(axes[1], tgt_audio, title=f"Target ({target_runtime})")
+plot_spectrogram_diff(axes[2], ref_audio, tgt_audio, title="Diff (dB)")
+plt.savefig(f"diff_{sample_id}_{target_runtime}.png", dpi=100)
+```
+
+これにより maintainer / contributor が「数値だけでなく視覚的に regression を理解できる」。 90 日 retention の artifact 内で参照可能。
+
+### Baseline JSON schema
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-18T00:00:00Z",
+  "canonical_runtime": "python",
+  "models": {
+    "multilingual-test-medium": {
+      "sha256": "abc...",
+      "config_sha256": "def..."
+    }
+  },
+  "samples": [
+    {
+      "id": "ja-short-001",
+      "language": "ja",
+      "text": "こんにちは",
+      "canonical_audio": {
+        "sha256": "111...",
+        "duration_ms": 1023,
+        "rms": 0.083,
+        "mel_spec_sha256": "222..."
+      }
+    }
+  ]
+}
+```
+
+---
+
+## 3. エージェントチームの役割と人数
+
+| ロール | 人数 | 担当範囲 |
+|--------|------|---------|
+| **audio quality engineer (lead)** | 1 | 階層化判定設計 / 閾値設計 / `scripts/audio_parity.py` / spectrogram 可視化 |
+| **Python runtime integration** | 1 | Python `--dump-wav` 確認 (既存 `--output-file` で代用検討) / baseline 生成 |
+| **Rust runtime integration** | 1 | Rust CLI `--dump-wav` 追加 / piper-core への WAV write API 露出 |
+| **C# runtime integration** | 1 | C# CLI `--dump-wav` 追加 / PiperPlus.Cli への flag |
+| **Go runtime integration** | 1 | Go CLI `--dump-wav` 追加 / `src/go/cmd/piper-plus/` への flag |
+| **WASM/JS runtime integration** | 1 | Node.js entry 作成 (既存に CLI 不在の場合) / openjtalk-web の synthesize API 経由で WAV 取得 |
+| **C++ runtime integration** | 1 | C++ CLI `--dump-wav` 追加 / `piper_plus_cli.cpp` への flag |
+| **MLOps / CI engineer** | 1 | `runtime-parity-deep.yml` workflow / matrix / cache / artifact / sticky comment |
+| **docs writer** | 1 | `audio-parity-contract.toml` 仕様化 / README / blocker 昇格判定 docs |
+| **reviewer (maintainer)** | 1 | 4 週後 blocker 昇格判定 / 各 runtime integration PR レビュー / allowlist 承認 |
+
+合計 **8-10 名規模**。 runtime integration 6 名 は並列作業 (各 PR 独立)、 lead 1 名 + MLOps 1 名 + docs 1 名 + reviewer 1 名で 4 週完遂。
+
+---
+
+## 4. 提供範囲とテスト項目
+
+### 提供範囲
+
+**IN-SCOPE**:
+
+- 6 runtime (Python / Rust / C# / Go / JS-WASM / C++) × 3 model の audio byte parity
+- 階層判定 (SHA256 → RMSE → chromaprint → mel-spec MSE)
+- 各 runtime CLI への `--dump-wav` flag 追加
+- `tests/fixtures/audio-corpus/` 共有 (M2.1 と)
+- diff spectrogram PNG artifact upload
+- 4 週間 informational 運用
+- `docs/spec/audio-parity-contract.toml` 仕様化
+
+**OUT-OF-SCOPE** (M2 期間内では実装しない):
+
+- iOS Swift / Android Kotlin の decoder 推論比較 (G2P only のため、 別チケット M-Stretch で別 workflow 化)
+- ORT input tensor まで遡った parity (`--dump-ort-inputs`) — M-Stretch (cross-runtime differential testing 完全版) で扱う
+- SSML AST parity — M-Stretch
+- Speaker embedding cosine parity — M-Stretch
+- OS matrix (Windows / macOS × Linux) — M2 では Linux ubuntu-latest 固定、 OS 差は M-Stretch
+- 4 model 以上への拡大 — informational 結果次第で M3 開始時に判断
+
+### Unit テスト
+
+| テスト | 対象 | 検証内容 |
+|--------|------|---------|
+| `tests/unit/test_audio_parity.py::test_sha256_identical` | `scripts/audio_parity.py` | 同一 WAV で SHA256 一致 → tier 1 pass |
+| `test_rmse_zero_threshold` | 同上 | 完全一致時の RMSE = 0、 SNR = inf 扱い |
+| `test_snr_threshold_below_pass` | 同上 | 微小ノイズ追加で SNR 70 dB → pass |
+| `test_snr_threshold_above_fail` | 同上 | 強ノイズで SNR 40 dB → fail |
+| `test_chromaprint_similarity` | 同上 | 同一 vs 異曲で 0.99 vs 0.30 範囲確認 |
+| `test_mel_spec_mse` | 同上 | mel spec の計算が librosa baseline と一致 |
+| `test_length_diff_allowance` | 同上 | EOS trim 差 256 sample 以下は許容 |
+| `test_spectrogram_png_generated` | 同上 | divergent 時に PNG が指定 path に出力される |
+| `test_contract_toml_loaded` | 同上 | `audio-parity-contract.toml` の閾値が反映 |
+| `test_allowlist_skips` | 同上 | allowlist entry の sample / runtime pair で fail せず |
+| `tests/unit/test_dump_wav_python.py` | Python CLI | `--dump-wav` flag が WAV を指定 path に write |
+| `src/rust/piper-cli/tests/test_dump_wav.rs` | Rust CLI | `--dump-wav` flag 動作確認 |
+| `src/csharp/PiperPlus.Cli.Tests/DumpWavTests.cs` | C# CLI | `--dump-wav` flag 動作確認 |
+| `src/go/cmd/piper-plus/dump_wav_test.go` | Go CLI | `--dump-wav` flag 動作確認 |
+| `src/cpp/tests/test_dump_wav.cpp` | C++ CLI | `--dump-wav` flag 動作確認 |
+| `src/wasm/openjtalk-web/test/js/dump_wav.test.js` | WASM Node CLI | Node entry が WAV 出力 |
+
+### E2E / 統合テスト
+
+| テスト | 内容 |
+|--------|------|
+| **happy path (canonical)** | baseline JSON と一致する model + canonical Python で workflow を流し、 全 pair が pass |
+| **regression: decoder swap** | MB-iSTFT model を HiFi-GAN model に差し替えた PR で必ず fail |
+| **regression: ORT version drift** | ORT version を意図的に旧版に pin した PR で SNR drop を検出 |
+| **regression: silence padding A/B/C drift** | short-text-contract の strategy A/B/C を一部 runtime で変更すると fail |
+| **regression: EOS trim drift** | PR #499 系の trim_eos_region を一部 runtime で off にすると length diff 超過で fail |
+| **CI timeout** | 6 runtime × 3 model × 30 sample が 40 min 以内に完了 |
+| **artifact retention** | diff spectrogram PNG / metrics JSON が 90 日 retain |
+| **sticky comment update** | 同一 PR の重複 push で comment が update される (header 3 つで model 別) |
+| **allowlist 機能** | spec toml に allowlist entry 追加すれば該当 pair が pass する |
+| **branch protection** | informational tier で `continue-on-error: true` のため fail しても merge button 緑 |
+| **blocker 昇格 dry-run** | `continue-on-error: false` に切替えで真の regression が merge を block |
+
+### 手動検証項目
+
+- [ ] 4 週間中、 weekly で `runtime-parity-deep.yml` の run history を maintainer がレビュー
+- [ ] divergent flagged な PR について diff spectrogram PNG を目視で確認
+- [ ] false positive 率 < 5% であるか集計 (M3 開始時)
+- [ ] runtime ごとの平均 SNR / mel-MSE の分布を集計 (どの runtime が systematic に低いか)
+- [ ] allowlist 運用が適切か (期限切れ entry が放置されていないか、 issue link 必須が守られているか)
+- [ ] 各 runtime の `--dump-wav` flag が ドキュメント (`docs/reference/cli-help/`) に反映されているか
+- [ ] cold cache 時の workflow 実行時間が timeout 内に収まるか
+- [ ] CLI flag の追加が **第二級** な breaking change にならないか (既存 user の workflow に影響なし)
+- [ ] CHANGELOG `[Unreleased] > Added` に各 runtime の `--dump-wav` flag 追加が記載されているか
+
+---
+
+## 5. 懸念事項とレビュー観点
+
+### 懸念事項
+
+1. **ORT provider × OS 差** — Linux x86_64 baseline で生成しても、 別 OS で実行すると浮動小数差が大きい。 M2 では Linux 固定、 OS matrix は M-Stretch。 「ubuntu-latest が固定でも minor version drift がある」 という指摘もあり得る、 `ubuntu-22.04` で pin する
+2. **WASM の Node.js CLI 不在** — `src/wasm/openjtalk-web/` は元々 browser 向け npm package で、 CLI entry が無い可能性が高い。 新規に Node.js entry を作る工数を見積もりに含めた
+3. **C++ CLI の `--dump-wav` flag 追加** — C++ CLI は CMake build 必須、 6 runtime の中で最も追加工数が大きい (~6h)
+4. **iOS / Android Kotlin の除外説明責任** — README / contract toml に「decoder 推論は host 側 ORT API 経由のためライブラリ単体で audio 生成不能」 を明記
+5. **3 model × 6 runtime × 30 sample = 540 WAV file の生成 / 比較 CI 時間** — 各 runtime あたり推論 ~10s × 30 = 5 分、 6 runtime で 30 分。 timeout 40 分は妥当だが noisy neighbor 影響でばらつく
+6. **diff spectrogram PNG の量** — divergent ケースが多発した場合 artifact が肥大化。 sample × runtime pair = 30 × 15 (6 runtime の組合せ) = 450 PNG 上限、 各 ~200 KB で 90 MB。 retention 90 日で許容範囲
+7. **allowlist の濫用リスク** — 一時的回避のはずが永続化する。 `expires` field 必須 + 期限切れで warn する CI gate を 1 つ別途追加 (M3 開始時)
+8. **canonical_runtime = "python" の偏り** — Python を基準にすると Python の bug が baseline 化する。 weekly で「全 runtime pairwise」 を nightly で別途回し、 Python と他 runtime の triangulation で baseline 正当性をチェック
+9. **モデル DL の HF Hub 依存** — HF Hub down で CI fail。 GitHub Release artifact mirror を予備で持つ
+10. **`--dump-wav` flag が CLI API の breaking change か** — 既存 user の `--output-file` と機能重複の場合あり。 各 runtime で「既存 flag を rename せず追加のみ」 の方針を守る (additive change)
+
+### レビュー観点 checklist
+
+- [ ] 6 runtime × 3 model のマトリクスが contract toml と CI matrix で sync
+- [ ] iOS / Android Kotlin の除外理由が docs に明記
+- [ ] `--dump-wav` flag が 6 runtime 全てで CLI help 文に出る (`/check-cross-runtime` 通過)
+- [ ] 各 runtime CLI の WAV write 実装が `audio-format-contract.toml` (もし既存) に従う (PCM 22050 Hz 16-bit mono)
+- [ ] 階層判定 (SHA256 → RMSE → chromaprint → mel-MSE) の short-circuit 動作が unit test で検証
+- [ ] SNR / mel-MSE / chromaprint の閾値が `audio-parity-contract.toml` に集約、 ハードコード無し
+- [ ] allowlist entry に `expires` / `issue` 必須を spec で強制
+- [ ] diff spectrogram PNG の dpi / size が「contributor が見て判定できる」 解像度
+- [ ] artifact retention 90 日が cost / debug 容易性で適切
+- [ ] `continue-on-error: true` が informational 期間中明示
+- [ ] sticky comment header が `audio-parity-${matrix.model}` で model 別に分離 (1 PR で 3 個まで)
+- [ ] M2.1 corpus との fixture path が衝突しない (corpus は M2.1 が canonical、 M2.2 は read-only 参照)
+- [ ] OS 固定 (ubuntu-22.04) が `runs-on` に明示
+- [ ] ORT version が `docs/reference/ort-versions.md` の pinned 値と一致
+- [ ] M3 開始時の blocker 昇格判定手順が docs に明記
+- [ ] CHANGELOG entry / migration doc (もし breaking) が用意されているか (`migration-changelog-parity.yml` 通過)
+
+---
+
+## 6. 一から作り直すとしたら
+
+「7 runtime 横断で audio byte parity を取る」 のではなく、 **「ORT 出力 logits までの parity」 + 「Python canonical の decoder 後処理を共有 C library 化」** とする alternative を検討した。 後者は技術的に正しい (decoder 後処理が divergent しないことを実装レベルで保証) が、 piper-plus の現在の 7 runtime 独立実装哲学を否定するため M2 期間内では採用しない。
+
+「audio byte parity を CI gate にする」 vs 「dashboard 化する」 でも逡巡した。 dashboard 化なら contributor friction 0 で trend 監視可能、 ただし regression を merge 前に止めることはできない。 informational tier 4 週で false positive 率を測り、 低ければ blocker、 高ければ M-Stretch (Bencher dashboard 化) に流す **二段階アプローチ** を採用。
+
+「mel-spec MSE ≤ 1e-3」 という閾値の根拠は **実測前の経験則** であり、 informational 4 週で「真の regression を検出する閾値」 として再較正する。 同時に 「**chromaprint だけで十分かもしれない**」 という極論も検証する (perceptual similarity が user-visible regression と最も相関するため)。
+
+3 model 並走を最初から行う本案に対し、 「最初 1 model に絞り安定後 3 model に拡大」 とする親 doc §5 の段階導入もあり得る。 本案では **3 model 並走 + 問題のあった model のみ除外** とする逆ベクトルを採用。 これは informational 4 週中に「全体像」 を一度見ておく方が、 後の blocker 化判定で意思決定しやすいため。
+
+---
+
+## 7. 後続タスクへの連絡事項
+
+### M2.1 との fixture 共有
+
+- 本チケットは `tests/fixtures/audio-corpus/` を M2.1 から **read-only で参照**。 corpus 編集権限は M2.1 に集約、 M2.2 は consumer のみ
+- corpus 編集が必要な場合は M2.1 ticket に request、 両者でレビューしてから merge
+
+### M3.1 (Public ABI snapshot) への引き継ぎ
+
+- 本チケットで 6 runtime に追加する `--dump-wav` flag は M3.1 で `public-abi-snapshot.yml` の対象になる (CLI signature の一部として記録)
+- baseline JSON の schema design pattern (schema_version / SHA256 / canonical runtime) は M3.1 の `tests/fixtures/public-abi/{c,swift,kotlin}.json` の参考
+
+### M-Stretch (cross-runtime differential testing 完全版) への引き継ぎ
+
+- 本チケットで実装する `--dump-wav` flag は、 M-Stretch で **`--dump-ort-inputs`** / **`--dump-phonemes`** / **`--dump-ssml-ast`** 追加の前例として再利用される
+- `scripts/audio_parity.py` の階層判定設計は、 ORT input tensor parity / SSML AST parity でも「階層判定 + threshold 設計」 として流用可能
+- 7 runtime のうち iOS Swift / Android Kotlin の decoder 推論統合は M-Stretch のスコープ
+
+### M-Stretch (Bencher dashboard) への引き継ぎ
+
+- `scripts/audio_parity.py` の出力 JSON は M-Stretch で Bencher Adapter 互換 schema に変換
+- divergence trend を時系列で見るために Bencher 化が有用
+
+### 4 週間後の blocker 昇格判定タイミング
+
+- M2 開始から 4 週後 (= M3 開始時) に maintainer が以下を実施:
+  1. `gh api repos/ayutaz/piper-plus/actions/workflows/runtime-parity-deep.yml/runs` で 4 週分の run を収集
+  2. 各 run の fail を「真の divergence」 / 「false positive (浮動小数 ABI 差)」 に分類
+  3. M2-overview.md §「informational → blocker 昇格判定基準」 の 3 条件を判定
+  4. model 別 / runtime 別に判定 (3 model のうち 1 model だけ問題なら他 2 つを blocker、 1 つは informational 継続のような部分昇格も可)
+  5. 判定結果を `docs/proposals/ci-expansion-milestones.md` に追記
+- 昇格しない場合は **informational 継続** または **M-Stretch (Bencher dashboard 化)** の選択
+
+---
+
+## 8. 関連ファイル
+
+### 新規作成
+
+- `.github/workflows/runtime-parity-deep.yml`
+- `scripts/audio_parity.py`
+- `tests/fixtures/audio-parity-baseline.json`
+- `docs/spec/audio-parity-contract.toml`
+- `tests/unit/test_audio_parity.py`
+- `src/rust/piper-cli/tests/test_dump_wav.rs`
+- `src/csharp/PiperPlus.Cli.Tests/DumpWavTests.cs`
+- `src/go/cmd/piper-plus/dump_wav_test.go`
+- `src/cpp/tests/test_dump_wav.cpp`
+- `src/wasm/openjtalk-web/test/js/dump_wav.test.js`
+- `src/wasm/openjtalk-web/scripts/cli-dump.js` (Node.js CLI entry、 存在しない場合)
+
+### 既存変更
+
+- `src/python_run/piper/__main__.py` — `--dump-wav` flag (既存 `--output-file` で代用可なら no-op)
+- `src/rust/piper-cli/src/main.rs` — `--dump-wav` flag
+- `src/csharp/PiperPlus.Cli/Program.cs` — `--dump-wav` flag
+- `src/go/cmd/piper-plus/main.go` — `--dump-wav` flag
+- `src/cpp/piper_plus_cli.cpp` — `--dump-wav` flag
+- `src/wasm/openjtalk-web/src/index.js` — synthesize → WAV buffer 露出 API
+- `CHANGELOG.md` — `[Unreleased] > Added` に各 runtime `--dump-wav` flag 追加
+- `docs/reference/cli-help/{python,rust,csharp,go,wasm,cpp}.txt` — CLI help 自動再生成 (M-Stretch Docs Tier S #3 の延長)
+
+### 参照のみ
+
+- `tests/fixtures/audio-corpus/` — M2.1 で作成済 fixture を共有
+- `docs/spec/ort-session-contract.toml` — ORT session 設定の前提
+- `docs/spec/short-text-contract.toml` — silence padding A/B/C の前提
+- `docs/reference/ort-versions.md` — ORT version pinning
+- `CLAUDE.md` — 3 model の出典・パス情報
+
+---
+
+## 9. 参照
+
+- [M2 phase overview](./M2-overview.md)
+- [M2.1 Audio MOS proxy gate (前提)](./M2-1-audio-mos-proxy.md)
+- [親調査 §2.2 音声品質](../proposals/ci-expansion-2026-05.md)
+- [親調査 §3.2 Cross-runtime differential testing](../proposals/ci-expansion-2026-05.md)
+- [親調査 §5 Top 10 #2](../proposals/ci-expansion-2026-05.md)
+- [親マイルストーン §M2.2](../proposals/ci-expansion-milestones.md#m22--cross-runtime-audio-byte-parity-top-10-2)
+- [M1.1 cancelled baseline alarm (前提)](./M1-1-cancelled-baseline-alarm.md)
+- [`.github/workflows/timing-parity.yml`](../../.github/workflows/timing-parity.yml) — 既存 parity gate の参考
+- [`.github/workflows/parity-hub.yml`](../../.github/workflows/parity-hub.yml) — parity gate 集約 workflow
+- AcoustID chromaprint (Lukáš Lalinský, 2010)
+- ITU-T G.711 / G.722 SNR conventions

--- a/docs/tickets/M2-overview.md
+++ b/docs/tickets/M2-overview.md
@@ -1,0 +1,175 @@
+# M2: Audio Quality Moat — Phase Overview
+
+**親マイルストーン**: [ci-expansion-milestones.md §M2](../proposals/ci-expansion-milestones.md#m2-audio-quality-moat)
+**親調査**: [ci-expansion-2026-05.md](../proposals/ci-expansion-2026-05.md)
+**期間**: Month 2 (4 週)
+**前提**: [M1.1 cancelled baseline alarm](./M1-1-cancelled-baseline-alarm.md) が稼働済
+**作成日**: 2026-05-18
+
+---
+
+## フェーズの狙い
+
+piper-plus は 93 workflow + 18+ contract gate を抱えながら、 **「合成音声そのものの user-visible regression」 を直接検出する gate が空白** という極めて非対称な状況にある。 既存の RTF / memory / bundle size gate は「速度・サイズ」 を見ているが、 「**音声品質**」 「**7 ランタイム間の音声等価性**」 という 2 軸は事実上 manual listening 任せで運用されてきた。 PR #320 (MB-iSTFT decoder 置換) や PR #499 系 (EOS trim) のように decoder / 後処理に手を入れると音声品質が静かに劣化するリスクは構造的に存在する。
+
+M2 はこの **piper-plus 最大の盲点** を 2 軸で塞ぐフェーズである。
+
+1. **音声品質 MOS proxy gate** (Top 10 #1) — PESQ-WB / STOI / UTMOS proxy / Whisper WER を **PR ごと** に golden corpus に対して計算し、 baseline JSON と diff を取って閾値割れで fail
+2. **Cross-runtime audio byte parity** (Top 10 #2) — 7 ランタイム × 3 model で「同一入力 → 同一音声」 を SHA256 / RMSE / chromaprint fingerprint / mel-spectrogram MSE の階層化で検証
+
+両者は fixture / golden sample を共有する設計とし、 M2.1 が先行し M2.2 が follow する依存関係になる。
+
+設計上の核は **最初の 4 週間を informational tier (non-blocking) で運用すること**。 浮動小数差 / ORT provider 差 / 音響指標の本質的な揺らぎを実測した上で blocker 化判定を行う。 これは PR #419 で発覚した「validation green に見えるが何も verify していない」 問題の逆パターン (false positive で merge を妨害して contributor friction を生む) を避けるための保険でもある。
+
+---
+
+## 含まれるチケット
+
+| ID | タイトル | Top 10 # | 想定工数 | 優先度 |
+|----|---------|---------|---------|--------|
+| [M2.1](./M2-1-audio-mos-proxy.md) | Audio MOS proxy gate (PESQ / STOI / UTMOS / WER) | #1 | 3-4 PR (~30h) | 高 |
+| [M2.2](./M2-2-cross-runtime-audio-parity.md) | Cross-runtime audio byte parity (7 runtime × 3 model) | #2 | 4-5 PR (~40h) | 高 |
+
+合計 7-9 PR / ~70h。 4 週で 1 maintainer が消化可能な上限近く、 並走には audio quality engineer 1 名 + runtime integration 各 1 名のチーム編成を要する。
+
+依存関係:
+
+```mermaid
+graph LR
+    M11[M1.1 cancelled baseline alarm] --> M21[M2.1 MOS proxy gate]
+    M21 --> M22[M2.2 cross-runtime audio parity]
+    M21 -.fixture 共有.-> M22
+    M22 --> M3[M3 ABI snapshot]
+    M21 --> Stretch[M-Stretch Bencher dashboard]
+```
+
+M1.1 が前提なのは、 M2 で新規導入する workflow が cancelled で silently skip されるリスクを cancelled baseline alarm で塞いだ後でないと、 informational → blocker 昇格判定そのものが信用できないため。
+
+---
+
+## なぜ informational tier から始めるのか
+
+audio quality と cross-runtime audio parity の 2 軸は、 既存の Format / Lint / version sync 系 gate と比べて **信号が確率的になる** 性質を持つ。 具体的には以下の理由で、 一気に blocker 化すると false positive が多発して contributor を消耗させる。
+
+### 1. 音響指標自体の揺らぎ
+
+- **PESQ-WB**: ITU-T P.862.2 アルゴリズム、 reference / degraded 間の MOS-LQO 推定。 piper-plus が出力する 22050 Hz audio に対しては理論上ばらつき少ないが、 短文 (< 1 秒) では信頼性が下がる
+- **STOI**: short-time objective intelligibility、 0-1 スコア。 短文での信頼性は PESQ より低い
+- **UTMOS22**: SSL representation ベース MOS proxy、 PyTorch 推論依存。 同一入力でも seed / device 依存で ±0.05 程度の揺らぎ
+- **Whisper WER**: ASR 経由の word error rate。 ja / zh のような音節言語では「単語境界」 の定義そのものが揺らぎ、 英語 (LibriTTS-R) 基準より高い natural variance を持つ
+
+### 2. ORT provider × OS 差
+
+ONNX Runtime は CPU EP でも MKL / OpenMP の実装差により浮動小数演算順序が変わる。 Linux / macOS / Windows で **bit-exact** ではなく、 SHA256 一致を要求すると即座に fail する。 RMSE / mel-spec MSE / SNR 閾値による許容設計が必須になるが、 「どの閾値が user-visible regression を捉えるか」 は実測でしか決まらない。
+
+### 3. FP16 / decoder アルゴリズム差
+
+`--no-fp16` が default off なので、 export 時の FP16 量子化で各 runtime の演算順序差が増幅される。 MB-iSTFT decoder の PQMF / iSTFT 実装が runtime 間で完全に同一かは未検証であり、 informational 期間中にこれを実測しないと閾値設計ができない。
+
+### 4. False positive の連鎖リスク
+
+contributor が「benign な refactor PR」 を出したときに MOS proxy gate が fail すると、 PR を諦めるか「flake だから rerun する」 文化が定着してしまう (PR #419 の cancelled silent skip と対称の問題)。 4 週 informational で **false positive 率 < 5%** を確認してから blocker 化することで、 この硬直化を回避する。
+
+### informational → blocker 昇格判定基準
+
+M3 開始時 (M2 開始から 4 週後) に以下の 3 条件を全て満たした場合のみ blocker 化:
+
+1. 4 週間中、 真の regression を検出した PR が 1 件以上ある (true positive 確認)
+2. 同期間中、 false positive 率 < 5% (rerun 不要で merge された PR 数 / 全 fail 数)
+3. CI 経過時間が PR 全体の tail latency を 5 分以上延長していない
+
+満たさなかった場合は informational 継続、 または M-Stretch (Bencher dashboard 化) への path で「PR gate ではなく trend 監視」 に再設計する。
+
+---
+
+## 一から設計し直すとしたら (Phase-level reinvention)
+
+M2 の方針自体を一度疑い、 alternative を 4 軸で並べた。 採用判断の参考として残す。
+
+### 1. アーキテクチャ: 本当に CI gate が正しいレイヤーか
+
+| alternative | 採用 | 理由 |
+|------------|------|------|
+| **PR gate (現案)** | yes | regression を merge 前に検出できる、 git bisect 不要 |
+| Nightly benchmark のみ | partial (M-Stretch) | tail latency 0、 ただし regression 発見は事後 |
+| リリース前 manual gate のみ | no | v1.12.0 breaking のような事例で人間が見落とす |
+| Bencher dashboard (informational のみ) | M2 期間の form | trend 可視化が PR feedback より強い |
+
+採用案: **PR gate (informational 4 週) → blocker または Bencher dashboard 化の二択**。 informational 期間中に collected data を Bencher に流し込めるよう、 metric 出力 schema は M2.1 時点で Bencher Adapter 互換 (JSON) にしておく (M-Stretch 連携)。
+
+### 2. 設計: PESQ / STOI / UTMOS という 3 指標は piper-plus にとって意味があるか
+
+PESQ-WB / STOI は元々 telecommunication speech (codec / VoIP) 用途で設計されており、 **TTS の合成音声に対しては理論上は不適合**。 とはいえ piper-plus が「baseline からの劣化検出」 用途で使うなら、 絶対値ではなく **相対差** で意味を持つ。 UTMOS は近年の TTS 専用 SSL ベース MOS proxy で piper-plus 用途に近いが、 PyTorch dependency が ~3GB と重く CI 実行時間に影響する。
+
+代替案として、 **「人間が聴いて regression と判定できる cluster」** を 1 度作っておき、 そこに対する各指標の sensitivity を実測する手もある。 ja / zh のような音節言語に対しては、 PESQ / STOI より **pitch contour DTW 距離** や **mel-spec L1 norm** のほうが感度が高い可能性がある。 M2.1 informational 期間中に複数指標を並列計算しておけば、 後で「どれを blocker 化するか」 を data-driven に決められる。
+
+### 3. 実装: 7 ランタイム全てで「同じ入力 → 同じ音声」 を要求するのは過剰か
+
+byte 一致を要求するなら過剰だが、 mel-spec MSE ≤ 1e-3 / SNR ≥ 60 dB ならば user-visible 等価性として妥当。 7 runtime のうち WASM / iOS / Android G2P は phoneme まで一致を保証していて、 ORT 推論部分は 7 runtime 共通 .onnx を読むため、 真の差は **runtime 固有の前処理 / 後処理コード** に集約される。 ここに drift があれば検出する価値は高い。
+
+ただし、 「**phoneme まで一致**」 の上で「**ORT 出力 logits まで一致**」 を Top 10 #2 の前段として入れる選択肢もある (親 doc §3.2 の "Golden ONNX inputs" 項目)。 これは M-Stretch (cross-runtime differential testing 完全版) で扱うが、 M2.2 で `--dump-wav` flag を実装しておけば後で `--dump-ort-inputs` の追加コストは低い。
+
+### 4. 思考プロセス: MOS proxy が「品質維持」 ではなく「品質向上ループ」 のためだったら
+
+PR ブロック型 gate ではなく、 **leaderboard 形式** にする選択肢。 各 PR で MOS proxy / WER score を sticky comment で表示し、 「baseline 比 +N%」 を可視化、 maintainer が「品質向上 PR」 を merge する文化を醸成する。 これは Bencher dashboard と親和性が高く、 M-Stretch で実装する。
+
+M2 期間中は **品質維持 (regression 防止) を主軸**、 **品質向上ループ** は M-Stretch 移行後の運用課題とする。 これは「unlimited CI」 を額面通り受け取らず、 piper-plus が直面している **最も致命的な盲点** から塞ぐ親 doc §4 の判断に従う。
+
+---
+
+## 後続フェーズへの連絡事項
+
+### M3 (ABI snapshot) への引き継ぎ
+
+- M2.1 で commit する `tests/fixtures/audio-mos-baseline.json` の schema 設計 (version pin / dataset / model hash の埋め込み) は、 M3.1 で commit する `tests/fixtures/public-abi/{c,swift,kotlin}.json` の参考にできる
+- M2 末尾に 4 週間 informational 観測結果をまとめ、 M3 開始時に blocker 昇格判定を行う (判定 owner: maintainer、 判定基準は本ドキュメント上記 §3 の 3 条件)
+
+### M-Stretch (Bencher dashboard) への引き継ぎ
+
+- M2.1 で作成する `scripts/audio_quality_metrics.py` の出力 JSON schema は **Bencher Adapter 互換** にしておく。 具体的には `{ "name": str, "value": float, "unit": str, "lower_value": float|null, "upper_value": float|null }` array 形式。 これにより M-Stretch で Bencher 移行する際の追加作業が最小化する
+- M2.2 で各 runtime に追加する `--dump-wav` flag は、 M-Stretch (cross-runtime differential testing 完全版) で **`--dump-ort-inputs` / `--dump-phonemes` / `--dump-ssml-ast`** の前例として再利用される
+
+### Golden corpus 設計の波及
+
+M2.1 の `tests/fixtures/audio-corpus/` (短文 / 長文 / SSML / ZH-EN 混在 / PUA の 5 カテゴリ × 6 言語 × 5 サンプル = 150 ファイル想定) は以下の後続作業でも fixture base として使う。
+
+- M2.2 cross-runtime audio parity (同 corpus を 7 runtime で合成して byte 比較)
+- M-Stretch SSML AST parity (SSML カテゴリのテキストを各 runtime で parse して AST 比較)
+- M-Stretch G2P differential testing (ZH-EN 混在 / PUA カテゴリを Python ↔ Rust G2P で出力等価性検証)
+
+corpus は LFS に置くか、 plain text + commit hash で sample 音声を nightly 再生成するか、 M2.1 開始時に決定する (現案: text は git にコミット、 baseline 音声は CI artifact / HF Hub にホスト)。
+
+### 4 週間後の blocker 昇格判定タイミング
+
+M2 開始から 4 週後 (= M3 開始時) に maintainer が以下を実施。
+
+1. `gh api repos/ayutaz/piper-plus/actions/workflows/audio-mos-proxy.yml/runs --paginate` で 4 週分の run を収集
+2. fail した run について「真の regression か / false positive か」 を log + spectrogram で分類
+3. 上記 §「informational → blocker 昇格判定基準」 の 3 条件を満たすか判定
+4. 結果を `docs/proposals/ci-expansion-milestones.md` に追記、 M3 開始通知の PR に含める
+
+---
+
+## 関連リンク
+
+### チケット
+
+- [M2.1 Audio MOS proxy gate](./M2-1-audio-mos-proxy.md)
+- [M2.2 Cross-runtime audio byte parity](./M2-2-cross-runtime-audio-parity.md)
+
+### 親ドキュメント
+
+- [ci-expansion-milestones.md §M2](../proposals/ci-expansion-milestones.md#m2-audio-quality-moat)
+- [ci-expansion-2026-05.md §2.2 音声品質](../proposals/ci-expansion-2026-05.md)
+- [ci-expansion-2026-05.md §3.2 Cross-runtime differential testing](../proposals/ci-expansion-2026-05.md)
+
+### 前提チケット
+
+- [M1.1 Cancelled baseline alarm](./M1-1-cancelled-baseline-alarm.md)
+
+### 既存資産
+
+- [`tools/benchmark/`](../../tools/benchmark/) — MOS サンプル生成、 PESQ/STOI 計算、 調査フォーム生成
+- [`tools/benchmark/compute_metrics.py`](../../tools/benchmark/compute_metrics.py) — UTMOS 計算機能あり
+- [`.github/workflows/multi-runtime-rtf.yml`](../../.github/workflows/multi-runtime-rtf.yml) — RTF gate (M2 が参考にする baseline JSON pattern)
+- [`docs/spec/ort-session-contract.toml`](../spec/ort-session-contract.toml) — ORT session 仕様 (M2.2 の浮動小数差許容設計の前提)

--- a/docs/tickets/M3-1-public-abi-snapshot.md
+++ b/docs/tickets/M3-1-public-abi-snapshot.md
@@ -1,0 +1,520 @@
+# [M3.1] Public ABI snapshot (C / Swift / Kotlin)
+
+**親マイルストーン**: [M3 ABI & Ecosystem Hardening](./M3-overview.md)
+**親調査**: [ci-expansion-2026-05.md §Top 10 #4](../proposals/ci-expansion-2026-05.md)
+**Top 10 内番号**: #4
+**ステータス**: 未着手
+**想定工数**: 3 PR (~25h)
+**優先度**: 高
+**作成日**: 2026-05-18
+
+---
+
+## 1. タスクの目的とゴール
+
+### 目的
+
+piper-plus が publish する **C API / Swift / Kotlin の public signature** を JSON snapshot
+として fixture commit し、 PR で diff 検出 → **非互換変更 (削除 / 型変更) で fail、 追加のみ pass** とする CI gate を構築する。
+
+### なぜ必要か
+
+- **既存 gate の盲点**: `cpp-abi-check.yml` は libabigail abidiff で C API のみ検査。
+  Swift Package (`Package.swift`) と Kotlin AAR (`io.github.ayutaz:piper-plus-g2p-android`)
+  の public signature 変更は **どの workflow でも検出されない**。
+- **semver 違反は publish 後修正不可**: 一度 SPM / Maven Central / NuGet / crates.io に
+  publish した artifact は yank しても downstream の lockfile に残り続ける。
+  「publish 前検出」 が唯一の現実的防御線。
+- **mobile 配信の前提条件**: iOS xcframework (`Package.swift`) と Kotlin AAR は v1.13.0+
+  M4 マイルストーンで正式 publish 予定。 ABI gate 不在のまま release すると次の
+  minor / patch bump で silent break するリスク。
+
+### ゴール (完了基準)
+
+- `.github/workflows/public-abi-snapshot.yml` workflow が dev / PR / push trigger で動作
+- `tests/fixtures/public-abi/{c,swift,kotlin}.json` の 3 baseline JSON が commit 済
+- PR で baseline と diff し、 **削除 / 型変更 → fail**、 **追加のみ → pass**、
+  詳細差分を PR sticky comment に投稿
+- baseline 更新ワークフロー (`update-abi-baseline` label / `[update-abi-baseline]` commit message)
+  で意図的な breaking 更新を許容
+
+---
+
+## 2. 実装する内容の詳細
+
+### 2.1 全体アーキテクチャ
+
+```mermaid
+flowchart TD
+    A[PR trigger] --> B[3 並列 job]
+    B --> B1[c-abi-extract]
+    B --> B2[swift-abi-extract]
+    B --> B3[kotlin-abi-extract]
+
+    B1 --> C1[libpiper_plus.so 軽量 build]
+    C1 --> D1[nm -D + abi-dumper で抽出]
+    D1 --> E1[c.json 生成]
+
+    B2 --> C2[swift package describe]
+    C2 --> D2[symbol graph 抽出]
+    D2 --> E2[swift.json 生成]
+
+    B3 --> C3[binary-compatibility-validator]
+    C3 --> D3[api ファイル生成]
+    D3 --> E3[kotlin.json 生成]
+
+    E1 --> F[diff job]
+    E2 --> F
+    E3 --> F
+
+    F --> G{baseline と diff}
+    G -->|削除/型変更| H[fail + sticky comment]
+    G -->|追加のみ| I[pass + sticky comment]
+    G -->|update-abi-baseline label| J[baseline 自動更新 PR]
+```
+
+### 2.2 C API ABI 抽出
+
+既存 `libpiper_plus.so` (Linux) / `libpiper_plus.dylib` (macOS) / `piper_plus.dll` (Windows) の
+3 platform の symbol を統一抽出。
+
+**抽出コマンド (Linux 例)**:
+
+```bash
+# 1. shared lib build (release, stripped)
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED=ON
+cmake --build build --target piper_plus -j
+
+# 2. dynamic symbol 一覧
+nm -D --defined-only build/libpiper_plus.so \
+    | awk '$2=="T" {print $3}' \
+    | sort -u > c-symbols.txt
+
+# 3. struct layout / function signature
+abi-dumper build/libpiper_plus.so -o c-abi.xml \
+    -lver 1.13.0 -public-headers src/cpp/piper_plus.h
+```
+
+**統一 JSON schema (`c.json`)**:
+
+```json
+{
+  "schema_version": 1,
+  "platform": "linux-x86_64",
+  "library": "libpiper_plus.so",
+  "version_tag": "v1.13.0",
+  "symbols": [
+    {
+      "name": "piper_plus_synthesize",
+      "kind": "function",
+      "signature": "int piper_plus_synthesize(piper_plus_voice_t*, const char*, piper_plus_audio_t*)",
+      "visibility": "public",
+      "since_version": "1.0.0"
+    }
+  ],
+  "structs": [
+    {
+      "name": "piper_plus_voice_t",
+      "size_bytes": 128,
+      "alignment": 8,
+      "fields": [
+        {"name": "model_path", "offset": 0, "type": "const char*", "size": 8}
+      ]
+    }
+  ],
+  "enums": [
+    {
+      "name": "piper_plus_result_t",
+      "underlying_type": "int32_t",
+      "values": [
+        {"name": "PIPER_PLUS_OK", "value": 0},
+        {"name": "PIPER_PLUS_ERROR_INVALID_ARG", "value": 1}
+      ]
+    }
+  ]
+}
+```
+
+**Diff ルール**:
+
+| 変更種別 | C API | 判定 |
+|----------|-------|------|
+| symbol 削除 | function / struct / enum value | **fail** |
+| 型変更 | function signature / struct size / enum underlying | **fail** |
+| field 順序変更 | struct fields の offset 変動 | **fail** |
+| field 追加 | struct 末尾追加 (size 増加) | **fail** (ABI break) |
+| 新 symbol 追加 | new function / struct | pass |
+| 新 enum value 末尾追加 | 既存値を変更しない | pass |
+
+### 2.3 Swift ABI 抽出
+
+`swift package describe --type json` + Swift Symbol Graph (`-emit-symbol-graph`) を使う。
+
+**抽出コマンド**:
+
+```bash
+# 1. package describe (high-level structure)
+swift package describe --type json > swift-package.json
+
+# 2. symbol graph 抽出 (詳細 API surface)
+swift build -Xswiftc -emit-symbol-graph \
+    -Xswiftc -emit-symbol-graph-dir -Xswiftc .build/symbol-graphs
+```
+
+**統一 JSON schema (`swift.json`)**:
+
+```json
+{
+  "schema_version": 1,
+  "platform": "apple-universal",
+  "package": "PiperPlus",
+  "version_tag": "v1.14.0",
+  "products": [
+    {"name": "PiperPlus", "type": "library", "targets": ["PiperPlus"]},
+    {"name": "PiperPlusG2P", "type": "library", "targets": ["PiperPlusG2P"]}
+  ],
+  "symbols": [
+    {
+      "kind": "class",
+      "name": "PiperPlus.Voice",
+      "access_level": "public",
+      "is_final": false,
+      "members": [
+        {
+          "kind": "function",
+          "name": "synthesize(text:speakerId:)",
+          "signature": "func synthesize(text: String, speakerId: Int) async throws -> AudioResult",
+          "access_level": "public"
+        }
+      ]
+    },
+    {
+      "kind": "struct",
+      "name": "PiperPlus.AudioResult",
+      "access_level": "public",
+      "members": [
+        {"kind": "property", "name": "samples", "type": "[Float]", "access_level": "public"}
+      ]
+    }
+  ]
+}
+```
+
+**Diff ルール**:
+
+| 変更種別 | Swift | 判定 |
+|----------|-------|------|
+| public symbol 削除 | class / struct / function / property | **fail** |
+| access_level 降格 | `public` → `internal` | **fail** |
+| signature 変更 | async / throws / 引数型 / 返り値型 | **fail** |
+| `final` 追加 | open class → final class | **fail** (subclass 破壊) |
+| 新 public symbol | new function / class | pass |
+| internal の変更 | access_level: internal | 検査対象外 |
+
+### 2.4 Kotlin ABI 抽出
+
+`binary-compatibility-validator` Gradle plugin (`org.jetbrains.kotlinx.binary-compatibility-validator`)
+を使う。 既に Kotlin / JVM ecosystem で de facto standard。
+
+**Gradle 設定**:
+
+```kotlin
+// android/piper-plus-g2p/build.gradle.kts
+plugins {
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.16.3"
+}
+
+apiValidation {
+    ignoredPackages.add("io.github.ayutaz.piperplus.internal")
+    nonPublicMarkers.add("io.github.ayutaz.piperplus.InternalApi")
+}
+```
+
+抽出される `api/piper-plus-g2p.api` ファイル (text 形式) を JSON 変換:
+
+**変換 script (`scripts/kotlin_api_to_json.py`)**:
+
+```python
+import re, json, sys
+from pathlib import Path
+
+def parse_kotlin_api(text: str) -> dict:
+    """`*.api` の plain text を JSON schema に変換"""
+    symbols = []
+    current_class = None
+    for line in text.splitlines():
+        if m := re.match(r'^public\s+(?:final\s+)?(class|interface|object)\s+(\S+)', line):
+            current_class = {"kind": m.group(1), "name": m.group(2), "members": []}
+            symbols.append(current_class)
+        elif m := re.match(r'^\s+public\s+(?:final\s+)?fun\s+(\S+)', line):
+            if current_class:
+                current_class["members"].append({"kind": "function", "signature": m.group(0).strip()})
+    return {"schema_version": 1, "platform": "android-aar",
+            "package": "io.github.ayutaz.piper-plus-g2p-android",
+            "symbols": symbols}
+```
+
+**統一 JSON schema (`kotlin.json`)**:
+
+```json
+{
+  "schema_version": 1,
+  "platform": "android-aar",
+  "package": "io.github.ayutaz:piper-plus-g2p-android",
+  "version_tag": "v1.0.0",
+  "symbols": [
+    {
+      "kind": "class",
+      "name": "io/github/ayutaz/piperplus/G2P",
+      "is_public": true,
+      "is_final": true,
+      "members": [
+        {
+          "kind": "function",
+          "signature": "public final fun phonemize(text: String, language: String): List<String>"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 2.5 軽量 build-only path の設計
+
+xcframework / AAR の release artifact を PR ごとに生成すると CI 時間が ~30 分かかる。
+ABI 抽出には **symbol 情報のみ必要** で release artifact は不要なため、 軽量 build-only path を実装:
+
+```yaml
+# .github/workflows/public-abi-snapshot.yml (抜粋)
+jobs:
+  swift-abi-extract:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Swift package describe (no compile)
+        run: swift package describe --type json > /tmp/swift-package.json
+      - name: Emit symbol graph (release, no codesign)
+        run: |
+          swift build \
+            -c release \
+            -Xswiftc -emit-symbol-graph \
+            -Xswiftc -emit-symbol-graph-dir -Xswiftc /tmp/symbol-graphs \
+            --target PiperPlus
+        # codesign / xcframework 生成は skip、 symbol graph のみ抽出 (~3 分)
+```
+
+Kotlin も同様に `./gradlew apiDump` のみ実行し、 AAR build は skip (~2 分)。
+
+### 2.6 baseline 更新フロー
+
+意図的な breaking 変更時の運用:
+
+```bash
+# 1. PR で signature 変更
+# 2. CI が fail (baseline と diff)
+# 3. PR に `update-abi-baseline` label を付与
+# 4. workflow が新 JSON を auto-commit (baseline 更新 PR を作る)
+# 5. レビュアーが 「これは意図された breaking か」 を確認
+# 6. main merge 時に new baseline が反映される
+```
+
+```yaml
+# label trigger workflow snippet
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  update-baseline:
+    if: github.event.label.name == 'update-abi-baseline'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Regenerate baseline & commit
+        run: |
+          ./scripts/regenerate_abi_baseline.sh
+          git config user.name "github-actions[bot]"
+          git add tests/fixtures/public-abi/
+          git commit -m "chore(abi): update baseline for $(git rev-parse --short HEAD)"
+          git push
+```
+
+---
+
+## 3. エージェントチームの役割と人数
+
+合計 **4-5 名** で実装:
+
+| 役割 | 人数 | 主な担当 |
+|------|------|----------|
+| ABI specialist (C) | 1 | `abi-dumper` / `nm` / libabigail 連携、 既存 `cpp-abi-check.yml` の延長判断 |
+| ABI specialist (Swift) | 1 | `swift package describe` / symbol graph / xcframework 軽量 build |
+| ABI specialist (Kotlin) | 1 | `binary-compatibility-validator` plugin / `apiDump` フロー / AAR 軽量 build |
+| Workflow / Scripts author | 1 | `public-abi-snapshot.yml` / `kotlin_api_to_json.py` / 統一 JSON schema / diff logic |
+| Reviewer | 1 (兼任可) | 統一 JSON schema レビュー / baseline JSON 更新フローの sanity check |
+
+**進行モデル**: 3 言語の specialist が並列で抽出 script を実装し、 workflow author が
+diff logic と統一 JSON schema を担当。 reviewer は最終 PR の sanity check のみ。
+
+---
+
+## 4. 提供範囲とテスト項目
+
+### Unit テスト
+
+- `scripts/kotlin_api_to_json.py` の text → JSON 変換 (正常系 / コメント混在 / nested class)
+- C JSON schema の `version_tag` parser (`v1.13.0` / `v1.13.0-rc1` / `v1.13.0+local` の 3 形式)
+- Swift symbol graph JSON の access_level (public / open / internal / private) filtering
+- Diff logic: 削除 / 型変更 / 追加 を 3 cases × 3 言語で table-driven test
+
+### E2E / 統合テスト
+
+- 3 言語の baseline JSON を初期 commit し、 dev で CI green になることを確認
+- 故意に C function 削除 PR → fail することを確認
+- 故意に Swift property 追加 PR → pass することを確認
+- 故意に Kotlin class を `final` 化 PR → fail することを確認
+- `update-abi-baseline` label workflow の auto-commit が動作することを確認
+
+### 手動検証項目
+
+- 3 platform (Linux / macOS / Windows) で C ABI 抽出結果に差がないか
+  (calling convention / struct padding の OS 差を確認)
+- Swift xcframework の simulator slice / device slice で symbol graph が同一か
+- Kotlin AAR の minSdkVersion 24 / 31 / 35 で API ファイルが同一か
+
+---
+
+## 5. 懸念事項とレビュー観点
+
+### 懸念事項
+
+1. **xcframework / AAR 軽量 build の安定性**
+   `swift build` で symbol graph 抽出時に xcframework と挙動が異なる可能性。
+   release artifact ベースの抽出に fallback できる設計が必要。
+
+2. **3 言語の統一 JSON schema の妥当性**
+   C (struct layout) / Swift (protocol / generics) / Kotlin (extension functions) は
+   表現力が異なる。 統一 schema が C の細かさを犠牲にしていないか要確認。
+
+3. **既存 `cpp-abi-check.yml` との重複**
+   libabigail abidiff の XML 出力と新 JSON schema の二重メンテになる可能性。
+   net flat policy として M3 完了後に削除判断する。
+
+4. **baseline 更新の自動化リスク**
+   `update-abi-baseline` label を maintainer 以外が付けられないよう、
+   label workflow の `permissions:` / branch protection を厳格化する必要。
+
+### レビュー観点
+
+- [ ] 統一 JSON schema が 3 言語の差を吸収しつつ semver 判定に十分な情報を持つか
+- [ ] 軽量 build path が release artifact 生成と同じ symbol を出すか (差異がないか)
+- [ ] `update-abi-baseline` label workflow に bypass 脆弱性がないか
+- [ ] 既存 `cpp-abi-check.yml` と重複する範囲が明確で、 deprecate plan があるか
+- [ ] PR sticky comment が `feedback_pr_body_over_comments` 準拠か (新規コメント追加せず本文 update)
+
+---
+
+## 6. 一から作り直すとしたら
+
+### 案 A: ABI snapshot を CI gate ではなく semver 専用 bot 化する
+
+ABI snapshot を PR blocker にせず、 publish 直前に **bot が自動で semver bump 提案**
+を行う設計。 例: `cargo-semver-checks` (Rust) と同じ思想で、 C / Swift / Kotlin にも
+semver-bump-suggester を実装する。
+
+| 比較軸 | CI gate (現案) | semver bot |
+|--------|----------------|------------|
+| 検出タイミング | PR 時 | release 直前 |
+| 修正コスト | PR rebase で吸収 | release blocker (重い) |
+| false positive | baseline 更新で吸収可 | bot 誤判定が release 妨害 |
+| 実装複雑度 | 中 | 高 (bump 自動提案) |
+
+**結論**: CI gate (現案) の方が piper-plus の release 頻度 (quarterly + patch) に適合。
+semver bot は M-Stretch で別検討。
+
+### 案 B: release 前 manual review
+
+ABI gate を CI 化せず、 release engineer が release 前に手動で diff を確認する運用。
+
+- pros: 工数最小、 false positive ゼロ
+- cons: release 直前に発見すると blocker / release delay、 reviewer の見落としリスク
+
+**結論**: 不採用。 release が quarterly になると 「3 ヶ月分の ABI 変更を一気にレビュー」
+は実用上不可能。 PR ごとに小さく gate するのが妥当。
+
+### 案 C: 1 言語のみで start (C のみ / Swift のみ)
+
+scope を絞り、 1 言語のみで運用してから他言語に拡大する。
+
+- pros: scope 最小、 false positive 率を 1 言語で観測してから拡大可能
+- cons: Swift / Kotlin の mobile release が M4 で控えており、 C のみ先行 → 3 ヶ月後に
+  慌てて Swift / Kotlin 追加すると schedule 圧迫
+
+**結論**: 3 言語並列実装が最適。 ただし baseline JSON は 1 言語ずつ commit し、 段階的
+green 化する戦略は有効。
+
+---
+
+## 7. 後続タスクへの連絡事項
+
+### M3.2 / M3.3 への影響
+
+- M3.2 (license auto-injection) の `data-sources.yml` schema 設計時に、
+  M3.1 の JSON schema 設計パターンを再利用する。 `schema_version: 1` + forward-compat
+  loader の 2 パターンを共通化推奨。
+- M3.3 (typosquatting scan) は M3.1 と独立だが、 「publish 前検査 (M3.1) /
+  publish 後監視 (M3.3)」 の対比として README で説明可能。
+
+### M-Stretch への接続
+
+- M-Stretch cross-runtime differential testing 完全版 (親 doc §3.2) で
+  `--dump-ort-inputs` flag を 7 runtime 全実装する際、 M3.1 の統一 JSON schema 設計
+  パターンが入力になる。
+- M-Stretch SLSA Build L3 で provenance に ABI snapshot hash を含めると、
+  「どの commit のどの ABI で artifact を build したか」 が追跡可能になる。
+
+### 既存 workflow との関係整理 (M3 完了後)
+
+- `cpp-abi-check.yml` (libabigail) を deprecate するか、 補完として残すか判断
+- `public-api-diff.yml` (.NET ApiCompat) を M3.1 の C# 部分として統合検討
+  (Top 10 #4 は C / Swift / Kotlin のみだが、 C# も将来追加可能)
+
+---
+
+## 8. 関連ファイル
+
+### 新規作成
+
+- `.github/workflows/public-abi-snapshot.yml` — メイン workflow
+- `tests/fixtures/public-abi/c.json` — C API baseline
+- `tests/fixtures/public-abi/swift.json` — Swift baseline
+- `tests/fixtures/public-abi/kotlin.json` — Kotlin baseline
+- `scripts/extract_c_abi.sh` — C ABI 抽出 script
+- `scripts/extract_swift_abi.sh` — Swift ABI 抽出 script
+- `scripts/extract_kotlin_abi.sh` — Kotlin ABI 抽出 script
+- `scripts/kotlin_api_to_json.py` — `.api` ファイル → JSON 変換
+- `scripts/diff_abi_snapshot.py` — 3 言語統一 diff logic
+- `scripts/regenerate_abi_baseline.sh` — baseline 一括再生成
+- `docs/spec/public-abi-contract.toml` — 統一 JSON schema 仕様
+
+### 既存ファイルへの影響
+
+- `.github/workflows/cpp-abi-check.yml` — M3 完了後に deprecate 判断
+- `.github/workflows/public-api-diff.yml` — Rust / C# 部分は既存維持、 統合は M-Stretch
+- `Package.swift` — symbol graph emit のための `swiftSettings` 追加検討
+- `android/piper-plus-g2p/build.gradle.kts` — `binary-compatibility-validator` plugin 追加
+- `CONTRIBUTING.md` — ABI 変更時の baseline 更新フロー記載
+
+---
+
+## 9. 参照
+
+- 親調査: [ci-expansion-2026-05.md §5 Top 10 #4](../proposals/ci-expansion-2026-05.md)
+- マイルストーン詳細: [ci-expansion-milestones.md §M3.1](../proposals/ci-expansion-milestones.md)
+- M3 overview: [M3-overview.md](./M3-overview.md)
+- 既存 ABI check: `.github/workflows/cpp-abi-check.yml`
+- 既存 API diff: `.github/workflows/public-api-diff.yml`
+- `binary-compatibility-validator` plugin: <https://github.com/Kotlin/binary-compatibility-validator>
+- `abi-dumper`: <https://github.com/lvc/abi-dumper>
+- Swift Symbol Graph: <https://github.com/swiftlang/swift/blob/main/docs/SymbolGraph.md>
+- semver 仕様: <https://semver.org/spec/v2.0.0.html>
+- `cargo-semver-checks`: <https://github.com/obi1kenobi/cargo-semver-checks> (参考実装)

--- a/docs/tickets/M3-2-license-auto-injection.md
+++ b/docs/tickets/M3-2-license-auto-injection.md
@@ -1,0 +1,535 @@
+# [M3.2] Model card / license auto-injection
+
+**親マイルストーン**: [M3 ABI & Ecosystem Hardening](./M3-overview.md)
+**親調査**: [ci-expansion-2026-05.md §Top 10 #7](../proposals/ci-expansion-2026-05.md)
+**Top 10 内番号**: #7
+**ステータス**: 未着手
+**想定工数**: 2 PR (~15h)
+**優先度**: 中
+**作成日**: 2026-05-18
+
+---
+
+## 1. タスクの目的とゴール
+
+### 目的
+
+HF Hub にアップロードされる ONNX 同梱物に、 **学習データセット (LibriTTS-R / AISHELL-3 / CML-TTS / MOE-Speech) の attribution / license 情報** を build 時に
+自動 injection する。
+
+### なぜ必要か
+
+- **法務リスクの非対称性**: 各データセットには attribution 要件がある
+  (CML-TTS は CC BY 4.0 で attribution required、 AISHELL-3 は Apache-2.0、
+  LibriTTS-R は CC BY 4.0、 MOE-Speech は CC BY-SA 4.0 想定 — 要確認)。
+  HF Hub 上の ONNX を再配布する downstream が attribution を持たないと
+  license violation の連鎖が発生する。
+- **手動忘れの再発防止**: release engineer が手動で `MODEL_CARD.md` を書く運用は、
+  quarterly release / patch release の頻度が上がると attribution 漏れ確率が線形上昇。
+- **deterministic injection の副次効果**: 「どの commit のどの dataset 状態で生成された
+  ONNX か」 が HF Hub 上の README から追跡可能になり、 reproducibility に寄与。
+
+### ゴール (完了基準)
+
+- `data-sources.yml` (canonical source) を repository root に commit
+- `scripts/generate_model_card.py` が `data-sources.yml` から `MODEL_CARD.md` +
+  `LICENSE_ATTRIBUTIONS.md` を deterministic 生成
+- `.github/workflows/release-shared-lib.yml` と `deploy-huggingface.yml` の publish 直前に
+  hook が動作し、 ONNX 同梱物に attribution が含まれる
+- 次回 HF Hub release で `MODEL_CARD.md` が auto-injection されることを手動確認
+
+---
+
+## 2. 実装する内容の詳細
+
+### 2.1 対象データセット (6 言語マルチリンガル base)
+
+CLAUDE.md のデータセット表より、 `dataset-multilingual-6lang-filtered` の内訳:
+
+| 言語 | データセット | 話者数 | 発話数 | License (推定) | URL |
+|------|------------|--------|--------|----------------|-----|
+| ja | MOE-Speech (20 speakers) | 20 | 60,148 | CC BY-SA 4.0 (要確認) | <https://huggingface.co/datasets/ayousanz/moe-speech-20speakers-ljspeech> |
+| en | LibriTTS-R | 310 | 74,912 | CC BY 4.0 | <https://www.openslr.org/141/> |
+| zh | AISHELL-3 | 142 | 63,223 | Apache-2.0 | <https://www.aishelltech.com/aishell_3> |
+| es | CML-TTS (es subset) | 63 | 168,374 | CC BY 4.0 | <https://github.com/freds0/CML-TTS-Dataset> |
+| fr | CML-TTS (fr subset) | 28 | 107,464 | CC BY 4.0 | <https://github.com/freds0/CML-TTS-Dataset> |
+| pt | CML-TTS (pt subset) | 8 | 34,066 | CC BY 4.0 | <https://github.com/freds0/CML-TTS-Dataset> |
+
+つくよみちゃん FT 版は別途 つくよみちゃんコーパスの license 表記 (CC BY 4.0 + 個別商用利用条件) が必要。
+
+### 2.2 `data-sources.yml` の schema 設計
+
+canonical source として repository root に配置。 `scripts/generate_model_card.py` の
+input。 forward-compat を考慮した `schema_version` 付き:
+
+```yaml
+# data-sources.yml
+schema_version: 1
+last_reviewed: "2026-05-18"
+review_period_months: 3  # quarterly review 推奨
+
+datasets:
+  - id: moe-speech-20speakers
+    language: ja
+    language_code: 0
+    title: "MOE-Speech (20 speakers, LJSpeech format)"
+    speakers: 20
+    utterances: 60148
+    license:
+      spdx: "CC-BY-SA-4.0"  # TODO: 要確認 (placeholder)
+      verified: false        # verified=true まで MODEL_CARD に warning 表記
+      url: "https://creativecommons.org/licenses/by-sa/4.0/"
+    source:
+      url: "https://huggingface.co/datasets/ayousanz/moe-speech-20speakers-ljspeech"
+      commit_or_version: "HF Hub revision @ 2026-03-16"
+    attribution_required: true
+    attribution_text: |
+      MOE-Speech 20 speakers corpus, distributed under CC BY-SA 4.0 by ayousanz.
+
+  - id: libritts-r
+    language: en
+    language_code: 1
+    title: "LibriTTS-R"
+    speakers: 310
+    utterances: 74912
+    license:
+      spdx: "CC-BY-4.0"
+      verified: true
+      url: "https://creativecommons.org/licenses/by/4.0/"
+    source:
+      url: "https://www.openslr.org/141/"
+      commit_or_version: "v1.0"
+    attribution_required: true
+    attribution_text: |
+      LibriTTS-R: A Restored Multi-Speaker Text-to-Speech Corpus, Y. Koizumi et al., 2023.
+      Distributed under CC BY 4.0.
+
+  - id: aishell-3
+    language: zh
+    language_code: 2
+    title: "AISHELL-3"
+    speakers: 142
+    utterances: 63223
+    license:
+      spdx: "Apache-2.0"
+      verified: true
+      url: "https://www.apache.org/licenses/LICENSE-2.0"
+    source:
+      url: "https://www.aishelltech.com/aishell_3"
+      commit_or_version: "v1.0"
+    attribution_required: true
+    attribution_text: |
+      AISHELL-3 multi-speaker Mandarin TTS corpus, Y. Shi et al., 2020.
+      Licensed under Apache-2.0.
+
+  - id: cml-tts
+    languages: [es, fr, pt]
+    title: "CML-TTS (Multilingual TTS Dataset)"
+    splits:
+      - {language: es, language_code: 3, speakers: 63, utterances: 168374}
+      - {language: fr, language_code: 4, speakers: 28, utterances: 107464}
+      - {language: pt, language_code: 5, speakers: 8, utterances: 34066}
+    license:
+      spdx: "CC-BY-4.0"
+      verified: true
+      url: "https://creativecommons.org/licenses/by/4.0/"
+    source:
+      url: "https://github.com/freds0/CML-TTS-Dataset"
+      commit_or_version: "2023-10-01"
+    attribution_required: true
+    attribution_text: |
+      CML-TTS Dataset, F. S. Oliveira et al., 2023. Distributed under CC BY 4.0.
+
+# Finetuned model (Tsukuyomi-chan) の場合、 追加で記載
+finetune_overrides:
+  - finetune_id: tsukuyomi-6lang-v2
+    base_datasets: [moe-speech-20speakers, libritts-r, aishell-3, cml-tts]
+    additional_dataset:
+      id: tsukuyomi-chan-corpus
+      title: "つくよみちゃんコーパス Vol.1 〜 Vol.2"
+      license:
+        spdx: "CC-BY-4.0"  # 商用利用は別途条件あり
+        verified: true
+        url: "https://tyc.rei-yumesaki.net/material/corpus/"
+      attribution_required: true
+      attribution_text: |
+        つくよみちゃんコーパス (CV: 夢前黎)
+        © Rei Yumesaki / 夢前黎
+        Distributed under CC BY 4.0 (商用利用は別途規約参照)
+```
+
+### 2.3 `MODEL_CARD.md` template
+
+`scripts/generate_model_card.py` が `data-sources.yml` + git commit hash から生成:
+
+```markdown
+# Piper-Plus Multilingual Model Card
+
+**Model**: piper-plus-multilingual-6lang
+**Version**: v1.13.0
+**Commit**: 121698b5
+**Generated**: 2026-05-18T10:30:00Z
+
+## Training Data
+
+This model was trained on the following datasets:
+
+| Language | Dataset | Speakers | Utterances | License |
+|----------|---------|----------|------------|---------|
+| ja | MOE-Speech (20 speakers) | 20 | 60,148 | CC BY-SA 4.0 |
+| en | LibriTTS-R | 310 | 74,912 | CC BY 4.0 |
+| zh | AISHELL-3 | 142 | 63,223 | Apache-2.0 |
+| es | CML-TTS (es) | 63 | 168,374 | CC BY 4.0 |
+| fr | CML-TTS (fr) | 28 | 107,464 | CC BY 4.0 |
+| pt | CML-TTS (pt) | 8 | 34,066 | CC BY 4.0 |
+
+**Total**: 571 speakers / 508,187 utterances across 6 languages.
+
+## Attribution Requirements
+
+If you redistribute this model or use it in a product, you MUST include the
+following attributions (see `LICENSE_ATTRIBUTIONS.md` for full text):
+
+- MOE-Speech 20 speakers corpus (CC BY-SA 4.0)
+- LibriTTS-R (CC BY 4.0)
+- AISHELL-3 (Apache-2.0)
+- CML-TTS Dataset (CC BY 4.0)
+
+## Model Architecture
+
+- VITS-based multilingual TTS
+- MB-iSTFT decoder (replaces HiFi-GAN, 2.21x faster on CPU)
+- WavLM discriminator (training only)
+- Prosody features (A1/A2/A3) from OpenJTalk
+
+## Intended Use
+
+- Research and non-commercial TTS applications
+- Commercial use requires individual review of each dataset's license
+  (see `LICENSE_ATTRIBUTIONS.md`)
+
+## Limitations
+
+- 6 languages only (ja/en/zh/es/fr/pt); Korean / Swedish not included in training data
+- Single-speaker fine-tuning (e.g., Tsukuyomi-chan) requires additional dataset attribution
+```
+
+### 2.4 `LICENSE_ATTRIBUTIONS.md` template
+
+template 全体 (fence なしで直接展開):
+
+```text
+# License Attributions
+
+This file lists the attribution requirements for all training datasets used in
+piper-plus models. Compliance with these attributions is required for
+redistribution.
+
+## MOE-Speech 20 speakers corpus
+
+- License: CC BY-SA 4.0
+- URL: https://huggingface.co/datasets/ayousanz/moe-speech-20speakers-ljspeech
+- Attribution:
+  > MOE-Speech 20 speakers corpus, distributed under CC BY-SA 4.0 by ayousanz.
+
+## LibriTTS-R
+
+- License: CC BY 4.0
+- URL: https://www.openslr.org/141/
+- Citation (BibTeX):
+    @inproceedings{koizumi23_interspeech,
+      author={Yuma Koizumi and Heiga Zen and Shigeki Karita et al.},
+      title={LibriTTS-R: A Restored Multi-Speaker Text-to-Speech Corpus},
+      year=2023, booktitle={Interspeech 2023}
+    }
+
+## AISHELL-3
+
+- License: Apache-2.0
+- URL: https://www.aishelltech.com/aishell_3
+- Citation (BibTeX):
+    @inproceedings{shi2021aishell,
+      title={AISHELL-3: A multi-speaker mandarin TTS corpus},
+      author={Yao Shi and Hui Bu and Xin Xu et al.},
+      year={2021}
+    }
+
+## CML-TTS
+
+- License: CC BY 4.0
+- URL: https://github.com/freds0/CML-TTS-Dataset
+- Citation (BibTeX):
+    @article{oliveira2023cml,
+      title={CML-TTS: A Multilingual Dataset for Speech Synthesis in Low-Resource Languages},
+      author={Frederico S. Oliveira et al.}, year={2023}
+    }
+```
+
+### 2.5 `release-shared-lib.yml` / `deploy-huggingface.yml` への hook
+
+既存 workflow の publish step 直前に `generate_model_card.py` 実行を挿入:
+
+```yaml
+# .github/workflows/deploy-huggingface.yml (抜粋)
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download ONNX artifact
+        # ... existing ...
+
+      - name: Generate MODEL_CARD.md and LICENSE_ATTRIBUTIONS.md
+        run: |
+          python scripts/generate_model_card.py \
+            --data-sources data-sources.yml \
+            --model-id piper-plus-multilingual-6lang \
+            --commit-hash ${{ github.sha }} \
+            --output-dir ./hf-upload/
+
+      - name: Validate attribution completeness
+        run: |
+          python scripts/check_attribution_completeness.py \
+            --model-card ./hf-upload/MODEL_CARD.md \
+            --required-spdx CC-BY-4.0,Apache-2.0,CC-BY-SA-4.0
+        # fail if any required attribution is missing
+
+      - name: Upload to HF Hub with metadata
+        uses: huggingface/hub-action@v1
+        with:
+          path: ./hf-upload/
+          repo: ayousanz/piper-plus-base
+          token: ${{ secrets.HF_TOKEN }}
+```
+
+### 2.6 forward-compat loader
+
+`data-sources.yml` は `schema_version` を持ち、 未知フィールドを warning で受理:
+
+```python
+# scripts/generate_model_card.py (抜粋)
+import yaml
+from pathlib import Path
+
+SUPPORTED_SCHEMA_VERSIONS = [1]
+
+def load_data_sources(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text())
+    if data["schema_version"] not in SUPPORTED_SCHEMA_VERSIONS:
+        if data["schema_version"] > max(SUPPORTED_SCHEMA_VERSIONS):
+            print(f"WARNING: data-sources.yml schema_version {data['schema_version']} "
+                  f"is newer than supported ({SUPPORTED_SCHEMA_VERSIONS}). "
+                  f"Forward-compat: unknown fields will be ignored.", file=sys.stderr)
+        else:
+            raise ValueError(f"Unsupported schema_version: {data['schema_version']}")
+    return data
+```
+
+### 2.7 license verification status の扱い
+
+`license.verified: false` のエントリは MODEL_CARD に明示的 warning:
+
+```markdown
+## Training Data
+
+> **Note**: license `verified: false` の dataset は upstream への問い合わせで未確定。
+> 商用利用前に必ず upstream の最新条件を確認してください。
+
+| Language | Dataset | License | Verified |
+|----------|---------|---------|----------|
+| ja | MOE-Speech | CC BY-SA 4.0 (推定) | NO - upstream confirmation pending |
+```
+
+quarterly review (`review_period_months: 3`) で `verified: true` 化を目指す。
+
+---
+
+## 3. エージェントチームの役割と人数
+
+合計 **4 名** で実装:
+
+| 役割 | 人数 | 主な担当 |
+|------|------|----------|
+| Legal / License researcher | 1 | 各 dataset の license 確認 / SPDX identifier 確定 / upstream 問い合わせ |
+| Script author | 1 | `generate_model_card.py` / `check_attribution_completeness.py` / forward-compat loader |
+| Release engineer | 1 | `release-shared-lib.yml` / `deploy-huggingface.yml` への hook 実装 |
+| Docs writer | 1 | `MODEL_CARD.md` / `LICENSE_ATTRIBUTIONS.md` template / README 連携 |
+
+**進行モデル**: Legal researcher が `data-sources.yml` の license 情報を確定 (1 週間)、
+並行して script author が generator を実装。 release engineer が hook を組み込み、
+docs writer が template を仕上げる。
+
+---
+
+## 4. 提供範囲とテスト項目
+
+### Unit テスト
+
+- `generate_model_card.py` の `data-sources.yml` parsing (schema_version 1 / 99 future)
+- `MODEL_CARD.md` deterministic generation (同 input → 同 output、 改行・空白まで byte 一致)
+- `check_attribution_completeness.py` で `CC-BY-4.0` 必須宣言時に欠落で fail
+- forward-compat loader が unknown field を warning で許容
+- `finetune_overrides` 経路 (Tsukuyomi-chan FT) で base + additional dataset 両方が
+  attribution に含まれる
+
+### E2E / 統合テスト
+
+- `deploy-huggingface.yml` の dry-run で `MODEL_CARD.md` + `LICENSE_ATTRIBUTIONS.md` が
+  artifact に含まれることを確認
+- HF Hub staging repo に test upload し、 README として正しくレンダリングされるか
+- 既存の HF Hub release (`ayousanz/piper-plus-base`) と比較し、 attribution の
+  完全性が向上しているか
+
+### 手動検証項目
+
+- 各 dataset の license URL が live で 404 でないことを quarterly review
+- 商用利用条件 (e.g., つくよみちゃんコーパスの個別条件) が MODEL_CARD で明示されているか
+- 6 言語の attribution 順序が言語コード (ja=0, en=1, zh=2, es=3, fr=4, pt=5) に従っているか
+- `license.verified: false` の dataset が次回 review で `verified: true` 化されるか
+  追跡できる (Issue label `legal:license-review` で管理)
+
+---
+
+## 5. 懸念事項とレビュー観点
+
+### 懸念事項
+
+1. **license 情報の正確性**
+   現状の `data-sources.yml` の license 値は **placeholder を含む** (特に MOE-Speech)。
+   実装前に upstream への確認が必須。 確認結果次第で attribution_text を書き換える。
+
+2. **upstream license の時間経過変更**
+   CC BY 4.0 → CC BY-NC 4.0 への変更可能性 (低いが非ゼロ)。 quarterly review で
+   `data-sources.yml` を update する運用が必要。
+
+3. **HF Hub upload metadata の挙動差**
+   HF Hub の README.md は YAML frontmatter (`---`) を model metadata として
+   parse する。 既存 `deploy-huggingface.yml` の YAML frontmatter と整合性を取る必要。
+
+4. **既存 `license-check.yml` との関係**
+   既存 workflow は dependency license (cargo / pip / npm) のみで、 dataset license は
+   対象外。 重複しないため併設で OK だが、 README で役割分担を明示する。
+
+5. **Finetuned model の attribution chain**
+   Tsukuyomi-chan FT 版は base model (6lang) の dataset attribution +
+   つくよみちゃんコーパス attribution の **両方** が必要。 `finetune_overrides`
+   schema が正しく chain しているか要確認。
+
+### レビュー観点
+
+- [ ] `data-sources.yml` の license SPDX identifier が正しい
+- [ ] `verified: false` のエントリが MODEL_CARD で warning として表示される
+- [ ] forward-compat loader が `schema_version: 99` で panic しない
+- [ ] HF Hub README YAML frontmatter と generator output が衝突しない
+- [ ] Finetuned model で base + additional dataset 両方が attribution chain される
+- [ ] generator が deterministic (同 input → 同 output、 timestamp / random seed なし)
+- [ ] PR sticky comment が `feedback_pr_body_over_comments` 準拠 (本文 update のみ)
+
+---
+
+## 6. 一から作り直すとしたら
+
+### 案 A: license attribution を build 時 injection せず、 release artifact に常時同梱
+
+ONNX export 時に `MODEL_CARD.md` を ONNX ファイルの metadata (custom op metadata key)
+として埋め込み、 ranlib / objcopy のような post-processing で attribution を分離不可能化する。
+
+| 比較軸 | build 時 injection (現案) | metadata embed |
+|--------|--------------------------|----------------|
+| 分離耐性 | downstream が README を消せば attribution chain 破壊 | metadata は ONNX 内に常駐 |
+| toolchain 依存 | Python script のみ | ONNX SDK / protobuf 知識必要 |
+| 実装複雑度 | 低 | 中 |
+| 法的拘束力 | 同等 (どちらも attribution を提供したことは事実) | 同等 |
+
+**結論**: 現案 (build 時 injection) が piper-plus の現状に適合。 metadata embed は
+M-Stretch で検討。 ただし `LICENSE_ATTRIBUTIONS.md` を ONNX ファイルと **必ず同梱
+(別ファイルでも OK)** とする運用ルールを README で明示する。
+
+### 案 B: 完全手動 (CI 化せず、 release process checklist で対応)
+
+`MODEL_CARD.md` を release engineer が手動で記述し、 PR review で確認する。
+
+- pros: CI 工数ゼロ
+- cons: M3 overview §3 で論じた通り、 release 頻度が上がると attribution 漏れ確率が
+  線形上昇。 法務リスクの非対称性 (失敗時の damage が大きい) を考えると CI 化が ROI 高い
+
+**結論**: 不採用。 ただし license 確定情報がない (verified: false) 状況では
+generator が正しく warning を出す設計とし、 「CI で auto-generation + 人間が
+最終チェック」 の hybrid 運用が現実解。
+
+### 案 C: HF Hub の Model Card schema を canonical source にする
+
+HF Hub の Model Card schema (`huggingface_hub.ModelCard`) を canonical source とし、
+`data-sources.yml` を廃止して HF Hub schema 直書きにする。
+
+- pros: HF Hub native でレンダリングが綺麗
+- cons: HF Hub 以外 (PyPI / NuGet / npm) で同じ attribution を使い回しできない、
+  schema が HF Hub のロックインに依存
+
+**結論**: 不採用。 `data-sources.yml` を canonical source とし、 HF Hub / PyPI README /
+GitHub Releases / docs/ それぞれの format に generator で展開する設計が柔軟。
+
+---
+
+## 7. 後続タスクへの連絡事項
+
+### M3.1 / M3.3 への影響
+
+- M3.1 の JSON schema 設計パターン (`schema_version` + forward-compat loader) を
+  `data-sources.yml` で同様採用。 schema 設計の一貫性を保つ。
+- M3.3 (typosquatting) の検出時 Issue に M3.2 で生成された attribution chain を
+  記載することで、 typosquatting package が attribution を持たないことを示す材料に使える。
+
+### M-Stretch への接続
+
+- M-Stretch SLSA Build L3 の provenance に `data-sources.yml` の commit hash を
+  含めることで、 「どの dataset 状態で build したか」 を SLSA attestation で証明可能。
+- M-Stretch OpenSSF Scorecard 9.3+ の `Maintained` / `License` カテゴリで加点。
+
+### 関連 phase / 既存仕組みとの接続
+
+- `CHANGELOG.md` の `[Unreleased] > Added` 節に新 dataset 追加時のエントリを書く
+  運用を `data-sources.yml` 更新と連動させる (M1.2 migration lint との関係整理)
+- `CONTRIBUTING_MODELS.md` (既存) に `data-sources.yml` 更新ガイドを追記
+- quarterly review schedule を `.github/workflows/license-quarterly-review.yml` 等で
+  schedule trigger (cron: `0 0 1 */3 *`) し、 Issue auto-create する仕組みは
+  M-Stretch で検討
+
+---
+
+## 8. 関連ファイル
+
+### 新規作成
+
+- `data-sources.yml` — canonical source (repository root)
+- `scripts/generate_model_card.py` — `MODEL_CARD.md` + `LICENSE_ATTRIBUTIONS.md` generator
+- `scripts/check_attribution_completeness.py` — attribution 漏れ検出
+- `docs/spec/data-sources-contract.toml` — `data-sources.yml` schema 仕様
+- `tests/test_generate_model_card.py` — generator unit test
+- `tests/fixtures/data-sources-sample.yml` — test fixture
+
+### 既存ファイルへの影響
+
+- `.github/workflows/deploy-huggingface.yml` — generator hook 追加
+- `.github/workflows/release-shared-lib.yml` — generator hook 追加 (iOS / Android shared lib にも attribution 同梱)
+- `CLAUDE.md` — データセット表が `data-sources.yml` の参照と連動することを明記
+- `CONTRIBUTING_MODELS.md` — 新規 dataset 追加時の `data-sources.yml` 更新フロー記載
+- `README.md` — license badge / model card への link 追加検討
+
+---
+
+## 9. 参照
+
+- 親調査: [ci-expansion-2026-05.md §5 Top 10 #7](../proposals/ci-expansion-2026-05.md)
+- マイルストーン詳細: [ci-expansion-milestones.md §M3.2](../proposals/ci-expansion-milestones.md)
+- M3 overview: [M3-overview.md](./M3-overview.md)
+- 既存 license check: `.github/workflows/license-check.yml`
+- 既存 HF deploy: `.github/workflows/deploy-huggingface.yml`
+- HF Hub Model Card spec: <https://huggingface.co/docs/hub/model-cards>
+- SPDX license identifiers: <https://spdx.org/licenses/>
+- CC BY 4.0: <https://creativecommons.org/licenses/by/4.0/>
+- CC BY-SA 4.0: <https://creativecommons.org/licenses/by-sa/4.0/>
+- LibriTTS-R: <https://www.openslr.org/141/>
+- AISHELL-3: <https://www.aishelltech.com/aishell_3>
+- CML-TTS: <https://github.com/freds0/CML-TTS-Dataset>
+- つくよみちゃんコーパス: <https://tyc.rei-yumesaki.net/material/corpus/>

--- a/docs/tickets/M3-3-typosquatting-watch.md
+++ b/docs/tickets/M3-3-typosquatting-watch.md
@@ -1,0 +1,630 @@
+# [M3.3] Typosquatting weekly scan
+
+**親マイルストーン**: [M3 ABI & Ecosystem Hardening](./M3-overview.md)
+**親調査**: [ci-expansion-2026-05.md §Top 10 #8](../proposals/ci-expansion-2026-05.md)
+**Top 10 内番号**: #8
+**ステータス**: 未着手
+**想定工数**: 2 PR (~12h)
+**優先度**: 中
+**作成日**: 2026-05-18
+
+---
+
+## 1. タスクの目的とゴール
+
+### 目的
+
+PyPI / npm / crates.io / NuGet / Maven Central の 5 registry を週次 polling し、
+`piper-plus` の類似名 (Levenshtein distance ≤ 2 / 視覚的偽装 / underscore-dash 混同)
+package が新規 publish された場合に **GitHub Issue を auto-create** する supply-chain
+監視 workflow を構築する。
+
+加えて、 重要な namespace (`piper_plus` / `piperplus` / npm `@piper-plus/*` scope) を
+**placeholder publish で先取り予約** する予防策も併設する。
+
+### なぜ必要か
+
+- **ecosystem 認知度上昇 = 攻撃価値上昇**: piper-plus は 7 ランタイム × 6+ registry で
+  publish されており、 認知度が上がるほど typosquatting の経済的インセンティブが増す。
+  npm の `noblox.js` / PyPI の `python-sqlite` 等、 著名 OSS への typosquatting 攻撃は
+  実際に発生している。
+- **検出経路が空白**: 既存 supply-chain gate (CodeQL / Trivy / dependency-review) は
+  inbound (我々が依存する package) のみ検査し、 outbound (我々を typosquat する package)
+  の監視は空白。
+- **publish 後の防御策が限られる**: registry は typosquatting package の通報手続きを
+  持つが対応に数週間〜数ヶ月かかる。 早期検出 → 通報により被害を最小化する必要。
+
+### ゴール (完了基準)
+
+- `.github/workflows/typosquatting-watch.yml` workflow が schedule (週次) で動作
+- `scripts/check_typosquatting.py` が 5 registry の API を polling し、
+  Levenshtein distance ≤ 2 の package を検出
+- 新規検出時に GitHub Issue auto-create (label `security:typosquatting`)
+- 既知 false positive (`piper-text-utils` 等の無関係 package) を
+  `tests/fixtures/typosquatting-allowlist.json` で除外
+- 重要 namespace の placeholder publish が完了 (PyPI `piper_plus` / `piperplus` /
+  npm `@piper-plus/*` scope の確保 と README 整備)
+- 各 registry の squatting policy への適合性が事前確認済
+
+---
+
+## 2. 実装する内容の詳細
+
+### 2.1 対象 registry / canonical package 名
+
+| Registry | canonical name | URL pattern | API endpoint |
+|----------|---------------|-------------|--------------|
+| PyPI | `piper-plus` | `https://pypi.org/project/piper-plus/` | `https://pypi.org/simple/` (PEP 691 JSON) |
+| npm | `piper-plus`, `@piper-plus/g2p` | `https://www.npmjs.com/package/piper-plus` | `https://registry.npmjs.org/-/v1/search?text=piper` |
+| crates.io | `piper-plus`, `piper-plus-cli`, `piper-plus-g2p` | `https://crates.io/crates/piper-plus` | `https://crates.io/api/v1/crates?q=piper` |
+| NuGet | `PiperPlus.Core`, `PiperPlus.Cli` | `https://www.nuget.org/packages/PiperPlus.Core/` | `https://azuresearch-usnc.nuget.org/query?q=piper` |
+| Maven Central | `io.github.ayutaz:piper-plus-g2p-android` | `https://central.sonatype.com/artifact/io.github.ayutaz/piper-plus-g2p-android` | `https://search.maven.org/solrsearch/select?q=piper` |
+
+### 2.2 検出パターン (Levenshtein + 視覚的偽装 + separator 混同)
+
+3 種類の検出ロジックを組み合わせる:
+
+#### 2.2.1 Levenshtein distance
+
+`piper-plus` から edit distance 1-2 の package 名を検出:
+
+```python
+# scripts/check_typosquatting.py (抜粋)
+def levenshtein(s1: str, s2: str) -> int:
+    """O(m*n) edit distance"""
+    if len(s1) < len(s2):
+        return levenshtein(s2, s1)
+    if len(s2) == 0:
+        return len(s1)
+    previous_row = range(len(s2) + 1)
+    for i, c1 in enumerate(s1):
+        current_row = [i + 1]
+        for j, c2 in enumerate(s2):
+            insertions = previous_row[j + 1] + 1
+            deletions = current_row[j] + 1
+            substitutions = previous_row[j] + (c1 != c2)
+            current_row.append(min(insertions, deletions, substitutions))
+        previous_row = current_row
+    return previous_row[-1]
+
+def is_typosquat(candidate: str, canonical: str = "piper-plus", max_distance: int = 2) -> bool:
+    candidate_lower = candidate.lower()
+    if candidate_lower == canonical:
+        return False  # canonical 自身は除外
+    dist = levenshtein(candidate_lower, canonical)
+    return 0 < dist <= max_distance
+```
+
+#### 2.2.2 視覚的偽装 (homograph attack)
+
+ASCII / Cyrillic 偽装 / 大文字 I で l を偽装 / 0 で o を偽装:
+
+```python
+HOMOGRAPH_PAIRS = [
+    ("l", "I"),   # 小文字 l ↔ 大文字 I
+    ("o", "0"),   # o ↔ 0
+    ("e", "3"),   # e ↔ 3 (leet)
+    ("i", "1"),   # i ↔ 1
+    ("p", "р"),   # ASCII p ↔ Cyrillic ер (U+0440)
+    ("e", "е"),   # ASCII e ↔ Cyrillic ie (U+0435)
+    ("a", "а"),   # ASCII a ↔ Cyrillic a (U+0430)
+]
+
+def has_homograph_attack(candidate: str, canonical: str = "piper-plus") -> bool:
+    """canonical を任意 homograph 置換した文字列と candidate が一致するか"""
+    candidate_norm = candidate.lower()
+    # 全置換組み合わせを brute force (canonical 短いので可)
+    from itertools import product
+    char_options = []
+    for c in canonical:
+        opts = {c}
+        for a, b in HOMOGRAPH_PAIRS:
+            if c == a: opts.add(b.lower())
+            if c == b.lower(): opts.add(a)
+        char_options.append(opts)
+    for combo in product(*char_options):
+        if "".join(combo) == candidate_norm and "".join(combo) != canonical:
+            return True
+    return False
+
+# 検出例: "piper-pIus" (l → I), "p1per-plus" (i → 1), "рiper-plus" (Cyrillic р)
+```
+
+#### 2.2.3 separator 混同
+
+`piper-plus` ↔ `piper_plus` ↔ `piperplus` ↔ `piperplus-g2p` の混同:
+
+```python
+def normalize_separator(name: str) -> str:
+    """- / _ / なし を統一して比較"""
+    return name.lower().replace("-", "").replace("_", "")
+
+def is_separator_variant(candidate: str, canonical: str = "piper-plus") -> bool:
+    norm_canonical = normalize_separator(canonical)
+    norm_candidate = normalize_separator(candidate)
+    if candidate == canonical:
+        return False  # canonical 自身
+    return norm_candidate == norm_canonical or \
+           norm_candidate.startswith(norm_canonical) or \
+           norm_canonical.startswith(norm_candidate)
+```
+
+### 2.3 registry API 呼び出し (rate limit + backoff)
+
+```python
+# scripts/check_typosquatting.py (抜粋)
+import time
+import requests
+from typing import Iterator
+
+class RegistryClient:
+    def __init__(self, name: str, search_url: str, rate_limit_per_sec: float = 1.0):
+        self.name = name
+        self.search_url = search_url
+        self.rate_limit_per_sec = rate_limit_per_sec
+        self._last_call = 0.0
+
+    def search(self, query: str, retries: int = 3) -> Iterator[dict]:
+        elapsed = time.time() - self._last_call
+        if elapsed < 1.0 / self.rate_limit_per_sec:
+            time.sleep(1.0 / self.rate_limit_per_sec - elapsed)
+        for attempt in range(retries):
+            try:
+                resp = requests.get(self.search_url, params={"q": query}, timeout=30)
+                self._last_call = time.time()
+                if resp.status_code == 429:  # rate limit
+                    backoff = 2 ** attempt * 5
+                    print(f"Rate limited on {self.name}, backing off {backoff}s")
+                    time.sleep(backoff)
+                    continue
+                resp.raise_for_status()
+                yield from self._parse(resp.json())
+                return
+            except requests.RequestException as e:
+                if attempt == retries - 1:
+                    raise
+                time.sleep(2 ** attempt)
+
+    def _parse(self, data: dict) -> Iterator[dict]:
+        raise NotImplementedError  # 各 registry で override
+
+class PyPIClient(RegistryClient):
+    def __init__(self):
+        super().__init__("pypi", "https://pypi.org/simple/")
+
+    def search(self, query: str, retries: int = 3) -> Iterator[dict]:
+        # PyPI は search API 廃止済 (2020-07)、 PEP 691 simple index を直接 scan
+        resp = requests.get("https://pypi.org/simple/", headers={"Accept": "application/vnd.pypi.simple.v1+json"}, timeout=60)
+        resp.raise_for_status()
+        for project in resp.json()["projects"]:
+            if query.lower() in project["name"].lower():
+                yield {"name": project["name"]}
+
+class NpmClient(RegistryClient):
+    def __init__(self):
+        super().__init__("npm", "https://registry.npmjs.org/-/v1/search")
+
+    def _parse(self, data: dict) -> Iterator[dict]:
+        for obj in data.get("objects", []):
+            yield {"name": obj["package"]["name"],
+                   "version": obj["package"]["version"],
+                   "publisher": obj["package"].get("publisher", {}).get("username")}
+
+# 他 registry も同様に実装 (crates / NuGet / Maven)
+```
+
+### 2.4 全体フロー (擬似コード)
+
+```python
+# scripts/check_typosquatting.py main flow
+import json
+from pathlib import Path
+
+def main():
+    canonical_names = {
+        "pypi": ["piper-plus"],
+        "npm": ["piper-plus", "@piper-plus/g2p"],
+        "crates": ["piper-plus", "piper-plus-cli", "piper-plus-g2p"],
+        "nuget": ["PiperPlus.Core", "PiperPlus.Cli"],
+        "maven": ["io.github.ayutaz:piper-plus-g2p-android"],
+    }
+    allowlist = json.loads(Path("tests/fixtures/typosquatting-allowlist.json").read_text())
+    detections = []
+
+    clients = {"pypi": PyPIClient(), "npm": NpmClient(), ...}
+    for registry, names in canonical_names.items():
+        client = clients[registry]
+        for canonical in names:
+            # registry を "piper" prefix で広く search
+            for candidate in client.search("piper"):
+                cand_name = candidate["name"]
+                if cand_name in allowlist.get(registry, []):
+                    continue
+                if cand_name in canonical_names[registry]:
+                    continue  # 自分自身は除外
+                # 3 種検出ロジック
+                reasons = []
+                if is_typosquat(cand_name, canonical):
+                    reasons.append(f"levenshtein<={2}")
+                if has_homograph_attack(cand_name, canonical):
+                    reasons.append("homograph")
+                if is_separator_variant(cand_name, canonical):
+                    reasons.append("separator-variant")
+                if reasons:
+                    detections.append({
+                        "registry": registry,
+                        "name": cand_name,
+                        "canonical": canonical,
+                        "reasons": reasons,
+                        "metadata": candidate,
+                    })
+    # 既存 Issue との重複を除いて GitHub Issue auto-create
+    create_github_issues(detections)
+```
+
+### 2.5 GitHub Issue auto-create
+
+```python
+def create_github_issues(detections: list[dict]):
+    import os, requests
+    gh_token = os.environ["GITHUB_TOKEN"]
+    repo = "ayutaz/piper-plus"
+    # 既存 open issue を取得し重複排除
+    existing = requests.get(
+        f"https://api.github.com/repos/{repo}/issues",
+        params={"state": "open", "labels": "security:typosquatting"},
+        headers={"Authorization": f"Bearer {gh_token}"},
+    ).json()
+    existing_titles = {issue["title"] for issue in existing}
+
+    for d in detections:
+        title = f"[security:typosquatting] {d['registry']}: {d['name']} (similar to {d['canonical']})"
+        if title in existing_titles:
+            continue  # 重複防止
+        body = f"""
+## Typosquatting Detection
+
+- **Registry**: {d['registry']}
+- **Detected package**: `{d['name']}`
+- **Canonical**: `{d['canonical']}`
+- **Detection reasons**: {', '.join(d['reasons'])}
+- **Metadata**:
+{json.dumps(d['metadata'], indent=2)}
+
+### 対応手順
+
+1. 当該 package の content を手動確認
+2. 悪意のある場合 → registry の typosquatting 通報手続きを実施
+3. 誤検出の場合 → `tests/fixtures/typosquatting-allowlist.json` に追加
+4. Issue を close
+"""
+        requests.post(
+            f"<https://api.github.com/repos/{repo}/issues>",
+            headers={"Authorization": f"Bearer {gh_token}"},
+            json={"title": title, "body": body, "labels": ["security:typosquatting"]},
+        )
+```
+
+### 2.6 false positive allowlist
+
+```json
+// tests/fixtures/typosquatting-allowlist.json
+{
+  "_schema_version": 1,
+  "_description": "既知の無関係な類似名 package を typosquatting 検出から除外",
+  "_review_period_months": 6,
+
+  "pypi": [
+    "piper-cli",
+    "piper-text",
+    "piper-utils"
+  ],
+  "npm": [
+    "piper",
+    "piper-cli"
+  ],
+  "crates": [
+    "piper"
+  ],
+  "nuget": [],
+  "maven": []
+}
+```
+
+allowlist エントリには `reason` field を持たせ、 半年毎に review:
+
+```json
+{
+  "name": "piper-cli",
+  "reason": "Unrelated PyPI project (last reviewed 2026-05-18)",
+  "added_at": "2026-05-18",
+  "last_reviewed": "2026-05-18"
+}
+```
+
+### 2.7 placeholder publish 設計
+
+重要 namespace の予約。 各 registry の squatting policy を事前確認した上で実施:
+
+```mermaid
+flowchart LR
+    A[canonical] --> B[piper-plus on PyPI]
+    A --> C[piper-plus on npm]
+    A --> D[piper-plus on crates.io]
+
+    E[placeholder] --> F[piper_plus on PyPI]
+    E --> G[piperplus on PyPI]
+    E --> H["@piper-plus/* on npm"]
+
+    F --> I["README: 'This is a placeholder. The real package is piper-plus.'"]
+    G --> I
+    H --> I
+
+    style B fill:#90EE90
+    style C fill:#90EE90
+    style D fill:#90EE90
+    style F fill:#FFD700
+    style G fill:#FFD700
+    style H fill:#FFD700
+```
+
+placeholder package の content:
+
+```python
+# PyPI placeholder package (`piper_plus` / `piperplus`)
+# setup.py 最小化
+from setuptools import setup
+setup(
+    name="piper_plus",  # or "piperplus"
+    version="0.0.1",
+    description="Placeholder for piper-plus. The real package is 'piper-plus' (with dash).",
+    long_description="""
+# Placeholder Package
+
+This package name is reserved by the piper-plus maintainers to prevent typosquatting.
+
+**The actual package is `piper-plus`** (with a dash, not underscore).
+
+Install via: `pip install piper-plus`
+
+GitHub: https://github.com/ayutaz/piper-plus
+""",
+    long_description_content_type="text/markdown",
+    install_requires=["piper-plus"],  # placeholder install で本物に redirect
+)
+```
+
+**registry squatting policy 確認**:
+
+| Registry | squatting policy | placeholder publish 可否 |
+|----------|-----------------|--------------------------|
+| PyPI | [PEP 541](https://peps.python.org/pep-0541/) で 「name squatting」 禁止だが、 trademark / project rename 目的は許容 | OK (README で目的明示すれば) |
+| npm | [Disputes Policy](https://docs.npmjs.com/policies/disputes) で squatting 禁止だが、 同一 org の defensive registration は許容 | OK (`@piper-plus` scope は安全) |
+| crates.io | 「squatting」 禁止 (FAQ で明示) — placeholder publish はリスク | **要慎重判断** |
+| NuGet | 明示的 policy なし、 trademark / brand protection は許容 | OK |
+| Maven Central | groupId namespace ベースで `io.github.ayutaz.*` 全部予約済 | 不要 |
+
+**結論**: PyPI / npm / NuGet で placeholder publish 実施、 crates.io は監視のみ。
+
+### 2.8 schedule cron
+
+既存 schedule cron 9 本のうち 6 本が月曜 UTC 朝に集中 (親 doc §1.1 で SPOF 指摘)。
+typosquatting watch は **水曜 UTC 朝** に schedule して cron 集中を緩和:
+
+```yaml
+# .github/workflows/typosquatting-watch.yml (抜粋)
+name: Typosquatting Weekly Scan
+
+on:
+  schedule:
+    - cron: "0 6 * * 3"  # 水曜 UTC 06:00 (JST 水曜 15:00)
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: pip install requests
+      - name: Run typosquatting scan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/check_typosquatting.py
+```
+
+---
+
+## 3. エージェントチームの役割と人数
+
+合計 **3-4 名** で実装:
+
+| 役割 | 人数 | 主な担当 |
+|------|------|----------|
+| Security engineer | 1 | 検出ロジック設計 (Levenshtein / homograph / separator) / 既知 typosquatting 攻撃パターンの調査 |
+| Script author | 1 | `check_typosquatting.py` / registry client / rate limit / Issue create logic |
+| Registry researcher | 1 | 各 registry の squatting policy 確認 / placeholder publish の規約適合性確認 |
+| Reviewer | 1 (兼任可) | allowlist sanity check / false positive rate observation |
+
+---
+
+## 4. 提供範囲とテスト項目
+
+### Unit テスト
+
+- `levenshtein()` 関数 (空文字列 / 同一文字列 / distance 1-3 のケース)
+- `has_homograph_attack()` で `piper-pIus` (大文字 I) / `рiper-plus` (Cyrillic) を検出
+- `is_separator_variant()` で `piper_plus` / `piperplus` を検出
+- allowlist が `piper-cli` 等を正しく除外
+- Issue 重複検出 (同じ package を二重 Issue 化しない)
+
+### E2E / 統合テスト
+
+- 5 registry client が rate limit / 429 で正しく backoff
+- mock registry response で 「悪意ある typosquat 発見」 シナリオ → Issue 1 件 create
+- 既存 open Issue がある場合 → 重複 Issue 不作成
+- allowlist に追加した package → 検出されない
+- `workflow_dispatch` で手動実行が成功する
+
+### 手動検証項目
+
+- 初回実行で false positive 率を観測 (目標 < 30%、 allowlist で 5% 以下に下げる)
+- 5 registry の API 応答時間が timeout (30s) 内に収まる
+- placeholder publish 後、 PyPI / npm / NuGet で README が正しくレンダリングされる
+- placeholder package の `install_requires=["piper-plus"]` で本物が install される
+- registry squatting policy への適合性が確認できる (policy 違反警告が来ないか半年観察)
+
+---
+
+## 5. 懸念事項とレビュー観点
+
+### 懸念事項
+
+1. **registry API rate limit / breaking change**
+   PyPI search API は 2020 年に廃止済 (現在 PEP 691 simple index のみ)。 npm / crates /
+   NuGet / Maven も API 仕様変更リスクあり。 週次 schedule なので影響は限定的だが、
+   client 実装に try/except でログ + 次週まで skip する設計が必要。
+
+2. **false positive 率の初期値**
+   初回 scan で `piper-cli` / `piper-text` 等が大量に検出される可能性。 allowlist の
+   初期化作業に時間がかかる。 最初の 4 週間は **informational tier** で動作させ、
+   allowlist を整備してから Issue auto-create を有効化する設計推奨。
+
+3. **placeholder publish の規約違反リスク**
+   crates.io は 「squatting」 を明示禁止。 PyPI / npm / NuGet も解釈次第。
+   placeholder package の README で 「defensive registration for trademark protection」
+   を明示し、 install すると本物に redirect する設計が安全側。 ただし registry 管理者の
+   judgment 次第で package が削除される可能性は残る。
+
+4. **Issue auto-create のノイズ**
+   検出 → Issue 自動化は便利だが、 false positive で Issue を量産すると signal noise が
+   発生。 まず最初の 4 週間は 「Issue ではなく Slack DM」 で報告する path も検討
+   (現状の `slack-utils.sh` 仕組みと整合)。
+
+5. **registry によっては 'piper' で広範囲 search できない**
+   PyPI simple index は全 project 一覧 (~50 万 project) のため大きい。 npm / crates は
+   `piper` キーワードで絞り込み可能。 5 registry で挙動差を吸収する client 設計が必要。
+
+### レビュー観点
+
+- [ ] 検出ロジックの 3 種類 (Levenshtein / homograph / separator) が複合 OR で動作
+- [ ] allowlist の `_schema_version` / `_review_period_months` / `last_reviewed` が機能
+- [ ] Issue auto-create が重複防止 (`title` 一致で skip) を実装
+- [ ] schedule cron が **月曜以外** で SPOF 緩和に寄与
+- [ ] registry API rate limit に backoff 実装
+- [ ] placeholder publish 前に 5 registry の squatting policy を確認した記録あり
+- [ ] `feedback_pr_body_over_comments` 準拠 (Issue body は新規追加せず、 既存があれば update)
+
+---
+
+## 6. 一から作り直すとしたら
+
+### 案 A: OpenSSF の既存ツール (guarddog) で済むのではないか
+
+[OpenSSF guarddog](https://github.com/DataDog/guarddog) は PyPI / npm の悪意ある
+package を検出するツール。 typosquatting 単体ではなく malicious behavior (install hook /
+suspicious imports) も検出する。
+
+| 比較軸 | 自前 script (現案) | guarddog |
+|--------|--------------------|----------|
+| 対象 registry | 5 (PyPI / npm / crates / NuGet / Maven) | 2 (PyPI / npm のみ) |
+| 検出範囲 | typosquatting のみ | typosquatting + malicious behavior |
+| 設定柔軟性 | allowlist / canonical name custom | rule based |
+| メンテナンス | 自前更新 | DataDog が更新 |
+
+**結論**: guarddog は npm / PyPI のみで、 crates / NuGet / Maven をカバーできない。
+piper-plus は 5 registry に publish しているため自前実装が必要。 ただし guarddog の
+heuristic rule を参考にして自前 script に取り込む価値あり (M-Stretch で検討)。
+
+### 案 B: 監視のみ、 placeholder publish 不実施
+
+placeholder publish の規約違反リスクを避け、 監視 (検出 → Issue) のみで運用する案。
+
+- pros: registry policy 違反リスクゼロ、 メンテナンス工数最小
+- cons: 攻撃者が先に `piper_plus` / `piperplus` を publish した場合、 namespace を取り戻す
+  手段が registry TOS 違反通報のみ (数週間〜数ヶ月)
+
+**結論**: 限定予防策 (PyPI / npm / NuGet のみ placeholder、 crates 監視のみ) が妥当な
+妥協点。 M3 overview §3 の議論を参照。
+
+### 案 C: GitHub Dependabot / OSV-Scanner の延長として実装
+
+GitHub Dependabot は inbound の vulnerability check が主機能だが、 outbound monitoring
+(自プロジェクトに対する typosquatting) は対象外。 OSV-Scanner も同様。
+
+**結論**: 既存ツールが outbound monitoring を提供しないため、 自前実装が必要。
+将来 GitHub が typosquatting watch 機能を提供したら移行検討。
+
+---
+
+## 7. 後続タスクへの連絡事項
+
+### M3.1 / M3.2 への影響
+
+- M3.2 で生成される `LICENSE_ATTRIBUTIONS.md` を typosquatting 検出時の Issue 本文に
+  「本物の attribution chain との対比」 として含めることで、 typosquatting package が
+  attribution を持たないことを明示できる。
+- M3.1 と独立だが、 同 phase で 「publish 前検査 (M3.1) / publish 後監視 (M3.3)」 の
+  対比を README で説明可能。
+
+### M-Stretch への接続
+
+- M-Stretch SLSA Build L3 + Sigstore Rekor verification (親 doc §3.6) と組み合わせると、
+  typosquatting package を install しても Sigstore 検証で fail させる二段防御になる。
+- M-Stretch OpenSSF Scorecard 9.3+ の `Dangerous-Workflow` / `Token-Permissions` で加点。
+- M-Stretch で guarddog rule の取り込み検討 (malicious behavior 検出も含める)。
+
+### 関連 phase / 既存仕組みとの接続
+
+- `SECURITY.md` に typosquatting 検出 → Issue 起票の連絡経路を記載
+- 既存 schedule cron 9 本のうち月曜集中の 6 本を別曜日に分散する機会として M3.3 を
+  使う (typosquatting watch を水曜に置き、 既存の monthly review を金曜に移動等)
+- `slack-utils.sh` (既存) を使って高 priority 検出時に Slack DM 通知する path を将来
+  追加検討 (Issue auto-create が ノイズ化した場合の fallback)
+
+---
+
+## 8. 関連ファイル
+
+### 新規作成
+
+- `.github/workflows/typosquatting-watch.yml` — メイン workflow
+- `scripts/check_typosquatting.py` — 検出ロジック + registry client + Issue auto-create
+- `tests/fixtures/typosquatting-allowlist.json` — false positive 除外リスト
+- `tests/test_check_typosquatting.py` — unit test
+- `docs/spec/typosquatting-watch-contract.toml` — schema + 運用ルール仕様
+- placeholder packages (各 registry に個別配置、 repo 内には source のみ):
+  - `tools/placeholder-packages/pypi/piper_plus/` (setup.py + README.md)
+  - `tools/placeholder-packages/pypi/piperplus/`
+  - `tools/placeholder-packages/npm/piper-plus-scope/` (`@piper-plus/*` placeholder)
+  - `tools/placeholder-packages/nuget/PiperPlus.Placeholder/`
+
+### 既存ファイルへの影響
+
+- `SECURITY.md` — typosquatting 検出経路を追記
+- `.github/labels.yml` (もしあれば) — `security:typosquatting` label 追加
+- `README.md` — typosquatting awareness セクション追加検討 (「install 時の name 確認」 注意喚起)
+
+---
+
+## 9. 参照
+
+- 親調査: [ci-expansion-2026-05.md §5 Top 10 #8](../proposals/ci-expansion-2026-05.md)
+- マイルストーン詳細: [ci-expansion-milestones.md §M3.3](../proposals/ci-expansion-milestones.md)
+- M3 overview: [M3-overview.md](./M3-overview.md)
+- PyPI PEP 691 (simple index JSON): <https://peps.python.org/pep-0691/>
+- PyPI PEP 541 (name dispute policy): <https://peps.python.org/pep-0541/>
+- npm Disputes Policy: <https://docs.npmjs.com/policies/disputes>
+- crates.io name squatting policy: <https://crates.io/policies>
+- OpenSSF guarddog: <https://github.com/DataDog/guarddog>
+- typosquatting attack research:
+  - <https://www.usenix.org/conference/usenixsecurity20/presentation/tschacher>
+  - <https://snyk.io/blog/typosquatting-attacks/>
+- Levenshtein distance: <https://en.wikipedia.org/wiki/Levenshtein_distance>
+- Homograph attack: <https://en.wikipedia.org/wiki/IDN_homograph_attack>

--- a/docs/tickets/M3-overview.md
+++ b/docs/tickets/M3-overview.md
@@ -1,0 +1,239 @@
+# M3: ABI & Ecosystem Hardening — Phase Overview
+
+**親マイルストーン**: [ci-expansion-milestones.md §M3](../proposals/ci-expansion-milestones.md#m3-abi--ecosystem-hardening)
+**親調査**: [ci-expansion-2026-05.md](../proposals/ci-expansion-2026-05.md)
+**期間**: Month 3 (4 週)
+**作成日**: 2026-05-18
+
+---
+
+## フェーズの狙い
+
+M3 は **「semver 違反 / 法務リスク / supply chain 攻撃」 の 3 軸** を塞ぐ phase。
+M1 (Defensive Foundations) で既存 gate の構造欠陥を、 M2 (Audio Quality Moat) で user-visible
+音声品質回帰を防いだ後、 M3 では **「リリース後に user / downstream / ecosystem に
+user-visible damage を与える境界」 の検査** を集中して導入する。
+
+具体的に塞ぐ穴:
+
+1. **semver 違反** (#4 Public ABI snapshot) — C API / Swift / Kotlin の public signature が
+   patch / minor release で silent break する事故。 一度 publish した crate / NuGet /
+   Maven artifact は yank しても downstream の `Cargo.lock` / `packages.lock.json` に
+   残り続けるため、 publish 前検出が唯一の現実解。
+2. **法務リスク** (#7 model card / license auto-injection) — HF Hub にアップロードされる
+   ONNX に LibriTTS-R / AISHELL-3 / CML-TTS / MOE-Speech の出典・ライセンス情報が
+   同梱されない問題。 OSS audience が下流で再配布する際の attribution chain が切れ、
+   license violation を引き起こす可能性。
+3. **supply chain 攻撃** (#8 typosquatting weekly scan) — `piper-pIus` (大文字 I で l を偽装) /
+   `piper_plus_g2p` / `piperplus` のような typosquatting package が 5 registry に publish
+   された場合の検出経路がない。 ecosystem 認知度が上がるほど攻撃価値も上がる。
+
+メンテナンス税は M1 / M2 よりさらに低い (workflow 3 本追加、 うち 2 本は schedule 起動)。
+ただし OSS としての信頼性 (Scorecard / SLSA / 法務 / ecosystem trust) への寄与は最大。
+
+---
+
+## 含まれるチケット
+
+| ID | タイトル | Top 10 # | 想定工数 | 優先度 |
+|----|----------|----------|----------|--------|
+| [M3.1](./M3-1-public-abi-snapshot.md) | Public ABI snapshot (C / Swift / Kotlin) | #4 | 3 PR (~25h) | 高 |
+| [M3.2](./M3-2-license-auto-injection.md) | Model card / license auto-injection | #7 | 2 PR (~15h) | 中 |
+| [M3.3](./M3-3-typosquatting-watch.md) | Typosquatting weekly scan | #8 | 2 PR (~12h) | 中 |
+
+合計 **7 PR / ~52h / 4 週間**。 1 maintainer の容量で実装可能。
+
+```mermaid
+graph LR
+    A[M3 開始] --> B[M3.1 Public ABI snapshot]
+    A --> C[M3.2 license auto-injection]
+    A --> D[M3.3 typosquatting scan]
+    B --> E[3 workflow 稼働 + baseline commit]
+    C --> E
+    D --> E
+    E --> F[M3 完了 / M-Stretch へ]
+
+    style B fill:#e1f5ff
+    style C fill:#fff4e1
+    style D fill:#ffe1e1
+```
+
+3 チケットは独立しており順序依存はない (並列実装可)。 ただし M3.1 が最も工数が
+大きいため最初に着手し、 M3.2 / M3.3 は余裕を見て後半に並走させるのが現実的。
+
+---
+
+## 一から設計し直すとしたら
+
+### 1. アーキテクチャ: 3 つを 1 phase に束ねた妥当性
+
+ABI snapshot (#4) / license attribution (#7) / typosquatting (#8) は本来別軸の問題:
+
+- **#4** は **build-time / publish-time** の自動検査 (PR ブロック blocker)
+- **#7** は **release artifact 生成時** の deterministic injection (publish chain hook)
+- **#8** は **publish 後** の外部 ecosystem 監視 (schedule polling)
+
+タイムスケールも検査面も異なる。 にも関わらず 1 phase に束ねた根拠:
+
+- **共通点 1**: 「user / downstream に user-visible damage を与える境界の検査」 という
+  共通テーマ。 user 視点では 3 つとも 「リリース後に気づいて困る」 タイプの bug で、
+  CI gate にしないと検出機会がない。
+- **共通点 2**: メンテナンス税が低い (3 本合計でも他 phase 1 本分以下)。 個別 phase に
+  割ると overhead (kick-off / review / dev branch 切り替え) で工数が増える。
+- **共通点 3**: 既存の `cpp-abi-check.yml` / `license-check.yml` / `deploy-huggingface.yml` の
+  延長で実装可能で、 既存 gate との衝突が少ない。
+
+別軸ではあるが 「OSS として publish した後の dignity を守る」 という統一テーマで括る
+のは合理的。 ただし phase 完了後の retrospective で 「やはり別 phase に分けるべき
+だった」 という結論が出る可能性は留保。
+
+### 2. 設計: ABI snapshot を JSON diff にするか、 既存 workflow の延長にするか
+
+既存 `.github/workflows/cpp-abi-check.yml` (libabigail abidiff) / `public-api-diff.yml`
+(Rust public-api crate / .NET ApiCompat) が存在。 これを拡張するか、 完全新規 workflow
+にするかの判断:
+
+| 選択肢 | pros | cons |
+|--------|------|------|
+| A. 既存延長 (`cpp-abi-check.yml` を hub 化) | 既存 logic 再利用 / fixture 共有可能 | C API 向け設計が Swift / Kotlin に流用しづらい (`abidiff` が ELF 専用) |
+| B. 完全新規 (`public-abi-snapshot.yml`) | 3 言語に統一 JSON schema を強制可能 / 将来 Python ABI も追加しやすい | 既存 `cpp-abi-check.yml` との二重検査になる懸念 |
+
+**推奨は B**: 既存 `cpp-abi-check.yml` は libabigail の native diff 形式 (XML) で human-readable
+だが multi-language unify には不向き。 新規 JSON schema で 3 言語を統一し、 既存
+`cpp-abi-check.yml` は併設のまま将来 deprecate 判断する。
+
+### 3. 実装: license auto-injection を release process の手動 checklist で代用可能か
+
+license attribution は理論上、 release engineer が **手動で `MODEL_CARD.md` を生成 →
+HF Hub にアップロード** するフローでも代用可能。 それでも CI 化する判断基準:
+
+- **手動運用の失敗確率**: 過去の releases で `tsukuyomi-mb-istft-500epoch.onnx` の HF
+  upload 時に attribution 漏れがあった (推定、 git log 要確認)。 release 頻度が
+  quarterly に上がると手動忘れ確率が線形で上がる。
+- **法務リスクの非対称性**: license attribution 漏れは license violation を構成する可能性が
+  あり、 罰則が user の civil liability を含む (CML-TTS は CC BY 4.0 で attribution
+  required)。 「失敗時の damage が大きい」 タイプは手動 checklist より CI 化が
+  ROI 高い (CI 失敗時のコストは 数十分の手戻り、 license violation のコストは法務対応)。
+- **deterministic injection の副次効果**: HF Hub 上の `README.md` が PR commit hash に
+  紐づくため、 「どの commit のどの dataset 状態で生成された ONNX か」 を後追い可能。
+  reproducibility への寄与が大きい。
+
+結論: CI 化推奨。 ただし scope は最小限 (`MODEL_CARD.md` + `LICENSE_ATTRIBUTIONS.md`
+の 2 ファイル auto-generate のみ) に留め、 carbon footprint / training compute report 等の
+鬼ごっこには手を出さない。
+
+### 4. 思考プロセス: typosquatting は監視と予防の二段構え
+
+Top 10 #8 は本質的に二段階の問題:
+
+- **監視 (detection)**: 5 registry を週次 polling し、 Levenshtein distance ≤ 2 の package
+  を検出 → GitHub Issue auto-create
+- **予防 (prevention)**: PyPI `piper_plus` / `piperplus` / npm `@piper-plus/*` scope を
+  **placeholder publish で先取り予約**
+
+監視のみで止めるか予防まで踏み込むかの境界:
+
+| 選択肢 | リスク | 推奨度 |
+|--------|--------|--------|
+| 監視のみ | 攻撃者が先に publish した場合、 namespace を取り戻す手段が registry の TOS 違反通報のみ (数週間〜数ヶ月) | 中 |
+| 監視 + 予防 (placeholder publish) | placeholder publish 自体が squatting と見做され登録規約違反になる可能性 (各 registry の規約要確認) | 高 |
+
+**推奨は監視 + 限定予防**:
+
+- `piper-plus` (canonical name) は既に publish 済みなので保護対象外
+- `piper_plus` (underscore) / `piperplus` (no separator) / `@piper-plus/*` (scope) のみ
+  placeholder publish (README で「本物はこちら」 と明示)
+- それ以外 (例: `piper-pIus`, `pyper-plus`) は監視のみで、 検出時に手動対応
+
+placeholder publish の前提として、 各 registry の squatting policy を事前確認する
+タスクを M3.3 に含める。
+
+---
+
+## 後続フェーズへの連絡事項
+
+### M-Stretch との接続
+
+- **M-Stretch SLSA Build L3 公式 generator 移行** は M3.2 (license auto-injection) と
+  M3.3 (typosquatting prevention) の延長線上。 SLSA L3 を取るには provenance に
+  「どの commit のどの dataset で build したか」 が必須で、 M3.2 の `data-sources.yml`
+  と `MODEL_CARD.md` がそのまま入力になる。
+- **M-Stretch OpenSSF Scorecard 9.3+** は M3.3 の typosquatting prevention で
+  `Dangerous-Workflow` / `Token-Permissions` カテゴリの加点を得られる。
+- **M-Stretch Cross-runtime differential testing 完全版** の入力として、 M3.1
+  (Public ABI snapshot) の baseline JSON を再利用可能 (各 runtime の symbol /
+  API surface を統一 schema で持つことで diff 演算が単純化)。
+
+### M4 (informational tier) との接続
+
+- M4.1 (loanword / PUA forward-compat fuzz) で生成される `schema_version: 99` fuzz
+  input は、 M3.2 の `data-sources.yml` schema の forward-compat 検査にも転用可能。
+  両 phase で schema validator を共有する設計を推奨。
+
+### M3 完了後の文書更新
+
+M3 完了後、 「OSS としての信頼性」 が一段上がるため、 以下を更新検討:
+
+- **`README.md`** — badges 行に Scorecard / SLSA / SBOM の現状値を追記
+- **`SECURITY.md`** — typosquatting 検出 → Issue 起票の連絡経路を記載
+- **`CONTRIBUTING.md`** — ABI snapshot 更新が必要なケース (C API / Swift / Kotlin の
+  public signature 変更) を明記
+- **`docs/reference/`** — `MODEL_CARD.md` の template と `data-sources.yml` schema を
+  参照ドキュメント化
+
+### 既存 workflow との重複レビュー (net flat policy)
+
+M3 で 3 workflow 追加するため、 net flat policy に従い同数の削除候補を検討:
+
+| 削除候補 | 理由 |
+|----------|------|
+| `cpp-abi-check.yml` (libabigail abidiff のみ) | M3.1 の `public-abi-snapshot.yml` に統合検討 (ただし併設のまま start) |
+| 既存 schedule cron 9 本のうち月曜集中している 6 本 | M3.3 typosquatting (週次) を別曜日に置き、 cron 集中を緩和する機会に使う |
+| `public-api-diff.yml` の .NET 部分 | M3.1 で Swift / Kotlin を統合する際に C# も同 schema に寄せる検討 |
+
+削除実施は M3 完了後の retrospective で判断。
+
+---
+
+## 採用判断 checklist (M3 開始時)
+
+- [x] 親 doc §4 の批判的観点を再確認 (「追加しない」 が default)
+- [x] 含まれる 3 項目が 「既存と排他的でない / 既存 gate では構造的に検出不可能 /
+      user-visible damage を防ぐ」 のいずれかを満たす
+  - #4: 既存 `cpp-abi-check.yml` は Swift / Kotlin 未対応 → 構造欠陥
+  - #7: 既存 `license-check.yml` は dependency license のみで dataset 出典は対象外
+  - #8: 既存 supply-chain gate は inbound のみで outbound (typosquatting) は空白
+- [x] 同月内に削除候補となる既存 workflow があるか (net flat policy)
+  → 上記 「既存 workflow との重複レビュー」 で 3 候補リストアップ
+- [x] 想定工数が 4 週 / 1 maintainer の容量を超えないか
+  → 合計 ~52h、 週 13h ペースで実装可能
+
+---
+
+## 関連リンク
+
+### 親ドキュメント
+
+- [ci-expansion-2026-05.md](../proposals/ci-expansion-2026-05.md) — 親調査レポート (30 エージェント統合)
+- [ci-expansion-milestones.md](../proposals/ci-expansion-milestones.md) — 全 M1-M4 + Stretch のマイルストーン詳細
+
+### 個別チケット
+
+- [M3.1 Public ABI snapshot](./M3-1-public-abi-snapshot.md)
+- [M3.2 Model card / license auto-injection](./M3-2-license-auto-injection.md)
+- [M3.3 Typosquatting weekly scan](./M3-3-typosquatting-watch.md)
+
+### 既存仕様 / 関連 workflow
+
+- [`docs/spec/README.md`](../spec/README.md) — 既存 contract spec (19 toml)
+- [`docs/migration/v1.11-to-v1.12.md`](../migration/v1.11-to-v1.12.md) — breaking change の前例
+- `.github/workflows/cpp-abi-check.yml` — 既存 C API ABI check (M3.1 で延長)
+- `.github/workflows/public-api-diff.yml` — 既存 .NET / Rust public API diff (M3.1 で統合検討)
+- `.github/workflows/license-check.yml` — 既存 dependency license check (M3.2 と排他的)
+- `.github/workflows/deploy-huggingface.yml` — HF Hub deploy (M3.2 の hook 先)
+- `.github/workflows/release-shared-lib.yml` — iOS / Android shared lib release (M3.2 の hook 先)
+
+### 横断的な context
+
+- [`CLAUDE.md`](../../CLAUDE.md) — プロジェクト概要 (データセット表 / ランタイム一覧)
+- [`.claude/README.md`](../../.claude/README.md) — 既存 skill / hook / pre-commit gate

--- a/docs/tickets/M4-1-loanword-pua-forward-compat.md
+++ b/docs/tickets/M4-1-loanword-pua-forward-compat.md
@@ -1,0 +1,352 @@
+# M4.1: Loanword / PUA forward-compat fuzz
+
+**親マイルストーン**: [ci-expansion-milestones.md §M4.1](../proposals/ci-expansion-milestones.md#m41--loanword--pua-forward-compat-fuzz-top-10-6)
+**フェーズ**: [M4: Informational Tier](./M4-overview.md)
+**Top 10 #**: 6
+**ステータス**: 未着手
+**優先度**: 中
+**想定工数**: 1-2 PR (~10h)
+**作成日**: 2026-05-18
+
+---
+
+## 目的とゴール
+
+### 目的
+
+`schema_version: 99` のようなランダムな未来 schema バージョンと、 未定義の未来フィールドを混入させた `zh_en_loanword.json` / `pua.json` を 7 ランタイム (Python canonical + Rust×2 / Go / C# / WASM / C++ / Kotlin / Swift) に食わせ、 **panic / exception しないこと** を保証する forward-compat fuzz を informational tier で CI 化する。
+
+これは `feedback_data_asset_distribution.md` (新規データファイルは 7 箇所の package metadata 同時更新が必要) の延長で、 「データ asset 分散の正しさ」を「データ schema の forward-compat」まで拡張する取り組み。 親調査 §3.3 の「Differential fuzzing: Python ↔ Rust G2P」と問題意識を共有する。
+
+### ゴール
+
+| 項目 | 達成基準 |
+|------|---------|
+| workflow 存在 | 既存 `zh-en-loanword-sync.yml` と `pua-consistency.yml` に `fuzz-future-schema` job が追加されている |
+| informational 化 | 上記 job が `continue-on-error: true` で動作、 PR の Checks タブで「informational」表示 |
+| 7 ランタイム coverage | Python / Rust (piper-core, piper-plus-g2p) / Go / C# / WASM / C++ / Kotlin / Swift の **9 loader** すべてに対し fuzz 入力を投げる |
+| forward-compat 契約 | 9 loader すべてが (a) 未知フィールドを silently skip、 (b) `schema_version > 2` でも fatal 化せず warn log のみ、 を満たす |
+| Hypothesis seed | `--hypothesis-seed` を環境変数化、 失敗時に reproducible に再現可能 |
+| dashboard 連携 | 失敗履歴を `docs/ci-dashboard/data/forward-compat-fuzz.jsonl` に append |
+
+### 非ゴール
+
+- backward-compat (古い schema version で新しい loader が動くこと) は既存 fixture で担保済みのため対象外
+- schema_version 99 で **意味のある field を新規追加した場合の semantic 互換性** (lenient で読めるが意味が変わる場合) は対象外。 これは schema 設計時の責任 (M4 overview §2 参照)
+- 9 loader 間の出力 byte 一致 (differential fuzzing) は親調査 §3.3 で別途扱う領域。 M4.1 は「panic しない」のみ保証
+
+---
+
+## 実装詳細
+
+### アーキテクチャ
+
+```mermaid
+flowchart TB
+    A[Hypothesis strategy<br/>future_schema_json] --> B[scripts/fuzz_forward_compat.py]
+    B --> C1[Python loader]
+    B --> C2[Rust piper-core loader]
+    B --> C3[Rust piper-plus-g2p loader]
+    B --> C4[Go loader]
+    B --> C5[C# loader]
+    B --> C6[WASM loader]
+    B --> C7[C++ loader]
+    B --> C8[Kotlin/Android loader]
+    B --> C9[Swift/iOS loader]
+    C1 & C2 & C3 & C4 & C5 & C6 & C7 & C8 & C9 --> D{exit code 0?}
+    D -->|Yes| E[pass: forward-compat OK]
+    D -->|No| F[fail + record JSONL]
+    F --> G[gh-pages dashboard]
+```
+
+### Hypothesis strategy
+
+```python
+# scripts/fuzz_forward_compat.py (擬似コード)
+from hypothesis import given, strategies as st
+
+# 既存 schema v1/v2 の構造を base にし、 未来 field を混入
+future_field_value = st.one_of(
+    st.text(min_size=0, max_size=100),
+    st.integers(),
+    st.lists(st.text(), max_size=10),
+    st.dictionaries(st.text(), st.text(), max_size=5),
+    st.none(),
+)
+
+@st.composite
+def future_loanword_json(draw):
+    # 既存 v2 構造
+    base = {
+        "schema_version": draw(st.integers(min_value=3, max_value=999)),
+        "acronyms": draw(st.dictionaries(
+            keys=st.text(alphabet="ABCDEFGHIJKLMNOPQRSTUVWXYZ", min_size=1, max_size=5),
+            values=st.text(min_size=1, max_size=20),
+            max_size=10,
+        )),
+        "loanwords": draw(st.dictionaries(
+            keys=st.text(min_size=1, max_size=10),
+            values=st.text(min_size=1, max_size=20),
+            max_size=10,
+        )),
+        # 未来 field を 0-5 個混入
+        **{
+            draw(st.text(min_size=3, max_size=20)): draw(future_field_value)
+            for _ in range(draw(st.integers(min_value=0, max_value=5)))
+        },
+    }
+    return base
+
+@given(future_loanword_json())
+def test_all_loaders_no_panic(json_obj):
+    # 9 loader 全部に食わせて exit code 0 を期待
+    for loader_name in LOADERS:
+        result = invoke_loader(loader_name, json_obj)
+        assert result.returncode == 0, f"{loader_name} panicked on {json_obj}"
+```
+
+### workflow 統合
+
+既存の `zh-en-loanword-sync.yml` に追加する job:
+
+```yaml
+fuzz-future-schema:
+  name: ZH-EN Loanword Forward-Compat Fuzz (informational)
+  needs: json-sync  # 既存 byte 一致 gate の後に走る
+  continue-on-error: true  # informational
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@<sha>
+    - name: Setup multi-runtime
+      uses: ./.github/actions/setup-all-runtimes
+    - name: Run fuzz
+      env:
+        HYPOTHESIS_SEED: ${{ github.run_id }}
+      run: |
+        uv run python scripts/fuzz_forward_compat.py \
+          --target zh-en-loanword \
+          --max-examples 1000 \
+          --output docs/ci-dashboard/data/forward-compat-fuzz-loanword.jsonl
+    - name: Upload artifacts on failure
+      if: failure()
+      uses: actions/upload-artifact@<sha>
+      with:
+        name: fuzz-failures
+        path: docs/ci-dashboard/data/forward-compat-fuzz-*.jsonl
+```
+
+`pua-consistency.yml` も同様の構造で追加。
+
+### loader 呼び出し方式
+
+各ランタイムの loader を CLI 経由で呼ぶ:
+
+| ランタイム | 呼び出し |
+|-----------|---------|
+| Python | `uv run python -m piper_plus_g2p.chinese --load-dict <path> --no-phonemize` |
+| Rust piper-core | `cargo run --bin piper-plus -- --load-loanword-dict <path> --validate-only` |
+| Rust piper-plus-g2p | `cargo run --bin piper-plus-g2p -- --load-loanword-dict <path> --validate-only` |
+| Go | `go run ./cmd/piper-plus -- --load-loanword-dict <path> --validate-only` |
+| C# | `dotnet run --project src/csharp/PiperPlus.Cli -- --load-loanword-dict <path> --validate-only` |
+| WASM | `node --experimental-vm-modules scripts/load-dict-wasm.mjs <path>` |
+| C++ | `./build/piper_plus --load-loanword-dict <path> --validate-only` |
+| Kotlin | `./gradlew :piper-plus-g2p:loadDictTest -PdictPath=<path>` |
+| Swift | `swift run hello-g2p --load-loanword-dict <path> --validate-only` |
+
+新規 CLI flag `--validate-only` / `--load-loanword-dict` / `--load-pua-dict` は各ランタイムに追加実装する (既存にあれば再利用)。
+
+### dashboard schema
+
+```json
+{
+  "timestamp": "2026-05-18T10:23:45Z",
+  "run_id": "12345678",
+  "target": "zh-en-loanword",
+  "loader": "rust-piper-core",
+  "seed": 42,
+  "max_examples": 1000,
+  "failures": 0,
+  "shrunk_example": null
+}
+```
+
+失敗時は `shrunk_example` に Hypothesis が見つけた最小 failing case を JSON 文字列で保存。
+
+---
+
+## エージェントチーム
+
+実装時は以下の役割で 3 agent 並列を想定:
+
+| Agent | 担当 |
+|-------|------|
+| **Agent A: Python canonical** | `scripts/fuzz_forward_compat.py` の Hypothesis strategy 実装、 Python loader CLI `--validate-only` 追加、 既存 fixture との回帰テスト |
+| **Agent B: 6 non-Python runtime CLI 追加** | Rust×2 / Go / C# / WASM / C++ の loader CLI に `--validate-only` flag を統一追加。 各 loader の forward-compat 挙動 (silently skip / warn-only) を spec.toml と整合させる |
+| **Agent C: Mobile runtime (Kotlin / Swift) + workflow 統合** | Android / iOS runtime の dict loader test entry point を追加 (`./gradlew` task / `swift run` target)、 `zh-en-loanword-sync.yml` と `pua-consistency.yml` に job 追加、 dashboard JSON 生成 logic |
+
+merge order: A → B → C (canonical を確定してから mirror、 mirror が揃ってから workflow 統合)。
+
+---
+
+## 提供範囲とテスト
+
+### 提供範囲
+
+- 新規 script: `scripts/fuzz_forward_compat.py` (Python Hypothesis 駆動)
+- 既存 workflow 拡張: `.github/workflows/zh-en-loanword-sync.yml`, `pua-consistency.yml`
+- 9 ランタイムの loader CLI に `--validate-only` flag (or 同等の no-op validation 経路)
+- dashboard data: `docs/ci-dashboard/data/forward-compat-fuzz-{loanword,pua}.jsonl`
+- spec 更新: `docs/spec/loanword-contract.toml` / `docs/spec/pua-contract.toml` に `forward_compat: lenient` セクション追記
+
+### テスト
+
+| テスト | 場所 | 検査内容 |
+|--------|------|---------|
+| Python unit | `tests/test_fuzz_forward_compat.py` | Hypothesis strategy 自体が valid JSON を生成すること |
+| Python integration | `tests/test_loanword_loader_forward_compat.py` | schema_version 99 + 未知 field 入りの loanword を Python loader が `lenient` parse できる |
+| Rust integration | `src/rust/piper-plus-g2p/tests/forward_compat.rs` | 同上 (Rust 版) |
+| Go integration | `src/go/phonemize/forward_compat_test.go` | 同上 |
+| C# integration | `src/csharp/PiperPlus.Core.Tests/ForwardCompatTests.cs` | 同上 |
+| WASM integration | `src/wasm/openjtalk-web/test/js/forward-compat.test.js` | 同上 |
+| C++ integration | `src/cpp/tests/test_forward_compat.cpp` | 同上 |
+| Kotlin instrumented | `android/piper-plus-g2p/src/androidTest/.../ForwardCompatTest.kt` | 同上 |
+| Swift XCTest | `Tests/PiperPlusG2PTests/ForwardCompatTests.swift` | 同上 |
+| Fuzz smoke (CI) | `.github/workflows/zh-en-loanword-sync.yml` の新規 job | `--max-examples 10` で smoke、 PR ごと |
+| Fuzz full (CI nightly) | 同 workflow の `schedule:` トリガー | `--max-examples 1000` で full run |
+
+### 既存テストへの影響
+
+- `scripts/check_loanword_consistency.py` (既存 byte 一致 gate) は無変更で動作継続
+- `scripts/check_pua_consistency.py` 同上
+- `/check-loanword` skill は無変更
+- `/check-pua` skill は無変更
+
+---
+
+## 懸念事項
+
+### Rust serde の strict mode
+
+`serde_json::from_str` は default で未知 field を silently skip するが、 構造体に `#[serde(deny_unknown_fields)]` が付いていると fail する。 piper-plus の Rust loader (piper-core / piper-plus-g2p) が `deny_unknown_fields` を使っていないかを M4.1 実装前に grep で確認する必要がある。 もし使っている場合、 `forward_compat` セクションだけ別 struct に分けて `deny_unknown_fields` を外す改修が必要。
+
+### Go json.Unmarshal の strict mode
+
+Go の `encoding/json` は default で未知 field を skip するが、 `json.Decoder.DisallowUnknownFields()` を呼ぶと fail する。 同様に grep で確認、 使っていれば forward_compat path だけ disable する改修が必要。
+
+### Python pydantic strict / lenient 設定差
+
+Python loader が pydantic v2 を使っている場合、 `model_config = ConfigDict(extra="forbid" | "ignore" | "allow")` の設定で挙動が変わる:
+
+- `extra="forbid"`: 未知 field で `ValidationError` (現状もしこれなら forward-compat 違反)
+- `extra="ignore"`: 未知 field を silently skip (forward-compat OK)
+- `extra="allow"`: 未知 field を model 属性として保持 (forward-compat OK だが意図しない field を expose する副作用)
+
+M4.1 では `extra="ignore"` を canonical に統一し、 spec.toml に明記。
+
+### Hypothesis seed 安定性
+
+`HYPOTHESIS_SEED: ${{ github.run_id }}` だと PR ごとに seed が変わる。 メリットは coverage 増、 デメリットは「PR では fail なかったが next run で fail する」非再現性。 informational tier ではこれを許容するが、 dashboard 上で「同じ seed で連続失敗」が見えるよう seed を必ず JSON に記録する。
+
+### 9 loader を CI matrix で並列実行する場合の concurrent slot
+
+7 OS × 9 loader = 63 cell まで広げると GitHub concurrent slot を独占する。 親調査 §1.3 で「重量級 4 レーンが CI 経過時間の大半」と指摘済み。 M4.1 は Linux x86_64 のみ × 9 loader = 9 job で開始、 OS matrix 拡張は 3 ヶ月後 review で検討。
+
+### shrinking 時間
+
+Hypothesis が failure を見つけた後、 minimum failing example を探す shrinking に 2-5 分かかる場合がある。 timeout を 30 分に設定、 timeout 内に shrinking 完了しなければ「shrunk_example: timeout」として記録。
+
+### loader CLI 追加による既存 binary size 増
+
+`--validate-only` flag 追加は数 KB 程度の binary size 増。 既存 `bundle-size-gate.yml` の閾値に余裕があるか M4.1 実装前に確認。
+
+---
+
+## 一から作り直すとしたら (Ticket-level reinvention)
+
+### 1. アーキテクチャ: 9 loader を CLI から呼ぶか、 ライブラリとして直接 link するか
+
+CLI 経由は process spawn overhead が 9 ランタイム × 1000 ケース = 9000 回 invoke で ~10 分の純粋 overhead が発生する。 ライブラリ直接 link なら overhead ゼロだが、 Python から Rust / Go / C# / Kotlin / Swift を library として load するのは 5 種類の FFI bridge が必要で実装コストが大きい。
+
+ゼロから設計するなら、 **共通 IPC protocol** (JSON over stdin/stdout) を 9 loader に実装し、 各 loader を long-running process として spawn、 1 回の spawn で 1000 ケース投げ込む方式が最適。 process spawn overhead を 9 回に圧縮できる。 M4.1 では実装コストとのトレードオフで CLI per-invocation で開始し、 nightly run の所要時間が 30 分を超えたら IPC 化を検討する。
+
+### 2. 設計: schema_version の上限を設けるべきか
+
+現状 `schema_version` は 1 → 2 と incremental に上がる設計。 fuzz で `schema_version: 999` のような極端値を投げると、 「将来絶対に到達しない値」を検査することになり、 検出される bug の現実性が薄い。
+
+ゼロから設計するなら、 **`schema_version: current + 1 〜 current + 10` 程度の "現実的な未来" 範囲に絞る** のが妥当。 piper-plus の release cycle は ~半年に 1 回 schema bump (推定) で、 10 step 先 = 5 年先までを cover すれば実用上十分。 M4.1 では `min_value=3, max_value=999` で開始し、 3 ヶ月レビューで `max_value=10` 程度に絞ることを検討。
+
+### 3. 実装: Hypothesis vs 自前 generator vs proptest 連動
+
+Hypothesis (Python) は piper-plus に既に dependency として入っており追加コストが低い。 一方で Rust 側は `proptest` がネイティブだが、 Python から Rust proptest を起動する bridge がない。
+
+ゼロから設計するなら、 **JSON 入力を中央集権的に生成し、 全 loader に同じ入力を投げる** 方が differential fuzzing としても価値が高い (親調査 §3.3 の Differential fuzzing と整合)。 M4.1 では Hypothesis を central generator として採用、 Rust proptest は M-Stretch §S6 (Sanitizer 拡張) と統合する形で将来検討。
+
+### 4. 思考プロセス: 「panic しない」だけで forward-compat と言えるか
+
+「panic しない」は最低限の保証で、 真の forward-compat は **「未知 field を保持して output に反映できる」** または **「明示的に warning を出して呼び出し側に判断委ねる」** が望ましい。 M4.1 のスコープは前者の最低限保証に留まる。
+
+ゼロから設計するなら、 forward-compat を 3 段階に階層化する:
+
+- **L1 (M4.1 範囲)**: panic / exception しない
+- **L2**: 未知 field を warn log で報告 (silently skip しない)
+- **L3**: 未知 field を保持して downstream に渡す (Python dict / Rust `serde_json::Value` で raw として保持)
+
+M4.1 は L1 のみ。 L2/L3 は schema migration (例: v2 → v3 移行時) の責任で実装すべきと整理し、 M4 overview §2 で議論した「schema 設計時の責任」と接続する。
+
+---
+
+## 後続連絡
+
+- **M-Stretch §S1 (OSS-Fuzz) で harness 再利用**: `scripts/fuzz_forward_compat.py` を libFuzzer 互換に書き換え可能な構造にしておく (Hypothesis strategy → bytes 入力 adapter)
+- **M-Stretch §S2 (Bencher dashboard) で trend 表示**: `docs/ci-dashboard/data/forward-compat-fuzz-*.jsonl` を Bencher の custom adapter で読めるよう、 schema を `metric_kind: "fuzz_failures"` で統一
+- **`feedback_data_asset_distribution.md` に schema_version 規約を追記**: 新規データ asset 追加時に schema_version の forward-compat 要件 (lenient parse) も同時に満たすこと、 を明記
+- **3 ヶ月レビュー (Month 7 想定)**: signal が 0 件なら削除、 1-2 件なら維持、 3 件以上 (真の bug) なら blocker 昇格検討
+
+---
+
+## 関連ファイル
+
+### 既存
+
+- [`.github/workflows/zh-en-loanword-sync.yml`](../../.github/workflows/zh-en-loanword-sync.yml)
+- [`.github/workflows/pua-consistency.yml`](../../.github/workflows/pua-consistency.yml)
+- [`scripts/check_loanword_consistency.py`](../../scripts/check_loanword_consistency.py)
+- [`scripts/check_pua_consistency.py`](../../scripts/check_pua_consistency.py)
+- [`src/python/g2p/piper_plus_g2p/data/zh_en_loanword.json`](../../src/python/g2p/piper_plus_g2p/data/zh_en_loanword.json) (canonical)
+- [`docs/spec/pua-contract.toml`](../spec/pua-contract.toml)
+- [`docs/reference/zh-en-loanword/README.md`](../reference/zh-en-loanword/README.md)
+
+### 新規
+
+- `scripts/fuzz_forward_compat.py`
+- `docs/spec/loanword-contract.toml` (新規 or 既存 zh-en-loanword spec の拡張)
+- `docs/ci-dashboard/data/forward-compat-fuzz-loanword.jsonl`
+- `docs/ci-dashboard/data/forward-compat-fuzz-pua.jsonl`
+- `tests/test_fuzz_forward_compat.py`
+
+### 影響を受けるランタイム loader
+
+| ランタイム | path |
+|-----------|------|
+| Python | `src/python/g2p/piper_plus_g2p/chinese.py` (loanword loader 部分) |
+| Rust piper-core | `src/rust/piper-core/src/loanword.rs` (要確認) |
+| Rust piper-plus-g2p | `src/rust/piper-plus-g2p/src/chinese.rs` |
+| Go | `src/go/phonemize/chinese.go` |
+| C# | `src/csharp/PiperPlus.Core/Phonemize/Chinese.cs` |
+| WASM | `src/wasm/g2p/src/chinese.js` |
+| C++ | `src/cpp/g2p/chinese.cpp` (要確認) |
+| Kotlin | `android/piper-plus-g2p/src/main/.../Chinese.kt` |
+| Swift | `Sources/PiperPlusG2P/Chinese.swift` |
+
+---
+
+## 参照
+
+- [親マイルストーン: §M4.1](../proposals/ci-expansion-milestones.md#m41--loanword--pua-forward-compat-fuzz-top-10-6)
+- [親調査: §3.3 Property-based & Fuzzing 拡張](../proposals/ci-expansion-2026-05.md)
+- [親調査: §5 Top 10 #6](../proposals/ci-expansion-2026-05.md)
+- [M4 overview](./M4-overview.md)
+- [M-Stretch overview §S1 OSS-Fuzz](./M-Stretch-overview.md)
+- [`feedback_data_asset_distribution.md`](../../.claude/memory/) (延長元の memory)
+- [`/check-loanword` skill](../../.claude/skills/check-loanword/SKILL.md)
+- [`/check-pua` skill](../../.claude/skills/check-pua/SKILL.md)

--- a/docs/tickets/M4-2-timing-monotonicity-property.md
+++ b/docs/tickets/M4-2-timing-monotonicity-property.md
@@ -1,0 +1,396 @@
+# M4.2: Phoneme timing monotonicity property test
+
+**親マイルストーン**: [ci-expansion-milestones.md §M4.2](../proposals/ci-expansion-milestones.md#m42--phoneme-timing-monotonicity-property-test-top-10-9)
+**フェーズ**: [M4: Informational Tier](./M4-overview.md)
+**Top 10 #**: 9
+**ステータス**: 未着手
+**優先度**: 中
+**想定工数**: 1 PR (~8h)
+**作成日**: 2026-05-18
+
+---
+
+## 目的とゴール
+
+### 目的
+
+任意のテキスト入力 (8 言語 / SSML / silence option 組み合わせ) に対して phoneme timing 出力が以下の **temporal monotonicity 不変条件** を満たすことを Hypothesis で 1000 ケース検査する。
+
+1. 各 phoneme について `start <= end`
+2. 隣接 phoneme について `next.start >= prev.end` (overlap しない)
+3. 全 phoneme の累積時間 ≈ audio duration (許容誤差 ±50ms)
+4. SSML `<break>` 挿入箇所で前後 phoneme の `end` / `start` が break duration を含む
+
+これらは [`docs/spec/phoneme-timing-contract.toml`](../spec/phoneme-timing-contract.toml) で定義されている不変条件だが、 現状の `timing-parity.yml` は **byte 一致 (固定 fixture)** のみ検査しており、 任意入力で不変条件が崩れる timing 計算 bug は検出できない。 親調査 §5 Top 10 #9 の指摘通り、 PR ブロックすると false positive (浮動小数累積誤差 / SSML break boundary 演算誤差) が混じるため、 **PR ブロックせず informational** に留める。
+
+### ゴール
+
+| 項目 | 達成基準 |
+|------|---------|
+| workflow 存在 | 既存 `timing-parity.yml` に `monotonicity-property` job が追加されている |
+| informational 化 | 上記 job が `continue-on-error: true` で動作、 PR の Checks タブで「informational」表示 |
+| 7 ランタイム coverage | Python canonical + Rust / Go / C# / WASM / C++ / iOS Swift G2P の **7 runtime** で property test を実行 (Kotlin G2P は timing 未実装のため対象外、 timing 実装 PR と同時に追加) |
+| 不変条件 4 つ全部検査 | 上記 4 条件すべてを単一 `@given` で検査 |
+| Hypothesis 設定 | `max_examples=1000`, `deadline=None` (CI で deadline 切れを避ける), shrinking enabled |
+| dashboard 連携 | 失敗履歴を `docs/ci-dashboard/data/timing-monotonicity.jsonl` に append、 gh-pages で trend 表示 |
+| spec 連動 | `docs/spec/phoneme-timing-contract.toml` の不変条件節と property test の実装が 1:1 対応 |
+
+### 非ゴール
+
+- timing parity (Python ↔ Rust の byte 一致) は既存 `timing-parity.yml` で担保済みのため対象外
+- audio duration の絶対精度検証 (例: ±10ms) は対象外。 ±50ms 程度の許容で「明らかな bug」を検出する目的に絞る
+- streaming vs batch 出力の timing 一致は親調査 §2.2 の Tier 1 #5 で別途扱う領域。 M4.2 は単一 mode 内の不変条件のみ
+
+---
+
+## 実装詳細
+
+### アーキテクチャ
+
+```mermaid
+flowchart LR
+    A[Hypothesis strategy<br/>arbitrary text + ssml + options] --> B[Python canonical timing]
+    B --> C{4 invariants hold?}
+    A --> D[Rust CLI --emit-timing]
+    A --> E[Go CLI --emit-timing]
+    A --> F[C# CLI --emit-timing]
+    A --> G[WASM JS API timing]
+    A --> H[C++ CLI --emit-timing]
+    A --> I[Swift G2P CLI --emit-timing]
+    D & E & F & G & H & I --> J{4 invariants hold?}
+    C --> K[record JSONL]
+    J --> K
+    K --> L[gh-pages dashboard]
+```
+
+### Hypothesis strategy
+
+```python
+# tests/test_timing_monotonicity_property.py (擬似コード)
+from hypothesis import given, strategies as st, settings, HealthCheck
+
+LANGUAGES = ["ja", "en", "zh", "es", "fr", "pt", "ko", "sv"]
+
+# 各言語の現実的な文字種を含む text strategy
+@st.composite
+def localized_text(draw):
+    lang = draw(st.sampled_from(LANGUAGES))
+    if lang == "ja":
+        alphabet = "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん。、！？"
+    elif lang == "zh":
+        alphabet = "你好世界中文测试，。！？"
+    elif lang == "ko":
+        alphabet = "안녕하세요세계한국어테스트。、！？"
+    else:
+        alphabet = st.characters(min_codepoint=0x20, max_codepoint=0x7E, blacklist_categories=("Cs",))
+    text = draw(st.text(alphabet=alphabet, min_size=1, max_size=50))
+    return (lang, text)
+
+@st.composite
+def synth_input(draw):
+    lang, text = draw(localized_text())
+    # SSML 包む確率
+    use_ssml = draw(st.booleans())
+    if use_ssml:
+        # <break time="..."/> を 0-3 回挿入
+        break_count = draw(st.integers(min_value=0, max_value=3))
+        for _ in range(break_count):
+            pos = draw(st.integers(min_value=0, max_value=len(text)))
+            ms = draw(st.integers(min_value=10, max_value=1000))
+            text = text[:pos] + f'<break time="{ms}ms"/>' + text[pos:]
+        text = f"<speak>{text}</speak>"
+
+    sentence_silence_ms = draw(st.integers(min_value=0, max_value=500))
+    phoneme_silence_ms = draw(st.integers(min_value=0, max_value=100))
+
+    return {
+        "language": lang,
+        "text": text,
+        "is_ssml": use_ssml,
+        "sentence_silence_ms": sentence_silence_ms,
+        "phoneme_silence_ms": phoneme_silence_ms,
+    }
+
+@settings(max_examples=1000, deadline=None,
+          suppress_health_check=[HealthCheck.too_slow])
+@given(synth_input())
+def test_timing_monotonicity(input_dict):
+    timing = run_synthesis_with_timing(input_dict)
+
+    # 不変条件 1: start <= end
+    for ph in timing.phonemes:
+        assert ph.start_ms <= ph.end_ms, f"start>end: {ph}"
+
+    # 不変条件 2: 隣接 phoneme の monotonicity
+    for prev, curr in zip(timing.phonemes, timing.phonemes[1:]):
+        assert curr.start_ms >= prev.end_ms - 1e-3, \
+            f"overlap: prev={prev}, curr={curr}"
+
+    # 不変条件 3: 累積 ≈ audio duration
+    last_end = timing.phonemes[-1].end_ms
+    audio_duration_ms = timing.audio_duration_ms
+    assert abs(last_end - audio_duration_ms) <= 50.0, \
+        f"cumulative drift: last_end={last_end}, audio={audio_duration_ms}"
+
+    # 不変条件 4: SSML break で前後 phoneme の境界が break duration 含む
+    if input_dict["is_ssml"]:
+        verify_ssml_break_boundaries(timing, input_dict["text"])
+```
+
+### workflow 統合
+
+```yaml
+# .github/workflows/timing-parity.yml に追加
+monotonicity-property:
+  name: Timing Monotonicity Property (informational)
+  needs: parity-check  # 既存 byte 一致 gate の後に走る
+  continue-on-error: true
+  strategy:
+    fail-fast: false
+    matrix:
+      runtime: [python, rust, go, csharp, wasm, cpp, swift]
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@<sha>
+    - name: Setup ${{ matrix.runtime }}
+      uses: ./.github/actions/setup-runtime
+      with:
+        runtime: ${{ matrix.runtime }}
+    - name: Run property test
+      env:
+        HYPOTHESIS_SEED: ${{ github.run_id }}
+        TARGET_RUNTIME: ${{ matrix.runtime }}
+      run: |
+        uv run pytest tests/test_timing_monotonicity_property.py \
+          --hypothesis-show-statistics \
+          --hypothesis-seed=$HYPOTHESIS_SEED \
+          -v
+    - name: Record dashboard JSON
+      if: always()
+      run: |
+        uv run python scripts/record_property_result.py \
+          --runtime ${{ matrix.runtime }} \
+          --target timing-monotonicity \
+          --output docs/ci-dashboard/data/timing-monotonicity.jsonl
+    - name: Upload artifacts on failure
+      if: failure()
+      uses: actions/upload-artifact@<sha>
+      with:
+        name: timing-monotonicity-${{ matrix.runtime }}
+        path: |
+          docs/ci-dashboard/data/timing-monotonicity.jsonl
+          .hypothesis/
+```
+
+### 各ランタイムへの delegation
+
+Python 以外は `run_synthesis_with_timing()` を CLI 経由で呼ぶ:
+
+```python
+def run_synthesis_with_timing(input_dict):
+    target = os.environ["TARGET_RUNTIME"]
+    if target == "python":
+        return _python_canonical(input_dict)
+    elif target == "rust":
+        return _invoke_cli(["piper-plus", "--emit-timing-json", ...], input_dict)
+    elif target == "go":
+        return _invoke_cli(["./piper-plus-go", "--emit-timing-json", ...], input_dict)
+    # ... 同様
+```
+
+各ランタイムの `--emit-timing-json` flag は既存実装を流用 (親 CLAUDE.md「Phoneme Timing 出力」節参照、 全 6 ランタイムで JSON/TSV/SRT 出力済)。 Swift G2P のみ G2P-only のため timing 計算は phoneme level でモック、 audio duration は length_scale ベースで近似。
+
+### dashboard schema
+
+```json
+{
+  "timestamp": "2026-05-18T10:23:45Z",
+  "run_id": "12345678",
+  "target": "timing-monotonicity",
+  "runtime": "rust",
+  "seed": 42,
+  "max_examples": 1000,
+  "passed_examples": 998,
+  "failures": 2,
+  "shrunk_examples": [
+    {
+      "input": {"language": "ja", "text": "あ", "is_ssml": false, "sentence_silence_ms": 0, "phoneme_silence_ms": 0},
+      "violation": "invariant_3_cumulative_drift",
+      "details": "last_end=1024.3 audio=974.1 diff=50.2"
+    }
+  ]
+}
+```
+
+---
+
+## エージェントチーム
+
+実装時は以下の役割で 2 agent 並列を想定:
+
+| Agent | 担当 |
+|-------|------|
+| **Agent A: Python canonical property test** | `tests/test_timing_monotonicity_property.py` 実装、 4 不変条件の helper 関数、 `phoneme-timing-contract.toml` との 1:1 対応確認、 Python timing API での single-runtime green 確認 |
+| **Agent B: 6 non-Python runtime delegation + workflow** | 各ランタイム CLI の `--emit-timing-json` 流用 wrapper、 matrix workflow 構築、 dashboard JSON 生成 logic、 Swift G2P の audio duration モック実装 |
+
+merge order: A → B (Python canonical を確定してから multi-runtime delegation)。
+
+---
+
+## 提供範囲とテスト
+
+### 提供範囲
+
+- 新規 test: `tests/test_timing_monotonicity_property.py`
+- 既存 workflow 拡張: `.github/workflows/timing-parity.yml` に `monotonicity-property` job 追加
+- dashboard data: `docs/ci-dashboard/data/timing-monotonicity.jsonl`
+- dashboard 表示: `docs/ci-dashboard/timing-monotonicity.html` (gh-pages publish)
+- spec 更新: `docs/spec/phoneme-timing-contract.toml` に「不変条件 4 つ」の節を追記 (既存があれば property test 実装と対照表を追加)
+- helper script: `scripts/record_property_result.py` (M4.1 と共有可能)
+
+### テスト
+
+| テスト | 場所 | 検査内容 |
+|--------|------|---------|
+| Property test (Python canonical) | `tests/test_timing_monotonicity_property.py::test_timing_monotonicity` | 4 不変条件、 1000 examples |
+| Property test (per-runtime) | 同 file、 `TARGET_RUNTIME` env で分岐 | 7 runtime それぞれで 1000 examples |
+| Smoke test (CI PR) | 同 file | `max_examples=10` で smoke (PR ごと) |
+| Full test (CI nightly) | 同 file | `max_examples=1000` で full run (nightly cron) |
+| Unit test (helper) | `tests/test_timing_helpers.py` | `verify_ssml_break_boundaries` 単体 |
+
+### 既存テストへの影響
+
+- 既存 `timing-parity.yml` の byte 一致 job は無変更
+- 既存 `tests/test_timing_parity.py` (もしあれば) は無変更
+- `src/python_run/piper/timing.py` の API は無変更 (検査対象のみ)
+
+---
+
+## 懸念事項
+
+### 浮動小数累積誤差
+
+不変条件 3 (累積 = audio duration) は浮動小数演算の累積で ±10ms 程度の drift が発生し得る。 ±50ms 許容に設定したが、 sentence_silence_ms=500 を 10 sentence に挿入するような extreme ケースでは drift が増幅する可能性。 1000 examples 中の真の bug を検出するためには許容幅を狭くしたいが、 false positive を増やすトレードオフ。
+
+対策: 初期 ±50ms で開始、 4 週間 review 時点で実際の drift 分布を `hypothesis-show-statistics` から取得し、 許容幅を data-driven に調整。
+
+### SSML break 挿入時の境界
+
+不変条件 4 (`<break>` 前後の phoneme の `end` / `start` が break duration を含む) は SSML 実装ランタイムでのみ検査可能。 piper-plus は 6 runtime + npm G2P で SSML 対応 (CLAUDE.md 参照) だが、 Swift G2P / Kotlin G2P は SSML 未対応のため Swift の matrix は SSML フラグを `False` 固定にする。 matrix cell を変える必要があり、 workflow 設計が少し複雑化する。
+
+### multi-sentence 分割時の連続性
+
+v1.12.0 で `PiperVoice.phonemize()` が複数要素を返すよう breaking change された (CLAUDE.md 参照)。 multi-sentence 入力では各 sentence の timing が個別 array で返り、 sentence 境界での連続性 (sentence N の最後 end_ms == sentence N+1 の最初 start_ms - sentence_silence_ms) を検査する必要がある。
+
+対策: 不変条件 2 を「sentence 内で monotonic、 sentence 境界では sentence_silence_ms gap を許容」に拡張。 spec.toml にこの拡張ルールを明記。
+
+### Hypothesis の deadline
+
+Hypothesis default の `deadline=200ms` だと、 1 ケースあたり phonemize + ONNX inference で 200ms を超えるケースが頻発し `Flaky` 判定で skip される。 `deadline=None` で off にするが、 CI 全体の timeout (workflow timeout) は 30 分で hard cap。 1000 examples × ~500ms = ~500 秒で収まる想定。
+
+### 言語別 alphabet strategy の偏り
+
+ASCII text strategy だと英語以外で意味のない文字列になり、 phonemizer が「空 phonemes」を返す可能性。 言語別の現実的な alphabet を strategy で指定したが、 言語混在 (ja + en の code-switching) パターンは現状未 cover。 親 CLAUDE.md の「ZH-EN 混在ピンイン化」のような実用パターンは別途 fixture-based test で担保し、 property test は単一言語に絞る方針。
+
+### Swift G2P の timing 計算
+
+Swift G2P は G2P-only パッケージで synthesis を行わないため、 真の audio duration が取れない。 phoneme count × length_scale × hop_length / sample_rate で**近似 audio duration** を計算するが、 実際の synthesis 結果と一致しない。 不変条件 3 の検査は Swift では skip し、 不変条件 1/2/4 のみ検査する。 matrix workflow で `skip_invariant_3: true` flag を Swift cell のみ立てる。
+
+### shrinking timeout
+
+不変条件失敗時の minimum case shrinking に 2-5 分かかる。 informational なので時間内に shrink できなくても許容するが、 dashboard JSON 上で `shrunk_examples: timeout` を区別して記録。
+
+---
+
+## 一から作り直すとしたら (Ticket-level reinvention)
+
+### 1. アーキテクチャ: 全 runtime を 1 testbinary で実行するか matrix で並列するか
+
+現案は matrix (7 cell 並列) で各 runtime ごとに pytest 起動。 利点は failure isolation と並列度、 欠点は Hypothesis statistics の集約が分散される (各 cell の `.hypothesis/` directory が別)。
+
+ゼロから設計するなら、 **Python が central runner として全 runtime に CLI 呼び出しを delegate し、 1 つの pytest run で全 runtime を検査する** 方が statistics 集約と Hypothesis shrinking の重複削減に有利。 ただし 1 cell の所要時間が ~50 分 (7 × ~7 分) に伸び、 cancellation 時のロス大。 M4.2 では matrix で開始し、 4 週間後に statistics 集約の困難度を見て再評価。
+
+### 2. 設計: 不変条件を spec.toml で宣言、 test 側は spec を読んで自動生成、 は可能か
+
+不変条件 4 つを test code に直書きすると、 spec.toml と code が drift するリスクがある (親調査 §3.7 の「spec contract toml ⇔ implementation 同期 gate」と同じ問題)。
+
+ゼロから設計するなら、 spec.toml に invariant DSL を定義し、 test code は spec を parse して invariant を自動生成する meta-test 設計が望ましい。 例:
+
+```toml
+[invariants.start_le_end]
+expression = "ph.start_ms <= ph.end_ms"
+description = "各 phoneme の start <= end"
+
+[invariants.cumulative_drift]
+expression = "abs(phonemes[-1].end_ms - audio_duration_ms) <= 50.0"
+description = "累積時間が audio duration ±50ms"
+```
+
+M4.2 ではこの DSL 設計を後続改善 (M-Stretch §S7 cross-runtime differential testing 完全版) のスコープに譲り、 直書きで開始する。
+
+### 3. 実装: Hypothesis vs 自前 random vs proptest 連動
+
+Hypothesis を選んだ理由は (a) Python canonical なので Python ランタイムで自然、 (b) shrinking 機能で minimum failing case を自動探索、 (c) `hypothesis-show-statistics` で coverage 分析。 自前 random だと shrinking 自前実装が必要、 proptest は Rust ネイティブだが Python から呼べない。
+
+ゼロから設計するなら、 Hypothesis で central generator、 Rust 側は Rust 内 unit test で proptest を独立に走らせる **dual track** が最適。 ただし dual maintain のコスト大。 M4.2 は Hypothesis 一本で開始し、 Rust 側の proptest 統合は M-Stretch §S6 (Sanitizer 拡張) と統合検討。
+
+### 4. 思考プロセス: 「informational なら本当に必要か」 — dashboard only で十分か
+
+M4 overview §4 で議論した通り、 informational tier は「blocker への助走期間」または「3 ヶ月 no-signal で削除」または「dashboard only に降格」の 3 経路に収束する。 M4.2 が真の timing bug を検出した場合は blocker 昇格すべきだが、 nightly schedule + dashboard だけでも実用上の trend 監視は可能。
+
+ゼロから設計するなら、 PR run を完全に外し **schedule (nightly) のみ実行 + Slack 通知 + dashboard** とする選択が最も noise が少ない。 M4.2 では paths filter (`src/python_run/piper/timing.py` / `src/rust/piper-core/src/streaming.rs` / `docs/spec/phoneme-timing-contract.toml` 変更時のみ PR run、 それ以外は nightly) という hybrid で開始する。
+
+---
+
+## 後続連絡
+
+- **M-Stretch §S2 (Bencher dashboard) で trend 表示**: `docs/ci-dashboard/data/timing-monotonicity.jsonl` を Bencher の custom adapter で読めるよう、 schema を M4.1 と統一
+- **M-Stretch §S7 (Cross-runtime differential testing 完全版) で invariant DSL 化**: spec.toml で invariant 宣言、 test code 自動生成の設計を昇格判断時に再検討
+- **`phoneme-timing-contract.toml` の更新**: 4 不変条件を明記、 property test 実装ファイル名を逆参照
+- **3 ヶ月レビュー (Month 7 想定)**: signal が 0 件なら削除 / dashboard only に降格、 1-2 件なら維持、 3 件以上 (真の bug) なら blocker 昇格検討
+- **Kotlin G2P (timing 未実装) の追加**: timing 実装 PR と同時に matrix へ追加。 issue として `M4.2 followup: add kotlin timing matrix` を起票
+
+---
+
+## 関連ファイル
+
+### 既存
+
+- [`.github/workflows/timing-parity.yml`](../../.github/workflows/timing-parity.yml)
+- [`src/python_run/piper/timing.py`](../../src/python_run/piper/timing.py)
+- [`src/rust/piper-core/src/streaming.rs`](../../src/rust/piper-core/src/streaming.rs)
+- [`docs/spec/phoneme-timing-contract.toml`](../spec/phoneme-timing-contract.toml)
+- [`docs/spec/text-splitter-contract.toml`](../spec/text-splitter-contract.toml)
+
+### 新規
+
+- `tests/test_timing_monotonicity_property.py`
+- `tests/test_timing_helpers.py`
+- `scripts/record_property_result.py` (M4.1 と共有)
+- `docs/ci-dashboard/data/timing-monotonicity.jsonl`
+- `docs/ci-dashboard/timing-monotonicity.html` (gh-pages)
+
+### 影響を受けるランタイムの timing 実装
+
+| ランタイム | path |
+|-----------|------|
+| Python canonical | `src/python_run/piper/timing.py`, `voice.py:synthesize_with_timing` |
+| Rust | `src/rust/piper-core/src/timing.rs` (要確認) |
+| Go | `src/go/piperplus/timing.go` |
+| C# | `src/csharp/PiperPlus.Core/Timing/` |
+| WASM | `src/wasm/openjtalk-web/src/timing.js` |
+| C++ | `src/cpp/timing.cpp` (要確認) |
+| Swift G2P | `Sources/PiperPlusG2P/Timing.swift` (要確認、 phoneme-only) |
+
+---
+
+## 参照
+
+- [親マイルストーン: §M4.2](../proposals/ci-expansion-milestones.md#m42--phoneme-timing-monotonicity-property-test-top-10-9)
+- [親調査: §2.2 Tier 1 (audio quality)](../proposals/ci-expansion-2026-05.md) (timing は audio quality と隣接領域)
+- [親調査: §3.3 Property-based & Fuzzing 拡張](../proposals/ci-expansion-2026-05.md)
+- [親調査: §5 Top 10 #9](../proposals/ci-expansion-2026-05.md)
+- [M4 overview](./M4-overview.md)
+- [M-Stretch overview §S2 Bencher dashboard, §S7 Cross-runtime differential](./M-Stretch-overview.md)
+- [`docs/spec/phoneme-timing-contract.toml`](../spec/phoneme-timing-contract.toml)
+- CLAUDE.md「Phoneme Timing 出力」節

--- a/docs/tickets/M4-overview.md
+++ b/docs/tickets/M4-overview.md
@@ -1,0 +1,141 @@
+# M4: Informational Tier — Phase Overview
+
+**親マイルストーン**: [ci-expansion-milestones.md §M4](../proposals/ci-expansion-milestones.md#m4-informational-tier-任意-m3-と並走可)
+**親調査**: [ci-expansion-2026-05.md](../proposals/ci-expansion-2026-05.md)
+**期間**: M3 並走可 (Month 3 後半 〜 Month 4 序盤)
+**作成日**: 2026-05-18
+**ステータス**: 未着手
+
+---
+
+## フェーズの狙い
+
+informational tier = **PR ブロックせず trend 監視のみ** を行う workflow 層。 確率的 / flaky / shrinking に時間がかかる検査を本筋 gate から隔離することで、 「signal noise の蓄積」と「flake = 無視」の常態化を未然に防ぐ。 親調査 §4 で批判的に列挙された「Hypothesis nightly や fuzzer のような確率的検査は特に "flake = 無視" が常態化する」リスクへの構造的対応。
+
+M4 の対象は Top 10 のうち **#6 forward-compat fuzz** と **#9 timing monotonicity property test** の 2 本。 いずれも
+
+- 1000 ケース規模の property-based / fuzz テストで、 失敗時の shrinking に時間がかかる
+- 真の bug 検出率は低くないが、 false positive (環境差 / 浮動小数累積誤差 / Hypothesis seed 依存) が混じる構造を持つ
+- PR ブロックすると contributor friction を急上昇させる一方、 trend 監視には十分な価値がある
+
+という共通性質を持ち、 informational tier に置くべき典型例。
+
+---
+
+## 含まれるチケット
+
+| ID | タイトル | Top 10 # | 想定工数 | 優先度 |
+|----|---------|----------|---------|--------|
+| [M4.1](./M4-1-loanword-pua-forward-compat.md) | Loanword / PUA forward-compat fuzz | #6 | 1-2 PR (~10h) | 中 |
+| [M4.2](./M4-2-timing-monotonicity-property.md) | Phoneme timing monotonicity property test | #9 | 1 PR (~8h) | 中 |
+
+合計想定工数: 2-3 PR / ~18h (M3 と並走しても 1 maintainer 容量に収まる)。
+
+---
+
+## informational tier 運用ルール
+
+M4 で初めて「明示的な informational tier」を CI 上に作るため、 後続 M-Stretch も含めた運用ルールを本フェーズで確立する。
+
+### lifecycle ルール
+
+```mermaid
+flowchart LR
+    A[新規追加: informational] -->|4 週| B{false positive 率 < 5%?}
+    B -->|Yes| C{真の bug を 1 度でも検出?}
+    B -->|No| D[suppression 拡充 or 設計見直し]
+    C -->|Yes| E[blocker 昇格判断 review]
+    C -->|No, 3 ヶ月継続| F[削除候補レビュー]
+    D --> A
+    E --> G[blocker / informational 維持を判定]
+    F --> H[net flat policy で削除 or 維持]
+```
+
+具体ルール:
+
+- **3 ヶ月連続で 1 度も signal を出さなかった場合、 削除候補** (net flat policy の一環)
+- 失敗履歴は gh-pages dashboard に集約 (`docs/ci-dashboard/informational-tier/` 配下に static HTML)
+- **4 週間 / 12 週間レビュー時点で blocker 昇格 / informational 維持 / 削除の 3 択** を実施
+- 4 週間 review は M4 完了の翌週 (Month 4 序盤)
+- 12 週間 review は M-Stretch 開始判定と合わせて実施
+
+### workflow 実装規約
+
+informational tier の workflow は以下を必須化する:
+
+| 項目 | 必須要件 |
+|------|---------|
+| `continue-on-error` | job レベルで `true` (run conclusion は success にならないが、 PR check は skip 表示) |
+| GitHub check display | `if: always()` + `continue-on-error: true` の組み合わせで「failed (informational)」として表示 |
+| Slack / Issue 通知 | 失敗時の通知は **schedule run のみ** (PR run では通知しない、 noise 削減) |
+| dashboard 連携 | 失敗履歴を `gh-pages` の dashboard JSON に append (`docs/ci-dashboard/data/`) |
+| 命名規約 | workflow file 名末尾に `-informational.yml` または job 名末尾に `(informational)` を付与 |
+
+### M1.1 gateway workflow との関係
+
+M1.1 で導入される `required_status_check_gate.yml` は **informational workflow を required に含めない**。 これは M1.1 設計時点で「cancelled / skipped を fail に変換するのは required check のみ」と明示しておく必要がある。 informational tier は gateway の対象外であることを M1.1 完了時の docs (`docs/reference/branch-protection-history.md`) に明記する。
+
+---
+
+## 一から設計し直すとしたら (Phase-level reinvention)
+
+### 1. アーキテクチャ: informational workflow を CI に組み込まず、 nightly cron + Slack 通知だけで済むか
+
+ゼロから設計するなら、 **PR trigger は外して schedule (nightly) のみで走らせる** 選択肢は強い。 informational が PR ごとに走ると、 contributor の Checks タブに「failed (informational)」が並ぶ視覚ノイズが発生し、 「informational」というラベルの意味を学習していない初回 contributor は混乱する。 nightly cron だけで走らせれば、 (a) dashboard には十分な data point が貯まる、 (b) contributor の Checks タブはクリーンに保てる、 (c) Slack / GitHub Issue auto-create でメンテナだけが通知を受ける、 の 3 利点が得られる。
+
+ただし「PR で導入された regression を nightly まで検出できない」という遅延リスクがある。 M4.1 forward-compat fuzz は schema_version の上限が現状 2 で、 新規 mirror 追加時にのみ regression が発生し得るため nightly で十分。 M4.2 timing monotonicity は timing.py / streaming.rs の変更 PR でのみ regression し得るため、 paths filter で該当ファイル変更時のみ PR run、 それ以外は nightly run、 という hybrid が現実解。 M4.1/M4.2 個別チケットでこの判断を再評価する。
+
+### 2. 設計: forward-compat fuzz は本来「schema 設計時の責任」 — CI で検査せず schema migration 時のみ走らせる設計
+
+親調査 §3.3 の Property-based & Fuzzing 拡張で「Differential fuzzing: text_splitter 7 ランタイム」が #346 / #499 系 drift の構造的再発防止として挙げられている通り、 fuzzing は **drift が構造的に起きやすい場所** で価値が高い。 schema forward-compat は本来 schema 設計時点の責任 (`schema_version` フィールドの semantics、 unknown field の handling 規約、 mirror generator の strict / lenient 設定) で担保されるべきで、 CI fuzz は事後検出に過ぎない。
+
+理想設計は (a) schema toml に `forward_compat: strict / lenient` を明記、 (b) mirror generator (Python canonical → 9 mirror) が `lenient` field を未知 field skip 経路に変換、 (c) CI fuzz は「mirror generator が contract 通り動いているか」の最終 verification、 という 3 層構造。 M4.1 では現状の `--fuzz-future-schema` job 追加に留めるが、 後続改善として contract toml への schema 設計責務移行を提案する。
+
+### 3. 実装: Hypothesis property test の 1000 ケースは過剰か過少か
+
+Hypothesis の `@given` で `max_examples=1000` は default の `max_examples=100` の 10 倍。 piper-plus の他 property test (例: `test_text_splitter_property.py`) は default の 100 を採用している。 1000 ケースは:
+
+- **検出力**: 入力空間が広い (任意テキスト × 8 言語 × SSML × silence option) ため、 100 では coverage が薄い。 1000 で初めて意味のある shrinking が期待できる
+- **時間**: 1 ケースあたり phonemize + ONNX inference + timing 計算で ~500ms (CPU)、 1000 ケース = ~500 秒。 7 ランタイム並列なら ~10 分。 unlimited CI 前提なら問題ない
+- **shrinking**: 失敗時に Hypothesis が minimum failing case を探す時間が追加で ~2-5 分。 1000 examples だと shrink budget も大きく、 真の minimum を見つける確率が上がる
+
+逆に過少を疑うなら 10000 ケース (約 100 分) も選択肢。 ただし real-world でこのレベルの coverage が必要なのは OSS-Fuzz 領域 (continuous fuzz) で、 M-Stretch §S1 で扱うべき粒度。 informational tier は「真の bug を月 1-2 件検出できれば成功」のレベル感が妥当で、 1000 ケースで開始し 3 ヶ月後の signal 量で再評価する。
+
+### 4. 思考プロセス: 「informational」というステータスが長期的に "warning fatigue" を生むなら、 そもそも informational tier 自体を廃止して dashboard only にすべきか
+
+これは M4 phase 設計の根本問いであり、 親調査 §4 の「signal-to-noise 閾値割れ」批判への直接的応答。 informational tier の存在意義は **「blocker にする前の助走期間」** であり、 永続的に informational のまま走らせる workflow は存在意義が薄い。 すべての informational workflow は以下の 3 道のいずれかに収束すべき:
+
+- (a) 4-12 週後に blocker 昇格
+- (b) 3 ヶ月連続 no-signal で削除
+- (c) dashboard only に降格 (CI runner は使わず、 schedule で生成したレポートを gh-pages に publish するだけ)
+
+(c) の dashboard only は本フェーズで明示的に第 3 の道として定義する。 M4.1/M4.2 が 12 週間で blocker 昇格できなかった場合、 削除する前に dashboard only に降格する選択肢を残す。 これは M-Stretch §S2 (Bencher dashboard) と統合可能で、 informational signal を 1 つの dashboard に集約する将来像と整合する。
+
+別案として「informational tier を完全廃止し、 確率的検査は最初から OSS-Fuzz (M-Stretch §S1) に委譲する」も検討した。 piper-plus 単独では OSS-Fuzz 申請 1-2 週間 + harness 整備のコストがかかるため、 M4 の 2 本 (forward-compat / timing monotonicity) は自前 informational で開始し、 OSS-Fuzz 採択後に harness 統合する段階的アプローチを採る。
+
+---
+
+## 後続フェーズへの連絡事項
+
+- **M-Stretch §S2 (Bencher dashboard) と統合**: informational signal を 1 つの dashboard に集約予定。 M4 で `docs/ci-dashboard/data/` に append する JSON schema を、 後の Bencher 移行で読み替え可能な形で設計する (`bencher.dev/docs/explanation/adapters` 互換)
+- **各 informational workflow には 3 ヶ月後の review reminder を Issue として起票**: M4.1/M4.2 完了 PR の本文に `Issue: review at YYYY-MM-DD` を記載、 該当日に GitHub Actions schedule workflow が Issue auto-create
+- **false positive 率 / true positive 率を集計するメタ workflow を将来追加検討**: M-Stretch §S2 Bencher と組み合わせれば自動集計可能。 単体での実装は ROI 低のため M-Stretch 待ち
+- **M-Stretch §S1 (OSS-Fuzz) 採択時の harness 統合計画**: M4.1 forward-compat fuzz は OSS-Fuzz harness としても再利用可能な構造 (`scripts/fuzz_forward_compat.py` を libFuzzer 互換に書ける)。 M4.1 実装時にこの再利用を視野に入れる
+- **net flat policy の宿題**: M4 で 2 workflow 追加するため、 同期間に **2 本の workflow を削除候補としてレビュー** する。 候補 (M4 期間中に評価):
+  - `legacy-fuzz-smoke.yml` (もし `cargo fuzz` smoke が既存にあれば M4.1 と重複する可能性)
+  - schedule cron が月曜朝に集中している 6 本のうち、 trend 監視で代替可能なもの
+  - `pua-consistency.yml` と `zh-en-loanword-sync.yml` の forward-compat schema 部分 (M4.1 完了後)
+
+---
+
+## 関連リンク
+
+- [M4.1: Loanword / PUA forward-compat fuzz](./M4-1-loanword-pua-forward-compat.md)
+- [M4.2: Phoneme timing monotonicity property test](./M4-2-timing-monotonicity-property.md)
+- [M-Stretch overview](./M-Stretch-overview.md)
+- [親マイルストーン: ci-expansion-milestones.md §M4](../proposals/ci-expansion-milestones.md#m4-informational-tier-任意-m3-と並走可)
+- [親調査: ci-expansion-2026-05.md §3.3](../proposals/ci-expansion-2026-05.md) (Property-based & Fuzzing 拡張)
+- [親調査: ci-expansion-2026-05.md §4](../proposals/ci-expansion-2026-05.md) (批判的観点 — signal-to-noise)
+- [M1 overview](./M1-overview.md) (informational tier と gateway workflow の関係)
+- [feedback memory: feedback_data_asset_distribution.md](../../.claude/memory/) (M4.1 の延長元)
+- [docs/spec/phoneme-timing-contract.toml](../spec/phoneme-timing-contract.toml) (M4.2 の検査対象 spec)

--- a/docs/tickets/README.md
+++ b/docs/tickets/README.md
@@ -1,0 +1,162 @@
+# Tickets — CI/CD 拡張プラン 個別実装チケット
+
+**親調査**: [proposals/ci-expansion-2026-05.md](../proposals/ci-expansion-2026-05.md) (30 エージェント統合調査)
+**親マイルストーン**: [proposals/ci-expansion-milestones.md](../proposals/ci-expansion-milestones.md) (Top 10 → M1-M4 + M-Stretch 分解)
+**作成日**: 2026-05-18
+**ステータス**: 全 10 チケット 未着手
+
+このディレクトリは [親マイルストーン doc](../proposals/ci-expansion-milestones.md) を実装単位のチケットに分解したものです。 マイルストーン doc が "全体マップ / 採用判断 / phase レベル運用ルール" を扱うのに対し、 各チケットは "実装者が一人で着手できるレベル" まで具体化されています。
+
+---
+
+## チケット ↔ マイルストーン 相互マップ
+
+| Phase | Overview | 個別チケット | Top 10 # | 想定工数 | 優先度 | ステータス |
+|-------|----------|-------------|---------|----------|--------|-----------|
+| **M1** Defensive Foundations | [M1-overview.md](./M1-overview.md) | [M1.1 Cancelled baseline alarm](./M1-1-cancelled-baseline-alarm.md) | #10 | 1-2 PR (~8h) | 高 | 未着手 |
+| | | [M1.2 Migration guide lint](./M1-2-migration-guide-lint.md) | #3 | 1 PR (~6h) | 高 | 未着手 |
+| | | [M1.3 First-PR fast lane](./M1-3-first-pr-fast-lane.md) | #5 | 2 PR (~12h) | 高 | 未着手 |
+| **M2** Audio Quality Moat | [M2-overview.md](./M2-overview.md) | [M2.1 Audio MOS proxy gate](./M2-1-audio-mos-proxy.md) | #1 | 3-4 PR (~30h) | 高 | 未着手 |
+| | | [M2.2 Cross-runtime audio byte parity](./M2-2-cross-runtime-audio-parity.md) | #2 | 4-5 PR (~40h) | 高 | 未着手 |
+| **M3** ABI & Ecosystem Hardening | [M3-overview.md](./M3-overview.md) | [M3.1 Public ABI snapshot](./M3-1-public-abi-snapshot.md) | #4 | 3 PR (~25h) | 高 | 未着手 |
+| | | [M3.2 Model card / license auto-injection](./M3-2-license-auto-injection.md) | #7 | 2 PR (~15h) | 中 | 未着手 |
+| | | [M3.3 Typosquatting weekly scan](./M3-3-typosquatting-watch.md) | #8 | 2 PR (~12h) | 中 | 未着手 |
+| **M4** Informational Tier | [M4-overview.md](./M4-overview.md) | [M4.1 Loanword/PUA forward-compat fuzz](./M4-1-loanword-pua-forward-compat.md) | #6 | 1-2 PR (~10h) | 低 | 未着手 |
+| | | [M4.2 Phoneme timing monotonicity](./M4-2-timing-monotonicity-property.md) | #9 | 1 PR (~8h) | 低 | 未着手 |
+| **M-Stretch** Strategic Bets | [M-Stretch-overview.md](./M-Stretch-overview.md) | (個別チケット未起票、 候補 S1-S8) | — | 各 milestone 規模 | 検討 | 未着手 |
+
+**合計**: 10 チケット (M1-M4) + 8 候補 (M-Stretch) / 想定工数 19-21 PR / ~166h (M1-M4 のみ)
+
+---
+
+## 依存グラフ
+
+```mermaid
+graph TD
+    M1_1[M1.1 cancelled baseline alarm]
+    M1_2[M1.2 migration guide lint]
+    M1_3[M1.3 first-PR fast lane]
+    M2_1[M2.1 audio MOS proxy]
+    M2_2[M2.2 cross-runtime audio parity]
+    M3_1[M3.1 public ABI snapshot]
+    M3_2[M3.2 license auto-injection]
+    M3_3[M3.3 typosquatting watch]
+    M4_1[M4.1 forward-compat fuzz]
+    M4_2[M4.2 timing monotonicity]
+
+    M1_1 --> M1_3
+    M1_1 --> M2_1
+    M1_1 --> M2_2
+    M2_1 --> M2_2
+
+    M1_1 -.optional.-> M3_1
+    M1_1 -.optional.-> M3_2
+    M1_1 -.optional.-> M3_3
+    M1_1 -.optional.-> M4_1
+    M1_1 -.optional.-> M4_2
+
+    classDef m1 fill:#e3f2fd,stroke:#1976d2
+    classDef m2 fill:#fff3e0,stroke:#f57c00
+    classDef m3 fill:#f3e5f5,stroke:#7b1fa2
+    classDef m4 fill:#e8f5e9,stroke:#388e3c
+
+    class M1_1,M1_2,M1_3 m1
+    class M2_1,M2_2 m2
+    class M3_1,M3_2,M3_3 m3
+    class M4_1,M4_2 m4
+```
+
+- **強依存** (実線): M1.1 cancelled baseline alarm → M2.1 / M2.2 (silent skip を塞いでから informational tier を載せる)、 M2.1 → M2.2 (fixture 共有)
+- **弱依存** (点線): M1.1 → M3.x / M4.x (cancelled silent skip 防止は全 phase の前提だが、 M3/M4 は M1.1 未完でも先行着手可能)
+- **並列可**: M1.2 / M1.3 は M1.1 と独立に着手可能。 M3.1 / M3.2 / M3.3 / M4.1 / M4.2 は全て相互独立
+
+---
+
+## チケット標準フォーマット
+
+全チケットは以下 9 節構成で統一されています:
+
+1. **タスクの目的とゴール** — 目的 (1-2 行) と Definition of Done (検証可能な箇条書き)
+2. **実装する内容の詳細** — 背景 / アーキテクチャ / 具体的変更 / 設定例 (mermaid / yaml / 擬似コード)
+3. **エージェントチームの役割と人数** — ロール別に具体的人数と担当範囲を明記
+4. **提供範囲とテスト項目** — IN/OUT-SCOPE / Unit テスト / E2E / 手動検証
+5. **懸念事項とレビュー観点** — 親 doc の「リスク」を起点に拡張、 review checklist
+6. **一から作り直すとしたら (Reinvention)** — 既存制約を取り払った再設計案 / 採用しなかった代案
+7. **後続タスクへの連絡事項 (Handoff)** — 共通 fixture / script の再利用、 依存チケットへの更新事項
+8. **関連ファイル** — 既存改修対象 / 新規作成 / 仕様 toml / docs
+9. **参照** — 親 doc / feedback memory / 関連 PR / Issue
+
+各 Phase overview には更に **phase-level reinvention** (4 視点: アーキテクチャ / 設計 / 実装 / 思考プロセス) と **後続フェーズへの連絡事項** が記載されています。
+
+---
+
+## 進捗の見方
+
+このページの「ステータス」列を更新することでマイルストーン進捗を把握できます。 状態遷移:
+
+```text
+未着手 → 着手中 (PR draft) → レビュー中 (PR open) → 完了 (PR merged + 1 週間 green)
+                                                  ↓
+                                          informational tier 維持 (M2/M4 のみ)
+                                                  ↓
+                                          blocker 昇格 or 削除 (3 ヶ月後判定)
+```
+
+各チケットの **ステータス** ヘッダも同時に更新してください (チケット top 部に記載)。
+
+---
+
+## 運用ルール (各 phase 共通)
+
+[ci-expansion-milestones.md §マイルストーン横断の運用ルール](../proposals/ci-expansion-milestones.md#マイルストーン横断の運用ルール) からの抜粋:
+
+### 採用判断 (各 M 開始時)
+
+- 親 doc §4 の批判的観点を再確認 (「追加しない」が default)
+- 「既存と排他的でない / 既存 gate では構造的に検出不可能 / user-visible damage を防ぐ」の 3 条件いずれかを満たすか
+- 同月内に削除候補となる既存 workflow があるか (**net flat policy**)
+
+### 完了判定 (各 M 終了時)
+
+- 含まれる workflow が dev で 1 週間 green を維持
+- false positive 率 < 5% (informational tier は除く)
+- contributor friction 報告なし
+- 削除候補レビュー実施済み
+
+### 中止判定 (M 内で blocker 発生時)
+
+- false positive 率 > 20% → informational tier 降格
+- 工数が見積もりの 2 倍超 → scope 半減
+- contributor friction 報告 ≥ 3 件 → 設計再検討
+
+---
+
+## エージェントチーム配置サマリ
+
+各チケットで想定するエージェントチーム規模 (詳細は各チケット §3 参照):
+
+| Phase | 合計人数 (述べ) | 主要ロール |
+|-------|---------------|----------|
+| M1 | 12-15 名 | GitHub Actions specialist / Python script author / docs writer / reviewer / QA |
+| M2 | 10-15 名 | audio quality engineer / runtime integration specialist (各 runtime) / MLOps / docs writer |
+| M3 | 11-13 名 | ABI specialist (C/Swift/Kotlin) / legal researcher / security engineer / release engineer |
+| M4 | 6-8 名 | property test author / fuzz engineer / runtime specialist (forward-compat 7 runtime) |
+
+M1-M4 合計 39-51 名 (重複含む述べ人数)。 単一実装者でも順次着手可能だが、 並列実行で最短 3 ヶ月達成を想定。
+
+---
+
+## 関連ドキュメント
+
+- [親調査 ci-expansion-2026-05.md](../proposals/ci-expansion-2026-05.md) — Top 10 選定根拠 / 30 エージェント統合
+- [親マイルストーン ci-expansion-milestones.md](../proposals/ci-expansion-milestones.md) — phase 全体マップ / 採用判断 framework
+- [既存 spec INDEX](../spec/README.md) — 18+ contract toml (PUA / phoneme-timing / SSML 等)
+- [既存 reference INDEX](../reference/README.md) — 設計書 (Kotlin/Swift G2P / iOS shared-lib / ZH-EN 等)
+- [.claude/README.md](../../.claude/README.md) — 既存 skill / hook / pre-commit gate
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — M1.3 で更新予定
+
+## 変更履歴
+
+| 日付 | 変更 | 関連 PR |
+|------|------|---------|
+| 2026-05-18 | 初版作成 (10 チケット + 5 overview / 計 5314 行 / 4 エージェント並列執筆) | — |


### PR DESCRIPTION
## Summary

30 エージェント並列調査の Top 10 を「実装者が一人で着手できる粒度」まで分解した個別チケットを `docs/tickets/` に追加します。 各チケットは 9 節構成 (目的 / 詳細 / チーム配置 / Unit&E2E テスト / 懸念 / Reinvention / Handoff / 関連ファイル / 参照) で、 親調査 (`ci-expansion-2026-05.md`) と親マイルストーン (`ci-expansion-milestones.md`) に双方向リンクします。

## Affected Components

- [x] Documentation

## Type

- [x] Documentation

## Risk Level

- [x] patch (docs のみ / 既存ファイルへの破壊的変更なし)

## Contract Impact

- [x] None (`docs/spec/*.toml` への影響なし)

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| 個別実装チケット 10 本 | Top 10 を「一人で着手可能」レベルまで分解 (合計 4500+ 行) | 親 doc が方針サマリ止まりで実装者が初動でブロックする |
| Phase overview 5 本 | M1-M4 / M-Stretch の phase レベル reinvention 含む | phase 全体の設計意図が散逸する |
| Index README + 依存グラフ | mermaid で強依存・弱依存を可視化、 標準フォーマット 9 節を定義 | 着手順や粒度判断の根拠が分散する |
| 親 milestone doc への backlink | 11 箇所、 各 M.X セクションに対応チケットへのリンク追加 | チケットから親への片方向リンクで進捗追跡が壊れる |
| `docs/README.md` への Tickets セクション追加 | 上位 docs INDEX から到達可能に | docs 全体から見えない孤立 doc になる |

## 設計判断

- 9 節標準フォーマットを採用 — reinvention + handoff まで含む長尺。 「ここに書くべき」が決まっている方が後続チケット執筆の認知負荷が低い
- 2 層構造 (overview + 個別チケット) で phase レベル / チケットレベルの再設計議論を独立化
- 双方向 backlink (親 milestone → ticket / ticket → 親 / `docs/README.md` → tickets INDEX) の 3 経路すべて。 一方向だと「進捗から仕様」または「仕様から進捗」のどちらかが壊れる
- markdownlint pre-commit pass 済み (MD022 / MD032 / MD040 / MD025 / MD031 / MD034 / MD048 / MD056 を 7 件手動修正、 入れ子 fence は indent 形式で回避)

## Test Plan

- [ ] `docs/tickets/README.md` の mermaid 依存グラフが GitHub 上で render される
- [ ] `docs/proposals/ci-expansion-milestones.md` の 11 backlink が全てチケットへ正しく到達する
- [ ] 各チケット内の `../proposals/ci-expansion-milestones.md` 相対リンクが全て解決する (404 なし)
- [ ] `pre-commit run --files docs/tickets/*.md docs/proposals/ci-expansion-milestones.md docs/README.md` が pass

## Checklist

- [x] Tests pass locally (markdownlint / pre-commit)
- [x] No GPL-LGPL deps
- [x] Documentation updated (本 PR 自身)

## Related Issues

なし (CI 拡張プラン親調査 `docs/proposals/ci-expansion-2026-05.md` から派生)
