### PR TITLE
perf(ci): pre-commit env setup を setup-uv + venv cache + shallow fetch で高速化

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -58,10 +58,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
         with:
-          # Tier 2-F: changed-files mode requires both base and head SHAs in
-          # local history so `git diff <base>..<head>` resolves. `fetch-depth: 0`
-          # gets the full history (still fast: shallow PR clones are ~MB).
-          fetch-depth: 0
+          # fetch-depth: 1 (HEAD only) — the base SHA needed for
+          # `pre-commit run --from-ref` is fetched explicitly in the next
+          # step. Avoids the full-history clone (saves ~10-20s on large
+          # repos vs `fetch-depth: 0`).
+          fetch-depth: 1
+
+      - name: Fetch base SHA for diff
+        # `git fetch --depth=1 <sha>` pulls just the base commit's tree
+        # (no intermediate history). Sufficient for `git diff base..HEAD`
+        # which is what `pre-commit run --from-ref` uses internally.
+        # Skipped when BASE_SHA is empty (e.g. workflow_dispatch event).
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [ -n "${BASE_SHA:-}" ] && ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            git fetch --no-tags --depth=1 origin "${BASE_SHA}"
+          fi
 
       - uses: actions/setup-python@v6.2.0
         with:
@@ -75,24 +88,37 @@ jobs:
           pip install pre-commit==4.0.1
 
       - name: Install uv
-        # Several sync-gate hooks (loanword-consistency, ort-version-sync,
-        # voice-catalog-parity, language-id-map-contract, action-pin-gate,
-        # dictionary-consistency, ruff-version-sync, loanword-forward-compat,
-        # pua-cross-runtime-consistency, pua-fixture-drift) invoke
-        # `uv run python scripts/check_*.py` per the project convention
-        # (feedback_use_uv.md). Without uv on PATH they fail with
-        # `uv: command not found`. The local pre-commit relies on the
-        # contributor's uv install; CI must materialise it explicitly.
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        # Official astral-sh/setup-uv action — faster than `curl | sh`
+        # (downloads pre-built binary from action's CDN, no shell exec).
+        # `enable-cache: true` caches `~/.cache/uv` (package download
+        # cache) keyed on `uv.lock` by default → restored on subsequent
+        # runs so `uv sync` doesn't re-fetch wheels.
+        #
+        # Several sync-gate hooks (loanword-consistency, ort-version-sync, etc.)
+        # invoke `uv run --no-sync python scripts/check_*.py` and need uv on
+        # PATH (feedback_use_uv.md). setup-uv handles PATH automatically.
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Cache uv venv
+        # Cache `.venv/` so `uv sync --frozen` is near-no-op on warm cache.
+        # Key on (uv.lock, pyproject.toml) → invalidates if either changes.
+        # setup-uv's `~/.cache/uv` (pkg download cache) is separate; this
+        # caches the materialised venv (resolved + linked packages).
+        uses: actions/cache@v4.3.0
+        with:
+          path: .venv
+          key: uv-venv-${{ runner.os }}-py3.11-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+          restore-keys: |
+            uv-venv-${{ runner.os }}-py3.11-
 
       - name: Sync uv environment
         # Tier 1-B: pre-commit hooks use `uv run --no-sync python ...` to skip
         # env-validation overhead per hook (saves ~1-2s × 30+ hooks). This step
         # materialises `.venv/` once up-front so `--no-sync` doesn't hit a
-        # missing-venv error. `--frozen` keeps uv.lock pinned (no resolution
-        # side-effect).
+        # missing-venv error. `--frozen` keeps uv.lock pinned. Near-no-op when
+        # the `.venv/` cache above hits.
         run: uv sync --frozen
 
       - name: Cache pre-commit hook environments


### PR DESCRIPTION
## Summary

post-merge baseline 1m 43s の内訳推定:
- env setup(checkout / install pre-commit / install uv / cache restore / uv sync)≈ 30-50s
- hook execution(changed files only)≈ 30-60s
- GitHub Actions overhead ≈ 10s

env setup を 3 観点で最適化:
1. `fetch-depth: 0 → 1` + explicit base SHA point-fetch
2. `curl uv install` → `astral-sh/setup-uv@v8.1.0`(+ `~/.cache/uv` 自動 cache)
3. `.venv/` cache 追加(`actions/cache@v4.3.0`)

期待: 1m 43s → **~1m 0s**(warm cache)。 cold cache は不変。

## Affected Components

