### PR TITLE
chore(deps): bump ruff to 0.15.15 across all pin sites

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install Ruff
       run: |
         python -m pip install --upgrade pip
-        pip install ruff==0.15.12
+        pip install ruff==0.15.15
 
     - name: Run Ruff check
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@
 # # Version pinning:
 #   ruff version below MUST match the pins in
 #   .github/workflows/python-lint.yml and .github/workflows/ci.yml
-#   (currently 0.15.12). Drift between pre-commit and CI =
+#   (currently 0.15.15). Drift between pre-commit and CI =
 #   local-clean / CI-fail mismatch (PR #401 cause).
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.15
     hooks:
       - id: ruff
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,9 +16,10 @@
 #
 # # Version pinning:
 #   ruff version below MUST match the pins in
-#   .github/workflows/python-lint.yml and .github/workflows/ci.yml
-#   (currently 0.15.15). Drift between pre-commit and CI =
-#   local-clean / CI-fail mismatch (PR #401 cause).
+#   .github/workflows/python-lint.yml and pyproject.toml (dev / test /
+#   tool.uv dependency groups) — currently 0.15.15. Drift between these =
+#   local-clean / CI-fail mismatch (PR #401 cause). Enforced by
+#   scripts/check_ruff_version_sync.py (ruff-version-sync gate, 5 pin sites).
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ dev = [
     "flake8==6.1.0",
     "mypy>=1.20.2",
     "pylint==3.3.9",
-    "ruff==0.15.12",
+    "ruff==0.15.15",
     "pytest>=9.0.3,<10",
     "pytest-cov==4.1.0",
     "pytest-xdist==3.8.0",
@@ -130,7 +130,7 @@ test = [
     "pytest-mock==3.15.1",
     "pytest-asyncio>=0.24",  # NEW: async FastAPI tests
     "coverage[toml]>=7.14.0",
-    "ruff==0.15.12",
+    "ruff==0.15.15",
     "mypy>=1.20.2",
     "types-requests==2.33.0.20260508",
     "types-PyYAML==6.0.12",
@@ -165,7 +165,7 @@ members = [
 # よう root を `piper-plus-workspace` にした上で非 install 化)。
 package = false
 dev-dependencies = [
-    "ruff==0.15.12",
+    "ruff==0.15.15",
     "pytest>=9.0.3,<10",
     "pytest-timeout>=2.2.0",
     "black==26.3.1",

--- a/uv.lock
+++ b/uv.lock
@@ -3347,8 +3347,8 @@ requires-dist = [
     { name = "pytorch-lightning", specifier = ">=2.0" },
     { name = "pytorch-lightning", marker = "extra == 'train'", specifier = ">=2.0" },
     { name = "pyyaml", marker = "extra == 'train'", specifier = ">=6.0.3" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
-    { name = "ruff", marker = "extra == 'test'", specifier = "==0.15.12" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.15" },
+    { name = "ruff", marker = "extra == 'test'", specifier = "==0.15.15" },
     { name = "scipy", marker = "extra == 'train'", specifier = ">=1.17.1" },
     { name = "seaborn", marker = "extra == 'train'", specifier = ">=0.13" },
     { name = "soundfile", marker = "extra == 'inference'", specifier = ">=0.12" },
@@ -3386,7 +3386,7 @@ dev = [
     { name = "openai", specifier = ">=1.50.0" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pytest-timeout", specifier = ">=2.2.0" },
-    { name = "ruff", specifier = "==0.15.12" },
+    { name = "ruff", specifier = "==0.15.15" },
 ]
 
 [[package]]
@@ -4293,27 +4293,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.12"
+version = "0.15.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
-    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
-    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
-    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
-    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
-    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Dependabot #541 (python-uv-workspace group) は ruff `0.15.12 → 0.15.15` を `pyproject.toml`(×3) + `uv.lock` のみで bump し、`.pre-commit-config.yaml` / `.github/workflows/python-lint.yml` を 0.15.12 のまま残したため、`6 ruff pin sites agree` ゲート (`scripts/check_ruff_version_sync.py`) が version drift で fail していた (CLAUDE.md が PR #401/#442 で予見している drift パターン)。全 active pin site を 0.15.15 に統一して drift を解消する。

## Affected Components

- [ ] Python (`src/python/`, `src/python_run/`)
- [ ] Rust (`src/rust/`)
- [ ] C# (`src/csharp/`)
- [ ] C++ (`src/cpp/`)
- [ ] Go (`src/go/`)
- [ ] WASM/npm (`src/wasm/`)
- [ ] Docker (`docker/`)
- [x] CI/CD (`.github/`, `.pre-commit-config.yaml`)
- [ ] Documentation (`docs/`)

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] CI/CD
- [x] Dependencies

## Risk Level

- [x] patch (バグ修正 / 内部変更)
- [ ] minor (新機能 / 非破壊)
- [ ] major (破壊的変更)

## Contract Impact

- [x] None — `docs/spec/*.toml` への影響なし (lint ツール pin の同期のみ)

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|------------------------|
| ruff pin 全 site 同期 | `.pre-commit-config.yaml` rev / `python-lint.yml` / `pyproject.toml` ×3 を 0.15.15 に統一 | 5 site の version が不一致 → `6 ruff pin sites agree` ゲートが fail (local-clean / CI-fail mismatch) |
| uv.lock 再解決 | `uv lock` で ruff のみ 0.15.12 → 0.15.15 に再解決 (227 packages、ruff-only diff) | pyproject の pin と uv.lock が乖離 → lockfile consistency ゲートが fail |
| pin コメント更新 | `.pre-commit-config.yaml` の `(currently 0.15.12)` を 0.15.15 に追従 | ドキュメントが stale 化 |

## 設計判断

- **ruff-only に限定**: #541 は 12 package group だが、cross-site pin ゲートを持つのは ruff のみ。`uv lock` の出力も `Updated ruff v0.15.12 -> v0.15.15` の単一更新 (他 11 package と lockfile format version=1 は不変) を確認し、ruff だけの最小 diff に保った。残り 11 package は #541 側の通常 bump として扱う。
- **uv.lock は手編集せず `uv lock` で再生成**: ruff block の hash/URL を正とするため。再生成は lockfile version=1 を維持し whole-file rewrite を起こさないことを diff で確認済み。
- **5 site 同時 bump が必須**: ゲートは「全 site 一致」を要求するため、部分 bump では逆に drift を発生させる。pre-commit / workflow / pyproject ×3 を 1 commit で揃えた。
- **#541 との関係**: 本 PR は #541 の ruff 部分のみを supersede する (`Closes` しない)。#541 の他 11 package 更新は本 PR merge 後に recreate で扱う。

## Test Plan

- [x] `python scripts/check_ruff_version_sync.py` → 5 site 全て `ruff==0.15.15` で一致 (OK)。
- [x] `uvx ruff@0.15.15 check` → `All checks passed!` (0.15.15 で新規 lint 違反なし)。
- [x] `uvx ruff@0.15.15 format --check` → `225 files already formatted`。
- [x] `uv lock --check` → 227 packages 整合 (pyproject ↔ uv.lock 一致)。
- [x] `pre-commit run --files <changed>` → `ruff version pin synchronization` 含む全 hook Passed (Failed: 0)。

## Checklist

- [x] Tests pass locally (sync gate / ruff check / lock check / pre-commit)
- [x] No GPL/LGPL dependencies added
- [x] Documentation updated (`.pre-commit-config.yaml` の pin コメント追従)

## Related Issues

- Dependabot #541 の `6 ruff pin sites agree` ゲート fail を解消 (ruff 部分を supersede)。`Closes` はしない (他 11 package 更新は #541 で継続)。
- 関連: #547 (Dependabot commit prefix を chore に統一)。
