### PR TITLE
fix(tests): guard fuzz hypothesis import + doc macOS local tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,17 @@ CHANGELOG unreleased) を full-repo で実行 (~20-30 秒)。`SKIP=...` で comm
 > 6 箇所一致を CI gate (本 gate がなければ Dependabot uv-workspace PR が
 > pyproject.toml だけ bump → drift → 後追い PR が発生する)。
 
+### ローカルテスト実行 (特に macOS)
+
+各ランタイムを CI と同条件でローカル実行する際の注意点 (macOS で検証済み):
+
+- **Python**: `uv sync --extra dev` で pytest-cov 等を入れてから `uv run --no-sync pytest <dir> --no-cov`。bare `uv sync` は plugin を入れず pytest.ini の `addopts=--cov` で usage error (exit 4) になる。
+- **Rust**: per-crate (`cargo test -p piper-plus` 等) で実行。`cargo test --workspace` は piper-plus-python (pyo3 auto-initialize) を含み、macOS の framework Python (`/usr/bin/python3`) では `@rpath` 解決失敗で SIGABRT。全 crate を回すなら `cargo test --workspace --exclude piper-plus-python --exclude piper-plus-wasm` (python は maturin / wasm は wasm-pack で別途テスト)。
+- **Go**: `src/go` と `src/go/phonemize` は別 go.mod。両方で `go test ./...` する。
+- **npm (openjtalk-web)**: `npm install "@piper-plus/g2p@file:../g2p"` でローカル g2p をリンク (registry 版は古いと isSsml 等の root export を欠く)。生成された file: リンクの lockfile は commit しない (lockfile-size gate)。
+- **C++**: `cmake -B build -DBUILD_TESTS=ON && cmake --build build -j && ctest --test-dir build` (ORT/OpenJTalk は cmake が自動 DL、sudo 不要)。
+- **Swift**: release 用 `Package.swift` は未リリース xcframework を参照するため `swift test` が 404。CI と同じ manifest swap か tag リリース後に実行する。
+
 ---
 
 ## 学習テンプレート

--- a/tests/fuzz/conftest.py
+++ b/tests/fuzz/conftest.py
@@ -18,7 +18,17 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from hypothesis import HealthCheck, Verbosity, settings
+
+try:
+    from hypothesis import HealthCheck, Verbosity, settings
+
+    _HAS_HYPOTHESIS = True
+except ImportError:
+    # hypothesis は fuzz 専用の optional dep (src/python/g2p[dev] / fuzz-smoke.yml で
+    # install)。未インストール時はこのディレクトリの collection をスキップし、
+    # repo-root の `pytest tests` 全体を ModuleNotFoundError で中断させない。
+    _HAS_HYPOTHESIS = False
+    collect_ignore_glob = ["test_*.py"]
 
 
 # Ensure the source modules under test are importable without installing the
@@ -34,21 +44,22 @@ for _p in (
             sys.path.insert(0, _path)
 
 
-settings.register_profile(
-    "dev",
-    max_examples=50,
-    deadline=None,
-    verbosity=Verbosity.normal,
-    suppress_health_check=[HealthCheck.too_slow, HealthCheck.large_base_example],
-)
+if _HAS_HYPOTHESIS:
+    settings.register_profile(
+        "dev",
+        max_examples=50,
+        deadline=None,
+        verbosity=Verbosity.normal,
+        suppress_health_check=[HealthCheck.too_slow, HealthCheck.large_base_example],
+    )
 
-settings.register_profile(
-    "ci",
-    max_examples=500,
-    deadline=None,
-    verbosity=Verbosity.normal,
-    suppress_health_check=[HealthCheck.too_slow, HealthCheck.large_base_example],
-)
+    settings.register_profile(
+        "ci",
+        max_examples=500,
+        deadline=None,
+        verbosity=Verbosity.normal,
+        suppress_health_check=[HealthCheck.too_slow, HealthCheck.large_base_example],
+    )
 
-# Default profile used when running pytest without `--hypothesis-profile`.
-settings.load_profile("dev")
+    # Default profile used when running pytest without `--hypothesis-profile`.
+    settings.load_profile("dev")


### PR DESCRIPTION
## Summary

macOS 上での全ランタイムローカルデバッグ中に見つかった 2 件の開発体験 (DX) 課題を修正する。(1) `tests/fuzz/conftest.py` が hypothesis を無条件 import するため、hypothesis 未インストール環境で repo-root の `pytest tests` を実行すると collection error (exit 2) で tests 全体が中断する。(2) 各ランタイムを CI と同条件でローカル実行する手順が未文書化で、`uv sync` だけでは pytest-cov が入らず usage error になる等の落とし穴があった。いずれも CI には影響しない (CI は明示的に extra/依存を install するため発生しない local-only の現象)。

## Affected Components

- [x] Python
- [x] Documentation

## Type

- [x] Bug fix
- [x] Documentation

## Risk Level

- [x] patch

## Contract Impact

- [x] None

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| fuzz conftest の defensive import | hypothesis を `try/except ImportError` でガードし、未インストール時は `collect_ignore_glob` で `tests/fuzz` の collection を skip | repo-root の `pytest tests` が `ModuleNotFoundError: hypothesis` で全体中断 (exit 2)。fuzz 以外のテストも巻き添えで実行不能になる |
| CLAUDE.md ローカルテスト節 | 各ランタイム (Python/Rust/Go/npm/C++/Swift) の CI 同等ローカル実行コマンドと落とし穴を明記 | 開発者が `uv sync` → `pytest` で usage error、`cargo test --workspace` で SIGABRT 等に遭遇し原因不明で時間を浪費する |

## 設計判断

- conftest は import を `try/except ImportError` でガードし、欠如時のみ `collect_ignore_glob` で当該ディレクトリを無言 skip。test 本体は既に `pytest.importorskip` 済みのため二重ガードにならない最小変更。
- `fuzz-smoke.yml` は明示的に `hypothesis>=6.0` を install してから実行するため try 節が成立し、CI の挙動 (fuzz 301 件実行) は不変。
- CLAUDE.md は新規 doc 節の追加のみ。コード・設定・lock に一切触れないため CI ゼロ影響。

## Test Plan

- [ ] hypothesis 無し環境で `uv run --no-sync pytest tests -q` が collection error にならず fuzz が skip されること
- [ ] hypothesis 有り環境で `uv run --with hypothesis pytest tests/fuzz/ -c tests/fuzz/pytest.ini --hypothesis-profile=ci` が従来どおり全 pass すること (検証時: 301 passed)
- [ ] CLAUDE.md の各コマンド (`uv sync --extra dev` / cargo per-crate / go 2モジュール / npm `file:../g2p` / cmake `-DBUILD_TESTS=ON` / swift manifest swap) が記載どおり動作すること

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL deps added
- [x] Documentation updated

## Related Issues

なし
