### PR TITLE
fix(scripts): cp932 F6 漏れ 20 gate script + export-onnx test 修正

### DIFF
--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -52,6 +52,10 @@ import re
 import sys
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_DIR = REPO_ROOT / ".github/workflows"
@@ -144,7 +148,9 @@ def main(argv: list[str] | None = None) -> int:
     stale_baseline = sorted(baseline - sliding_refs)
 
     if other_refs:
-        print(f"WARN: {len(other_refs)} 'other' ref(s) (branch/release-name pin); review:")
+        print(
+            f"WARN: {len(other_refs)} 'other' ref(s) (branch/release-name pin); review:"
+        )
         for wf, lineno, ref in other_refs:
             print(f"  {wf.relative_to(REPO_ROOT)}:{lineno}  {ref}")
         print()

--- a/scripts/check_asymmetric_latency.py
+++ b/scripts/check_asymmetric_latency.py
@@ -19,6 +19,11 @@ import json
 import sys
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 ROOT = Path(__file__).resolve().parent.parent
 BASELINE = ROOT / "tests" / "fixtures" / "multi-runtime-rtf-baseline.json"
 

--- a/scripts/check_bundle_size.py
+++ b/scripts/check_bundle_size.py
@@ -63,7 +63,11 @@ import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_BASELINE = REPO_ROOT / "tests" / "fixtures" / "bundle-size-baseline.json"
@@ -78,10 +82,10 @@ DEFAULT_BASELINE = REPO_ROOT / "tests" / "fixtures" / "bundle-size-baseline.json
 class Artifact:
     """One distributable unit on a public registry."""
 
-    package: str       # registry-facing name (e.g. ``piper-plus``)
-    ecosystem: str     # one of ``npm`` / ``nuget`` / ``cargo`` / ``maven``
-    tolerance: float   # fractional, e.g. ``0.03`` for ±3 %
-    glob: str          # POSIX glob relative to REPO_ROOT
+    package: str  # registry-facing name (e.g. ``piper-plus``)
+    ecosystem: str  # one of ``npm`` / ``nuget`` / ``cargo`` / ``maven``
+    tolerance: float  # fractional, e.g. ``0.03`` for ±3 %
+    glob: str  # POSIX glob relative to REPO_ROOT
 
 
 # Per-ecosystem tolerances (kept here to make the policy obvious in review).
@@ -155,14 +159,14 @@ def _baseline_key(art: Artifact) -> str:
     return f"{art.ecosystem}::{art.package}"
 
 
-def _resolve_size_bytes(art: Artifact) -> Optional[int]:
+def _resolve_size_bytes(art: Artifact) -> int | None:
     """Return the on-disk size of the matching artifact, or None."""
     matches = sorted(glob.glob(str(REPO_ROOT / art.glob)))
     if not matches:
         return None
     # If multiple matches (e.g. several versions in target/package), take
     # the newest by mtime so reruns within one CI job stay deterministic.
-    matches.sort(key=lambda p: os.path.getmtime(p))
+    matches.sort(key=os.path.getmtime)
     return os.path.getsize(matches[-1])
 
 
@@ -181,7 +185,11 @@ BASELINE_SCHEMA_VERSION = "1.0"
 
 def _load_baseline(path: Path) -> dict:
     if not path.exists():
-        return {"schema_version": BASELINE_SCHEMA_VERSION, "version": 1, "artifacts": {}}
+        return {
+            "schema_version": BASELINE_SCHEMA_VERSION,
+            "version": 1,
+            "artifacts": {},
+        }
     with path.open(encoding="utf-8") as fh:
         data = json.load(fh)
     declared = data.get("schema_version")
@@ -237,17 +245,17 @@ class Comparison:
     package: str
     ecosystem: str
     tolerance: float
-    baseline: Optional[int]
-    observed: Optional[int]
+    baseline: int | None
+    observed: int | None
 
     @property
-    def delta_bytes(self) -> Optional[int]:
+    def delta_bytes(self) -> int | None:
         if self.baseline is None or self.observed is None:
             return None
         return self.observed - self.baseline
 
     @property
-    def delta_pct(self) -> Optional[float]:
+    def delta_pct(self) -> float | None:
         if self.baseline is None or not self.baseline or self.observed is None:
             return None
         return (self.observed - self.baseline) / self.baseline
@@ -287,7 +295,7 @@ def _compare(baseline: dict, observed: dict) -> list[Comparison]:
 # ---------------------------------------------------------------------------
 
 
-def _fmt_bytes(n: Optional[int]) -> str:
+def _fmt_bytes(n: int | None) -> str:
     if n is None:
         return "n/a"
     if n < 1024:
