### PR TITLE
chore(docker): upgrade pip/setuptools/wheel in distributable images

### DIFF
--- a/docker/python-inference/Dockerfile
+++ b/docker/python-inference/Dockerfile
@@ -23,6 +23,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -sf /usr/bin/python3.11 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*
 
+# Upgrade pip / setuptools / wheel to clear Trivy supply-chain CVEs that ride
+# on the apt-installed python3-pip (Ubuntu 22.04 ships pip 22.0.2, setuptools
+# 59.6.0, wheel 0.37.x — all on multiple HIGH/MEDIUM advisories). Run before
+# installing uv so the upgraded pip is what bootstraps the rest.
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
 # Install uv (Ubuntu 22.04's pip doesn't support --break-system-packages)
 RUN pip install --no-cache-dir uv
 

--- a/docker/python-inference/Dockerfile.cpu
+++ b/docker/python-inference/Dockerfile.cpu
@@ -49,6 +49,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsndfile1-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Upgrade pip / setuptools / wheel to clear Trivy supply-chain CVEs riding on
+# the python:3.11-slim-bookworm default pip (24.x) and bundled
+# setuptools/wheel. Run before uv install so the upgraded toolchain is what
+# bootstraps everything else.
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
 # Pin uv to the same major version range used by docker/wyoming/Dockerfile
 # (workspace-editable handling is uv version-sensitive).
 RUN pip install --no-cache-dir "uv>=0.9,<1"

--- a/docker/python-inference/Dockerfile.cpu.distroless
+++ b/docker/python-inference/Dockerfile.cpu.distroless
@@ -64,6 +64,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsndfile1-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Upgrade pip / setuptools / wheel to clear Trivy supply-chain CVEs. This
+# is critical for the distroless variant: the builder stage's site-packages
+# (under /usr/local/lib/python3.11/site-packages, including wheel /
+# setuptools / pip metadata) are copied verbatim into the final distroless
+# stage, so upgrading here propagates into the published image.
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
 # Pin uv to the same major version range used by the canonical
 # Dockerfile.cpu — workspace-editable handling is uv-version sensitive.
 RUN pip install --no-cache-dir "uv>=0.9,<1"

