### PR TITLE
fix(dependabot): ignore ruff in uv group to stop pin-sync treadmill

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,8 +96,8 @@ updates:
       # python-lint.yml の pin を残すため `6 ruff pin sites agree` ゲート
       # (scripts/check_ruff_version_sync.py) が必ず fail する。
       # 事例: #541→#548 で 0.15.15 に sync した数時間後、#549 が 0.15.16 で再 drift。
-      # ruff version は 5 pin site を /bump-deps で一括手動更新する
-      # (CLAUDE.md「ruff version pin」節 参照)。
+      # ruff version は check_ruff_version_sync.py が検査する pin site を
+      # /bump-deps で一括手動更新する (CLAUDE.md「ruff version pin」節 参照)。
       - dependency-name: "ruff"
 
   # Rust: src/rust (Cargo workspace)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -91,6 +91,14 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # ruff は dependabot で更新しない (cross-site pin sync の treadmill を断つ)。
+      # dependabot は pyproject.toml の pin のみ bump し .pre-commit-config.yaml /
+      # python-lint.yml の pin を残すため `6 ruff pin sites agree` ゲート
+      # (scripts/check_ruff_version_sync.py) が必ず fail する。
+      # 事例: #541→#548 で 0.15.15 に sync した数時間後、#549 が 0.15.16 で再 drift。
+      # ruff version は 5 pin site を /bump-deps で一括手動更新する
+      # (CLAUDE.md「ruff version pin」節 参照)。
+      - dependency-name: "ruff"
 
   # Rust: src/rust (Cargo workspace)
   - package-ecosystem: "cargo"


### PR DESCRIPTION
## Summary

Dependabot は ruff を `pyproject.toml` (uv group) のみで bump し、`.pre-commit-config.yaml` の `rev` / `.github/workflows/python-lint.yml` の pin を据え置くため、ruff bump のたびに `6 ruff pin sites agree` ゲート (`scripts/check_ruff_version_sync.py`) が必ず fail する。実例: #541→#548 で 0.15.15 に sync した数時間後、dependabot が #549 で 0.15.16 を提案し**再び drift**。ruff は毎週パッチが出るため放置すると恒常的な treadmill になる。uv ecosystem の `ignore` に ruff を追加して dependabot 管理外にし、ruff version は 5 pin site を `/bump-deps` で一括手動更新する運用 (CLAUDE.md 既定) に一本化する。

## Affected Components

- [ ] Python (`src/python/`, `src/python_run/`)
- [ ] Rust (`src/rust/`)
- [ ] C# (`src/csharp/`)
- [ ] C++ (`src/cpp/`)
- [ ] Go (`src/go/`)
- [ ] WASM/npm (`src/wasm/`)
- [ ] Docker (`docker/`)
- [x] CI/CD (`.github/`)
- [ ] Documentation (`docs/`)

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] CI/CD
- [x] Dependencies

## Risk Level

- [x] patch (バグ修正 / 内部変更)
- [ ] minor (新機能 / 非破壊)
- [ ] major (破壊的変更)

## Contract Impact

- [x] None — `docs/spec/*.toml` への影響なし (dependabot 設定のみ)

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|------------------------|
| ruff を dependabot ignore | uv ecosystem の `ignore` に `dependency-name: "ruff"` を追加 | dependabot が ruff を pyproject のみ bump → `6 ruff pin sites agree` が毎回 fail し、後追いの手動 sync PR が無限に発生 |
| 理由コメント | ignore エントリに treadmill の経緯 (#541/#548/#549) と手動管理方針を明記 | 将来 ignore が外され treadmill が再発する |

## 設計判断

- **ruff のみ ignore (全 update-type)**: ruff は dev lint ツールで runtime/security critical ではなく、プロジェクトは元々 5 pin site を手動 pin している。dependabot 管理から外しても運用と整合する。他 package は引き続き dependabot が更新。
- **uv ecosystem 限定**: ruff の pin は root の uv group にのみ存在するため、ignore も uv ecosystem 1 箇所に追加 (YAML assert で確認済み)。
- **代替案を不採用**: (a) ruff を毎回追従 sync = treadmill 継続。(b) CI を `uv run ruff` に変えて pin を 1 本化 = 5 site→1 site の大きな refactor。本 PR は最小変更で treadmill を断つ ignore 方式を採る。
- **#549 への効果**: 本 PR merge 後に `@dependabot recreate #549` で ruff が group から外れ、残り 12 updates が `6 ruff pin sites agree` を fail させずに pass する。

## Test Plan

- [x] `python -c "import yaml; ..."` で YAML valid、`updates` 11 ecosystem、ruff ignore が **uv ecosystem のみ**に存在することを assert 済み (`ruff_ecos == ['uv/']`)。
- [ ] 本 PR の `validate` / `lint` が green (title `fix(dependabot): ...` が許可 type)。
- [ ] merge 後に `@dependabot recreate #549` → 再生成された #549 の diff に ruff が含まれず、`6 ruff pin sites agree` / `pre-commit run --all-files` が pass することを確認。

## Checklist

- [x] Tests pass locally (YAML validation + ruff-ignore placement assert)
- [x] No GPL/LGPL dependencies added
- [x] Documentation updated (dependabot.yml 内に理由コメントを追記)

## Related Issues

- #549 (python-uv-workspace group) の `6 ruff pin sites agree` 恒常 fail を構造的に解消。
- 関連: #547 (commit prefix 統一)、#548 (ruff 0.15.15 sync)。
