### PR TITLE
chore(docs): scope-out cpp-dev distroless, narrow M3 to 4 images

### DIFF
--- a/docs/tickets/milestones/M3-supply-chain.md
+++ b/docs/tickets/milestones/M3-supply-chain.md
@@ -17,11 +17,13 @@
 
 両者とも **1 PR で 1 image / 1 registry** の cadence。 一括移行禁止 (R-2 / R-4 緩和)。
 
+> **2026-05-20 scope 変更**: Distroless は **5 image → 4 image** に縮小。 cpp-dev (T-016) は scope-out 確定。 理由は PR #524 で spike 目的 (multi-stage pattern / ABI 整合 / entrypoint 移植) が webui + cpp-inference の trial bundle により達成済、 加えて dev image は distroless 哲学と本質的に不整合 (cmake/gdb 等を final stage に残さざるを得ない) で大目的への寄与が限定的なため。 詳細は [T-016 §Note](../tickets/T-016-distroless-cpp-dev.md) 参照。
+
 ---
 
 ## 2. 配下チケット
 
-### Distroless × 5 image (`python-train` は GPU CUDA toolkit 依存で対象外)
+### Distroless × 4 image (`python-train` は GPU CUDA toolkit 依存で対象外、 `cpp-dev` は 2026-05-20 scope-out)
 
 | ID | タイトル | 提案項目 | 影響範囲 | Status | PR |
 |----|--------|---------|--------|--------|----|
@@ -29,7 +31,7 @@
 | [T-013](../tickets/T-013-distroless-webui.md) | `webui` distroless 化 | `#1-2` | Gradio demo | 計画中 | — |
 | [T-014](../tickets/T-014-distroless-wyoming.md) | `wyoming` distroless 化 | `#1-3` | Home Assistant addon | 計画中 | — |
 | [T-015](../tickets/T-015-distroless-cpp-inference.md) | `cpp-inference` distroless 化 | `#1-4` | C++ runtime image | 計画中 | — |
-| [T-016](../tickets/T-016-distroless-cpp-dev.md) | `cpp-dev` distroless 化 | `#1-5` | C++ dev image | 計画中 | — |
+| ~~[T-016](../tickets/T-016-distroless-cpp-dev.md)~~ | ~~`cpp-dev` distroless 化~~ | ~~`#1-5`~~ | C++ dev image | **除外確定 (2026-05-20)** | PR #524 (spike 結果) |
 
 ### SLSA L3 × 5 registry (PyPI / NuGet は新設要否を user 判断)
 
@@ -43,7 +45,7 @@
 
 ### 依存関係
 
