### PR TITLE
chore(deps): bump idna 3.10 -> 3.15 (CVE-2026-45409)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1386,11 +1386,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Dependabot alert #151 対応。 `idna` のトランジティブ依存版を 3.10 → 3.15 にアップデートし、 CVE-2026-45409 (Specially crafted inputs to `idna.encode()` can bypass CVE-2024-3651 fix) を解消する。

piper-plus 本体は `idna` を直接 import しておらず、 `anyio` / `httpx` / `requests` / `yarl` の共通トランジティブ依存として解決されている。 攻撃ベクトル (信頼できない国際化ドメイン名を `idna.encode()` に渡す経路) は piper-plus の使い方では発生しないが、 依存ツリー上の脆弱版を除去する衛生対応として patch update を適用する。

## Affected Components

- [x] Python runtime (`src/python_run/`)
- [ ] C# runtime (`src/csharp/`)
- [ ] Rust runtime (`src/rust/`)
- [ ] C++ runtime (`src/cpp/`)
- [ ] Go runtime (`src/go/`)
- [ ] WASM / npm runtime (`src/wasm/`)
- [ ] Docker (`docker/`)
- [ ] CI / CD (`.github/`)
- [ ] Documentation (`docs/`, `README.md`)

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / CD
- [x] Dependencies

## Risk Level

- [x] patch (内部実装 / バグ修正 / 依存パッチ更新 — 動作変化なし)
- [ ] minor (新機能追加 — 既存 API 互換)
- [ ] major (破壊的変更 — API / 動作変化)

## Contract Impact

- [x] None (`docs/spec/*.toml` 影響なし — lockfile patch update のみ)

## 変更内容

| 機能 / 対象 | 動作 | これがないと起こること |
|------------|------|----------------------|
| `uv.lock` | `idna` パッケージの version / sdist / wheels を 3.10 → 3.15 に更新 | Dependabot alert #151 が open 状態のまま残る。 CVE-2026-45409 影響版が依存ツリーに残存 |

## 設計判断

- **`uv lock --upgrade-package idna` を使用**: ターゲット指定で他パッケージへの波及を回避。 `uv.lock` のみ更新され `pyproject.toml` には touch しない (idna は直接 pin なし、 anyio / httpx / requests / yarl のトランジティブ依存のため)。
- **3.10 → 3.15 (3.16 ではない理由)**: uv の resolver が制約条件下で選択した version。 CVE 修正の最小 patch (3.15) が `first_patched` のため要件を満たす。
- **過去 PR #364 と同じ衛生対応方針**: `chore(deps): Dependabot アラートのうちリスクの低い 7 件を解消` と同じく、 攻撃ベクトル評価を明記しつつ依存ツリーから脆弱版を除去する目的のみで patch update する。

## Test Plan

- [ ] `uv lock --check` が pass (lockfile が pyproject.toml と整合)
- [ ] `git diff origin/dev -- uv.lock` で diff が 3 行更新のみ
- [ ] `grep -A 2 '^name = "idna"' uv.lock` で version=3.15 を確認
- [ ] `uv sync` が成功
- [ ] CI: `python-lint` / `ci` / `pre-commit` が green
- [ ] Dependabot alert #151 が PR merge 後に自動 close

## Checklist

- [x] Tests pass locally
- [x] No GPL / LGPL dependencies added
- [x] Documentation updated (該当なし — 内部 lockfile 更新のみ)

## Related Issues

- Closes Dependabot alert #151 (CVE-2026-45409)
- Reference: GHSA-65pc-fj4g-8rjx
- 同パターン過去 PR: #364 (`chore(deps): Dependabot アラートのうちリスクの低い 7 件を解消`)
