### PR TITLE
ci: migration guide cross-ref lint

### DIFF
--- a/.github/workflows/migration-guide-lint.yml
+++ b/.github/workflows/migration-guide-lint.yml
@@ -1,0 +1,77 @@
+# Migration Guide Lint (M1.2)
+# ===========================
+# `CHANGELOG.md` の `[Unreleased] > ### Breaking` 節と
+# `docs/migration/v<X>-to-v<Y>.md` の cross-ref を構造的に強制する。
+# 既存 `migration-changelog-parity.yml` は CHANGELOG と migration doc の
+# 存在対応のみ検査するが、 こちらは entry 内の anchor link が実際に
+# 解決するかまで確認する。
+#
+# Enforce 条件 (false-positive 最小化):
+#   - `breaking` label が付与されている、 または
+#   - PR diff で CHANGELOG.md の `### Breaking` 節に新規 entry が追加されている
+#
+# patch / minor PR は paths filter で skip される。
+#
+# 関連: docs/tickets/M1-2-migration-guide-lint.md / parent
+# docs/proposals/ci-expansion-2026-05.md Top 10 #3。
+
+name: Migration Guide Lint
+
+on:
+  pull_request:
+    branches: [dev, main]
+    paths:
+      - 'CHANGELOG.md'
+      - 'docs/migration/**'
+      - 'scripts/check_migration_xref.py'
+      - '.github/workflows/migration-guide-lint.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Detect breaking-change signal
+        id: signal
+        run: |
+          set -euo pipefail
+          has_label=false
+          has_diff=false
+          if [ -n "${{ join(github.event.pull_request.labels.*.name, ',') }}" ]; then
+            if echo "${{ join(github.event.pull_request.labels.*.name, ',') }}" | tr ',' '\n' | grep -qx breaking; then
+              has_label=true
+            fi
+          fi
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          if [ -n "$base_sha" ]; then
+            git fetch --no-tags --depth=1 origin "$base_sha" 2>/dev/null || true
+            if git diff "$base_sha"...HEAD -- CHANGELOG.md 2>/dev/null | grep -E "^\+### Breaking" >/dev/null; then
+              has_diff=true
+            fi
+          fi
+          echo "has_label=$has_label" >> "$GITHUB_OUTPUT"
+          echo "has_diff=$has_diff" >> "$GITHUB_OUTPUT"
+          echo "Signal: label=$has_label diff=$has_diff"
+
+      - name: Run migration cross-ref lint
+        if: steps.signal.outputs.has_label == 'true' || steps.signal.outputs.has_diff == 'true' || github.event_name == 'workflow_dispatch'
+        run: python scripts/check_migration_xref.py
+
+      - name: Skipped (no breaking signal)
+        if: steps.signal.outputs.has_label != 'true' && steps.signal.outputs.has_diff != 'true' && github.event_name != 'workflow_dispatch'
+        run: echo "No breaking label and no ### Breaking diff; skipping migration cross-ref lint."

--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,8 @@ check_*.py
 !scripts/check_todo_age.py
 !scripts/check_workspace_python_parity.py
 !scripts/check_training_defaults.py
+# M1.2 — migration guide cross-ref lint
+!scripts/check_migration_xref.py
 create_comprehensive_*.py
 add_missing_*.py
 retrain_*.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -263,6 +263,17 @@ repos:
         files: ^(CHANGELOG\.md|docs/migration/.*\.md|scripts/check_migration_changelog_parity\.py)$
         pass_filenames: false
 
