### PR TITLE
ci: cancelled / skipped baseline alarm gateway

### DIFF
--- a/.github/workflows/required_status_check_gate.yml
+++ b/.github/workflows/required_status_check_gate.yml
@@ -1,0 +1,95 @@
+# Required Status Check Gate (M1.1)
+# ==================================
+# GitHub branch protection treats `cancelled` and `skipped` workflow runs as
+# a pass (fail-open). PR #419 (memory `feedback_ci_cancelled_baseline`) showed
+# how that lets a baseline collapse merge silently. This workflow is the hub
+# of a hub-and-spoke gateway: it asks the REST API for the latest run of
+# every monitored spoke at `head_sha` and fails if any spoke is missing,
+# cancelled, skipped, failed, or timed out.
+#
+# Why a separate workflow rather than touching the spokes:
+#   - The 18+ contract gates have well-isolated responsibilities; we don't
+#     want to add fail-open guards into each of them.
+#   - Spoke renames / consolidations don't touch branch protection — only
+#     the `MONITORED_WORKFLOWS` env below changes.
+#
+# Add a workflow to MONITORED_WORKFLOWS after it has been green on dev for
+# at least one week (informational tiers from M2/M4 stay off this list).
+
+name: Required Status Check Gate
+
+on:
+  pull_request:
+    branches: [dev]
+    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows:
+      - Multi-Runtime RTF Benchmark
+      - Memory regression (per-language)
+      - CodeQL
+      - Parity Hub
+      - PUA Consistency Gate
+    types: [completed]
+
+# Avoid self-cancellation when several spokes complete in quick succession;
+# letting the gate be cancelled is exactly the fail-open path we are closing.
+concurrency:
+  group: required-gate-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    env:
+      MONITORED_WORKFLOWS: >-
+        Multi-Runtime RTF Benchmark,Memory regression (per-language),CodeQL,Parity Hub,PUA Consistency Gate
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Resolve head_sha and PR number
+        id: ctx
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "pr=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "base_branch=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            # `workflow_run` doesn't carry the PR number directly; surface the
+            # head branch so the next step can look it up if needed.
+            echo "pr=" >> "$GITHUB_OUTPUT"
+            echo "base_branch=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Aggregate spoke conclusions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.ctx.outputs.sha }}
+          PR_NUMBER: ${{ steps.ctx.outputs.pr }}
+          BASE_BRANCH: ${{ steps.ctx.outputs.base_branch }}
+        run: |
+          set -euo pipefail
+          extra_args=()
+          if [ -n "${PR_NUMBER}" ]; then
+            extra_args+=("--post-pr-comment" "${PR_NUMBER}")
+          fi
+          if [ -n "${BASE_BRANCH}" ]; then
+            extra_args+=("--branch-for-supersede" "${BASE_BRANCH}")
+          fi
+          python scripts/check_required_gate.py \
+            --head-sha "${HEAD_SHA}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --monitored "${MONITORED_WORKFLOWS}" \
+            --on-cancelled fail \
+            --on-skipped fail \
+            "${extra_args[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,8 @@ check_*.py
 !scripts/check_todo_age.py
 !scripts/check_workspace_python_parity.py
 !scripts/check_training_defaults.py
+# M1.1 — cancelled / skipped baseline alarm gateway
+!scripts/check_required_gate.py
 create_comprehensive_*.py
 add_missing_*.py
 retrain_*.py

--- a/docs/reference/branch-protection-history.md
+++ b/docs/reference/branch-protection-history.md
@@ -1,0 +1,117 @@
+# Branch protection history
+
+Single source of truth for changes to `dev` (and later `main`) branch
+protection rules on `ayutaz/piper-plus`. Each entry records the change
+intent, the `gh api` snapshot before / after, and the verification command
+a reviewer can use to confirm the change landed.
+
+The motivating context is M1.1 (cancelled / skipped baseline alarm). GitHub
+branch protection treats `cancelled` and `skipped` workflow runs as a pass
+(fail-open), and PR #419 showed that this lets a baseline collapse merge
+silently. The hub-and-spoke gateway (`required_status_check_gate.yml`) closes
+the gap by translating `cancelled` / `skipped` into an explicit `failure`
+check, but it must also be wired into branch protection — that's the change
+this document tracks.
+
+## Why this file exists, not a `gh api` script
+
+Branch protection edits are one of the few changes that can lock the
+repository out of legitimate work. We deliberately do **not** automate
+`PATCH /repos/.../branches/dev/protection` in CI; instead, every change is
+performed by a maintainer, captured here as a before/after JSON snapshot,
+and reviewed in a PR. Future M1 / M2 / M3 tickets that add a required
+check append to this file rather than starting a new doc.
+
+## Snapshot conventions
+
+- Use `gh api repos/ayutaz/piper-plus/branches/dev/protection > /tmp/before.json`
+  for the **before** snapshot. Redact noisy fields (`url`, timestamps) so the
+  diff stays meaningful.
+- Capture `gh api ... > /tmp/after.json` immediately after applying the PATCH.
+- Commit only the **diff-relevant fields** (`required_status_checks.contexts`,
+  `required_pull_request_reviews`, `enforce_admins`, `restrictions`). Full
+  payloads contain user-id arrays that change too often to be useful.
+- Always state who applied the change, when, and with which gh CLI invocation.
+
+## Changes
+
+### 2026-05-XX — Add `Required Status Check Gate` to `dev` required checks (M1.1)
+
+Status: pending (awaiting M1.1 ticket merge + 1 week green run on dev)
+
+**Why**: PR #419 caused a baseline collapse because three required checks
+finished `cancelled` and GitHub treated that as a pass. The new
+`required_status_check_gate.yml` workflow converts `cancelled` / `skipped` /
+`failure` of monitored spokes into an explicit failure; making the gate a
+required check is what actually blocks merges.
+
+**Before** (`required_status_checks.contexts`, abridged):
+
+```json
+{
+  "strict": false,
+  "contexts": [
+    "Multi-Runtime RTF Benchmark / rtf",
+    "Memory regression (per-language) / regression",
+    "CodeQL / analyze (python)",
+    "CodeQL / analyze (cpp)",
+    "Parity Hub / parity",
+    "PUA Consistency Gate / check"
+  ]
+}
+```
+
+**After** (additive — no existing entries removed):
+
+```json
+{
+  "strict": false,
+  "contexts": [
+    "Multi-Runtime RTF Benchmark / rtf",
+    "Memory regression (per-language) / regression",
+    "CodeQL / analyze (python)",
+    "CodeQL / analyze (cpp)",
+    "Parity Hub / parity",
+    "PUA Consistency Gate / check",
+    "Required Status Check Gate / gate"
+  ]
+}
+```
+
+**Apply command** (run by maintainer after 1 week green on dev):
+
+```bash
+gh api repos/ayutaz/piper-plus/branches/dev/protection > /tmp/before.json
+jq '.required_status_checks.contexts += ["Required Status Check Gate / gate"]
+    | {required_status_checks, required_pull_request_reviews, enforce_admins, restrictions}' \
+  /tmp/before.json > /tmp/patch.json
+gh api -X PATCH repos/ayutaz/piper-plus/branches/dev/protection \
+  --input /tmp/patch.json
+gh api repos/ayutaz/piper-plus/branches/dev/protection > /tmp/after.json
+```
+
+**Verify**:
+
+```bash
+gh api repos/ayutaz/piper-plus/branches/dev/protection \
+  | jq -r '.required_status_checks.contexts[]' \
+  | grep "Required Status Check Gate"
+```
+
+**Rollback** (if the gate produces sustained false-positive failures):
+
+```bash
+gh api repos/ayutaz/piper-plus/branches/dev/protection > /tmp/now.json
+jq '.required_status_checks.contexts |= map(select(. != "Required Status Check Gate / gate"))
+    | {required_status_checks, required_pull_request_reviews, enforce_admins, restrictions}' \
+  /tmp/now.json > /tmp/revert.json
+gh api -X PATCH repos/ayutaz/piper-plus/branches/dev/protection \
+  --input /tmp/revert.json
+```
+
+**Operator**: pending — to be filled in when the change is applied.
+
+---
+
+Future entries (M1.3 first-PR fast lane, M2 audio-tier blockers, M3 ABI
+gate, …) append below this section without renaming earlier headings.

--- a/docs/tickets/M1-1-cancelled-baseline-alarm.md
+++ b/docs/tickets/M1-1-cancelled-baseline-alarm.md
@@ -3,7 +3,7 @@
 **親マイルストーン**: [M1 Defensive Foundations](./M1-overview.md)
 **親調査**: [ci-expansion-2026-05.md §Top 10 #10](../proposals/ci-expansion-2026-05.md#5-真に追加する価値があるトップ-10)
 **Top 10 内番号**: #10
-**ステータス**: 未着手
+**ステータス**: 着手中 (PR draft)
 **想定工数**: 1-2 PR (~8h)
 **優先度**: 高
 **作成日**: 2026-05-18

--- a/docs/tickets/README.md
+++ b/docs/tickets/README.md
@@ -13,7 +13,7 @@
 
 | Phase | Overview | 個別チケット | Top 10 # | 想定工数 | 優先度 | ステータス |
 |-------|----------|-------------|---------|----------|--------|-----------|
-| **M1** Defensive Foundations | [M1-overview.md](./M1-overview.md) | [M1.1 Cancelled baseline alarm](./M1-1-cancelled-baseline-alarm.md) | #10 | 1-2 PR (~8h) | 高 | 未着手 |
+| **M1** Defensive Foundations | [M1-overview.md](./M1-overview.md) | [M1.1 Cancelled baseline alarm](./M1-1-cancelled-baseline-alarm.md) | #10 | 1-2 PR (~8h) | 高 | 着手中 (PR draft) |
 | | | [M1.2 Migration guide lint](./M1-2-migration-guide-lint.md) | #3 | 1 PR (~6h) | 高 | 未着手 |
 | | | [M1.3 First-PR fast lane](./M1-3-first-pr-fast-lane.md) | #5 | 2 PR (~12h) | 高 | 未着手 |
 | **M2** Audio Quality Moat | [M2-overview.md](./M2-overview.md) | [M2.1 Audio MOS proxy gate](./M2-1-audio-mos-proxy.md) | #1 | 3-4 PR (~30h) | 高 | 未着手 |

--- a/scripts/check_required_gate.py
+++ b/scripts/check_required_gate.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Required status-check gate (M1.1 — cancelled / skipped baseline alarm).
+
+GitHub branch protection treats ``cancelled`` and ``skipped`` workflow runs
+as a pass (fail-open). PR #419 (memory ``feedback_ci_cancelled_baseline``)
+showed how that lets a baseline collapse merge silently. This script is the
+hub of a hub-and-spoke gateway: it asks the REST API for the latest run of
+every monitored spoke workflow at ``head_sha`` and exits non-zero if any
+spoke is missing, cancelled, skipped, failed, or timed out.
+
+The script is deliberately stdlib-only (``urllib`` + ``json``) so the gate
+workflow has no install step. ``GITHUB_TOKEN`` (read-only ``actions:read``
++ ``pull-requests:write`` is enough) is read from the environment.
+
+CLI usage::
+
+    python scripts/check_required_gate.py \
+        --head-sha "$HEAD_SHA" \
+        --monitored "Multi-Runtime RTF Benchmark,CodeQL,Parity Hub" \
+        --repo owner/name \
+        [--on-cancelled fail] [--on-skipped fail] \
+        [--post-pr-comment 123] \
+        [--latest-sha-for-supersede $(git rev-parse origin/dev)]
+
+For unit tests the network layer is replaced via ``--runs-json`` (path to a
+pre-recorded ``GET /actions/runs?head_sha=...`` payload) and
+``--latest-sha-for-supersede`` (skips the second REST call).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+GITHUB_API = "https://api.github.com"
+USER_AGENT = "piper-plus-required-gate/1.0"
+STICKY_MARKER = "<!-- required-status-check-gate -->"
+
+# Conclusions that branch protection treats as pass but we want to reject.
+FAIL_OPEN_CONCLUSIONS = {"cancelled", "skipped", "failure", "timed_out", "action_required"}
+
+
+@dataclass(frozen=True)
+class SpokeRun:
+    name: str
+    conclusion: str | None
+    status: str
+    head_sha: str
+    html_url: str
+    run_id: int
+
+
+def gh_get(path: str, token: str, *, max_retries: int = 4) -> dict:
+    url = f"{GITHUB_API}{path}"
+    backoff = 1.0
+    last_err: Exception | None = None
+    for attempt in range(max_retries):
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": USER_AGENT,
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            last_err = exc
+            if exc.code in (403, 429) and attempt < max_retries - 1:
+                reset = exc.headers.get("X-RateLimit-Reset")
+                sleep_for = backoff
+                if reset and reset.isdigit():
+                    sleep_for = max(sleep_for, int(reset) - int(time.time()) + 1)
+                time.sleep(min(sleep_for, 60))
+                backoff *= 2
+                continue
+            raise
+        except urllib.error.URLError as exc:
+            last_err = exc
+            if attempt < max_retries - 1:
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            raise
+    raise RuntimeError(f"gh_get failed: {last_err}")
+
+
+def fetch_runs_for_sha(repo: str, head_sha: str, token: str) -> list[dict]:
+    query = urllib.parse.urlencode({"head_sha": head_sha, "per_page": "100"})
+    data = gh_get(f"/repos/{repo}/actions/runs?{query}", token)
+    return list(data.get("workflow_runs", []))
+
+
+def fetch_branch_head_sha(repo: str, branch: str, token: str) -> str:
+    data = gh_get(f"/repos/{repo}/branches/{urllib.parse.quote(branch)}", token)
+    return str(data["commit"]["sha"])
+
+
+def pick_latest_per_workflow(
+    runs: list[dict], monitored: list[str], head_sha: str
+) -> tuple[dict[str, SpokeRun], list[str]]:
+    """Return (latest_run_per_workflow, missing_workflow_names).
+
+    ``runs`` is the raw ``workflow_runs`` list from the REST API. We filter
+    to entries whose ``head_sha`` matches and whose ``name`` is in
+    ``monitored``, then keep the most recent ``run_number`` per workflow.
+    Workflows that monitored expects but never appear are reported as
+    missing — those are also a fail-open path (paths-filter skipped the
+    workflow entirely, no run was queued).
+    """
+    best: dict[str, tuple[int, SpokeRun]] = {}
+    for raw in runs:
+        if raw.get("head_sha") != head_sha:
+            continue
+        name = raw.get("name")
+        if name not in monitored:
+            continue
+        run_number = int(raw.get("run_number", 0))
+        candidate = SpokeRun(
+            name=name,
+            conclusion=raw.get("conclusion"),
+            status=raw.get("status", ""),
+            head_sha=raw["head_sha"],
+            html_url=raw.get("html_url", ""),
+            run_id=int(raw.get("id", 0)),
+        )
+        prev = best.get(name)
+        if prev is None or run_number >= prev[0]:
+            best[name] = (run_number, candidate)
+    by_name = {name: run for name, (_, run) in best.items()}
+    missing = sorted(set(monitored) - set(by_name))
+    return by_name, missing
+
+
+def classify(
+    spokes: dict[str, SpokeRun],
+    *,
+    on_cancelled: str,
+    on_skipped: str,
+) -> list[tuple[str, str]]:
+    """Return [(workflow_name, reason)] of spokes that must fail the gate."""
+    bad: list[tuple[str, str]] = []
+    for name, run in spokes.items():
+        if run.status != "completed":
+            bad.append((name, f"still {run.status}"))
+            continue
+        conclusion = run.conclusion or "missing"
+        if conclusion == "success":
+            continue
+        if conclusion == "cancelled" and on_cancelled != "fail":
+            continue
+        if conclusion == "skipped" and on_skipped != "fail":
+            continue
+        if conclusion in FAIL_OPEN_CONCLUSIONS:
+            bad.append((name, conclusion))
+        elif conclusion != "success":
+            bad.append((name, conclusion))
+    return bad
+
+
+def format_diagnostic(
+    head_sha: str,
+    missing: list[str],
+    bad: list[tuple[str, str]],
+    spokes: dict[str, SpokeRun],
+) -> str:
+    lines = [
+        STICKY_MARKER,
+        "## Required status-check gate",
+        "",
+        f"Head SHA: `{head_sha[:7]}`",
+        "",
+    ]
+    if missing:
+        lines.append("**Missing spokes** (no run queued — paths filter or trigger gap):")
+        for name in missing:
+            lines.append(f"- `{name}`")
+        lines.append("")
+    if bad:
+        lines.append("**Non-success spokes** (cancelled / skipped / failure / timed_out):")
+        for name, reason in bad:
+            url = spokes[name].html_url if name in spokes else ""
+            suffix = f" — [run]({url})" if url else ""
+            lines.append(f"- `{name}` → `{reason}`{suffix}")
+        lines.append("")
+    if not missing and not bad:
+        lines.append("All monitored spokes succeeded.")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def format_deferred(head_sha: str, latest_sha: str) -> str:
+    return (
+        f"{STICKY_MARKER}\n"
+        "## Required status-check gate (deferred)\n\n"
+        f"Head SHA `{head_sha[:7]}` is no longer the branch tip "
+        f"(latest: `{latest_sha[:7]}`). Waiting for the new commit's "
+        "spoke runs to complete before re-evaluating.\n"
+    )
+
+
+def upsert_sticky_comment(repo: str, pr_number: int, body: str, token: str) -> None:
+    comments = gh_get(
+        f"/repos/{repo}/issues/{pr_number}/comments?per_page=100", token
+    )
+    target_id: int | None = None
+    if isinstance(comments, list):
+        for c in comments:
+            if STICKY_MARKER in (c.get("body") or ""):
+                target_id = int(c["id"])
+                break
+    payload = json.dumps({"body": body}).encode("utf-8")
+    if target_id is None:
+        url = f"{GITHUB_API}/repos/{repo}/issues/{pr_number}/comments"
+        method = "POST"
+    else:
+        url = f"{GITHUB_API}/repos/{repo}/issues/comments/{target_id}"
+        method = "PATCH"
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    urllib.request.urlopen(req, timeout=30).close()
+
+
+def parse_monitored(arg: str) -> list[str]:
+    return [w.strip() for w in arg.split(",") if w.strip()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else None)
+    p.add_argument("--head-sha", required=True)
+    p.add_argument(
+        "--monitored",
+        required=True,
+        help="Comma-separated list of spoke workflow names (case-sensitive).",
+    )
+    p.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    p.add_argument("--on-cancelled", choices=["fail", "ignore"], default="fail")
+    p.add_argument("--on-skipped", choices=["fail", "ignore"], default="fail")
+    p.add_argument("--post-pr-comment", type=int, default=None)
+    p.add_argument(
+        "--branch-for-supersede",
+        default="",
+        help="If set, gate defers when head-sha != branch tip.",
+    )
+    p.add_argument(
+        "--latest-sha-for-supersede",
+        default="",
+        help="Test hook: skip the branch-tip REST call.",
+    )
+    p.add_argument(
+        "--runs-json",
+        type=Path,
+        default=None,
+        help="Test hook: read workflow_runs JSON from a file instead of REST.",
+    )
+    return p
+
+
+def run(args: argparse.Namespace) -> int:
+    monitored = parse_monitored(args.monitored)
+    if not monitored:
+        print("--monitored is empty", file=sys.stderr)
+        return 2
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if args.runs_json is not None:
+        payload = json.loads(args.runs_json.read_text())
+        runs = list(payload.get("workflow_runs", payload if isinstance(payload, list) else []))
+    else:
+        if not token or not args.repo:
+            print("GITHUB_TOKEN and --repo (or GITHUB_REPOSITORY) required", file=sys.stderr)
+            return 2
+        runs = fetch_runs_for_sha(args.repo, args.head_sha, token)
+
+    latest_sha = args.latest_sha_for_supersede
+    if not latest_sha and args.branch_for_supersede and args.runs_json is None:
+        latest_sha = fetch_branch_head_sha(args.repo, args.branch_for_supersede, token)
+    if latest_sha and latest_sha != args.head_sha:
+        body = format_deferred(args.head_sha, latest_sha)
+        print(body)
+        if args.post_pr_comment and token and args.repo:
+            upsert_sticky_comment(args.repo, args.post_pr_comment, body, token)
+        return 0
+
+    spokes, missing = pick_latest_per_workflow(runs, monitored, args.head_sha)
+    bad = classify(spokes, on_cancelled=args.on_cancelled, on_skipped=args.on_skipped)
+    body = format_diagnostic(args.head_sha, missing, bad, spokes)
+    print(body)
+    if args.post_pr_comment and token and args.repo and args.runs_json is None:
+        upsert_sticky_comment(args.repo, args.post_pr_comment, body, token)
+    return 1 if (missing or bad) else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run(build_parser().parse_args(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/fixtures/gh_runs_all_success.json
+++ b/tests/scripts/fixtures/gh_runs_all_success.json
@@ -1,0 +1,50 @@
+{
+  "total_count": 5,
+  "workflow_runs": [
+    {
+      "id": 100001,
+      "name": "Multi-Runtime RTF Benchmark",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/100001"
+    },
+    {
+      "id": 100002,
+      "name": "Memory regression (per-language)",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/100002"
+    },
+    {
+      "id": 100003,
+      "name": "CodeQL",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/100003"
+    },
+    {
+      "id": 100004,
+      "name": "Parity Hub",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/100004"
+    },
+    {
+      "id": 100005,
+      "name": "PUA Consistency Gate",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/100005"
+    }
+  ]
+}

--- a/tests/scripts/fixtures/gh_runs_cancelled.json
+++ b/tests/scripts/fixtures/gh_runs_cancelled.json
@@ -1,0 +1,50 @@
+{
+  "total_count": 5,
+  "workflow_runs": [
+    {
+      "id": 200001,
+      "name": "Multi-Runtime RTF Benchmark",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "cancelled",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/200001"
+    },
+    {
+      "id": 200002,
+      "name": "Memory regression (per-language)",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/200002"
+    },
+    {
+      "id": 200003,
+      "name": "CodeQL",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/200003"
+    },
+    {
+      "id": 200004,
+      "name": "Parity Hub",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/200004"
+    },
+    {
+      "id": 200005,
+      "name": "PUA Consistency Gate",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/200005"
+    }
+  ]
+}

--- a/tests/scripts/fixtures/gh_runs_failure.json
+++ b/tests/scripts/fixtures/gh_runs_failure.json
@@ -1,0 +1,50 @@
+{
+  "total_count": 5,
+  "workflow_runs": [
+    {
+      "id": 400001,
+      "name": "Multi-Runtime RTF Benchmark",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/400001"
+    },
+    {
+      "id": 400002,
+      "name": "Memory regression (per-language)",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "failure",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/400002"
+    },
+    {
+      "id": 400003,
+      "name": "CodeQL",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/400003"
+    },
+    {
+      "id": 400004,
+      "name": "Parity Hub",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/400004"
+    },
+    {
+      "id": 400005,
+      "name": "PUA Consistency Gate",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/400005"
+    }
+  ]
+}

--- a/tests/scripts/fixtures/gh_runs_head_sha_mismatch.json
+++ b/tests/scripts/fixtures/gh_runs_head_sha_mismatch.json
@@ -1,0 +1,23 @@
+{
+  "total_count": 2,
+  "workflow_runs": [
+    {
+      "id": 600001,
+      "name": "Multi-Runtime RTF Benchmark",
+      "head_sha": "0000000000000000000000000000000000000000",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/600001"
+    },
+    {
+      "id": 600002,
+      "name": "CodeQL",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/600002"
+    }
+  ]
+}

--- a/tests/scripts/fixtures/gh_runs_skipped.json
+++ b/tests/scripts/fixtures/gh_runs_skipped.json
@@ -1,0 +1,50 @@
+{
+  "total_count": 5,
+  "workflow_runs": [
+    {
+      "id": 300001,
+      "name": "Multi-Runtime RTF Benchmark",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/300001"
+    },
+    {
+      "id": 300002,
+      "name": "Memory regression (per-language)",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/300002"
+    },
+    {
+      "id": 300003,
+      "name": "CodeQL",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "skipped",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/300003"
+    },
+    {
+      "id": 300004,
+      "name": "Parity Hub",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/300004"
+    },
+    {
+      "id": 300005,
+      "name": "PUA Consistency Gate",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "success",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/300005"
+    }
+  ]
+}

--- a/tests/scripts/fixtures/gh_runs_supersede.json
+++ b/tests/scripts/fixtures/gh_runs_supersede.json
@@ -1,0 +1,14 @@
+{
+  "total_count": 1,
+  "workflow_runs": [
+    {
+      "id": 500001,
+      "name": "Multi-Runtime RTF Benchmark",
+      "head_sha": "deadbeef0000000000000000000000000000beef",
+      "status": "completed",
+      "conclusion": "cancelled",
+      "run_number": 1,
+      "html_url": "https://github.com/owner/repo/actions/runs/500001"
+    }
+  ]
+}

--- a/tests/scripts/test_check_required_gate.py
+++ b/tests/scripts/test_check_required_gate.py
@@ -1,0 +1,148 @@
+"""Unit tests for scripts/check_required_gate.py (M1.1)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_required_gate.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+HEAD_SHA = "deadbeef0000000000000000000000000000beef"
+MONITORED = (
+    "Multi-Runtime RTF Benchmark,Memory regression (per-language),"
+    "CodeQL,Parity Hub,PUA Consistency Gate"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_required_gate", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gate():
+    return _load_module()
+
+
+def _run(gate, fixture_name: str, **extra) -> tuple[int, str]:
+    argv = [
+        "--head-sha", HEAD_SHA,
+        "--monitored", MONITORED,
+        "--runs-json", str(FIXTURES / fixture_name),
+    ]
+    for k, v in extra.items():
+        argv.append(f"--{k.replace('_', '-')}")
+        argv.append(str(v))
+    parser = gate.build_parser()
+    args = parser.parse_args(argv)
+    rc = gate.run(args)
+    return rc, ""
+
+
+def test_all_success_exits_zero(gate, capsys):
+    rc, _ = _run(gate, "gh_runs_all_success.json")
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "All monitored spokes succeeded" in captured.out
+
+
+def test_single_cancelled_fails_gate(gate, capsys):
+    rc, _ = _run(gate, "gh_runs_cancelled.json")
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "Multi-Runtime RTF Benchmark" in captured.out
+    assert "cancelled" in captured.out
+
+
+def test_single_skipped_fails_gate(gate, capsys):
+    rc, _ = _run(gate, "gh_runs_skipped.json")
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "CodeQL" in captured.out
+    assert "skipped" in captured.out
+
+
+def test_single_failure_fails_gate(gate, capsys):
+    rc, _ = _run(gate, "gh_runs_failure.json")
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "Memory regression (per-language)" in captured.out
+    assert "failure" in captured.out
+
+
+def test_supersede_returns_zero_with_deferred_message(gate, capsys):
+    rc, _ = _run(
+        gate,
+        "gh_runs_supersede.json",
+        latest_sha_for_supersede="cafebabe0000000000000000000000000000babe",
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "deferred" in captured.out.lower()
+    assert "cafebab" in captured.out
+
+
+def test_head_sha_mismatch_is_missing(gate, capsys):
+    """Runs whose head_sha differs from the requested SHA must not satisfy
+    the spoke — even if the workflow name matches."""
+    rc, _ = _run(gate, "gh_runs_head_sha_mismatch.json")
+    captured = capsys.readouterr()
+    assert rc == 1
+    # Multi-Runtime RTF Benchmark exists in fixture but at the wrong head_sha,
+    # so it must be reported as missing rather than as a success.
+    assert "Multi-Runtime RTF Benchmark" in captured.out
+    assert "Missing spokes" in captured.out
+
+
+def test_on_cancelled_ignore_lets_cancelled_pass(gate, capsys):
+    rc, _ = _run(gate, "gh_runs_cancelled.json", on_cancelled="ignore")
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "All monitored spokes succeeded" in captured.out
+
+
+def test_on_skipped_ignore_lets_skipped_pass(gate, capsys):
+    rc, _ = _run(gate, "gh_runs_skipped.json", on_skipped="ignore")
+    captured = capsys.readouterr()
+    assert rc == 0
+
+
+def test_diagnostic_contains_sticky_marker(gate, capsys):
+    _run(gate, "gh_runs_cancelled.json")
+    captured = capsys.readouterr()
+    assert gate.STICKY_MARKER in captured.out
+
+
+def test_picks_most_recent_run_per_workflow(gate, tmp_path):
+    payload = {
+        "workflow_runs": [
+            {
+                "id": 1, "name": "Parity Hub", "head_sha": HEAD_SHA,
+                "status": "completed", "conclusion": "cancelled", "run_number": 1,
+                "html_url": "https://example/1",
+            },
+            {
+                "id": 2, "name": "Parity Hub", "head_sha": HEAD_SHA,
+                "status": "completed", "conclusion": "success", "run_number": 2,
+                "html_url": "https://example/2",
+            },
+        ]
+    }
+    runs_file = tmp_path / "runs.json"
+    runs_file.write_text(json.dumps(payload))
+    args = gate.build_parser().parse_args([
+        "--head-sha", HEAD_SHA,
+        "--monitored", "Parity Hub",
+        "--runs-json", str(runs_file),
+    ])
+    rc = gate.run(args)
+    assert rc == 0


### PR DESCRIPTION
## Summary

GitHub branch protection が `cancelled` / `skipped` を fail-open として通過させる構造的欠陥を hub-and-spoke gateway で塞ぎます。 PR #419 では required check が `cancelled` のまま merge されて baseline が崩壊しましたが、 本 PR の gateway workflow は監視対象 spoke workflow の最新 run conclusion を REST API で集計し、 `cancelled` / `skipped` / `failure` / `timed_out` を明示的 fail に変換します。

> Stacked on #508 (docs tickets)。 docs PR を merge 後に dev rebase します。

## Affected Components

- [x] CI-CD

## Type

- [x] CI/CD

## Risk Level

- [x] minor (新規 workflow 追加 / 既存挙動への破壊的変更なし)

## Contract Impact

- [x] None (`docs/spec/*.toml` への影響なし)

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| `scripts/check_required_gate.py` | stdlib-only (urllib + json)、 spoke 最新 run を head_sha でフィルタし conclusion を集計 / 分類 / sticky comment 化 | `gh` CLI 経由だと workflow 内 install が増え、 また rate-limit / retry の制御も難しい |
| `.github/workflows/required_status_check_gate.yml` | `pull_request` + `workflow_run` trigger、 actions SHA pin、 `concurrency.cancel-in-progress: false` で gateway 自身の cancel を防止 | gateway が cancelled になると二重 fail-open (本来の問題が gateway 内で再発) |
| pytest 10 シナリオ + fixture 6 本 | all-success / cancelled / skipped / failure / supersede / head_sha mismatch / on-cancelled=ignore / on-skipped=ignore / sticky marker / latest-per-workflow を網羅 | 「ignore モード」「supersede defer」「head_sha mismatch を missing 扱い」の 3 つの非自明分岐がリグレッションする |
| `docs/reference/branch-protection-history.md` | branch protection 変更の単一 source of truth、 before/after snapshot + apply + rollback コマンドを記録 | protection 変更が PR 履歴に埋もれ、 rollback 手順が散逸する |
| memory `feedback_ci_cancelled_baseline.md` への追記 | gateway 化された旨と参照先 | 過去の事故文脈と現在の防御策が分離する |
| `.gitignore` への allowlist 追加 | `scripts/check_required_gate.py` が `check_*.py` 一般 ignore に巻き込まれないよう exception | script がコミットされず gateway が動作しない |

## 設計判断

- **stdlib only** — gateway workflow 内で pip install 不要、 setup-python のキャッシュ依存も最小化。 `urllib` で REST 直接呼び出し、 retry は exponential backoff
- **supersede cancel guard** — force-push 直後の古い commit gateway が新 commit を block しないよう、 branch tip と head_sha を比較して defer (REST 2 回目の呼び出し)
- **head_sha mismatch を missing 扱い** — REST が誤って別 sha の run を返した場合、 spoke 集計に含めず missing 扱いにすることで fail-open 経路を 1 つ追加で塞ぐ
- **`concurrency.cancel-in-progress: false`** — gateway 自身が cancel されると二重 fail-open (PR #419 と同じ構造) が起きるため、 重複呼び出しは並列実行する設計
- **sticky comment** — `<!-- required-status-check-gate -->` marker で PR 上に 1 件だけ存在させる (`feedback_pr_body_over_comments` と整合、 新規 comment 追記しない)
- **`--runs-json` テストフック** — pytest が REST を mock せずに JSON fixture から読めるよう CLI 分岐を残す。 監視ロジック本体は production パスと共通

## Test Plan

- [ ] `uv run --no-project pytest tests/scripts/test_check_required_gate.py -v --no-cov` で 10 件 pass
- [ ] gateway workflow を一時的に post-pr-comment 省略形で dev PR に対して手動 dispatch し、 集計結果が PR 本文どおり表示されることを確認
- [ ] 既存 baseline workflow (`Multi-Runtime RTF Benchmark` / `Memory regression (per-language)` / `CodeQL` / `Parity Hub` / `PUA Consistency Gate`) の name 文字列が gateway の `MONITORED_WORKFLOWS` と byte-equal
- [ ] `docs/reference/branch-protection-history.md` の apply コマンドが dev で実行可能 (rollback 手順も含む)
- [ ] gateway が green になってから 1 週間観測後に dev branch protection に required-check として追加 (本 PR scope 外、 後続 ops で実施)

## Checklist

- [x] Tests pass locally (10 / 10 pytest)
- [x] No GPL-LGPL deps (stdlib only)
- [x] Documentation updated (`docs/reference/branch-protection-history.md` 新規 / memory feedback 追記)

## Related Issues

なし (チケット `docs/tickets/M1-1-cancelled-baseline-alarm.md` / 親調査 `docs/proposals/ci-expansion-2026-05.md` Top 10 #10 から派生)
