### PR TITLE
chore(ci): scope Trivy container scan to distributable images

### DIFF
--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -171,13 +171,15 @@ jobs:
   # docker system prune で intermediate cache を全部削除。
   #
   # Scope policy (SECURITY.md "Docker Image Scope" 参照):
-  #   - 配布 / 本番運用される image のみ Trivy 監視対象とする
-  #   - 開発専用 image (python-train: 4-GPU ML 学習スタック、 個別開発者環境のみ
-  #     で実行され、 production cluster へ配布されない) は scan 対象外
+  #   - 配布 / 本番運用される image と contributor-baseline 開発 helper を
+  #     Trivy 監視対象とする
+  #   - 個別研究者環境のみで実行される開発専用 image (python-train:
+  #     4-GPU ML 学習スタック、 個別開発者環境のみで実行され production
+  #     cluster へ配布されない) は scan 対象外
   #   - 上記方針により python-train を 2026-05 に scan-heavy matrix から除外。
-  #     既存 alert はすべて won't fix で dismiss 済み (Trivy advisory の attack
-  #     surface は ML training stack の内部依存に閉じており exposed network
-  #     経路を持たないため)
+  #     除外と並行して既存 alert は won't fix で個別 dismiss を実施
+  #     (Trivy advisory の attack surface は ML training stack の内部依存に
+  #     閉じており exposed network 経路を持たないため)
   # ---------------------------------------------------------------------------
   scan-heavy:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -167,8 +167,17 @@ jobs:
   # ---------------------------------------------------------------------------
   # Scheduled heavy scan (Wave 3, T12).
   # 通常 PR / push では disk OOM で除外している heavy image (webui / wyoming /
-  # python-train / cpp-inference final) を週次でスキャン。 free-disk-space で
-  # 10GB+ 確保し、 docker system prune で intermediate cache を全部削除。
+  # cpp-inference final) を週次でスキャン。 free-disk-space で 10GB+ 確保し、
+  # docker system prune で intermediate cache を全部削除。
+  #
+  # Scope policy (SECURITY.md "Docker Image Scope" 参照):
+  #   - 配布 / 本番運用される image のみ Trivy 監視対象とする
+  #   - 開発専用 image (python-train: 4-GPU ML 学習スタック、 個別開発者環境のみ
+  #     で実行され、 production cluster へ配布されない) は scan 対象外
+  #   - 上記方針により python-train を 2026-05 に scan-heavy matrix から除外。
+  #     既存 alert はすべて won't fix で dismiss 済み (Trivy advisory の attack
+  #     surface は ML training stack の内部依存に閉じており exposed network
+  #     経路を持たないため)
   # ---------------------------------------------------------------------------
   scan-heavy:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -185,9 +194,6 @@ jobs:
             build_target: builder
           - name: cpp-inference
             dockerfile: docker/cpp-inference/Dockerfile
-            build_target: builder
-          - name: python-train
-            dockerfile: docker/python-train/Dockerfile
             build_target: builder
 
     steps:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,6 +79,31 @@ reporters informed if a particular issue requires more time.
 - Vulnerabilities that require physical access to the user's machine or that
   rely solely on already-compromised host environments.
 
