### PR TITLE
fix(deps): pin nltk/joblib transitive security floors for pip-audit

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -8,6 +8,7 @@ on:
       - "uv.lock"
       - "src/python/pyproject.toml"
       - "src/python_run/setup.py"
+      - "src/python_run/requirements.txt"
       - "src/rust/**/Cargo.toml"
       - "src/rust/**/Cargo.lock"
       - "src/rust/Cargo.lock"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,6 +300,9 @@ v1.12.0 で 5 ランタイム (Python/Rust/C#/Go/WASM) に展開した SSML / Vo
 
 - `release-shared-lib.yml` の workflow-level permissions を `contents: read` に縮小、`release` ジョブのみ `contents: write` を opt-in
 - tag validator の regex を `^[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9.-]+)?$` に anchored 化 (例: `1.0.0-malicious$(rm)` 形のタグ injection を拒否)
+- `src/python_run/requirements.txt`: `g2p-en` 経由 transitive 依存 (`g2p-en` → `nltk` → `joblib`) にセキュリティ下限を明示 (`nltk>=3.9.4` / `joblib>=1.5.0`)。診断手順を `docs/getting-started/troubleshooting.md` ("Security Audit CI Issues") に追加
+  - 2026-05 の `Security Audit / pip-audit (Python)` dev push 失敗は **上流 advisory データ欠陥** が原因で piper-plus 側のコード/依存問題ではない: `nltk` `PYSEC-2026-97` (CVE-2026-0846) と `joblib` `PYSEC-2024-277` (CVE-2024-34997) が 2026-05-20 に `last_affected` 欠落で生成され、安全な `nltk 3.9.4` / `joblib 1.5.3` を含む全バージョンが flag された (同一 commit が後の schedule run では pass)。`pypa/advisory-database` PR #289 ("Update records generated incorrectly", 2026-05-21) で修正済み
+  - 下限ピンは将来の dependency resolution が真に脆弱なバージョンへ退行するのを防ぐ regression insurance
 
 ## [1.12.0] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,7 @@ v1.12.0 で 5 ランタイム (Python/Rust/C#/Go/WASM) に展開した SSML / Vo
 - `src/python_run/requirements.txt`: `g2p-en` 経由 transitive 依存 (`g2p-en` → `nltk` → `joblib`) にセキュリティ下限を明示 (`nltk>=3.9.4` / `joblib>=1.5.0`)。診断手順を `docs/getting-started/troubleshooting.md` ("Security Audit CI Issues") に追加
   - 2026-05 の `Security Audit / pip-audit (Python)` dev push 失敗は **上流 advisory データ欠陥** が原因で piper-plus 側のコード/依存問題ではない: `nltk` `PYSEC-2026-97` (CVE-2026-0846) と `joblib` `PYSEC-2024-277` (CVE-2024-34997) が 2026-05-20 に `last_affected` 欠落で生成され、安全な `nltk 3.9.4` / `joblib 1.5.3` を含む全バージョンが flag された (同一 commit が後の schedule run では pass)。`pypa/advisory-database` PR #289 ("Update records generated incorrectly", 2026-05-21) で修正済み
   - 下限ピンは将来の dependency resolution が真に脆弱なバージョンへ退行するのを防ぐ regression insurance
+- `.github/workflows/security-audit.yml`: pull_request `paths` に `src/python_run/requirements.txt` を追加。従来 `setup.py` のみが対象で、実際の依存定義 source (setup.py がパースする requirements.txt) の変更が PR の pip-audit gate を通らなかった漏れを修正
 
 ## [1.12.0] - 2026-05-04
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -9,6 +9,7 @@ This guide helps resolve common issues when using Piper, especially with Japanes
 - [Platform-Specific Issues](#platform-specific-issues)
 - [Build Issues](#build-issues)
 - [Performance Issues](#performance-issues)
+- [Security Audit CI Issues](#security-audit-ci-issues)
 - [Training Troubleshooting](#training-troubleshooting)
 - [C# CLI (PiperPlus) のトラブルシューティング](#c-cli-piperplus-のトラブルシューティング)
 
@@ -344,6 +345,60 @@ If issues persist:
 | "Unknown multi-character phoneme" | Wrong phoneme format | Update to latest version |
 | "Checksum verification failed" | Corrupt download | Re-download files |
 | "UnicodeEncodeError" (Windows) | Console encoding | Use chcp 65001 |
+
+## Security Audit CI Issues
+
+### `Security Audit / pip-audit` fails on a transitive dependency CVE
+
+**Symptoms**: The `Security Audit / pip-audit (Python)` job fails on a `push` to
+`dev` / `main` (it is `continue-on-error` on pull requests, so PRs only warn),
+reporting a CVE / PYSEC advisory against a package that is **not** listed
+directly in `requirements.txt` — e.g. a `g2p-en` → `nltk` → `joblib` transitive
+dependency. The *same commit* may pass in a later `schedule` run.
+
+**Most common root cause**: a transient **upstream advisory-data defect**, not a
+real regression in this repo. OSV / PyPA advisories are sometimes auto-generated
+with a missing `last_affected` / `fixed` field, which OSV interprets as "all
+versions affected" — so even an already-patched version gets flagged. Once the
+advisory is corrected upstream, the finding disappears with no code change.
+
+> Real example (2026-05): `nltk` `PYSEC-2026-97` and `joblib` `PYSEC-2024-277`
+> were generated on 2026-05-20 with `introduced: 0` and no `last_affected`, so
+> the safe versions `nltk 3.9.4` / `joblib 1.5.3` were flagged. The
+> `pypa/advisory-database` PR #289 ("Update records generated incorrectly",
+> 2026-05-21) added `last_affected: 3.9.2` / `1.4.2`, after which the same
+> commit passed.
+
+**Diagnosis**:
+
+1. Open the failed job and note which step failed (`Audit root requirements` vs
+   `Audit src/python_run`) and the exact `Name / Version / ID` rows.
+2. Check whether the flagged version is actually inside the advisory's affected
+   range by inspecting the advisory YAML `ranges` events:
+
+   ```bash
+   gh api repos/pypa/advisory-database/contents/vulns/<pkg>/<PYSEC-ID>.yaml \
+     -H "Accept: application/vnd.github.raw" | grep -E "introduced|last_affected|fixed"
+   ```
+
+3. If the resolved version is **above** `last_affected` (or `last_affected` is
+   missing entirely), suspect an upstream data defect. Inspect the advisory's
+   commit history to see whether the range was recently corrected:
+
+   ```bash
+   gh api "repos/pypa/advisory-database/commits?path=vulns/<pkg>/<PYSEC-ID>.yaml"
+   ```
+
+**Resolution**:
+
+- If upstream already corrected the range, a re-run / re-push clears it — no
+  code change required.
+- To stop a future *resolution* from regressing into a truly-affected version,
+  add a lower-bound floor for the transitive package in
+  `src/python_run/requirements.txt` (e.g. `nltk>=3.9.4`, `joblib>=1.5.0`).
+- Avoid `pip-audit --ignore-vuln <ID>` unless the advisory is a documented,
+  vendor-disputed false positive; if used, add a comment citing the dispute and
+  a removal condition so the suppression cannot hide a future genuine finding.
 
 ## Training Troubleshooting
 

--- a/src/python_run/requirements.txt
+++ b/src/python_run/requirements.txt
@@ -9,5 +9,16 @@ pyopenjtalk-plus>=0.4.1.post8
 # English phonemization
 g2p-en>=2.1.0
 
+# g2p-en transitive dependency security floors (chain: g2p-en -> nltk -> joblib).
+# Keep these above the OSV/PyPA advisory affected ranges so a fresh dependency
+# resolution can never regress into a genuinely-vulnerable version. See
+# docs/getting-started/troubleshooting.md ("Security Audit CI Issues").
+#   nltk>=3.9.4   : above PYSEC-2026-97 / CVE-2026-0846 (filestring() arbitrary
+#                   file read, last_affected 3.9.2); 3.9.4 also fixes nltk DoS/XSS.
+#   joblib>=1.5.0 : above PYSEC-2024-277 / CVE-2024-34997 (NumpyArrayWrapper
+#                   pickle, vendor-DISPUTED false positive, last_affected 1.4.2).
+nltk>=3.9.4
+joblib>=1.5.0
+
 # Chinese phonemization
 pypinyin>=0.55.0

--- a/tests/fixtures/doc_examples_audit/audit.json
+++ b/tests/fixtures/doc_examples_audit/audit.json
@@ -3,14 +3,14 @@
   "generated_at": "2026-05-21T12:06:10Z",
   "totals": {
     "executable": 207,
-    "needs_placeholder": 2,
+    "needs_placeholder": 4,
     "skip_warranted": 199,
-    "total": 408
+    "total": 410
   },
   "by_language": {
     "bash": {
       "executable": 158,
-      "needs_placeholder": 2,
+      "needs_placeholder": 4,
       "skip_warranted": 24
     },
     "csharp": {
@@ -860,8 +860,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 21,
-      "line_end": 23,
+      "line_start": 22,
+      "line_end": 24,
       "language_raw": "text",
       "language": "unknown",
       "category": "skip_warranted",
@@ -875,8 +875,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 36,
-      "line_end": 38,
+      "line_start": 37,
+      "line_end": 39,
       "language_raw": "text",
       "language": "unknown",
       "category": "skip_warranted",
@@ -890,8 +890,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 54,
-      "line_end": 56,
+      "line_start": 55,
+      "line_end": 57,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -903,8 +903,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 60,
-      "line_end": 62,
+      "line_start": 61,
+      "line_end": 63,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -916,8 +916,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 81,
-      "line_end": 83,
+      "line_start": 82,
+      "line_end": 84,
       "language_raw": "text",
       "language": "unknown",
       "category": "skip_warranted",
@@ -931,8 +931,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 89,
-      "line_end": 95,
+      "line_start": 90,
+      "line_end": 96,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -944,8 +944,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 107,
-      "line_end": 110,
+      "line_start": 108,
+      "line_end": 111,
       "language_raw": "text",
       "language": "unknown",
       "category": "skip_warranted",
@@ -959,8 +959,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 116,
-      "line_end": 119,
+      "line_start": 117,
+      "line_end": 120,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -972,8 +972,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 123,
-      "line_end": 131,
+      "line_start": 124,
+      "line_end": 132,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -985,8 +985,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 142,
-      "line_end": 144,
+      "line_start": 143,
+      "line_end": 145,
       "language_raw": "text",
       "language": "unknown",
       "category": "skip_warranted",
@@ -1000,8 +1000,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 161,
-      "line_end": 167,
+      "line_start": 162,
+      "line_end": 168,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1013,8 +1013,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 181,
-      "line_end": 187,
+      "line_start": 182,
+      "line_end": 188,
       "language_raw": "cmd",
       "language": "unknown",
       "category": "skip_warranted",
@@ -1028,8 +1028,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 199,
-      "line_end": 202,
+      "line_start": 200,
+      "line_end": 203,
       "language_raw": "cmd",
       "language": "unknown",
       "category": "skip_warranted",
@@ -1043,8 +1043,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 206,
-      "line_end": 212,
+      "line_start": 207,
+      "line_end": 213,
       "language_raw": "cmd",
       "language": "unknown",
       "category": "skip_warranted",
@@ -1058,8 +1058,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 228,
-      "line_end": 231,
+      "line_start": 229,
+      "line_end": 232,
       "language_raw": "powershell",
       "language": "unknown",
       "category": "skip_warranted",
@@ -1073,8 +1073,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 239,
-      "line_end": 242,
+      "line_start": 240,
+      "line_end": 243,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1086,8 +1086,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 250,
-      "line_end": 256,
+      "line_start": 251,
+      "line_end": 257,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1099,8 +1099,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 264,
-      "line_end": 267,
+      "line_start": 265,
+      "line_end": 268,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1112,8 +1112,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 275,
-      "line_end": 277,
+      "line_start": 276,
+      "line_end": 278,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1125,8 +1125,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 281,
-      "line_end": 290,
+      "line_start": 282,
+      "line_end": 291,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1138,8 +1138,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 324,
-      "line_end": 326,
+      "line_start": 325,
+      "line_end": 327,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1151,8 +1151,38 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 358,
-      "line_end": 360,
+      "line_start": 379,
+      "line_end": 382,
+      "language_raw": "bash",
+      "language": "bash",
+      "category": "needs_placeholder",
+      "suggested_action": "wrap_with_doctest_skip_until_t011",
+      "placeholders_detected": [
+        "<PYSEC-ID>"
+      ],
+      "directives_detected": [],
+      "env_dependencies": [],
+      "hash_sha1": "13bbd7405ae8337cf56168e444627af1429be951"
+    },
+    {
+      "file": "docs/getting-started/troubleshooting.md",
+      "line_start": 388,
+      "line_end": 390,
+      "language_raw": "bash",
+      "language": "bash",
+      "category": "needs_placeholder",
+      "suggested_action": "wrap_with_doctest_skip_until_t011",
+      "placeholders_detected": [
+        "<PYSEC-ID>"
+      ],
+      "directives_detected": [],
+      "env_dependencies": [],
+      "hash_sha1": "4490bd9ff4478b5a1ba96832edc65a8d3bd93cd5"
+    },
+    {
+      "file": "docs/getting-started/troubleshooting.md",
+      "line_start": 413,
+      "line_end": 415,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1164,8 +1194,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 364,
-      "line_end": 366,
+      "line_start": 419,
+      "line_end": 421,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1177,8 +1207,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 370,
-      "line_end": 372,
+      "line_start": 425,
+      "line_end": 427,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1190,8 +1220,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 382,
-      "line_end": 386,
+      "line_start": 437,
+      "line_end": 441,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1203,8 +1233,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 390,
-      "line_end": 392,
+      "line_start": 445,
+      "line_end": 447,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",
@@ -1216,8 +1246,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 404,
-      "line_end": 407,
+      "line_start": 459,
+      "line_end": 462,
       "language_raw": "bash",
       "language": "bash",
       "category": "skip_warranted",
@@ -1231,8 +1261,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 411,
-      "line_end": 414,
+      "line_start": 466,
+      "line_end": 469,
       "language_raw": "bash",
       "language": "bash",
       "category": "skip_warranted",
@@ -1246,8 +1276,8 @@
     },
     {
       "file": "docs/getting-started/troubleshooting.md",
-      "line_start": 432,
-      "line_end": 434,
+      "line_start": 487,
+      "line_end": 489,
       "language_raw": "bash",
       "language": "bash",
       "category": "executable",

--- a/uv.lock
+++ b/uv.lock
@@ -3072,6 +3072,8 @@ name = "piper-plus"
 source = { editable = "src/python_run" }
 dependencies = [
     { name = "g2p-en" },
+    { name = "joblib" },
+    { name = "nltk" },
     { name = "numpy" },
     { name = "onnxruntime" },
     { name = "pyopenjtalk-plus" },
@@ -3099,6 +3101,8 @@ test = [
 requires-dist = [
     { name = "fastapi", marker = "extra == 'http'", specifier = ">=0.110,<1" },
     { name = "g2p-en", specifier = ">=2.1.0" },
+    { name = "joblib", specifier = ">=1.5.0" },
+    { name = "nltk", specifier = ">=3.9.4" },
     { name = "numpy", specifier = ">=1.26.4,<3.0" },
     { name = "onnxruntime", specifier = ">=1.26.0" },
     { name = "onnxruntime-gpu", marker = "extra == 'gpu'", specifier = ">=1.26.0,<2" },


### PR DESCRIPTION
## Summary

`Security Audit / pip-audit (Python)` が dev への push で fail していた事象を調査した。直接原因は piper-plus 側ではなく、上流 PyPA advisory database の一時的データ欠陥(`PYSEC-2026-97` / `PYSEC-2024-277` が 2026-05-20 に `last_affected` 欠落で生成され、安全な `nltk 3.9.4` / `joblib 1.5.3` を含む全バージョンを flag)であり、`pypa/advisory-database` PR #289 で既に修正済み・CI も schedule run で緑復帰済み。本 PR は再発時の診断容易化と将来の依存解決退行防止のための予防的変更(transitive 下限ピン + 診断手順 doc)。あわせて、`security-audit.yml` の pull_request `paths` に `requirements.txt` を追加し、依存変更が PR の pip-audit gate を通らない漏れも修正する。

## Affected Components

- [x] Python (src/python/, pyproject.toml)
- [ ] Rust (src/rust/)
- [ ] C# (src/csharp/)
- [ ] C++ (src/cpp/, CMakeLists.txt)
- [ ] Go (src/go/)
- [ ] WASM/npm (src/wasm/)
- [ ] Docker (docker/)
- [x] CI/CD (.github/workflows/)
- [x] Documentation (docs/, README*)

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [x] CI/CD
- [x] Dependencies

## Risk Level

- [x] **patch** — bug fix / internal refactor / docs only
- [ ] **minor** — new feature / additive API / no breaking change
- [ ] **major** — breaking change (API removal, schema migration, behavior reversal)

## Contract Impact

- [x] None (Python/runtime-internal change only)

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| transitive 依存セキュリティ下限ピン | `src/python_run/requirements.txt` に `nltk>=3.9.4` / `joblib>=1.5.0` を追加(`g2p-en` → `nltk` → `joblib` chain) | 将来 `g2p-en` の依存解決が affected バージョン(nltk ≤ 3.9.2 / joblib ≤ 1.4.2)へ退行しても予防できず、pip-audit が再び fail し得る |
| pip-audit 失敗の診断手順 | `docs/getting-started/troubleshooting.md` に "Security Audit CI Issues" セクションを追加 | 上流 advisory の誤生成(`last_affected` 欠落)で再び dev push が赤くなった際、原因特定に時間を要する |
| Security Audit の paths 漏れ修正 | `.github/workflows/security-audit.yml` の pull_request `paths` に `src/python_run/requirements.txt` を追加 | requirements.txt の依存変更が PR の pip-audit gate を通らず、本 PR の下限ピンも PR 上で検証されない |
| uv.lock 同期 | requirements.txt の floor を `uv.lock` の piper-plus 定義(dependencies + requires-dist)に反映 | uv workspace の lock drift で、`uv run` を entry に持つ pre-commit hook が起動時の lock 再生成で fail する |
| doc-examples snapshot 更新 | troubleshooting.md の新規 fenced block 2 件を `needs_placeholder` 分類で `audit.json` に反映 | doc-examples-gate が snapshot drift で fail する |

## 設計判断

- **根本原因は piper-plus 外**: 2026-05 の pip-audit 失敗は、上流 PyPA advisory database が `PYSEC-2026-97` (nltk) / `PYSEC-2024-277` (joblib) を 2026-05-20 に `last_affected` 欠落で自動生成し、OSV 仕様上「全バージョン affected」と解釈された結果、安全な `nltk 3.9.4` / `joblib 1.5.3` まで flag されたことによる。`pypa/advisory-database` PR #289("Update records generated incorrectly", 2026-05-21)で `last_affected: 3.9.2` / `1.4.2` が追加され修正済み。同一 commit が後の schedule run では pass し、CI は既に緑復帰している。よって本 PR は緊急のコード修正ではなく、再発時の診断容易化 + 退行防止の予防的変更。
- **下限ピンの効果範囲を正直に明記**: 下限ピンは「将来の resolution が affected バージョンへ退行するのを防ぐ regression insurance」。今回の上流データ欠陥(全バージョン flag)自体は下限ピンでは防げないため、過大な効果は主張しない。
- **floor 値の根拠**: `nltk>=3.9.4` は PYSEC-2026-97 の last_affected 3.9.2 より上、かつ nltk の別の DoS/XSS advisory も 3.9.4 で fix 済み。`joblib>=1.5.0` は PYSEC-2024-277 の last_affected 1.4.2 より上(加えて当 CVE-2024-34997 は vendor が false positive として DISPUTE)。
- **paths 漏れ修正で PR 検証を可能に**: `security-audit.yml` の pull_request `paths` は従来 `setup.py` のみが対象だったが、実際に依存を定義するのは setup.py がパースする `requirements.txt`。これを追加することで、依存変更が PR の pip-audit gate でチェックされ、本 PR の下限ピンも PR 上で green 検証される。
- **single source 維持**: `requirements.txt` は `setup.py` がパースして `install_requires` に流す唯一の依存定義。`pyproject.toml` に二重定義せず、ここに floor を集約。コメント行(`#`)と空行は setup.py のパースで除外されることをローカル検証済み。
- **`--ignore-vuln` を採らない**: 将来の genuine な検出を隠してしまうため。下限ピン + ドキュメント化が OSS セキュリティ運用上適切と判断。
- **CHANGELOG は既存 Security に統合**: Unreleased に既存の `### Security` セクションがあるため、重複 H3 を作らず統合(MD024 `siblings_only` 準拠)。

## Test Plan

- [ ] install_requires パース: `python3 -c "reqs=[l.strip() for l in open('src/python_run/requirements.txt') if l.strip() and not l.strip().startswith('#')]; assert 'nltk>=3.9.4' in reqs and 'joblib>=1.5.0' in reqs and not any(r.startswith('#') for r in reqs); print(reqs)"` → 下限ピンが入りコメントが除外される
- [ ] doc-examples drift: `python scripts/check_doc_examples.py audit --check-snapshot tests/fixtures/doc_examples_audit/audit.json --generated-at 2026-05-19T00:00:00Z` → exit 0
- [ ] CHANGELOG gate: `python scripts/check_changelog_unreleased.py && python scripts/check_changelog_format.py` → 共に exit 0
- [ ] markdownlint: `markdownlint-cli2 --config .markdownlint.yaml docs/getting-started/troubleshooting.md` → 0 errors
- [ ] 本 PR で `Security Audit` workflow がトリガーされ(`security-audit.yml` paths への requirements.txt 追加により)、`pip-audit (Python)` ジョブが green(`nltk 3.9.4` / `joblib 1.5.3` は現在の advisory 範囲外)

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL dependencies added (nltk=Apache-2.0 / joblib=BSD-3-Clause、いずれも copyleft でない既存 transitive 依存への floor 指定のみ)
- [x] Documentation updated (if applicable)

## Related Issues

なし(上流 `pypa/advisory-database` PR #289 が根本修正)。