--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -6,6 +6,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsndfile1 \
     && rm -rf /var/lib/apt/lists/*
 
+# Upgrade pip / setuptools / wheel to clear Trivy supply-chain CVEs that
+# ride on the python:3.13.13-slim-trixie default toolchain.
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
 # Install uv
 RUN pip install --no-cache-dir uv
 

--- a/docker/webui/Dockerfile.distroless
+++ b/docker/webui/Dockerfile.distroless
@@ -48,6 +48,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsndfile1-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Upgrade pip / setuptools / wheel to clear Trivy supply-chain CVEs. The
+# builder's site-packages (under /usr/local/lib/python3.11) is COPYed
+# verbatim into the distroless final stage, so upgrading here propagates
+# into the published image.
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
 # Pin uv. The canonical docker/webui/Dockerfile currently does an
 # unpinned `pip install uv`; pinning here is intentional drift to
 # protect the trial build against a future breaking uv release.

--- a/docker/webui/Dockerfile.distroless
+++ b/docker/webui/Dockerfile.distroless
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Upgrade pip / setuptools / wheel to clear Trivy supply-chain CVEs. The
-# builder's site-packages (under /usr/local/lib/python3.11) is COPYed
+# builder's site-packages (under /usr/local/lib/python3.11) is copied
 # verbatim into the distroless final stage, so upgrading here propagates
 # into the published image.
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel

--- a/docker/wyoming/Dockerfile
+++ b/docker/wyoming/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Upgrade pip / setuptools / wheel to clear Trivy supply-chain CVEs. The
 # builder stage's `/usr/local` is copied verbatim into the runtime stage
-# (line 89), so upgrading here propagates into the published image.
+# (see the `COPY --from=builder /usr/local /usr/local` instruction below),
+# so upgrading here propagates into the published image.
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 
 # Pin uv to a known-good major version (workspace editable handling is uv version-sensitive)

--- a/docker/wyoming/Dockerfile
+++ b/docker/wyoming/Dockerfile
@@ -22,6 +22,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsndfile1-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Upgrade pip / setuptools / wheel to clear Trivy supply-chain CVEs. The
+# builder stage's `/usr/local` is copied verbatim into the runtime stage
+# (line 89), so upgrading here propagates into the published image.
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
 # Pin uv to a known-good major version (workspace editable handling is uv version-sensitive)
 RUN pip install --no-cache-dir "uv>=0.9,<1"
 


### PR DESCRIPTION
## Summary

配布対象 Docker image の builder / system Python に `pip install --no-cache-dir --upgrade pip setuptools wheel` を追加し、 Trivy が検出している supply-chain CVE を解消する。 base image (`nvidia/cuda`, `python:3.11-slim-bookworm`, `python:3.13.13-slim-trixie`) が同梱する pip / setuptools / wheel が古く、 HIGH 含む 15 件前後の Trivy alert を引き起こしているため。

PR #534 で scope 外化された `python-train` の同種 CVE は別の dismiss op で処理済み。 本 PR は配布対象 image 内の supply-chain ハーデニングに専念する。

## Affected Components

- [ ] Python runtime (`src/python_run/`)
- [ ] C# runtime (`src/csharp/`)
- [ ] Rust runtime (`src/rust/`)
- [ ] C++ runtime (`src/cpp/`)
- [ ] Go runtime (`src/go/`)
- [ ] WASM / npm runtime (`src/wasm/`)
- [x] Docker (`docker/`)
- [ ] CI / CD (`.github/`)
- [ ] Documentation (`docs/`, `README.md`)

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / CD
- [x] Dependencies

## Risk Level

- [x] patch (内部実装 / バグ修正 / 依存パッチ更新 — 動作変化なし)
- [ ] minor (新機能追加 — 既存 API 互換)
- [ ] major (破壊的変更 — API / 動作変化)

## Contract Impact

- [x] None (`docs/spec/*.toml` 影響なし — Dockerfile への pip upgrade 行追加のみ)

## 変更内容

| 機能 / 対象 | 動作 | これがないと起こること |
|------------|------|----------------------|
| `docker/python-inference/Dockerfile` (CUDA) | `apt-get install python3-pip` 直後に `pip install --upgrade pip setuptools wheel` を追加 | Ubuntu 22.04 同梱の pip 22.0.2 / setuptools 59.6.0 / wheel 0.37.x が image に残り、 Trivy supply-chain CVE が継続検出 |
| `docker/python-inference/Dockerfile.cpu` | `pip install uv` の前に upgrade を挿入 | python:3.11-slim-bookworm 同梱の古い pip (24.0) / setuptools / wheel に伴う CVE 残存 |
| `docker/python-inference/Dockerfile.cpu.distroless` (builder stage) | uv install 前に upgrade。 builder の `/usr/local/lib/python3.11` が distroless final stage へ COPY されるため published image にも反映 | builder で upgrade しない場合、 final stage の site-packages に古い wheel-0.45.1 / setuptools が残り CVE-2026-24049 / CVE-2026-23949 などが継続検出 |
| `docker/webui/Dockerfile` | `pip install uv` の前に upgrade | python:3.13.13-slim-trixie の pip 26.0.1 系 CVE (CVE-2026-3219 / CVE-2026-6357) が残る |
| `docker/webui/Dockerfile.distroless` (builder stage) | builder の `/usr/local/lib/python3.11` が distroless final へ COPY されるため builder で upgrade | distroless final stage の published artefact に CVE が残る |
| `docker/wyoming/Dockerfile` (builder stage) | uv install 前に upgrade。 builder の `/usr/local` 全体が runtime stage に COPY されるため伝播 | runtime image に古い pip / setuptools / wheel が残り、 Trivy CVE が解消されない |

## 設計判断

- **builder / system Python 側で upgrade、 uv より前に実行**: `pip install --upgrade pip setuptools wheel` を `pip install uv` の前 (もしくは `apt-get install python3-pip` の直後) に置くことで、 以降の uv 経由インストールが新版 pip / setuptools / wheel を前提に走る。 後段で `uv pip install --system` が site-packages を上書きする際にも古い metadata は残らない。
- **distroless 系の builder で upgrade する理由**: distroless final stage には pip が無く、 builder stage の `/usr/local/lib/python3.11` (site-packages 含む) をそのまま COPY する。 builder で upgrade しないと、 distroless image に古い wheel-0.45.1 / setuptools が残り CVE-2026-24049 / CVE-2026-23949 が published artefact に乗ったままになる。
- **wyoming は builder の `/usr/local` 全体を COPY**: line 89 で `COPY --from=builder /usr/local /usr/local` しているため、 builder の pip 更新がそのまま runtime stage に伝播する。
- **`pip install -U setuptools wheel` を別 RUN 行に分けない**: 1 RUN で `pip + setuptools + wheel` を一括 upgrade することで Docker layer 数の増加を最小化、 build cache 利用効率も維持。
- **`uv pip install --upgrade pip ...` ではなく `pip install --upgrade ...` を使う**: uv が install される前に走る初期段階のため、 system pip を使う。 uv インストール後の upgrade よりも依存解決の不確実性が小さい。
- **`python-train` (PR #534 で scope 外) は touch しない**: scope policy に従い、 監視対象でない image の Dockerfile は変更しない。 supply-chain ハーデニングが必要になったら別 PR で対応する選択肢を残す。
- **既存 `pip install --no-cache-dir uv` の構造を維持**: `--no-cache-dir` は layer サイズ削減のため。 本 PR の追加 RUN も同じ flag を継承して image 肥大化を避ける。

## Test Plan

- [ ] `docker-build.yml` workflow の以下 job が green:
  - [ ] `build-python-inference` (CUDA)
  - [ ] `build-python-inference-cpu` (multi-arch arm64 + amd64)
  - [ ] `build-distroless-trials` (CPU distroless / webui distroless)
  - [ ] `build-webui`
  - [ ] `build-wyoming` (multi-arch arm64 + amd64)
- [ ] build-time smoke test (Dockerfile 内 `RUN`): `onnxruntime` / `piper_train` / `gradio` / `wyoming` / `piper_plus_g2p` import 成功 (各 image)
- [ ] CUDA image の build log で `Successfully installed pip-XX.X.X setuptools-XX.X.X wheel-XX.X.X` (最新版) が出ること (回帰検証)
- [ ] `gh workflow run trivy-container-scan.yml --ref chore/upgrade-pip-setuptools-wheel-distributable-images` で Trivy scan を手動実行し、 CVE-2026-24049 / CVE-2026-23949 / CVE-2026-3219 / CVE-2026-6357 / CVE-2025-8869 / CVE-2026-1703 が消えていること
- [ ] Merge 後の次回 schedule scan (Monday 5:17 UTC) で配布 image の Trivy alert 数が ~15 件減少

## Checklist

- [x] Tests pass locally (Docker buildx + arm64 emulation が必要なため CI 側で検証。 ローカル full build は未実施)
- [x] No GPL / LGPL dependencies added (pip / setuptools / wheel は MIT 系で既存 license 範囲内)
- [x] Documentation updated (該当なし — Dockerfile 内コメントに upgrade 理由を inline 記載済み)

## Related Issues

- Reference: Trivy code-scanning alerts on `wheel` / `jaraco.context` / `pip` (配布 image 内 ~15 件)
- Related PR: #534 (Trivy scope policy / `python-train` を scan 対象外化) — 本 PR は scope 外 image を扱わないため compatible
- 同パターン過去 PR: #533 (python-inference base image bump) — base image レベルでは patch 配信遅延が残るため、 supply-chain 層は本 PR で独立にハーデニング