+### Docker Image Scope
+
+The repository ships several Docker images. We monitor automated container
+scanners (Trivy on a weekly schedule and on `docker/**` changes) **only against
+images that are distributed for production use**. Images intended solely for
+local development tasks are not actively monitored, and their Trivy alerts are
+dismissed as `won't fix` because they do not represent an external attack
+surface in their intended deployment.
+
+| Image | Distribution | Trivy monitored? | Notes |
+|-------|-------------|-----------------:|-------|
+| `python-inference` (CUDA) | Production (GHCR / DockerHub) | ✅ | OpenAI-compatible TTS API server for GPU clusters |
+| `python-inference-cpu-distroless` | Production | ✅ | Multi-arch CPU inference image |
+| `webui` / `webui-distroless` | Production | ✅ | Gradio demo / WebUI |
+| `wyoming` | Production | ✅ | Home Assistant Wyoming Protocol TTS |
+| `cpp-inference` / `cpp-inference-distroless` | Production | ✅ | Native C++ inference binary |
+| `cpp-dev` | Local development helper | ✅ | Build / debug environment (kept under monitoring as a hygiene baseline) |
+| `python-train` | **Local development only** (4-GPU training stack) | ❌ | Not deployed to clusters; executed on individual researcher machines. CVE alerts on the ML/training apt layer (CUDA + cuDNN + ML toolchain) do not represent an exposed network attack surface for piper-plus |
+
+If you identify a vulnerability in a development-only image that nonetheless
+has a credible attack path (for example, a researcher loading a malicious
+checkpoint in a shared training environment), please still report it via the
+private channels above — the scope policy is about scanner monitoring, not
+about whether we will fix exploitable defects.
+
 ## Security Best Practices for Users
 
 Even within supported versions there are operational pitfalls users should be

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,12 +81,14 @@ reporters informed if a particular issue requires more time.
 
 ### Docker Image Scope
 
-The repository ships several Docker images. We monitor automated container
-scanners (Trivy on a weekly schedule and on `docker/**` changes) **only against
-images that are distributed for production use**. Images intended solely for
-local development tasks are not actively monitored, and their Trivy alerts are
-dismissed as `won't fix` because they do not represent an external attack
-surface in their intended deployment.
+The repository ships several Docker images. Trivy container scanning runs on
+a weekly schedule and on changes to `docker/**/Dockerfile*` (and the workflow
+file). Monitoring scope is decided **per image**: production / distributed
+images and contributor-baseline development helpers are monitored, while
+purely-individual local development environments (such as the 4-GPU training
+stack) are excluded because their CVE alerts do not represent an external
+attack surface in their intended deployment. Existing alerts on excluded
+images are dismissed as `won't fix`.
 
 | Image | Distribution | Trivy monitored? | Notes |
 |-------|-------------|-----------------:|-------|


### PR DESCRIPTION
## Summary

Trivy container scan の対象を **配布 / 本番運用される Docker image のみ** に絞り、 開発専用 image (`piper-plus-python-train`) を scan-heavy matrix から除外する。 加えて SECURITY.md に "Docker Image Scope" subsection を追加し、 監視対象 / 対象外 image の判定根拠を明文化する。

これにより Trivy alert の総数を「実際に攻撃面を持つ image の集合」 に整理し、 reviewer / 利用者が判断しやすい状態にする。 既存 alert 2,020 件 (python-train 由来) は本 PR と別に won't fix で dismiss する運用に切り替える。

## Affected Components

- [ ] Python runtime (`src/python_run/`)
- [ ] C# runtime (`src/csharp/`)
- [ ] Rust runtime (`src/rust/`)
- [ ] C++ runtime (`src/cpp/`)
- [ ] Go runtime (`src/go/`)
- [ ] WASM / npm runtime (`src/wasm/`)
- [ ] Docker (`docker/`)
- [x] CI / CD (`.github/`)
- [x] Documentation (`docs/`, `README.md`)

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [x] CI / CD
- [ ] Dependencies

## Risk Level

- [x] patch (内部実装 / バグ修正 / 依存パッチ更新 — 動作変化なし)
- [ ] minor (新機能追加 — 既存 API 互換)
- [ ] major (破壊的変更 — API / 動作変化)

## Contract Impact

- [x] None (`docs/spec/*.toml` 影響なし — workflow + policy doc のみ更新)

## 変更内容

| 機能 / 対象 | 動作 | これがないと起こること |
|------------|------|----------------------|
| `.github/workflows/trivy-container-scan.yml` | `scan-heavy` matrix から `python-train` target を削除。 scope policy の根拠 comment を追記 | `piper-plus-python-train` が継続して scan され、 開発専用 image 由来の CVE alert (~2,020 件) が GitHub Security 画面の表示を圧迫する |
| `SECURITY.md` | 既存 "Scope" section 直下に "Docker Image Scope" subsection を追加。 image 一覧 (production / development) と Trivy 監視対象判定の根拠を明示 | scope policy が workflow comment のみに散らばり、 利用者 / contributor が「なぜ python-train だけ scan されないのか」 を理解できない |