@@ -297,7 +305,7 @@ def _fmt_bytes(n: Optional[int]) -> str:
     return f"{n / (1024 * 1024):.2f} MiB"
 
 
-def _fmt_pct(p: Optional[float]) -> str:
+def _fmt_pct(p: float | None) -> str:
     if p is None:
         return "n/a"
     return f"{p * 100:+.2f}%"
@@ -317,15 +325,7 @@ def _render_markdown(results: list[Comparison]) -> str:
     ]
     for r in results:
         lines.append(
-            "| {status} | {eco} | `{pkg}` | {base} | {obs} | {delta} | ±{tol:.0%} |".format(
-                status=_emoji(r.status),
-                eco=r.ecosystem,
-                pkg=r.package,
-                base=_fmt_bytes(r.baseline),
-                obs=_fmt_bytes(r.observed),
-                delta=_fmt_pct(r.delta_pct),
-                tol=r.tolerance,
-            )
+            f"| {_emoji(r.status)} | {r.ecosystem} | `{r.package}` | {_fmt_bytes(r.baseline)} | {_fmt_bytes(r.observed)} | {_fmt_pct(r.delta_pct)} | ±{r.tolerance:.0%} |"
         )
     skips = sum(1 for r in results if r.status == "skip")
     fails = sum(1 for r in results if r.status == "fail")

--- a/scripts/check_changelog_unreleased.py
+++ b/scripts/check_changelog_unreleased.py
@@ -38,6 +38,11 @@ import sys
 import tomllib
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
 RELEASE_VERSIONS_PATH = REPO_ROOT / "docs" / "spec" / "release-versions.toml"
