### PR TITLE
chore(deps): bump protobufjs 7.5.6 -> 7.5.8 (CVE-2026-45740)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -34,12 +34,19 @@ jobs:
           # (配布バイナリには含まれず copyleft 伝播リスクなし)。
           # ライセンスを広く allow する代わりに、対象パッケージを明示し
           # carve-out することで scope を最小化する。
+          #
+          # pkg:npm/protobufjs: 7.5.8+ で scancode が
+          # `BSD-3-Clause AND LicenseRef-scancode-protobuf` を検出する。
+          # 後者は Google Protocol Buffers のオリジナル license (BSD-3-Clause
+          # 系) で copyleft なし。 SPDX 標準名でないため allow-licenses では
+          # 通せず、 package 単位で carve-out する。
           allow-dependencies-licenses: >-
             pkg:pypi/astroid,
             pkg:pypi/matplotlib,
             pkg:pypi/mypy,
             pkg:pypi/pylint,
-            pkg:pypi/sphinx-rtd-theme
+            pkg:pypi/sphinx-rtd-theme,
+            pkg:npm/protobufjs
           # 自動 fail にせず、PR comment で報告
           warn-only: false
           # vulnerability scope

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -65,12 +65,19 @@ jobs:
           # dev / lint / docs 用 transitive dependency の例外
           # (配布バイナリには含まれず copyleft 伝播リスクなし)。
           # dependency-review.yml と同期。
+          #
+          # pkg:npm/protobufjs: 7.5.8+ で scancode が
+          # `BSD-3-Clause AND LicenseRef-scancode-protobuf` を検出する。
+          # 後者は Google Protocol Buffers のオリジナル license (BSD-3-Clause
+          # 系) で copyleft なし。 SPDX 標準名でないため allow-licenses では
+          # 通せず、 package 単位で carve-out する。
           allow-dependencies-licenses: >-
             pkg:pypi/astroid,
             pkg:pypi/matplotlib,
             pkg:pypi/mypy,
             pkg:pypi/pylint,
-            pkg:pypi/sphinx-rtd-theme
+            pkg:pypi/sphinx-rtd-theme,
+            pkg:npm/protobufjs
 
   # Python: pip-audit
   # PR では false-negative 防止のため block しないが (`continue-on-error: true`)、

--- a/src/wasm/openjtalk-web/package-lock.json
+++ b/src/wasm/openjtalk-web/package-lock.json
@@ -146,9 +146,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary

Dependabot alert #152 対応。 `protobufjs` のトランジティブ依存版を 7.5.6 → 7.5.8 にアップデートし、 CVE-2026-45740 (DoS via unbounded recursive JSON descriptor expansion in `Root.fromJSON` / `Namespace.addJSON`) を解消する。

piper-plus 本体は protobufjs を直接利用しておらず、 onnxruntime-web の peerDependency 経由で間接的に解決されている。 攻撃ベクトル (信頼できない JSON descriptor を読み込む経路) は piper-plus の使い方では発生しないが、 依存ツリー上の脆弱版を除去する衛生対応として patch update を適用する。

副次的に `dependency-review` workflow が 7.5.8 で `LicenseRef-scancode-protobuf` を検出して red になったため、 既存の `allow-dependencies-licenses` carve-out 機構 (astroid / matplotlib 等と同じ仕組み) に `pkg:npm/protobufjs` を追加する。

## Affected Components

- [ ] Python runtime (`src/python_run/`)
- [ ] C# runtime (`src/csharp/`)
- [ ] Rust runtime (`src/rust/`)
- [ ] C++ runtime (`src/cpp/`)
- [ ] Go runtime (`src/go/`)
- [x] WASM / npm runtime (`src/wasm/`)
- [ ] Docker (`docker/`)
- [x] CI / CD (`.github/`)
- [ ] Documentation (`docs/`, `README.md`)

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / CD
- [x] Dependencies

## Risk Level

- [x] patch (内部実装 / バグ修正 / 依存パッチ更新 — 動作変化なし)
- [ ] minor (新機能追加 — 既存 API 互換)
- [ ] major (破壊的変更 — API / 動作変化)

## Contract Impact

- [x] None (`docs/spec/*.toml` 影響なし — lockfile patch update のみ)

## 変更内容

| 機能 / 対象 | 動作 | これがないと起こること |
|------------|------|----------------------|
| `src/wasm/openjtalk-web/package-lock.json` | `protobufjs` entry の `version` / `resolved` / `integrity` を 7.5.6 → 7.5.8 に書き換え | Dependabot alert #152 が open 状態のまま残る。 CVE-2026-45740 影響版が依存ツリーに残存 |
| `.github/workflows/dependency-review.yml` | `allow-dependencies-licenses` に `pkg:npm/protobufjs` を追加 | `dependency-review` action が 7.5.8 の `LicenseRef-scancode-protobuf` 検出で license fail し PR が red になる |

## 設計判断

- **patch update のみ (7.5.6 → 7.5.8)**: 最新の 7.6.0 ではなく CVE fix を含む最小 patch を選択。 過去 PR #364 (7.5.4 → 7.5.6) と同じ方針で「依存ツリーの脆弱版除去」のみを目的とし、 minor bump で副次的に入る変更は別 PR に分離する。
- **手動 entry 書き換え方式を採用**: `npm update protobufjs --package-lock-only` を試したところ、 devDependencies の lock entry も大量に復活させてしまい diff が 1900+ 行に膨らんだ。 過去 PR #364 と同じく該当 entry の 3 フィールドのみを直接書き換える方式を採用 (diff 3 行)。
- **`package.json` 非変更**: onnxruntime-web (peerDependency `>=1.21.0`) は protobufjs を `^7.2.4` で要求するため 7.5.8 と互換。 package.json の編集は不要。
- **`onnxruntime-web` 同時 bump は別 PR**: 1.24.3 → 1.26.0 への bump は本 CVE 修正には不要。 単一責任原則で本 PR スコープから除外。
- **license carve-out の付与方式**: `allow-licenses` に `LicenseRef-scancode-protobuf` を追加する選択肢もあったが、 scancode-toolkit 独自の名前で SPDX 標準ではないため将来他 package で同名再利用された場合に意図しない通過を招く恐れがある。 既存パターン (astroid / matplotlib 等) と一貫させて package 単位 (`pkg:npm/protobufjs`) で carve-out する方を選択。

## Test Plan

- [ ] `cd src/wasm/openjtalk-web && python3 -c "import json; json.load(open('package-lock.json'))"` で JSON parse 成功
- [ ] `git diff origin/dev -- src/wasm/openjtalk-web/package-lock.json` で diff が 3 行更新のみ
- [ ] `cd src/wasm/openjtalk-web && grep -A 3 '"node_modules/protobufjs":' package-lock.json` で version=7.5.8 / resolved=protobufjs-7.5.8.tgz / integrity=sha512-dvpCIeLPbXZS... を確認
- [ ] CI: `wasm-build` / `wasm-test` / `security-audit` が green
- [ ] Dependabot alert #152 が PR merge 後に自動 close

## Checklist

- [x] Tests pass locally
- [x] No GPL / LGPL dependencies added
- [x] Documentation updated (該当なし — 内部 lockfile 更新のみ)

## Related Issues

- Closes Dependabot alert #152 (CVE-2026-45740)
- Reference: GHSA-jggg-4jg4-v7c6
- 同パターン過去 PR: #364 (`chore(deps): Dependabot アラートのうちリスクの低い 7 件を解消`)
