### PR TITLE
ci(g2p): adopt OIDC trusted publishing for g2p npm release

### DIFF
--- a/.github/workflows/g2p-wasm-ci.yml
+++ b/.github/workflows/g2p-wasm-ci.yml
@@ -148,6 +148,9 @@ jobs:
           cache-dependency-path: src/wasm/g2p/package.json
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm for OIDC trusted publishing (>= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Verify tag matches package.json version
         run: |
           TAG="${GITHUB_REF#refs/tags/wasm-g2p-v}"
@@ -163,6 +166,8 @@ jobs:
         run: npm install
 
       - name: Publish to npm
+        # OIDC trusted publishing: NODE_AUTH_TOKEN を使わず、GitHub Actions の
+        # OIDC token (permissions.id-token: write) で npm Trusted Publisher 設定に
+        # 対して認証する。org の 2FA 強制を回避し、token 失効/期限切れも根絶する。
+        # 要件: npm >= 11.5.1 (上で upgrade) + npm package 側の Trusted Publisher 登録。
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

g2p の npm 配信を NODE_AUTH_TOKEN 方式から OIDC trusted publishing に移行する。`NPM_TOKEN` が期限切れし、再発行しても `@piper-plus` org の 2FA 強制により automation/granular token が EOTP(one-time password required)で配信できない問題(4回失敗)を恒久解決する。OIDC trusted publishing は token を使わず GitHub Actions の OIDC token で認証するため、token 失効・2FA 強制の影響を受けない。

## Affected Components

- [x] CI-CD

## Type

- [x] CI/CD

## Risk Level

- [x] patch

## Contract Impact

- [x] None

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| OIDC trusted publishing | publish job から `NODE_AUTH_TOKEN` を削除し、既存の `id-token: write` で OIDC 認証 | `NPM_TOKEN` 期限切れ・org 2FA 強制で EOTP となり g2p を配信できない |
| npm upgrade step | 配信前に npm を 11.5.1+ に upgrade(OIDC trusted publishing 対応版) | 古い npm は OIDC trusted publishing 非対応で認証できない |

## 設計判断

- `id-token: write` は provenance 用に既に publish job に存在するため、permission 追加は不要(最小変更)。
- `NODE_AUTH_TOKEN` を削除するだけで OIDC 認証に切り替わる(npm 11.5.1+ + Trusted Publisher 登録が前提)。
- token 方式は npm が Classic を新規発行不可にし、Granular は org 2FA 強制で EOTP になるため、OIDC が唯一の確実な配信経路。

## Test Plan

- [ ] **マージ前**: npm package(`@piper-plus/g2p`)Settings → Trusted Publisher に GitHub Actions(`ayutaz/piper-plus`, workflow `g2p-wasm-ci.yml`)を登録
- [ ] マージ後、tag `wasm-g2p-v0.4.1` を新 HEAD に再作成して push し、publish job が OIDC で 0.4.1 を配信すること
- [ ] `npm view @piper-plus/g2p@0.4.1` が解決すること

## Checklist

- [x] Tests pass locally(workflow 変更のみ)
- [x] No GPL/LGPL deps added
- [x] Documentation updated(workflow 内コメントで OIDC 移行を記載)

## Related Issues

なし

---

**重要(マージ前にユーザー対応が必要)**: npm package の Trusted Publisher 登録がないと publish job が認証できません。マージ前に以下を登録してください:
- npmjs.com → `@piper-plus/g2p` → Settings → Trusted Publisher → GitHub Actions
- Organization or user: `ayutaz`
- Repository: `piper-plus`
- Workflow filename: `g2p-wasm-ci.yml`
- Environment: 空欄で可