@@ -112,7 +117,9 @@ def _detect_drift(
 
 def main() -> int:
     if not CHANGELOG_PATH.exists():
-        print(f"ERROR: {CHANGELOG_PATH.relative_to(REPO_ROOT)} not found", file=sys.stderr)
+        print(
+            f"ERROR: {CHANGELOG_PATH.relative_to(REPO_ROOT)} not found", file=sys.stderr
+        )
         return 1
     if not RELEASE_VERSIONS_PATH.exists():
         print(

--- a/scripts/check_chinese_tone_contract.py
+++ b/scripts/check_chinese_tone_contract.py
@@ -37,6 +37,11 @@ import sys
 import tomllib
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CONTRACT = REPO_ROOT / "docs/spec/chinese-tone-contract.toml"
 PUA_JSON = REPO_ROOT / "src/python/g2p/piper_plus_g2p/data/pua.json"
@@ -87,10 +92,17 @@ def load_pua_codepoints() -> dict[str, str]:
     out: dict[str, str] = {}
     entries = data.get("entries") or data.get("mappings") or []
     if isinstance(entries, dict):
-        entries = [{"token": k, **(v if isinstance(v, dict) else {"codepoint": v})} for k, v in entries.items()]
+        entries = [
+            {"token": k, **(v if isinstance(v, dict) else {"codepoint": v})}
+            for k, v in entries.items()
+        ]
     for entry in entries:
         token = entry.get("token") or entry.get("name")
-        cp = entry.get("codepoint") or entry.get("pua_codepoint") or entry.get("codepoint_hex")
+        cp = (
+            entry.get("codepoint")
+            or entry.get("pua_codepoint")
+            or entry.get("codepoint_hex")
+        )
         if token is None:
             continue
         normalized = _normalize_codepoint(cp)
@@ -168,7 +180,7 @@ def main() -> int:
         if 'f"tone{' not in fn_body and "f'tone{" not in fn_body:
             errors.append(
                 f"  canonical function {canonical_function} does not use "
-                f"`f\"tone{{tone}}\"` formatting — drift risk."
+                f'`f"tone{{tone}}"` formatting — drift risk.'
             )
 
     # 4. symbol literals in each runtime source

--- a/scripts/check_deprecated_api_lingering.py
+++ b/scripts/check_deprecated_api_lingering.py
@@ -37,6 +37,11 @@ import re
 import sys
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # 検査対象パス (`docs/`, `README*.md`)、 example / archive は除外。
@@ -48,7 +53,7 @@ EXCLUDE_PREFIXES = (
     "docs/archive/",
     "CHANGELOG-archive.md",
     "CHANGELOG.md",  # 歴史的記述 OK
-    "docs/spec/",    # contract spec は archived 注釈フォーマットが別
+    "docs/spec/",  # contract spec は archived 注釈フォーマットが別
 )
 
 # (キーワード, 廃止 version, 説明) の組
@@ -157,7 +162,9 @@ def main() -> int:
             findings.append((doc, ln, kw, line))
 
     if args.verbose:
-        print(f"scanned {len(docs)} doc files for {len(DEPRECATED_ITEMS)} deprecated keywords")
+        print(
+            f"scanned {len(docs)} doc files for {len(DEPRECATED_ITEMS)} deprecated keywords"
+        )
 
     if findings:
         print(

--- a/scripts/check_japanese_n_variant_contract.py
+++ b/scripts/check_japanese_n_variant_contract.py
@@ -34,6 +34,11 @@ import sys
 import tomllib
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CONTRACT = REPO_ROOT / "docs/spec/japanese-n-variant-contract.toml"
 
@@ -122,9 +127,7 @@ def extract_python_trigger_phonemes(py_src: str) -> dict[str, list[str]]:
             # Match `case (...)` / `case [...]` / `case {...}`
             cl = case_literal_re.search(up)
             if cl:
-                triggers[variant] = re.findall(
-                    r"['\"]([^'\"]+)['\"]", cl.group("body")
-                )
+                triggers[variant] = re.findall(r"['\"]([^'\"]+)['\"]", cl.group("body"))
                 break
             # Match `in (...)` possibly multi-line; accumulate until balanced.
             ilm = in_literal_start_re.search(up)

--- a/scripts/check_language_id_map_contract.py
+++ b/scripts/check_language_id_map_contract.py
@@ -30,6 +30,11 @@ import sys
 import tomllib
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CONTRACT_PATH = REPO_ROOT / "docs/spec/language-id-map-contract.toml"
 
@@ -94,9 +99,7 @@ def _extract_inline_python_list(path: Path, expected: list[str]) -> bool:
     return rendered_double in text or rendered_single in text
 
 
-def _extract_inline_substring_map(
-    path: Path, expected_map: dict[str, int]
-) -> bool:
+def _extract_inline_substring_map(path: Path, expected_map: dict[str, int]) -> bool:
     """Check that an inline JSON-shaped literal exists in the source file.
 
     Used for Rust source files where `language_id_map` appears as an embedded
@@ -112,9 +115,7 @@ def _extract_inline_substring_map(
         return True
     # Variant 2: comma + no-space form (`"k":v`).
     body2 = ", ".join(f'"{k}":{v}' for k, v in expected_map.items())
-    if body2 in text:
-        return True
-    return False
+    return body2 in text
 
 
 def _extract_json_field(path: Path, field: str) -> object:
@@ -132,7 +133,9 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument("--verbose", action="store_true", help="Print all checked values")
+    parser.add_argument(
+        "--verbose", action="store_true", help="Print all checked values"
+    )
     args = parser.parse_args()
 
     contract = tomllib.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
@@ -166,7 +169,9 @@ def main() -> int:
         values = list(mapping.values())
         if invariants["keys_lowercase"] and any(k != k.lower() for k in keys):
             errors.append(f"  {name}: keys_lowercase invariant violated ({keys!r})")
-        if invariants["values_consecutive_from_zero"] and sorted(values) != list(range(len(values))):
+        if invariants["values_consecutive_from_zero"] and sorted(values) != list(
+            range(len(values))
+        ):
             errors.append(
                 f"  {name}: values_consecutive_from_zero invariant violated "
                 f"(values={values!r})"
@@ -174,9 +179,13 @@ def main() -> int:
         if invariants["values_unique"] and len(set(values)) != len(values):
             errors.append(f"  {name}: values_unique invariant violated ({values!r})")
         if invariants["ja_is_zero"] and mapping.get("ja") != 0:
-            errors.append(f"  {name}: ja_is_zero invariant violated (ja={mapping.get('ja')!r})")
+            errors.append(
+                f"  {name}: ja_is_zero invariant violated (ja={mapping.get('ja')!r})"
+            )
         if invariants["en_is_one"] and mapping.get("en") != 1:
-            errors.append(f"  {name}: en_is_one invariant violated (en={mapping.get('en')!r})")
+            errors.append(
+                f"  {name}: en_is_one invariant violated (en={mapping.get('en')!r})"
+            )
     if invariants["values_consecutive_from_zero"]:
         # Cross-form: every shared key must agree across the 6/7/8-lang forms.
         # (Adding sv or ko must NEVER renumber an existing language.)
@@ -296,19 +305,48 @@ def main() -> int:
     }
     # Source-code-ish extensions only — skip binaries, generated files, models.
     sweep_extensions = {
-        ".py", ".rs", ".go", ".cs", ".cpp", ".cc", ".c", ".h", ".hpp",
-        ".js", ".ts", ".mjs", ".cjs", ".json", ".toml", ".yaml", ".yml",
-        ".kt", ".swift",
+        ".py",
+        ".rs",
+        ".go",
+        ".cs",
+        ".cpp",
+        ".cc",
+        ".c",
+        ".h",
+        ".hpp",
+        ".js",
+        ".ts",
+        ".mjs",
+        ".cjs",
+        ".json",
+        ".toml",
+        ".yaml",
+        ".yml",
+        ".kt",
+        ".swift",
     }
     # Directory names to prune entirely (anywhere in path).
     skip_dirs = {
-        "node_modules", "target", "build", "dist", "bin", "obj",
-        "__pycache__", ".pytest_cache", ".venv", "venv", "vendor",
+        "node_modules",
+        "target",
+        "build",
+        "dist",
+        "bin",
+        "obj",
+        "__pycache__",
+        ".pytest_cache",
+        ".venv",
+        "venv",
+        "vendor",
         "pkg",  # Go module cache
         # Tests legitimately exercise edge cases including non-canonical
         # language_id_map literals (e.g. http_server fallback paths). The
         # contract verifies SOURCE drift, not test fixture diversity.
-        "tests", "test", "testdata", "TestData", "fixtures",
+        "tests",
+        "test",
+        "testdata",
+        "TestData",
+        "fixtures",
     }
     forbidden = contract["expected_not_found"]["forbidden_outside_sources"]
     sweep_root = REPO_ROOT / "src"

--- a/scripts/check_loanword_forward_compat.py
+++ b/scripts/check_loanword_forward_compat.py
@@ -30,6 +30,11 @@ import json
 import sys
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURE = REPO_ROOT / "tests/fixtures/g2p/zh_en_loanword_forward_compat.json"
 

--- a/scripts/check_lockfile_consistency.py
+++ b/scripts/check_lockfile_consistency.py
@@ -32,6 +32,11 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # (relative_path, runtime_label, hard_required)
@@ -77,8 +82,10 @@ def check() -> int:
         for entry in empty:
             print(f"  empty (required):   {entry}", file=sys.stderr)
         if missing_soft:
-            print("  (soft-required lockfiles also missing — see warnings below)",
-                  file=sys.stderr)
+            print(
+                "  (soft-required lockfiles also missing — see warnings below)",
+                file=sys.stderr,
+            )
             for entry in missing_soft:
                 print(f"    soft-missing: {entry}", file=sys.stderr)
         return 1
@@ -87,11 +94,15 @@ def check() -> int:
         print("warning: optional lockfiles not yet committed:")
         for entry in missing_soft:
             print(f"  soft-missing: {entry}")
-        print("  Run `dotnet restore` / `./gradlew :<module>:dependencies "
-              "--write-locks` and commit the generated lockfile.")
+        print(
+            "  Run `dotnet restore` / `./gradlew :<module>:dependencies "
+            "--write-locks` and commit the generated lockfile."
+        )
 
-    print(f"OK: {len(LOCKFILES) - len(missing_soft)} lockfile(s) present, "
-          f"{len(missing_soft)} soft-missing.")
+    print(
+        f"OK: {len(LOCKFILES) - len(missing_soft)} lockfile(s) present, "
+        f"{len(missing_soft)} soft-missing."
+    )
     return 0
 
 

--- a/scripts/check_openjtalk_version_sync.py
+++ b/scripts/check_openjtalk_version_sync.py
@@ -50,6 +50,11 @@ import sys
 import tomllib
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CMAKE_FILE = REPO_ROOT / "cmake" / "ExternalDeps.cmake"
 
@@ -87,9 +92,7 @@ def _find_requirements() -> list[Path]:
     return out
 
 
-_CMAKE_URL_RE = re.compile(
-    r"pyopenjtalk_plus-(\d+\.\d+\.\d+(?:\.post\d+)?)\.tar\.gz"
-)
+_CMAKE_URL_RE = re.compile(r"pyopenjtalk_plus-(\d+\.\d+\.\d+(?:\.post\d+)?)\.tar\.gz")
 
 
 def _extract_cmake_version(path: Path) -> str | None:
@@ -163,7 +166,9 @@ def _extract_pyproject_specs(pyproject: Path) -> list[tuple[str, str]]:
         if isinstance(deps, dict):
             for name, val in deps.items():
                 if "pyopenjtalk" in name.lower():
-                    specs.append((f"{name}{val!s}", f"tool.{tooltable_key}.dependencies"))
+                    specs.append(
+                        (f"{name}{val!s}", f"tool.{tooltable_key}.dependencies")
+                    )
 
     return specs
 
@@ -215,8 +220,14 @@ def _classify_drift(spec: str, cmake_version: str) -> tuple[str, str]:
             major, minor = int(m_compat.group(1)), int(m_compat.group(2))
             cm_parts = cmake_version.split(".post", 1)[0].split(".")
             if int(cm_parts[0]) != major or int(cm_parts[1]) != minor:
-                return ("error", f"~= mismatch ({m_compat.group(0)} vs cmake {cmake_version})")
-        return ("warn", f"packaging library unavailable; only == / ~= checked for {constraint!r}")
+                return (
+                    "error",
+                    f"~= mismatch ({m_compat.group(0)} vs cmake {cmake_version})",
+                )
+        return (
+            "warn",
+            f"packaging library unavailable; only == / ~= checked for {constraint!r}",
+        )
 
     try:
         spec_set = SpecifierSet(constraint)
@@ -231,7 +242,10 @@ def _classify_drift(spec: str, cmake_version: str) -> tuple[str, str]:
     has_strict = any(s.operator in ("==", "~=") for s in spec_set)
     if has_strict:
         return ("error", f"cmake {cmake_version} violates strict pin {constraint!r}")
-    return ("warn", f"cmake {cmake_version} does not satisfy range constraint {constraint!r}")
+    return (
+        "warn",
+        f"cmake {cmake_version} does not satisfy range constraint {constraint!r}",
+    )
 
 
 def main() -> int:

--- a/scripts/check_ort_versions.py
+++ b/scripts/check_ort_versions.py
@@ -61,6 +61,10 @@ import argparse
 import re
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
 
 CMAKE_FILE = Path("cmake/OnnxRuntime.cmake")
 

--- a/scripts/check_phoneme_set_version.py
+++ b/scripts/check_phoneme_set_version.py
@@ -21,15 +21,22 @@ Exit code:
   0 = compliant
   1 = mismatch found
 """
+
 import json
 import re
 import sys
 from pathlib import Path
 
+
 try:
     import tomllib  # Python 3.11+
 except ImportError:
     import tomli as tomllib  # type: ignore[no-redef]
+
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SPEC = REPO_ROOT / "docs" / "spec" / "phoneme-set-version.toml"
@@ -116,7 +123,9 @@ def main() -> int:
         actual_count = len(pua["entries"])
     else:
         # Fallback: count any single-codepoint values in the top-level dict
-        actual_count = sum(1 for v in pua.values() if isinstance(v, str) and len(v) == 1)
+        actual_count = sum(
+            1 for v in pua.values() if isinstance(v, str) and len(v) == 1
+        )
 
     print(f"\npua.json: {actual_count} entries discovered")
 

--- a/scripts/check_phoneme_timing_contract.py
+++ b/scripts/check_phoneme_timing_contract.py
@@ -42,11 +42,16 @@ import re
 import sys
 from pathlib import Path
 
+
 try:
     import tomllib  # Python 3.11+
 except ImportError:
     import tomli as tomllib  # type: ignore[no-redef]
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CONTRACT = REPO_ROOT / "docs" / "spec" / "phoneme-timing-contract.toml"
@@ -142,8 +147,7 @@ def main() -> int:
     expected = "frame_time_ms = (hop_length / sample_rate) * 1000"
     if formula != expected:
         print(
-            f"::error::canonical formula drift: {formula!r} "
-            f"(expected {expected!r})",
+            f"::error::canonical formula drift: {formula!r} (expected {expected!r})",
             file=sys.stderr,
         )
         return 1

--- a/scripts/check_precommit_file_regex.py
+++ b/scripts/check_precommit_file_regex.py
@@ -41,6 +41,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CONFIG_PATH = REPO_ROOT / ".pre-commit-config.yaml"
 

--- a/scripts/check_readme_breaking_sync.py
+++ b/scripts/check_readme_breaking_sync.py
@@ -37,6 +37,11 @@ import re
 import sys
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CANONICAL = REPO_ROOT / "README.md"
 
@@ -112,7 +117,9 @@ def main() -> int:
                     f"  {name}: stale breaking banner v{v} (canonical has none)"
                 )
         if warnings:
-            print("README breaking sync: stale banner(s) in translations", file=sys.stderr)
+            print(
+                "README breaking sync: stale banner(s) in translations", file=sys.stderr
+            )
             for w in warnings:
                 print(w, file=sys.stderr)
             return 1 if args.strict else 0

--- a/scripts/check_readme_code_examples.py
+++ b/scripts/check_readme_code_examples.py
@@ -46,6 +46,11 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 LANG_TO_SOURCES: dict[str, list[str]] = {
@@ -65,23 +70,108 @@ LANG_TO_SOURCES: dict[str, list[str]] = {
 # Symbols that show up in examples but are intentionally documented before
 # being implemented, or which live in third-party packages.
 ALLOWLIST: set[str] = {
-    "print", "main", "println", "console", "log", "info", "warn", "error",
-    "len", "range", "list", "dict", "str", "int", "float", "bool",
-    "true", "false", "null", "None", "undefined", "Some",
-    "Ok", "Err", "Result", "Option", "Vec", "String", "HashMap",
-    "Box", "Arc", "Rc", "Default", "Debug", "Clone",
-    "fmt", "fs", "io", "os", "path", "regex", "json", "tomllib", "pathlib",
-    "Path", "open", "read", "write", "close",
-    "fn", "let", "var", "const", "func", "def", "class", "struct", "enum",
-    "import", "from", "use", "package", "namespace", "using",
+    "print",
+    "main",
+    "println",
+    "console",
+    "log",
+    "info",
+    "warn",
+    "error",
+    "len",
+    "range",
+    "list",
+    "dict",
+    "str",
+    "int",
+    "float",
+    "bool",
+    "true",
+    "false",
+    "null",
+    "None",
+    "undefined",
+    "Some",
+    "Ok",
+    "Err",
+    "Result",
+    "Option",
+    "Vec",
+    "String",
+    "HashMap",
+    "Box",
+    "Arc",
+    "Rc",
+    "Default",
+    "Debug",
+    "Clone",
+    "fmt",
+    "fs",
+    "io",
+    "os",
+    "path",
+    "regex",
+    "json",
+    "tomllib",
+    "pathlib",
+    "Path",
+    "open",
+    "read",
+    "write",
+    "close",
+    "fn",
+    "let",
+    "var",
+    "const",
+    "func",
+    "def",
+    "class",
+    "struct",
+    "enum",
+    "import",
+    "from",
+    "use",
+    "package",
+    "namespace",
+    "using",
     # Common stdlib / typing helpers that show up in cross-runtime examples.
-    "Optional", "Union", "Any", "Iterator", "Iterable", "Sequence", "Mapping",
-    "List", "Dict", "Tuple", "Set", "Type", "TypeVar", "Generic",
-    "dataclass", "field", "subprocess", "asyncio", "logging", "argparse",
-    "Callable", "Awaitable", "NoReturn", "Final",
+    "Optional",
+    "Union",
+    "Any",
+    "Iterator",
+    "Iterable",
+    "Sequence",
+    "Mapping",
+    "List",
+    "Dict",
+    "Tuple",
+    "Set",
+    "Type",
+    "TypeVar",
+    "Generic",
+    "dataclass",
+    "field",
+    "subprocess",
+    "asyncio",
+    "logging",
+    "argparse",
+    "Callable",
+    "Awaitable",
+    "NoReturn",
+    "Final",
     # JS / TS / Rust frequently seen names.
-    "Promise", "async", "await", "yield", "return", "throw", "catch",
-    "Self", "Box", "Future", "Stream", "Send", "Sync",
+    "Promise",
+    "async",
+    "await",
+    "yield",
+    "return",
+    "throw",
+    "catch",
+    "Self",
+    "Future",
+    "Stream",
+    "Send",
+    "Sync",
 }
 
 # Document tree roots to scan.
@@ -150,6 +240,7 @@ def grep_sources(ident: str, source_dirs: list[str]) -> bool:
                 capture_output=True,
                 text=True,
                 timeout=30,
+                check=False,
             )
             if result.returncode == 0 and result.stdout.strip():
                 return True
@@ -221,7 +312,10 @@ def main() -> int:
         )
         if args.strict:
             return 1
-        print("\n(non-strict mode: warning only — re-run with --strict to fail)", file=sys.stderr)
+        print(
+            "\n(non-strict mode: warning only — re-run with --strict to fail)",
+            file=sys.stderr,
+        )
         return 0
 
     if args.verbose:

--- a/scripts/check_readme_h2_parity.py
+++ b/scripts/check_readme_h2_parity.py
@@ -42,6 +42,11 @@ import re
 import sys
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CANONICAL = REPO_ROOT / "README.md"
 TRANSLATIONS = [
@@ -72,12 +77,20 @@ def count_h2(path: Path) -> tuple[int, list[str]]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="README H2 parity gate")
-    parser.add_argument("--strict", action="store_true",
-                        help="exit 1 on tolerance exceeded (default: warn only)")
-    parser.add_argument("--verbose", "-v", action="store_true",
-                        help="print full H2 lists per file")
-    parser.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE,
-                        help=f"max relative diff (default {DEFAULT_TOLERANCE})")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 on tolerance exceeded (default: warn only)",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="print full H2 lists per file"
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=DEFAULT_TOLERANCE,
+        help=f"max relative diff (default {DEFAULT_TOLERANCE})",
+    )
     args = parser.parse_args()
 
     if not CANONICAL.exists():
