### PR TITLE
chore(g2p): bump @piper-plus/g2p to 0.4.1 for SSML root exports

### DIFF
--- a/src/wasm/g2p/CHANGELOG.md
+++ b/src/wasm/g2p/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-07
+
+### Added
+
+- **SSML public API root exports (`isSsml` / `parseSsml` / `SsmlParser`)**: these root re-exports already exist in `src/index.js`, but the registry's 0.4.0 predates them, so consumers importing from the main entry (e.g. `openjtalk-web`'s `synthesizeSsml`) hit `does not provide an export named 'isSsml'`. This 0.4.1 release ships those existing root exports to the registry (version bump only — no source / API change).
+
 ### Fixed
 
 - **Swedish (sv) per-word language detection (Issue #539)**: Swedish words containing `å`/`ä`/`ö` (e.g. `så`, `och`, `för`, `är`) were misdetected as English. The Swedish LID is reworked from the previous char-level approach to a word-level post-pass with a **conservative policy** (strong indicators: `å`/`Å` or an exact match in a 46-word function-word list; `ä`/`ö` alone are NOT sufficient — shared with German/Finnish/loanwords). `UnicodeLanguageDetector` now loads the bundled `data/sv_function_words.json`, byte-identical to every other runtime mirror and enforced by a new cross-runtime sync gate.

--- a/src/wasm/g2p/package.json
+++ b/src/wasm/g2p/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piper-plus/g2p",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Multilingual G2P (Grapheme-to-Phoneme) for TTS — eSpeak-ng free, MIT licensed",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary

`@piper-plus/g2p` を 0.4.0 → 0.4.1 に bump し、SSML の root export (`isSsml` / `parseSsml` / `SsmlParser`) を npm registry へ反映可能にする。これらは `src/index.js` で既に root re-export されているが registry の 0.4.0 には含まれておらず (リリース漏れ)、`openjtalk-web` が registry 版を install すると `does not provide an export named 'isSsml'` で fail する。npm 配信ワークフローの validate job も同 import で潜在的に fail する。

## Affected Components

- [x] WASM-npm

## Type

- [x] Bug fix

## Risk Level

- [x] patch

## Contract Impact

- [x] None

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| g2p version bump (0.4.0 → 0.4.1) | tag push 時のリリースワークフローで 0.4.1 を配信し、SSML root export を registry に反映 | registry 版に isSsml 等が無いまま。openjtalk-web の `synthesizeSsml` 経路が `does not provide an export named 'isSsml'` で fail |
| CHANGELOG [0.4.1] エントリ | SSML root export 追加 + 既存 Swedish LID 修正を 0.4.1 として確定 | リリース内容が [Unreleased] のまま不明瞭。Keep a Changelog 違反 |

## 設計判断

- export 自体 (`src/index.js` の `export { isSsml, parseSsml, SsmlParser }`) は既存。本 PR は version bump と CHANGELOG 確定のみで、コード挙動は変えない (registry へ反映するための最小変更)。
- openjtalk-web 側の依存更新 (`^0.4.0` → `^0.4.1`) と lockfile baseline 更新は、0.4.1 が registry に配信された後でないと CI (`npm install`) が通らないため本 PR に含めず、配信後の follow-up とする (本文末尾に明記)。

## Test Plan

- [ ] `cd src/wasm/g2p && npm test` が pass すること (export は既存のため挙動不変)
- [ ] tag `wasm-g2p-v0.4.1` push 後、registry の 0.4.1 に `isSsml` / `parseSsml` / `SsmlParser` が含まれること
- [ ] 配信後 follow-up: `openjtalk-web` で `npm install` (registry 0.4.1) → `npm test` が全 pass すること (ローカルでは `@piper-plus/g2p@file:../g2p` リンクで 68/68 pass を確認済み)

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL deps added
- [x] Documentation updated

## Related Issues

なし

---

**Follow-up (本 PR マージ + 0.4.1 配信後):**
1. `src/wasm/openjtalk-web/package.json`: `@piper-plus/g2p` を `^0.4.1` へ更新
2. `npm install` で registry 版 lockfile を再生成
3. `docs/spec/lockfile-size-baseline.toml` の openjtalk-web エントリを実測値に更新
