### PR TITLE
fix(dependabot): commit prefix を chore に統一し CI gate を解消

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@
 # 各 ecosystem の依存関係を月次で更新。
 # - minor / patch は groups でまとめて 1 PR
 # - major bump は ignore (手動レビュー)
-# - PR 上限 5、commit prefix "deps"、labels ["dependencies","automated"]
+# - PR 上限 5、commit prefix "chore" (→ "chore(deps): ..." 形式)、labels ["dependencies","automated"]
 #
 # Reference:
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
@@ -24,6 +24,17 @@
 #   subdirectory の `pyproject.toml` を見つけても uv updater は root lock で
 #   解決可能 (Issue #418 で src/python_run に [project] テーブル追加 +
 #   workspace member 化が完了済)。
+#
+# ── commit-message.prefix は "chore" 固定 (type allow-list 制約) ──
+# `prefix: "deps"` だと title/commit が "deps(deps): ..." になり、 Conventional
+# Commits の type が "deps" 扱いになる。 だが本リポジトリの 2 ゲート
+#   - PR Title Check  (.github/workflows/pr-title-check.yml)
+#   - Commitlint      (.github/workflows/commitlint.yml + .commitlintrc.json)
+# は type allow-list を feat/fix/chore/docs/test/ci/refactor/perf/build/style/
+# revert に限定しており、 "deps" type を reject する (両 gate の help でも
+# "chore(deps): bump ..." を推奨)。 そのため prefix は "chore" に統一し、
+# include: "scope" と併せて "chore(deps): ..." 形式を生成する。 prefix を
+# "deps" に戻すと全 Dependabot PR の lint/validate が fail するので注意。
 
 version: 2
 
@@ -35,7 +46,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -65,7 +76,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -88,7 +99,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -111,7 +122,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -134,7 +145,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -157,7 +168,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -189,7 +200,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -212,7 +223,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -235,7 +246,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -271,7 +282,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -299,7 +310,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary

Dependabot の `.github/dependabot.yml` は全 11 ecosystem で `commit-message.prefix: "deps"` を使用しており、`include: "scope"` と併せて title/commit が `deps(deps): ...` を生成していた。このため Conventional Commits の type が `deps` 扱いとなり、本リポジトリの 2 gate (PR Title Check / Commitlint) が `deps` を許可 type 外として reject し、**現在 open な全 Dependabot PR (#540・#541・#542・#543・#544・#546) の `lint` / `validate` が fail** していた。prefix を `chore` に統一して `chore(deps): ...` 形式を生成し、両 gate を通す。

## Affected Components

- [ ] Python (`src/python/`, `src/python_run/`)
- [ ] Rust (`src/rust/`)
- [ ] C# (`src/csharp/`)
- [ ] C++ (`src/cpp/`)
- [ ] Go (`src/go/`)
- [ ] WASM/npm (`src/wasm/`)
- [ ] Docker (`docker/`)
- [x] CI/CD (`.github/`)
- [ ] Documentation (`docs/`)

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] CI/CD
- [ ] Dependencies

## Risk Level

- [x] patch (バグ修正 / 内部変更)
- [ ] minor (新機能 / 非破壊)
- [ ] major (破壊的変更)

## Contract Impact

- [x] None — `docs/spec/*.toml` への影響なし (CI 設定のみ)

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|------------------------|
| commit prefix 統一 | 全 11 ecosystem の `commit-message.prefix` を `deps` → `chore` に変更。`include: "scope"` と併せ `chore(deps): ...` を生成 | Dependabot PR の title/commit が `deps(deps): ...` となり、type allow-list 外の `deps` で Commitlint / PR Title Check が必ず fail |
| 再発防止コメント | `dependabot.yml` ヘッダに「prefix は chore 固定 (type allow-list 制約)」の理由を追記。2 gate のパスと推奨形式を明記 | 将来 `deps` 等に戻され全 Dependabot PR が再び red 化するのを防げない |

## 設計判断

- **`chore` を選択**: PR Title Check / Commitlint の help が共に `chore(deps): bump ...` を canonical form として推奨。type allow-list (`feat/fix/chore/docs/test/ci/refactor/perf/build/style/revert`) を緩めて `deps` を追加するのではなく、Dependabot 側を規約に合わせる (allow-list は意図的に標準 type のみに限定されているため)。
- **scope は `include: "scope"` を維持**: 結果の scope は `deps` / `deps-dev` となり、いずれも PR Title Check regex (kebab-case) と Commitlint (scope-enum なし) を通る。
- **CHANGELOG エントリ非追加**: 先例 #430 (`fix(dependabot): ...`) も `dependabot.yml` 単独変更で CHANGELOG 変更なし。CHANGELOG 関連 gate は全て `CHANGELOG.md` / `docs/migration/` に scope されており本変更には非該当。
- **既存 open PR の扱い**: 本 PR は設定変更のため、既存 Dependabot PR の title/commit は自動では変わらない。merge 後に各 PR へ `@dependabot recreate` を打ち、新 prefix で再生成して green 化する想定 (本 PR スコープ外)。

## Test Plan

- [x] `python3 -c "import yaml; d=yaml.safe_load(open('.github/dependabot.yml'))"` で YAML が valid、`updates` 11 件、全 `commit-message.prefix == "chore"` を確認済 (ローカル assert pass)。
- [ ] 本 PR 自身の `validate` (PR Title Check) / `lint` (Commitlint) が green であること (この PR の title `fix(dependabot): ...` が許可 type で通ることの実証)。
- [ ] merge 後、次回 Dependabot 実行 (または `@dependabot recreate`) で生成される PR title が `chore(deps): ...` 形式になり `lint` / `validate` が pass することを確認。

## Checklist

- [x] Tests pass locally (YAML 検証 + prefix assert)
- [x] No GPL/LGPL dependencies added
- [x] Documentation updated (`dependabot.yml` 内に理由コメントを追記)

## Related Issues

なし (現行 open Dependabot PR #540–#546 の CI fail を解消する設定修正)