@@ -86,8 +99,11 @@ def main() -> int:
 
     canon_count, canon_headings = count_h2(CANONICAL)
     if canon_count == 0:
-        print(f"warning: canonical {CANONICAL.name} has 0 H2 sections — "
-              "skipping comparison", file=sys.stderr)
+        print(
+            f"warning: canonical {CANONICAL.name} has 0 H2 sections — "
+            "skipping comparison",
+            file=sys.stderr,
+        )
         return 0
 
     print(f"canonical {CANONICAL.name}: {canon_count} H2 sections")

--- a/scripts/check_ruff_version_sync.py
+++ b/scripts/check_ruff_version_sync.py
@@ -38,6 +38,10 @@ import re
 import sys
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 

--- a/scripts/check_skill_health.py
+++ b/scripts/check_skill_health.py
@@ -33,6 +33,11 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_DIR = REPO_ROOT / ".claude/skills"
 HOOKS_DIR = REPO_ROOT / ".claude/hooks"
@@ -208,9 +213,7 @@ def main() -> int:
 
     if errors:
         return 1
-    print(
-        f"OK skill-health: {len(skills)} skill(s), {len(hooks)} hook(s) inspected"
-    )
+    print(f"OK skill-health: {len(skills)} skill(s), {len(hooks)} hook(s) inspected")
     return 0
 
 