## 設計判断

- **python-train のみ scope 外、 他の image は監視継続**: `python-train` は 4-GPU 学習スタックで個別開発者環境 (lab GPU box / 研究者ローカル) でのみ実行され、 production cluster へ image として配布される運用がない。 一方 `python-inference` / `wyoming` / `webui` / `cpp-inference` などは実際にネットワーク exposure を持ち、 配布されるため監視対象として維持する。
- **`cpp-dev` は監視維持**: 開発用ヘルパー image ではあるが、 contributor が手元で頻繁にビルドする canonical な開発環境として位置づけられ、 hygiene baseline の意味で監視を残す。 python-train との違いは「個人ごとに揮発的な使い捨て環境」 か 「contributor 全員が使う共有 baseline 環境」 か。
- **既存 alert は別オペで dismiss**: workflow 変更のみで既存 SARIF データは更新されないため、 既に紐づいている 2,020 件の alert は GitHub Security 画面に残り続ける。 これらは本 PR と分離して `gh api -X PATCH .../dependabot/alerts/<n>` で個別 dismiss する (workflow 変更とアラート整理を 1 PR にまとめると revert 範囲が広がるため意図的に分離)。
- **scope を SECURITY.md に明文化する理由**: 「なぜ python-train だけ scan されないのか」 を `git blame` を辿らずとも contributor / 監査担当者が理解できるよう、 SECURITY.md という公式 policy document に書く。 workflow comment は実装詳細としては適切だが、 policy の根拠としては不十分。
- **「monitor しない ≠ 直さない」 を明示**: Docker Image Scope の最後に「scope policy is about scanner monitoring, not about whether we will fix exploitable defects」 と注釈を入れ、 privately reported された脆弱性は monitoring scope と無関係に修正対象である旨を明確化。

## Test Plan

- [ ] `gh workflow run trivy-container-scan.yml --ref chore/trivy-scope-distributable-images` で手動 dispatch し、 `scan-heavy` job の matrix に `python-train` が含まれていないこと (`webui` / `wyoming` / `cpp-inference` の 3 job のみ実行されること)
- [ ] `scan` job (light scan、 PR/push trigger) は変更なし: `python-inference` / `python-inference-cpu-distroless` / `cpp-dev` / `cpp-inference-distroless` / `webui-distroless` の 5 job が引き続き green
- [ ] `markdownlint` / `markdown-link-check` (もし pre-commit で gate されていれば) が SECURITY.md table を通すこと
- [ ] `validate-pr-body` CI が green (本 PR 本文が template 準拠)
- [ ] Merge 後の次回 schedule scan (Monday 5:17 UTC) で `piper-plus-python-train` 関連の新規 alert が発生しないこと

## Checklist

- [x] Tests pass locally (workflow YAML lint は pre-commit `Lint GitHub Actions workflow files` で確認済み)
- [x] No GPL / LGPL dependencies added
- [x] Documentation updated (`SECURITY.md` に "Docker Image Scope" subsection を追加)

## Related Issues

- Reference: Trivy code-scanning alerts on `piper-plus-python-train` (~2,020 件)
- 関連: PR #532 (python-train CUDA 12.6.3 bump、 これでも apt 層 CVE が残るため構造的整理が必要と判明)、 PR #533 (python-inference base bump、 同様に Ubuntu 22.04 / NVIDIA image rebuild サイクル依存)
- 次段階 (別オペで): 既存 python-train alert 2,020 件を `dismissed_reason=won't fix` で個別 dismiss
- 次段階 (別 PR で): 配布 image に `pip install --upgrade pip setuptools wheel` を追加して supply-chain CVE (CVE-2026-24049 wheel / CVE-2025-47273 setuptools 等) を解消