+      # CHANGELOG `[Unreleased] > ### Breaking` entry の anchor link が
+      # 実際に docs/migration/v*.md の見出しに解決するかまで検査する。
+      # v1.12 で migration doc が breaking commit 後追いで作成された問題を
+      # 構造的に塞ぐ (`docs/tickets/M1-2-migration-guide-lint.md`)。
+      - id: migration-guide-lint
+        name: CHANGELOG breaking entries have resolvable migration cross-ref
+        entry: uv run python scripts/check_migration_xref.py
+        language: system
+        files: ^(CHANGELOG\.md|docs/migration/.*\.md|scripts/check_migration_xref\.py)$
+        pass_filenames: false
+
       # Short-text 戦略 (Silence Padding / Dynamic Scales / SSML break 自動
       # 挿入) の cross-runtime drift gate。 既存 CI のみだったものを
       # pre-commit 化。 6 runtime 並列実装の整合維持。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!--
+  Breaking changes must be listed under `### Breaking` and each entry must
+  include at least one `[label](docs/migration/v<X>-to-v<Y>.md#anchor)`
+  link. See `docs/migration/README.md` for the anchor slug rules.
+  `scripts/check_migration_xref.py` (workflow `Migration Guide Lint`)
+  enforces this automatically.
+-->
+
 ### Added
 
 #### Kotlin/Android G2P AAR を Maven Central に公開 (Issue #388)

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,57 @@
+# Migration guides
+
+`piper-plus` の version-to-version migration guide はすべてこのディレクトリに置きます。 ユーザー視点で **既存コードがそのままでは動かなくなる変更** (= breaking change) を解説するのが目的です。 内部リファクタや非互換ではない API 追加はここではなく `CHANGELOG.md` の `### Added` / `### Changed` 節で扱います。
+
+## ファイル命名規則
+
+`v<X>-to-v<Y>.md` の形 (例: `v1.11-to-v1.12.md`)。 hot-fix を伴う場合も major.minor 単位で 1 ファイルに集約し、 patch-level の細分化はしません (`v1.12.0-to-v1.12.1.md` 等は作らない)。
+
+## 見出し規約
+
+各 migration guide のトップ見出しは `# vX → vY migration guide`。 そのほかの構造は自由ですが、 個別の breaking change には **`## <change-id>` の H2 見出し** を 1 つずつ用意してください。 H2 見出しのテキストは GitHub Markdown anchor として CHANGELOG から `[label](docs/migration/vX-to-vY.md#change-id)` で参照されるので、 一度公開した H2 はリネームしないでください (anchor が壊れます)。
+
+H2 anchor slug の算出:
+
+1. lower-case にする
+2. `[^\w\s-]` (`\w` = alphanum + underscore) に該当する文字を削除
+3. 連続する空白 / underscore を単一 `-` に置換
+4. 先頭・末尾の `-` を trim
+
+例:
+
+| 見出し | anchor |
+|--------|--------|
+| `## foo removal` | `#foo-removal` |
+| ``## `Generator` class removal`` | `#generator-class-removal` |
+| `## config schema v2` | `#config-schema-v2` |
+
+絵文字や日本語を含む見出しは、 上記アルゴリズム後に空になる可能性があります。 その場合は ASCII subset の代替見出しを併設するか、 CHANGELOG 側から anchor を省略してください (anchor なしのファイル link は許可されます)。
+
+## CHANGELOG との cross-ref
+
+`CHANGELOG.md` の `## [Unreleased]` セクションに `### Breaking` 節を追加するとき、 各 entry には **少なくとも 1 つ** の `docs/migration/v*-to-v*.md` リンクを含めてください。 `scripts/check_migration_xref.py` (CI workflow `Migration Guide Lint` + pre-commit `migration-guide-lint`) が自動検査します。
+
+書式例:
+
+```markdown
+### Breaking
+
+- `Generator` クラスを削除。 MB-iSTFT base からの fine-tune に移行してください。 ([移行ガイド](docs/migration/v1.12-to-v1.13.md#generator-class-removal))
+- `phonemize()` 戻り値が単一要素から複数要素へ変更。 ([移行ガイド](docs/migration/v1.12-to-v1.13.md#phonemize-return-shape))
+```
+
+`### Breaking` という見出しテキストは厳密に一致する必要があります。 `### Changed (Breaking)` のような変則は検査対象外になるため、 ユーザー向け migration 情報は **必ず `### Breaking` 節に集約**してください。
+
+## anchor を省略してよい場合
+
+- migration guide の全体概要 link (`[v1.13 migration overview](docs/migration/v1.12-to-v1.13.md)`)
+- 同じ breaking change を別 entry が anchor 付きで参照済みで、 こちらは context link
+
+CI は anchor なしを fail にはしません。 ただし strict CI で `--strict-anchor` flag を指定するとき (release branch 等で運用予定) は anchor 必須になります。
+
+## 関連 doc
+
+- [CHANGELOG.md](../../CHANGELOG.md) — release notes
+- [docs/proposals/ci-expansion-2026-05.md](../proposals/ci-expansion-2026-05.md#5-真に追加する価値があるトップ-10) — Top 10 #3 親調査
+- [docs/tickets/M1-2-migration-guide-lint.md](../tickets/M1-2-migration-guide-lint.md) — 実装チケット
+- [docs/spec/release-versions.toml](../spec/release-versions.toml) — release version pin

--- a/docs/tickets/M1-2-migration-guide-lint.md
+++ b/docs/tickets/M1-2-migration-guide-lint.md
@@ -3,7 +3,7 @@
 **親マイルストーン**: [M1 Defensive Foundations](./M1-overview.md)
 **親調査**: [ci-expansion-2026-05.md §Top 10 #3](../proposals/ci-expansion-2026-05.md#5-真に追加する価値があるトップ-10)
 **Top 10 内番号**: #3
-**ステータス**: 未着手
+**ステータス**: 着手中 (PR draft)
 **想定工数**: 1 PR (~6h)
 **優先度**: 高
 **作成日**: 2026-05-18

--- a/docs/tickets/README.md
+++ b/docs/tickets/README.md
@@ -14,7 +14,7 @@
 | Phase | Overview | 個別チケット | Top 10 # | 想定工数 | 優先度 | ステータス |
 |-------|----------|-------------|---------|----------|--------|-----------|
 | **M1** Defensive Foundations | [M1-overview.md](./M1-overview.md) | [M1.1 Cancelled baseline alarm](./M1-1-cancelled-baseline-alarm.md) | #10 | 1-2 PR (~8h) | 高 | 未着手 |
-| | | [M1.2 Migration guide lint](./M1-2-migration-guide-lint.md) | #3 | 1 PR (~6h) | 高 | 未着手 |
+| | | [M1.2 Migration guide lint](./M1-2-migration-guide-lint.md) | #3 | 1 PR (~6h) | 高 | 着手中 (PR draft) |
 | | | [M1.3 First-PR fast lane](./M1-3-first-pr-fast-lane.md) | #5 | 2 PR (~12h) | 高 | 未着手 |
 | **M2** Audio Quality Moat | [M2-overview.md](./M2-overview.md) | [M2.1 Audio MOS proxy gate](./M2-1-audio-mos-proxy.md) | #1 | 3-4 PR (~30h) | 高 | 未着手 |
 | | | [M2.2 Cross-runtime audio byte parity](./M2-2-cross-runtime-audio-parity.md) | #2 | 4-5 PR (~40h) | 高 | 未着手 |

--- a/scripts/check_migration_xref.py
+++ b/scripts/check_migration_xref.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Migration guide cross-reference lint (M1.2).
+
+v1.12 で `Generator` 削除 + `phonemize()` 戻り値型変更を入れた際、
+`docs/migration/v1.11-to-v1.12.md` は breaking commit より後に作成された。
+本スクリプトは ``CHANGELOG.md`` の ``[Unreleased] > ### Breaking`` 節と
+``docs/migration/v*.md`` の cross-ref を強制し、 同じ事故の再発を防ぐ。
+
+検査ルール (false-positive 最小化のため意図的に保守的):
+
+* ``## [Unreleased]`` セクション内に ``### Breaking`` 見出しがなければ skip。
+* ``### Breaking`` 直下の bullet (``-`` で始まる) を 1 entry とみなす。
+* 各 entry に少なくとも 1 つ ``[text](docs/migration/v<X>-to-v<Y>.md#anchor)``
+  形式の link を要求 (anchor 省略は許可)。
+* link 先 file の存在を確認、 anchor 付きなら見出し slug と照合。
+
+slug 規約は GitHub Markdown 互換: lower-case ASCII alpha-num + hyphen、
+複数空白は単一 hyphen、 非単語文字は drop。 全角・絵文字も lowercase 後に
+drop されるので、 結果が空になる見出しは fixture で pinning。
+
+CLI:
+
+    python scripts/check_migration_xref.py
+    python scripts/check_migration_xref.py --changelog CHANGELOG.md
+    python scripts/check_migration_xref.py --strict-anchor  # anchor 必須
+
+テストフック: ``--changelog`` で代替ファイル、 ``--root`` で migration doc
+の検索 root を切り替える。 ``--strict-anchor`` を渡すと anchor 無しを fail
+として扱う (fixture テスト用)。
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+ANCHOR_LINK_RE = re.compile(
+    r"\[([^\]]+)\]\((docs/migration/v[\d\.]+-to-v[\d\.]+\.md)(#[^\)]+)?\)"
+)
+
+
+@dataclass(frozen=True)
+class BreakingEntry:
+    line_no: int
+    body: str
+
+
+@dataclass
+class Section:
+    name: str
+    entries: list[BreakingEntry] = field(default_factory=list)
+
+
+def slugify(heading: str) -> str:
+    """GitHub Markdown 互換の anchor slug を返す。
+
+    Markdown フレーバーの厳密仕様は未公開だが、 GitHub の挙動は
+    ``ascii lowercase → remove non-alphanumeric (except space, dash) →
+    spaces to dashes`` で近似できる。 連続 dash の collapse は
+    GitHub は行わないが、 fixture テストで pinning する。
+    """
+    s = heading.strip().lower()
+    s = re.sub(r"[^\w\s-]", "", s, flags=re.UNICODE)
+    s = re.sub(r"[\s_]+", "-", s)
+    return s.strip("-")
+
+
+def extract_headings(path: Path) -> set[str]:
+    """ファイル内の全 ATX 見出し (``## ...``) を slug 化して返す。"""
+    slugs: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        m = re.match(r"^#{1,6}\s+(.+?)\s*$", line)
+        if m:
+            slug = slugify(m.group(1))
+            if slug:
+                slugs.add(slug)
+    return slugs
+
+
+def parse_unreleased_breaking(text: str) -> list[BreakingEntry]:
+    """``## [Unreleased]`` の ``### Breaking`` セクションを抽出する。
+
+    keep-a-changelog では heading の入れ子は固定 (``##`` = version、
+    ``###`` = カテゴリ)。 別 version (``## [1.x]``) 見出しに到達したら
+    停止する。 ``### Breaking`` 配下では ``-`` で始まる line を 1 entry
+    とし、 continuation line (空でない / heading でない / ``-`` でない)
+    は同 entry に append する。
+    """
+    lines = text.splitlines()
+    in_unreleased = False
+    in_breaking = False
+    entries: list[BreakingEntry] = []
+    current_start: int | None = None
+    current_buf: list[str] = []
+
+    def flush() -> None:
+        nonlocal current_start, current_buf
+        if current_start is not None:
+            entries.append(
+                BreakingEntry(line_no=current_start, body="\n".join(current_buf).rstrip())
+            )
+        current_start = None
+        current_buf = []
+
+    for i, line in enumerate(lines, start=1):
+        if re.match(r"^##\s+\[?Unreleased\]?", line, re.IGNORECASE):
+            in_unreleased = True
+            in_breaking = False
+            continue
+        if in_unreleased and re.match(r"^##\s+\[", line):
+            # Reached the next versioned section.
+            flush()
+            break
+        if not in_unreleased:
+            continue
+        if re.match(r"^###\s+Breaking", line, re.IGNORECASE):
+            in_breaking = True
+            continue
+        if in_breaking and re.match(r"^###\s+", line):
+            flush()
+            in_breaking = False
+            continue
+        if not in_breaking:
+            continue
+        if line.startswith("- "):
+            flush()
+            current_start = i
+            current_buf = [line[2:].rstrip()]
+        elif current_start is not None and line.startswith(" "):
+            current_buf.append(line.rstrip())
+        elif line.strip() == "" and current_start is not None:
+            current_buf.append("")
+    flush()
+    return entries
+
+
+def validate_entries(
+    entries: list[BreakingEntry],
+    root: Path,
+    *,
+    strict_anchor: bool = False,
+) -> list[str]:
+    errors: list[str] = []
+    for entry in entries:
+        links = ANCHOR_LINK_RE.findall(entry.body)
+        if not links:
+            errors.append(
+                f"CHANGELOG.md:{entry.line_no}: breaking entry has no "
+                f"docs/migration/v*-to-v*.md link: {entry.body.splitlines()[0][:80]!r}"
+            )
+            continue
+        for _label, doc_path, anchor in links:
+            full = root / doc_path
+            if not full.exists():
+                errors.append(
+                    f"CHANGELOG.md:{entry.line_no}: migration doc not found: {doc_path}"
+                )
+                continue
+            if not anchor:
+                if strict_anchor:
+                    errors.append(
+                        f"CHANGELOG.md:{entry.line_no}: --strict-anchor: link to "
+                        f"{doc_path} has no #anchor"
+                    )
+                continue
+            anchor_slug = anchor.lstrip("#")
+            headings = extract_headings(full)
+            if anchor_slug not in headings:
+                errors.append(
+                    f"CHANGELOG.md:{entry.line_no}: anchor not found in "
+                    f"{doc_path}: #{anchor_slug}"
+                )
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else None)
+    p.add_argument("--changelog", type=Path, default=REPO_ROOT / "CHANGELOG.md")
+    p.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root used to resolve docs/migration/... paths.",
+    )
+    p.add_argument(
+        "--strict-anchor",
+        action="store_true",
+        help="Treat missing #anchor as an error (default: allow plain file link).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not args.changelog.exists():
+        print(f"CHANGELOG not found: {args.changelog}", file=sys.stderr)
+        return 2
+    text = args.changelog.read_text(encoding="utf-8")
+    entries = parse_unreleased_breaking(text)
+    if not entries:
+        print(f"{args.changelog.name}: no [Unreleased] > ### Breaking entries; skip.")
+        return 0
+    errors = validate_entries(entries, args.root, strict_anchor=args.strict_anchor)
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        print(
+            f"\nFAIL: {len(errors)} breaking-change cross-ref issue(s) in "
+            f"{args.changelog.name}.",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"{args.changelog.name}: {len(entries)} breaking entries OK "
+        f"(all cross-refs resolved)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/fixtures/migration_xref/changelog_anchor_mismatch.md
+++ b/tests/scripts/fixtures/migration_xref/changelog_anchor_mismatch.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+### Breaking
+
+- `foo()` removed. See [migration guide](docs/migration/v1.12-to-v1.13.md#bar-removal).

--- a/tests/scripts/fixtures/migration_xref/changelog_missing_file.md
+++ b/tests/scripts/fixtures/migration_xref/changelog_missing_file.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+### Breaking
+
+- `foo()` removed. See [migration guide](docs/migration/v9.9-to-v10.0.md#foo-removal).

--- a/tests/scripts/fixtures/migration_xref/changelog_missing_link.md
+++ b/tests/scripts/fixtures/migration_xref/changelog_missing_link.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [Unreleased]
+
+### Breaking
+
+- `foo()` removed in favor of `bar()`. No migration guide here.
+- Config schema upgraded to v2.
+
+### Added
+
+- Unrelated feature

--- a/tests/scripts/fixtures/migration_xref/changelog_no_anchor.md
+++ b/tests/scripts/fixtures/migration_xref/changelog_no_anchor.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+### Breaking
+
+- `foo()` removed. Overall migration overview: [v1.13 migration](docs/migration/v1.12-to-v1.13.md).

--- a/tests/scripts/fixtures/migration_xref/changelog_no_breaking.md
+++ b/tests/scripts/fixtures/migration_xref/changelog_no_breaking.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- New feature with no breaking impact.
+
+### Changed
+
+- Refactored internals.

--- a/tests/scripts/fixtures/migration_xref/changelog_pass.md
+++ b/tests/scripts/fixtures/migration_xref/changelog_pass.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [Unreleased]
+
+### Breaking
+
+- `foo()` removed in favor of `bar()`. See [migration guide](docs/migration/v1.12-to-v1.13.md#foo-removal).
+- Config schema upgraded to v2. ([移行ガイド](docs/migration/v1.12-to-v1.13.md#config-schema-v2))
+
+### Added
+
+- Unrelated feature

--- a/tests/scripts/fixtures/migration_xref/changelog_versioned_only.md
+++ b/tests/scripts/fixtures/migration_xref/changelog_versioned_only.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Pending feature
+
+## [1.12.0] - 2026-04-01
+
+### Breaking
+
+- Old breaking entry should be ignored. ([migration](docs/migration/v1.11-to-v1.12.md))

--- a/tests/scripts/fixtures/migration_xref/doc_v1.12-to-v1.13.md
+++ b/tests/scripts/fixtures/migration_xref/doc_v1.12-to-v1.13.md
@@ -1,0 +1,13 @@
+# v1.12 → v1.13 migration guide
+
+## foo removal
+
+`foo()` has been removed. Use `bar()` instead.
+
+## config schema v2
+
+Update your config to v2.
+
+## Generator class removal
+
+The `Generator` class was deleted.

--- a/tests/scripts/test_check_migration_xref.py
+++ b/tests/scripts/test_check_migration_xref.py
@@ -1,0 +1,147 @@
+"""Unit tests for scripts/check_migration_xref.py (M1.2)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import shutil
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_migration_xref.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "migration_xref"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_migration_xref", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def xref():
+    return _load_module()
+
+
+@pytest.fixture
+def stage(tmp_path: Path):
+    """Stage a CHANGELOG fixture + populate docs/migration/ from the fixture
+    set so the script's path resolution treats ``tmp_path`` as the repo root."""
+    def _stage(changelog_fixture: str, doc_fixtures: list[str] | None = None) -> Path:
+        (tmp_path / "docs" / "migration").mkdir(parents=True, exist_ok=True)
+        for d in doc_fixtures or []:
+            target_name = d.removeprefix("doc_")
+            shutil.copy(FIXTURES / d, tmp_path / "docs" / "migration" / target_name)
+        cl = tmp_path / "CHANGELOG.md"
+        shutil.copy(FIXTURES / changelog_fixture, cl)
+        return cl
+    return _stage
+
+
+def _run(xref, changelog: Path, root: Path, *flags) -> int:
+    args = xref.build_parser().parse_args(
+        ["--changelog", str(changelog), "--root", str(root), *flags]
+    )
+    return xref.main([
+        "--changelog", str(changelog),
+        "--root", str(root),
+        *flags,
+    ])
+
+
+def test_complete_pass(xref, stage, tmp_path, capsys):
+    cl = stage("changelog_pass.md", ["doc_v1.12-to-v1.13.md"])
+    rc = _run(xref, cl, tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "OK" in captured.out
+
+
+def test_missing_link_fails(xref, stage, tmp_path, capsys):
+    cl = stage("changelog_missing_link.md", ["doc_v1.12-to-v1.13.md"])
+    rc = _run(xref, cl, tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "no docs/migration" in captured.err
+
+
+def test_missing_file_fails(xref, stage, tmp_path, capsys):
+    cl = stage("changelog_missing_file.md", ["doc_v1.12-to-v1.13.md"])
+    rc = _run(xref, cl, tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "migration doc not found" in captured.err
+
+
+def test_anchor_mismatch_fails(xref, stage, tmp_path, capsys):
+    cl = stage("changelog_anchor_mismatch.md", ["doc_v1.12-to-v1.13.md"])
+    rc = _run(xref, cl, tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "anchor not found" in captured.err
+    assert "bar-removal" in captured.err
+
+
+def test_no_anchor_passes_by_default(xref, stage, tmp_path, capsys):
+    cl = stage("changelog_no_anchor.md", ["doc_v1.12-to-v1.13.md"])
+    rc = _run(xref, cl, tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 0
+
+
+def test_no_anchor_fails_in_strict_mode(xref, stage, tmp_path, capsys):
+    cl = stage("changelog_no_anchor.md", ["doc_v1.12-to-v1.13.md"])
+    rc = _run(xref, cl, tmp_path, "--strict-anchor")
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "strict-anchor" in captured.err
+
+
+def test_no_breaking_section_skips(xref, stage, tmp_path, capsys):
+    cl = stage("changelog_no_breaking.md")
+    rc = _run(xref, cl, tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "skip" in captured.out
+
+
+def test_versioned_breaking_is_ignored(xref, stage, tmp_path, capsys):
+    """Old release sections under ``## [1.x]`` must not be re-validated when
+    the [Unreleased] section is empty of Breaking entries."""
+    cl = stage("changelog_versioned_only.md")
+    rc = _run(xref, cl, tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "skip" in captured.out
+
+
+def test_slugify_handles_unicode(xref):
+    assert xref.slugify("Foo Bar") == "foo-bar"
+    assert xref.slugify("foo_bar") == "foo-bar"
+    assert xref.slugify("`Generator` class removal") == "generator-class-removal"
+    # The actual GitHub slug collapses runs of `-` differently per renderer;
+    # this assertion pins our implementation's deterministic behaviour so
+    # `\s+` runs (whether or not they used to contain `→`) collapse to a
+    # single dash. Drift here is OK as long as the fixture-side migration doc
+    # uses the matching anchor.
+    assert xref.slugify("v1.12 → v1.13 migration guide") == "v112-v113-migration-guide"
+
+
+def test_parse_extracts_continuation_lines(xref):
+    text = (
+        "## [Unreleased]\n"
+        "\n"
+        "### Breaking\n"
+        "\n"
+        "- first entry [a](docs/migration/v1.12-to-v1.13.md#x)\n"
+        "  continuation line\n"
+        "- second entry [b](docs/migration/v1.12-to-v1.13.md#y)\n"
+    )
+    entries = xref.parse_unreleased_breaking(text)
+    assert len(entries) == 2
+    assert "continuation line" in entries[0].body


### PR DESCRIPTION
## Summary

v1.12 で `docs/migration/v1.11-to-v1.12.md` が breaking commit より後に作成された問題を構造的に塞ぐため、 `CHANGELOG.md` の `[Unreleased] > ### Breaking` entry に `docs/migration/v*.md` への解決可能な anchor link を強制する keep-a-changelog 駆動の lint を追加します。 既存 `migration-changelog-parity.yml` (version 一致検査) とは責務分離した別 workflow + pre-commit hook の二重化です。

> Stacked on #508 (docs tickets)。 docs PR を merge 後に dev rebase します。

## Affected Components

- [x] CI-CD
- [x] Documentation

## Type

- [x] CI/CD

## Risk Level

- [x] minor (新規 workflow + 規約整備 / 既存挙動への破壊的変更なし)

## Contract Impact

- [x] None (`docs/spec/*.toml` への影響なし)

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| `scripts/check_migration_xref.py` | keep-a-changelog parser で `[Unreleased] > ### Breaking` entry を抽出、 link 内 `docs/migration/v*-to-v*.md#anchor` の file 存在 + anchor slug 一致を検査 | breaking entry に migration リンクなく merge され、 ユーザーが「警告だけあって移行方法不明」状態になる (v1.12 の再発) |
| `.github/workflows/migration-guide-lint.yml` | `breaking` label or CHANGELOG diff の `### Breaking` 追加検出時のみ enforce、 patch / minor PR は skip | 全 PR で重い検査が走って contributor friction が増える |
| `.pre-commit-config.yaml` hook `migration-guide-lint` | CHANGELOG / docs/migration 変更時のみローカル fail-fast | CI 待ち前に typo / 404 anchor に気付けない |
| `docs/migration/README.md` 新規 | 命名規則 (`v<X>-to-v<Y>.md`) と heading anchor slug 算出ルール + 書式例を canonical 化 | 「`### Changed (Breaking)`」のような変則書式で entry が検査対象から漏れる |
| `CHANGELOG.md` の `[Unreleased]` HTML コメント | link 規約と参照先を inline 化 | 規約の存在自体に新規 contributor が気付かない |
| pytest 10 シナリオ + fixture 7 種 | complete pass / missing link / missing file / anchor mismatch / no-anchor (default + strict) / no breaking / versioned only / slugify unicode / continuation lines | 「anchor 省略許可」「strict mode」「versioned 過去 entry の無視」の非自明分岐がリグレッションする |

## 設計判断

- **既存 `migration-changelog-parity.yml` との責務分離** — 既存は CHANGELOG entry の version 一致と migration doc の存在対応、 本 PR は entry 内 anchor link の解決可能性。 統合せず別 workflow + 別 hook
- **enforce 条件を `breaking` label OR `### Breaking` 追加 diff の OR** — patch / minor PR で false positive を出さない。 `workflow_dispatch` でも強制実行可能
- **anchor 省略は default で許可** — overview link (`docs/migration/v1.12-to-v1.13.md` 単独) は正当な書式。 `--strict-anchor` flag は release branch 等で運用予定 (future option)
- **slugify は実装値を fixture で pinning** — GitHub の正確な slug アルゴリズムは未公開なので、 連続 hyphen の collapse 挙動 (実装値: 単一 hyphen) を pinning する unicode テストを追加
- **stdlib only** — pre-commit hook 実行を高速化、 CI install step 不要
- **`### Breaking` 厳密 match** — `### Changed (Breaking)` のような変則を意図的に対象外にして、 `docs/migration/README.md` で「ユーザー向けは `### Breaking` 限定」と pinning

## Test Plan

- [ ] `uv run --no-project pytest tests/scripts/test_check_migration_xref.py -v --no-cov` で 10 件 pass
- [ ] `uv run --no-project python scripts/check_migration_xref.py` を実 `CHANGELOG.md` に対して実行し、 「no [Unreleased] > ### Breaking entries; skip.」 が出ること (現状の `[Unreleased]` は `### Added` のみ)
- [ ] `pre-commit run migration-guide-lint --files CHANGELOG.md` で pass する
- [ ] dummy PR で `### Breaking` セクションを link 無しで追加すると workflow が fail、 link を追加すると pass することを手動確認
- [ ] `docs/migration/README.md` の slug 規約表の通り `## foo removal` が `#foo-removal` に解決すること (`scripts/check_migration_xref.py` の slugify を直接呼ぶ unit テストで確認済み)

## Checklist

- [x] Tests pass locally (10 / 10 pytest)
- [x] No GPL-LGPL deps (stdlib only)
- [x] Documentation updated (`docs/migration/README.md` 新規 / `CHANGELOG.md` template コメント)

## Related Issues

なし (チケット `docs/tickets/M1-2-migration-guide-lint.md` / 親調査 `docs/proposals/ci-expansion-2026-05.md` Top 10 #3 から派生)