--- a/src/python/tests/test_export_onnx.py
+++ b/src/python/tests/test_export_onnx.py
@@ -7,14 +7,16 @@ import torch
 from torch import nn
 
 
-def _onnx_inference(onnx_path, phoneme_ids, prosody_features, noise_scale=0.667):
+def _onnx_inference(
+    onnx_path, phoneme_ids, prosody_features, noise_scale=0.667, noise_scale_w=0.8
+):
     """Run ONNX inference and return audio output."""
     import onnxruntime
 
     session = onnxruntime.InferenceSession(str(onnx_path))
     text = np.expand_dims(np.array(phoneme_ids, dtype=np.int64), 0)
     text_lengths = np.array([text.shape[1]], dtype=np.int64)
-    scales = np.array([noise_scale, 1.0, 0.8], dtype=np.float32)
+    scales = np.array([noise_scale, 1.0, noise_scale_w], dtype=np.float32)
 
     inputs = {
         "input": text,
@@ -75,25 +77,28 @@ class TestStochasticExport:
         sample_phoneme_ids,
         sample_prosody_features,
     ):
-        """Stochastic モードで noise_scale=0 なら deterministic と同等の出力"""
+        """noise_scale=0 + noise_scale_w=0 で stochastic export は deterministic と一致"""
+        # noise_scale_w=0 → SDP の z=randn*0=0、deterministic export の zeros と一致
         audio_det = _onnx_inference(
             temp_onnx_model,
             sample_phoneme_ids,
             sample_prosody_features,
             noise_scale=0.0,
+            noise_scale_w=0.0,
         )
         audio_stoch = _onnx_inference(
             temp_onnx_model_stochastic,
             sample_phoneme_ids,
             sample_prosody_features,
             noise_scale=0.0,
+            noise_scale_w=0.0,
         )
 
         np.testing.assert_allclose(
             audio_det,
             audio_stoch,
             atol=1e-4,
-            err_msg="Stochastic with noise_scale=0 should match deterministic output",
+            err_msg="Zero noise scales: stochastic export must equal deterministic",
         )
 
     def test_stochastic_produces_valid_audio(
@@ -292,7 +297,7 @@ class TestUnifyEmbLang:
 
         model_g = _make_mock_model_g(n_speakers=1, n_languages=6)
 
-        with pytest.raises(ValueError, match="must be 0..5"):
+        with pytest.raises(ValueError, match=r"must be 0..5"):
             unify_emb_lang_weights(model_g, source=10)
 
 


### PR DESCRIPTION
## Summary

最新 dev (#506/#507 マージ後) の release QA 再検証で発見した 2 件の修正。(1) QA finding F6 (PR #505) の修正漏れ — `check_asymmetric_latency.py` が Windows 日本語コンソール (cp932) で `UnicodeEncodeError` クラッシュ。`scripts/check_*.py` を全 40 件監査し、非 ASCII を出力するのに `force_utf8_output()` を欠く 20 スクリプトを修正。(2) `test_export_onnx.py::test_stochastic_with_zero_noise_scale` が成立しないテスト — ヘルパー `_onnx_inference` の `noise_scale_w` ハードコードを修正。2 commits / 21 files。

## Affected Components

- [x] Python (src/python/, pyproject.toml)
- [ ] Rust (src/rust/)
- [ ] C# (src/csharp/)
- [ ] C++ (src/cpp/, CMakeLists.txt)
- [ ] Go (src/go/)
- [ ] WASM/npm (src/wasm/)
- [ ] Docker (docker/)
- [x] CI/CD (.github/workflows/) — `scripts/` の CI gate / pre-commit hook スクリプト
- [ ] Documentation (docs/, README*)

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Dependencies

## Risk Level

- [x] **patch** — bug fix / internal refactor / docs only
- [ ] **minor** — new feature / additive API / no breaking change
- [ ] **major** — breaking change (API removal, schema migration, behavior reversal)

## Contract Impact

- [x] None (gate スクリプトとテストの修正のみ。`docs/spec/*.toml` の契約定義は変更なし)

## 変更内容

### F6 cp932 — gate スクリプトの UnicodeEncodeError クラッシュ

| 修正 | 動作 | これがないと起こること |
|------|------|----------------------|
| 20 gate スクリプトに `force_utf8_output()` | `platform_utils.force_utf8_output()` を import 時に呼び stdout/stderr を UTF-8 へ reconfigure | Windows cp932 コンソールで `—` `✓` `≥` `→` `×` `「」` 等の出力が `UnicodeEncodeError` クラッシュし、gate が pass/fail を報告できない |

`scripts/check_*.py` 全 40 件を監査。stdout/stderr に非 ASCII を出力するのに helper を欠く 20 件 (`check_asymmetric_latency.py` + 監査検出 19 件) を修正。非 ASCII がコメント/docstring のみのものは除外。

### export-onnx テスト修正

| 修正 | 動作 | これがないと起こること |
|------|------|----------------------|
| `_onnx_inference` に `noise_scale_w` 引数追加 | default 0.8 (既存呼び出しは挙動不変)、`test_stochastic_with_zero_noise_scale` で 0.0 を渡す | ヘルパーが `scales[2]` (noise_scale_w) を 0.8 固定していたため stochastic export を zero-noise にできず、音声長が deterministic と不一致 (2560 vs 4608) でテストが常に fail |

### 付随: ruff 0.15.12 latent drift 正規化

touch した一部スクリプトに残っていた ruff 0.15.12 の latent な check/format drift (import 整理 / `X|None` 注記 / f-string / 重複 set 要素 / `subprocess` の明示 `check=` / 改行) を正規化。pre-commit が touch ファイルに lint/format clean を要求し、F6 追加と同一ファイル内のため分離不可。機械的・挙動不変。

## 設計判断

- **F6 監査の範囲**: `scripts/check_*.py` を全 40 件監査し、非 ASCII が `print()` / stdout / stderr の出力に到達するスクリプトのみ修正。コメント/docstring のみのものは除外 (過剰修正の回避)。出力経路は AST ベースで判定。
- **ruff 正規化の同梱**: touch したスクリプトの latent な ruff drift は、CI が変更ファイルのみ lint するため未検出のまま蓄積していた。pre-commit が touch ファイルに clean を要求し、F6 追加と同一ファイルのため分離不能。`ruff format` / `ruff check --fix` の機械的・挙動不変な変更のみ。
- **export テストの premise は妥当**: `models.py` の SDP は `z = randn(...) * noise_scale_w` で duration ノイズを注入する。`noise_scale_w=0` で `z=0` となり deterministic export の zeros 経路と一致するため、「両ノイズ 0 で stochastic == deterministic」という前提は正しい。バグはヘルパーの引数ハードコードであり、premise を保ったまま最小修正した。

## Test Plan

- [ ] `PYTHONIOENCODING=cp932 uv run python scripts/check_asymmetric_latency.py` が `UnicodeEncodeError` なく結果を出力する (ローカル確認済)
- [ ] `uv run ruff check $(git diff --name-only dev..HEAD)` が clean (変更 21 ファイル、ローカル確認済)
- [ ] `uv run python -m py_compile` で変更 20 スクリプトが全て成功 (ローカル確認済)
- [ ] `cd src/python && uv run pytest tests/test_export_onnx.py tests/test_infer_onnx.py -o addopts="" -q` が全 PASS (ローカル: 71 + 55 passed)
- [ ] CI の contract / parity gate 群が従来どおり green
- [ ] CI の lint (ruff / pre-commit) が本 PR の変更ファイルで green

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL dependencies added ([License Policy](CONTRIBUTING.md#license-policy))
- [ ] Documentation updated (該当なし — gate スクリプト / テストの修正のみ)

## Related Issues

QA finding F6 は PR #505 で初回修正。本 PR は監査で検出した 19 件 + `check_asymmetric_latency.py` を補完する。export-onnx テスト修正は release QA の Phase 3.4 (学習 export テスト) で検出。Close する issue はなし。