- [ ] Python (src/python/, pyproject.toml)
- [ ] Rust (src/rust/)
- [ ] C# (src/csharp/)
- [ ] C++ (src/cpp/, CMakeLists.txt)
- [ ] Go (src/go/)
- [ ] WASM/npm (src/wasm/)
- [ ] Docker (docker/)
- [x] CI/CD (.github/workflows/) — `pre-commit.yml` のみ
- [ ] Documentation (docs/, README*)

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] CI/CD
- [ ] Dependencies

## Risk Level

- [x] **patch** — bug fix / internal refactor / docs only
- [ ] **minor** — new feature / additive API / no breaking change
- [ ] **major** — breaking change (API removal, schema migration, behavior reversal)

## Contract Impact

- [x] None(CI workflow のみ変更)

## 変更内容

| 変更 | 動作 | これがないと起こること |
|------|------|----------------------|
| `actions/checkout` を `fetch-depth: 0 → 1` | HEAD のみ取得、 base SHA は別 step で point-fetch | full history clone ~10-20s が毎回走る |
| 新規 `Fetch base SHA for diff` step | `git fetch --no-tags --depth=1 origin $BASE_SHA`。 既に history にあれば skip(`git cat-file -e` で check) | `--from-ref` が base commit を見つけられず CI fail |
| `Install uv`: `curl install.sh \| sh` → `astral-sh/setup-uv@v8.1.0` | 公式 action、 pre-built binary を action CDN から DL。 `enable-cache: true` で `~/.cache/uv` を自動 cache(uv.lock hash key) | wheel 再 DL × 毎回 ~10s、 curl 経由の手動 PATH 設定 |
| 新規 `Cache uv venv` step | `.venv/` を `actions/cache@v4.3.0` で保存。 Key `uv-venv-{os}-py3.11-{hash(uv.lock, pyproject.toml)}`、 fallback restore-keys あり | `uv sync` が warm でも venv materialise を毎回 ~10-20s 実行 |
| `Sync uv environment` の comment 更新 | 「`.venv/` cache 時に near-no-op」と記載 | (documentation only) |

## 設計判断

- **`fetch-depth: 1` + point-fetch を選んだ理由**: `fetch-depth: 50` 等の固定 depth では PR commit 数 ≥ depth で fail。 base SHA だけ explicit fetch すれば PR の規模を問わず安全。 既に history にあれば skip するので push event でも追加コストなし。
- **`setup-uv@v8.1.0` の version pin**: SemVer minor.patch pin(`@v8.1.0`、 sliding `@v8` ではない)。 repo の `action-pin-gate` policy(PR #414 incident 由来)に準拠。 setup-uv の最新は確認済(2026-04-16 release)。
- **`.venv/` cache key**: `(uv.lock, pyproject.toml)` の hash。 lockfile / project metadata の変更で cache invalidate(stale venv で ImportError を回避)。 restore-keys fallback で部分一致時の re-sync を許容。
- **setup-uv の `enable-cache` と `.venv/` cache の分離**: setup-uv は `~/.cache/uv`(package download cache、 wheel 等)を cache、 `actions/cache` は `.venv/`(materialised env)を cache。 役割が異なるため両方持つことで warm cache 時のステップ間 cost を最小化。

## Test Plan

- [ ] 本 PR の CI が green になることを確認(initial run は cold cache のためベースラインと同等。次回以降で warm cache 効果が出る)
- [ ] 本 PR の CI workflow log で:
  - [ ] `Install uv` step が `astral-sh/setup-uv@v8.1.0` を実行している
  - [ ] `Cache uv venv` step が log に出ている(初回 cache miss は正常)
  - [ ] `Fetch base SHA for diff` step が必要なら `git fetch --depth=1` を実行している
- [ ] dev merge 後、 次回の dev push event の CI 時間が 1m 43s より短縮されているか比較(warm cache 効果の測定)
- [ ] `action-pin-gate`(`scripts/check_action_pins.py`)が `astral-sh/setup-uv@v8.1.0` を SemVer pin として受理(sliding tag 警告なし)

## Checklist

- [x] Tests pass locally(YAML syntax `python -c "yaml.safe_load(...)"` OK)
- [x] No GPL/LGPL dependencies added ([License Policy](CONTRIBUTING.md#license-policy))
- [ ] Documentation updated — workflow 内 inline comment で各変更の why を明記済み

## Related Issues

pre-commit 高速化 follow-up(PR #514+#515+#516 で実装した stage 分離 + changed-files mode + --no-sync の延長線上)。 さらなる最適化は post-merge 計測ベースで検討。 Close する issue はなし。