-- Distroless 5 件は互いに独立、 並列実装可 (推奨実装順: 最も影響範囲が広い `python-inference` を最後にして、 学習を `cpp-dev` などから取る)
+- Distroless 4 件は互いに独立、 並列実装可 (cpp-dev による spike は PR #524 で webui + cpp-inference の trial bundle に置換され達成済、 残 T-012 / T-014 は trial 観測期間後の promotion + canonical 置換が主タスク)
 - SLSA L3 5 件も互いに独立だが、 **最初の 1 件 (推奨: T-019 crates.io、 GPG 署名共存制約なし)** を merged して運用知見を取ってから残 4 件に着手 (R-2 緩和)
 - Distroless と SLSA L3 は independence (異なる workflow を扱う)
 
@@ -197,3 +199,4 @@ cosign sign-blob --keyless ... attestation.intoto.jsonl > attestation.sig
 | 日付 | 変更 | 担当 |
 |------|------|------|
 | 2026-05-19 | 初版 | Claude Code |
+| 2026-05-20 | Distroless scope を 5 image → 4 image に縮小 (cpp-dev / T-016 scope-out 確定)。 PR #524 で webui (T-013) + cpp-inference (T-015) の trial bundle merged により spike 目的達成、 cpp-dev は production 経路なし & distroless 不整合で除外。 個別 ticket Status の merged 反映 (T-012 PR #523 / T-013 + T-015 PR #524) は別 PR で扱う。 | Claude Code |

--- a/docs/tickets/tickets/T-016-distroless-cpp-dev.md
+++ b/docs/tickets/tickets/T-016-distroless-cpp-dev.md
@@ -4,12 +4,30 @@
 **Milestone**: [M3 Supply Chain](../milestones/M3-supply-chain.md)
 **Proposal 項目**: `#1-5` (Distroless / Chainguard 移行 — `cpp-dev` image)
 **Tier**: Tier 3 (blast radius 小、 学習用 spike)
-**Status**: 計画中 (base image 戦略の見直しが必要)
-**PR**: (未作成、 PR #524 で wolfi-base trial を試行したが scope 矛盾を発見、 ticket 再設計が前提)
-**担当 (予定)**: Claude Code (agent team) + maintainer review
-**着手前提**: なし (M3 内 distroless 5 件の **最初に着手** することを推奨。 影響範囲最小、 spike 効果最大)
+**Status**: 除外確定 (M3 distroless scope-out 2026-05-20)
+**PR**: PR #524 (wolfi-base trial 実施 → scope 矛盾実証 → cpp-dev は除外確定)
+**担当 (予定)**: ―
+**着手前提**: ―
 
-> **Note (PR #524 wolfi-base trial 結果)**
+> **Note (2026-05-20 scope-out 確定)**
+>
+> 本 ticket は M3 distroless 移行 scope から **除外確定**。 大目的「production image の CVE 80%+ 削減 / size 50%+ 削減」 に対する寄与が限定的、 かつ ticket §1 の本来目的 (「学習用 spike」) は PR #524 で webui + cpp-inference の trial bundle により達成済。
+>
+> 除外根拠 (2 点):
+>
+> 1. **spike 目的が達成済**: ticket §1 で取得目的とされた multi-stage build pattern (Python C 拡張 / shared lib path / ABI 整合 / entrypoint 移植) は、 PR #524 の webui (Python + soundfile + NLTK + Gradio) と cpp-inference (C++ + ldconfig + glibc ABI 整合) で全て実証済。 cpp-dev で同等の spike を再実施する追加価値なし
+> 2. **dev image は distroless 哲学と本質的に不整合**: cmake / clang / gdb / valgrind を final stage に同居させないと dev experience が成立せず、 builder = final が事実上強制される。 PR #524 wolfi-base 試行で apk packaging 不足 (OpenJTalk / mecab / HTS Engine / iconv chain) も判明、 minimal 化の利益が消える構造。 加えて cpp-dev は GHCR で公開されているが **production 推論経路ではない dev image** (推論 user の attack surface ではない) ため、 supply chain 大目的への寄与も薄い
+>
+> 採用しない選択肢 (履歴記録):
+>
+> - **A. debian:12-slim 切替**: 「distroless 化」 ではないため M3 §1 FR-1.2 (cgr.dev/chainguard or gcr.io/distroless 二択) と不整合。 size 局所最適化として価値はあるが、 別 ticket (`docs/tickets/proposals/cpp-dev-base-optimization.md` 等) として再立案するのが integrity 上 clean
+> - **C. wolfi 継続**: 下記旧 Note の apk infinite chain により目的達成不能、 試行 cost 不明
+>
+> 大目的 (supply chain 防御) は残 4 image (T-012 python-inference / T-013 webui / T-014 wyoming / T-015 cpp-inference) で完結する。 M3 milestone は **distroless × 4 image** に scope 縮小。
+
+---
+
+> **旧 Note (PR #524 wolfi-base trial 結果、 履歴記録)**
 >
 > PR [#524](https://github.com/ayutaz/piper-plus/pull/524) で本 ticket §2.2 推奨の `cgr.dev/chainguard/wolfi-base` を試行したが、 以下の構造的問題で **wolfi-base + apk add のみで canonical 機能 parity を取れない** ことが判明:
 >
@@ -318,3 +336,4 @@ Comparison run at: <ISO-8601 timestamp>
 | 日付 | 変更 | 担当 |
 |------|------|------|
 | 2026-05-19 | 初版 | Claude Code |
+| 2026-05-20 | M3 distroless scope から除外確定。 PR #524 で webui + cpp-inference trial が成功し spike 目的 (multi-stage pattern / ABI 整合 / entrypoint 移植) は達成済。 cpp-dev は dev image (production 推論経路なし) で distroless 哲学と構造的不整合のため、 大目的 (supply chain 防御) への寄与が限定的と判断。 ticket は履歴 / 再着手時の参照用として保持、 M3 は 4 image (T-012 / T-013 / T-014 / T-015) に scope 縮小。 | Claude Code |

--- a/docs/tickets/tickets/T-016-distroless-cpp-dev.md
+++ b/docs/tickets/tickets/T-016-distroless-cpp-dev.md
@@ -5,9 +5,9 @@
 **Proposal 項目**: `#1-5` (Distroless / Chainguard 移行 — `cpp-dev` image)
 **Tier**: Tier 3 (blast radius 小、 学習用 spike)
 **Status**: 除外確定 (M3 distroless scope-out 2026-05-20)
-**PR**: PR #524 (wolfi-base trial 実施 → scope 矛盾実証 → cpp-dev は除外確定)
-**担当 (予定)**: ―
-**着手前提**: ―
+**PR**: #524 (wolfi-base trial 実施 → scope 矛盾実証 → cpp-dev は除外確定)
+**担当 (予定)**: なし
+**着手前提**: なし
 
 > **Note (2026-05-20 scope-out 確定)**
 >
@@ -20,7 +20,7 @@
 >
 > 採用しない選択肢 (履歴記録):
 >
-> - **A. debian:12-slim 切替**: 「distroless 化」 ではないため M3 §1 FR-1.2 (cgr.dev/chainguard or gcr.io/distroless 二択) と不整合。 size 局所最適化として価値はあるが、 別 ticket (`docs/tickets/proposals/cpp-dev-base-optimization.md` 等) として再立案するのが integrity 上 clean
+> - **A. debian:12-slim 切替**: 「distroless 化」 ではないため M3 §1 FR-1.2 (cgr.dev/chainguard or gcr.io/distroless 二択) と不整合。 size 局所最適化として価値はあるが、 別 proposal doc として独立 ticket で再立案するのが integrity 上 clean
 > - **C. wolfi 継続**: 下記旧 Note の apk infinite chain により目的達成不能、 試行 cost 不明
 >
 > 大目的 (supply chain 防御) は残 4 image (T-012 python-inference / T-013 webui / T-014 wyoming / T-015 cpp-inference) で完結する。 M3 milestone は **distroless × 4 image** に scope 縮小。

--- a/tests/fixtures/doc_examples_audit/audit.json
+++ b/tests/fixtures/doc_examples_audit/audit.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-19T00:00:00Z",
+  "generated_at": "2026-05-20T00:00:00Z",
   "totals": {
     "executable": 214,
     "needs_placeholder": 2,
@@ -5843,8 +5843,8 @@
     },
     {
       "file": "docs/tickets/milestones/M3-supply-chain.md",
-      "line_start": 129,
-      "line_end": 133,
+      "line_start": 131,
+      "line_end": 135,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -6036,8 +6036,8 @@
     },
     {
       "file": "docs/tickets/tickets/T-016-distroless-cpp-dev.md",
-      "line_start": 107,
-      "line_end": 146,
+      "line_start": 125,
+      "line_end": 164,
       "language_raw": "dockerfile",
       "language": "unknown",
       "category": "skip_warranted",
@@ -6051,8 +6051,8 @@
     },
     {
       "file": "docs/tickets/tickets/T-016-distroless-cpp-dev.md",
-      "line_start": 152,
-      "line_end": 164,
+      "line_start": 170,
+      "line_end": 182,
       "language_raw": "markdown",
       "language": "unknown",
       "category": "skip_warranted",


### PR DESCRIPTION
## Summary

distroless 移行 milestone (M3 supply chain) のうち、 cpp-dev image を scope-out する docs only PR。 trial bundle PR (webui + cpp-inference) で multi-stage build pattern / glibc ABI 整合 / shell-less entrypoint 移植の知見が既に揃ったため cpp-dev での再実証は不要。 加えて cpp-dev は dev image (production 推論経路なし、 GHCR 配布は dev 用のみ) で distroless 哲学と本質的に不整合 (cmake / clang / gdb を final stage に残さざるを得ない) のため、 大目的「container image の CVE 80%+ 削減 / size 50%+ 削減」 への寄与が限定的と判断。

## Affected Components

- [x] Documentation

## Type

- [x] Documentation

## Risk Level

- [x] patch (内部 docs 更新のみ、 production paths / build pipeline / contract gate 影響ゼロ、 audit fixture は line offset 吸収のみで block 数不変)

## Contract Impact

- [x] None — `docs/spec/*.toml` 不変更、 doc-examples audit fixture (`tests/fixtures/doc_examples_audit/audit.json`) は ticket line shift を吸収する regenerate のみで block 数 446 不変

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|---|---|---|
| cpp-dev ticket Status 「除外確定」 化 | Status 行を「計画中」→「除外確定 (M3 distroless scope-out 2026-05-20)」、 上部に scope-out rationale を明記 (spike 目的達成 + dev image 構造的不整合 + production 経路なしで supply chain 寄与限定)。 旧 wolfi-base trial の Note は履歴として保持 | 後続着手者が cpp-dev distroless を「未着手」と誤認して再着手し、 既に判明した構造的不整合 (apk packaging 不足 / dev tools が final stage 必須) を再発見する無駄が出る |
| M3 milestone scope 縮小 (5 → 4 image) | §1 直下に scope 変更注記を追加、 §2 配下チケット表 header を「Distroless × 5 image」→「Distroless × 4 image」、 cpp-dev 行を strikethrough + Status「除外確定」、 §2 依存関係を 4 件 | scope の認識が ticket と milestone で食い違い、 後続 promotion PR 計画時に「5 image 全部やる」 と誤った前提で動く |
| doc-examples audit fixture regenerate | ticket / milestone の line shift を吸収するため snapshot を再生成 (block 数 446 不変、 中身は code block の start/end line offset 更新のみ) | PR の audit gate (check-snapshot) が drift で fail し merge ブロック |

## 設計判断

- **scope-out の根拠を rationale 化** — 「やらない」 判断を明示的な doc として残すことで、 数ヶ月後の retrospective で根拠の再構築が不要になる。 spike 目的が達成済かどうかの判断材料 (trial bundle PR 番号 + 実証された pattern 3 種) を ticket §Note と milestone §1 の両方に重ね書き
- **ticket を削除せず履歴記録として保持** — 将来 dev image base 最適化を別 milestone で再着手する可能性があるため、 過去の検討と wolfi 試行失敗の構造的理由 (OpenJTalk / mecab / iconv chain の apk 不在) を消さない
- **個別 ticket の merged 反映は本 PR scope 外** — webui / cpp-inference / python-inference の Status 同期は別 PR (post-merge ticket Status update の cadence)。 本 PR は scope-out 判断 1 件だけに絞り、 review burden を最小化
- **代替案 (debian:12-slim 切替) は別 ticket 候補として明記** — scope-out は「distroless 化を止める」 だけで「dev image size 最適化を止める」 ではない。 後続の独立 ticket として再立案する余地を ticket §Note に残す
- **conservative 路線** — production paths (canonical Dockerfile / docker-compose / webui-test.yml / release pipeline) には一切触らない docs のみの変更で、 build / publish / deploy 経路への副作用ゼロ

## Test Plan

- [ ] `uv run python scripts/check_doc_examples.py audit --check-snapshot tests/fixtures/doc_examples_audit/audit.json` で audit fixture drift なし (block 数 446 不変、 exit 0) を確認
- [ ] cpp-dev ticket と M3 milestone doc を render し、 scope-out 根拠 (spike 目的達成 + dev image 不整合 + production 経路なし) が両方に書かれており参照整合が取れていることを目視確認
- [ ] `git diff dev...HEAD -- docker/ .github/ src/ docs/spec/` が空 (production paths / contract spec への副作用なし) を確認
- [ ] markdownlint / hadolint / pre-commit hooks が全て pass

## Checklist

- [ ] Tests pass locally (該当 contract gate / audit がすべて green)
- [ ] No GPL-LGPL deps (該当なし、 docs only)
- [ ] Documentation updated (本 PR 自体が documentation 更新)

## Related Issues

なし (M3 milestone の scope 縮小判断、 issue 紐付けなし)
