### PR TITLE
fix(cpp): repair Windows tsukuyomi download + guard inference bugs

### DIFF
--- a/.github/workflows/pua-consistency.yml
+++ b/.github/workflows/pua-consistency.yml
@@ -43,6 +43,12 @@ on:
       - 'docs/spec/pua-contract.toml'
       - 'scripts/check_pua_consistency.py'
       - '.github/workflows/pua-consistency.yml'
+  schedule:
+    # Weekly: catch a stale *distributed* (HuggingFace) config — e.g. the
+    # v1.12.0 ɔɪ/œ̃/ɐ̃ multi-codepoint leak that broke C++ inference on Windows.
+    # PR-time gates cannot see it because the artifact lives on HF, not the repo.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -213,3 +219,69 @@ jobs:
               print(f"OK: $cfg ({len(pid_map)} phoneme_id_map entries, all single-codepoint)")
           EOF
           done
+
+  distributed-config-validator:
+    name: Distributed (HF) config validator
+    # Only on schedule / manual dispatch: avoids HuggingFace egress on every
+    # PR. The in-repo configs are covered by config-key-validator above; this
+    # job catches a stale *distributed* config.json — the failure mode behind
+    # the v1.12.0 ɔɪ/œ̃/ɐ̃ leak that broke C++ inference for Windows users
+    # (the corrected config must be regenerated AND re-pushed to HuggingFace,
+    # which a PR-time gate cannot verify).
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - uses: actions/setup-python@v5.6.0
+        with:
+          python-version: '3.13'
+
+      - name: Validate HF-distributed model configs are PUA single-codepoint
+        run: |
+          python - <<'EOF'
+          import importlib.util, json, sys, urllib.request
+
+          # Load MODEL_ALIASES by file path so we don't import the piper_plus
+          # package __init__ (and its heavier optional deps). This dict is the
+          # single source of truth for which models we distribute.
+          spec = importlib.util.spec_from_file_location(
+              "_model_resolver", "src/python/piper_plus/_model_resolver.py")
+          mod = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(mod)
+          aliases = mod.MODEL_ALIASES
+
+          failures = []
+          for name, a in aliases.items():
+              url = (f"https://huggingface.co/{a['repo_id']}"
+                     f"/resolve/main/{a['config_file']}")
+              print(f"Checking '{name}': {url}")
+              try:
+                  with urllib.request.urlopen(url, timeout=30) as r:
+                      data = json.loads(r.read().decode("utf-8"))
+              except Exception as e:  # network/transient — log, do not flake-fail
+                  print(f"  WARN: could not fetch ({e}); skipping this model")
+                  continue
+              pid = data.get("phoneme_id_map", {})
+              bad = [k for k in pid if len(k) > 1]
+              if bad:
+                  hexed = ["+".join(f"U+{ord(c):04X}" for c in k) for k in bad]
+                  print(f"  FAIL: {len(bad)} multi-codepoint key(s): {hexed}")
+                  failures.append((name, hexed))
+              else:
+                  print(f"  OK: {len(pid)} entries, all single-codepoint")
+
+          if failures:
+              print("\nDistributed config validation FAILED:")
+              for name, hexed in failures:
+                  print(f"  {name}: {hexed}")
+              print(
+                  "\nFix: regenerate the config with PUA-encoded keys via "
+                  "`python scripts/regenerate_tsukuyomi_config.py` (or "
+                  "`python -m piper_train.update_model_config <cfg>`) and "
+                  "re-push it to HuggingFace. The C++ runtime rejects "
+                  "multi-codepoint phoneme_id_map keys (see "
+                  "src/cpp/tests/test_phonemize_config.cpp).")
+              sys.exit(1)
+          print("\nAll distributed configs OK.")
+          EOF

--- a/.github/workflows/release-shared-lib.yml
+++ b/.github/workflows/release-shared-lib.yml
@@ -42,6 +42,9 @@ env:
   # Issue #383 follow-up: ORT 1.17.0 → 1.20.0
   # C++ source build / Android PR CI / Kotlin G2P CI と整合 (docs/reference/ort-versions.md)
   ONNXRUNTIME_VERSION: "1.20.0"
+  # Issue #426 release smoke: the MB-iSTFT speaker_embedding fixture, generated
+  # on Linux and consumed by the Windows binary smoke job below.
+  FIXTURE_DIR: tests/fixtures/mb_istft_speaker_embedding
 
 jobs:
   build-shared:
@@ -180,6 +183,96 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: ${{ github.workspace }}/${{ matrix.artifact }}.${{ matrix.archive_ext }}
+
+  # ---------------------------------------------------------------------
+  # Issue #426 release smoke: confirm the released Windows piper.exe feeds
+  # speaker_embedding / speaker_embedding_mask for MB-iSTFT-VITS2 models.
+  # ---------------------------------------------------------------------
+  # PR #443 fixed the runtime to feed a zero embedding + mask=0 when a model
+  # declares those inputs, but v1.12.0 shipped a Windows binary built BEFORE
+  # that fix, so users hit ORT "Required inputs ... are missing" and a 0-byte
+  # WAV. No release-time gate caught it. These two jobs close that gap: the
+  # fixture is generated on Linux (fast torch wheel) and the actual released
+  # windows-x64 artifact is exercised against it on Windows.
+  build-fixture:
+    name: Build speaker_embedding fixture (Python + torch)
+    # Only when the windows-x64 artifact will exist (build-shared skips Windows
+    # on pull_request), so the downstream smoke job has something to test.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.13'
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Sync deps
+        run: uv sync --extra dev
+      - name: Build fixture
+        run: |
+          CUDA_VISIBLE_DEVICES="" uv run python "${FIXTURE_DIR}/build_fixture.py"
+          ls -la "${FIXTURE_DIR}"
+      - name: Upload fixture
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: mb-istft-speaker-embedding-fixture
+          path: ${{ env.FIXTURE_DIR }}/model.onnx*
+          retention-days: 1
+
+  smoke-windows-speaker-embedding:
+    name: Smoke test Windows binary (speaker_embedding / Issue #426)
+    needs: [build-shared, build-fixture]
+    if: github.event_name != 'pull_request'
+    runs-on: windows-2022
+    timeout-minutes: 15
+    steps:
+      - name: Download windows-x64 release artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: piper-plus-shared-windows-x64
+          path: release-artifact
+      - name: Download fixture
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: mb-istft-speaker-embedding-fixture
+          path: fixture
+      - name: Extract release archive and locate piper.exe
+        shell: pwsh
+        run: |
+          $zip = Get-ChildItem release-artifact -Filter *.zip | Select-Object -First 1
+          if (-not $zip) { Write-Error "windows-x64 .zip artifact not found"; exit 1 }
+          # bsdtar (Windows `tar`) reads the POSIX-path zip the build job produced.
+          tar -xf $zip.FullName -C release-artifact
+          $exe = Get-ChildItem release-artifact -Recurse -Filter piper.exe | Select-Object -First 1
+          if (-not $exe) { Write-Error "piper.exe not found in released artifact"; exit 1 }
+          Write-Output "piper.exe: $($exe.FullName)"
+          "PIPER_EXE=$($exe.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append
+      - name: Smoke synthesize a speaker_embedding model
+        shell: pwsh
+        run: |
+          # The fixture model DECLARES speaker_embedding / speaker_embedding_mask.
+          # A binary missing the Issue #426 fix fails here with ORT "Required
+          # inputs ... are missing" and produces no WAV. The synthesized audio
+          # quality is irrelevant — reaching session.run successfully is the
+          # signal that the runtime fed the inputs.
+          $wav = "smoke.wav"
+          "speaker embedding smoke test" | & "$env:PIPER_EXE" --model fixture/model.onnx --output_file $wav
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "piper.exe exited $LASTEXITCODE — likely missing the speaker_embedding feed (Issue #426 regression)"
+            exit 1
+          }
+          if (-not (Test-Path $wav)) { Write-Error "no WAV produced"; exit 1 }
+          $len = (Get-Item $wav).Length
+          $hdr = [System.Text.Encoding]::ASCII.GetString([System.IO.File]::ReadAllBytes($wav)[0..3])
+          if ($len -lt 100 -or $hdr -ne "RIFF") {
+            Write-Error "WAV invalid (len=$len, header=$hdr)"
+            exit 1
+          }
+          Write-Output "OK: released piper.exe synthesized a $len-byte RIFF WAV from a speaker_embedding model"
 
   build-ios:
     name: Build iOS ${{ matrix.slice }}
@@ -973,7 +1066,7 @@ jobs:
 
   release:
     name: Create Release
-    needs: [build-shared, build-ios, build-android, assemble-xcframework, assemble-g2p-xcframework]
+    needs: [build-shared, build-ios, build-android, assemble-xcframework, assemble-g2p-xcframework, smoke-windows-speaker-embedding]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
     # GitHub Release creation requires `contents: write`. Scoped to this job

--- a/.github/workflows/windows-cpp-e2e.yml
+++ b/.github/workflows/windows-cpp-e2e.yml
@@ -1,0 +1,113 @@
+name: "Windows C++ E2E (real tsukuyomi model)"
+
+# End-to-end gate that exercises the exact path that let bugs ①②③ ship to
+# Windows users: build the C++ piper.exe, `--download-model tsukuyomi` the real
+# distributed 6lang model, and synthesize Japanese text to a WAV. No existing
+# CI runs the *real* distributed model through the C++ runtime on Windows —
+# fixtures and pre-staged models hid all three regressions.
+#
+#   ③ download   : `--download-model` must succeed (PowerShell env-var fix).
+#   ②  config    : the distributed config.json is PUA-normalized in-flight
+#                  (workaround until the corrected config is re-pushed to HF;
+#                   the pua-consistency `distributed-config-validator` job is
+#                   the gate that the HF artifact gets fixed and stays fixed).
+#   ① embedding  : synthesis must feed speaker_embedding / speaker_embedding_mask
+#                  for the MB-iSTFT model and produce a non-empty RIFF WAV.
+#
+# Heavy (full C++ build + ~40 MB HF download), so scheduled weekly + manual
+# dispatch only — never on PR.
+
+on:
+  schedule:
+    - cron: '0 7 * * 1'  # weekly, Monday 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-real-model-e2e:
+    name: tsukuyomi 6lang -> WAV on Windows C++ piper.exe
+    runs-on: windows-2022
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: Configure CMake
+        shell: pwsh
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA=OFF -DBUILD_TESTS=OFF
+
+      - name: Build (full build stages the OpenJTalk dictionary under build/share)
+        shell: pwsh
+        run: cmake --build build --config Release -j $env:NUMBER_OF_PROCESSORS
+
+      - name: Locate piper.exe
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem build -Recurse -Filter piper.exe | Select-Object -First 1
+          if (-not $exe) { Write-Error "piper.exe was not built"; exit 1 }
+          Write-Output "piper.exe: $($exe.FullName)"
+          & $exe.FullName --version
+          "PIPER_EXE=$($exe.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Download real model (--download-model exercises the PowerShell fix, ③)
+        shell: pwsh
+        run: |
+          & "$env:PIPER_EXE" --download-model tsukuyomi --model-dir models
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "--download-model failed (PowerShell download regression?)"
+            exit 1
+          }
+          Get-ChildItem models
+
+      - name: Normalize distributed config to PUA (②, until HF is re-pushed)
+        # The HF config still carries raw multi-codepoint keys (ɔɪ/œ̃/ɐ̃) that
+        # the C++ parser rejects. PUA-encode it so the e2e can run; idempotent,
+        # so this is a no-op once the corrected config lands on HF.
+        shell: pwsh
+        run: |
+          $cfg = Get-ChildItem models -Recurse -Filter *.json | ForEach-Object { $_.FullName }
+          python scripts/fix_config_pua.py @cfg
+          if ($LASTEXITCODE -ne 0) { Write-Error "config PUA fix reported an unmappable key"; exit 1 }
+
+      - name: Synthesize Japanese text -> WAV (speaker_embedding feed, ①)
+        shell: pwsh
+        run: |
+          $model = Get-ChildItem models -Recurse -Filter *.onnx |
+            Where-Object { $_.Name -notlike '*.opt.onnx' } | Select-Object -First 1
+          if (-not $model) { Write-Error "downloaded .onnx not found"; exit 1 }
+          [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+          $OutputEncoding = [System.Text.Encoding]::UTF8
+          "こんにちは、これはエンドツーエンドのテストです。" |
+            & "$env:PIPER_EXE" --model $model.FullName --output_file out.wav
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "synthesis failed (speaker_embedding feed regression?)"
+            exit 1
+          }
+          if (-not (Test-Path out.wav)) { Write-Error "no WAV produced"; exit 1 }
+          $len = (Get-Item out.wav).Length
+          $hdr = [System.Text.Encoding]::ASCII.GetString([System.IO.File]::ReadAllBytes('out.wav')[0..3])
+          if ($len -lt 1000 -or $hdr -ne 'RIFF') {
+            Write-Error "invalid WAV (len=$len, header=$hdr)"
+            exit 1
+          }
+          Write-Output "OK: tsukuyomi 6lang -> $len-byte RIFF WAV via Windows C++ piper.exe"
+
+      - name: Upload synthesized WAV (diagnostic)
+        if: always()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: e2e-tsukuyomi-windows-wav
+          path: out.wav
+          if-no-files-found: ignore
+          retention-days: 7

--- a/scripts/fix_config_pua.py
+++ b/scripts/fix_config_pua.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""PUA-encode multi-codepoint phoneme_id_map keys in a model config.json.
+
+Lightweight, dependency-free companion to
+``piper_train.update_model_config`` / ``scripts/regenerate_tsukuyomi_config.py``:
+it reads the canonical PUA table from
+``src/python/g2p/piper_plus_g2p/data/pua.json`` and rewrites any raw
+multi-codepoint phoneme_id_map key (e.g. ɔɪ / œ̃ / ɐ̃) to its single PUA
+codepoint, in place. Idempotent — a config that is already all single-codepoint
+is left untouched.
+
+Why this exists: the v1.12.0 export leaked those three IPA tokens as raw
+multi-codepoint keys into the distributed configs, which the C++ runtime
+rejects (``"…" is not a single codepoint`` → Windows inference crash).
+``regenerate_tsukuyomi_config.py`` fixes it but pulls in the g2p package (and
+pyopenjtalk); this script needs only the stdlib, so it runs in minimal CI / e2e
+environments and serves as a quick local fix for users who already downloaded a
+stale config.
+
+Usage::
+
+    python scripts/fix_config_pua.py CONFIG [CONFIG ...]
+
+Exit code: 0 = fixed or already clean; 2 = an unmappable multi-codepoint key
+remained (a real PUA-table gap that must be investigated, not silently passed).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PUA_JSON = REPO_ROOT / "src" / "python" / "g2p" / "piper_plus_g2p" / "data" / "pua.json"
+
+
+def load_pua_mapping() -> dict[str, int]:
+    data = json.loads(PUA_JSON.read_text(encoding="utf-8"))
+    return {entry["token"]: int(entry["codepoint"], 16) for entry in data["entries"]}
+
+
+def _cps(s: str) -> str:
+    return "+".join(f"U+{ord(c):04X}" for c in s)
+
+
+def fix_config(path: Path, tok2cp: dict[str, int]) -> int:
+    cfg = json.loads(path.read_text(encoding="utf-8"))
+    id_map = cfg.get("phoneme_id_map")
+    if not isinstance(id_map, dict):
+        print(f"{path}: no phoneme_id_map - skipping")
+        return 0
+
+    new_map: dict[str, object] = {}
+    fixed: list[str] = []
+    unmapped: list[str] = []
+    for key, ids in id_map.items():
+        if len(key) > 1:
+            cp = tok2cp.get(key)
+            if cp is None:
+                unmapped.append(_cps(key))
+                new_map[key] = ids
+            else:
+                new_map[chr(cp)] = ids
+                fixed.append(f"{_cps(key)}->U+{cp:04X}")
+        else:
+            new_map[key] = ids
+
+    if unmapped:
+        print(
+            f"{path}: ERROR - unmappable multi-codepoint key(s): {unmapped}. "
+            "These are not in pua.json; investigate the PUA table.",
+            file=sys.stderr,
+        )
+        return 2
+    if not fixed:
+        print(f"{path}: already single-codepoint ({len(new_map)} keys) - no change")
+        return 0
+
+    cfg["phoneme_id_map"] = new_map
+    path.write_text(json.dumps(cfg, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"{path}: PUA-encoded {len(fixed)} key(s): {fixed}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(__doc__)
+        return 1
+    tok2cp = load_pua_mapping()
+    rc = 0
+    for arg in argv:
+        p = Path(arg)
+        if not p.is_file():
+            print(f"{p}: not found - skipping")
+            continue
+        rc = max(rc, fix_config(p, tok2cp))
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/cpp/model_manager.cpp
+++ b/src/cpp/model_manager.cpp
@@ -267,16 +267,26 @@ static bool downloadFile(const std::string& url,
     spdlog::info("Downloading {} ...", url);
 
 #ifdef _WIN32
-    // Pass URL / OutFile as separate parameters to PowerShell rather than
-    // embedding them in the -Command string — Invoke-WebRequest binds them
-    // to its named parameters without re-parsing.
-    const std::string ps_script =
-        std::string("Invoke-WebRequest -Uri $args[0] -OutFile $args[1]");
+    // PowerShell's -Command does NOT bind trailing positional arguments to
+    // $args (only -File does). The previous "-Uri $args[0] -OutFile $args[1]"
+    // form therefore left both empty, and Invoke-WebRequest failed with
+    // "Cannot validate argument on parameter 'Uri'. The argument is null or
+    // empty." — breaking --download-model on Windows entirely.
+    //
+    // Pass URL / OutFile via environment variables instead: the _spawnvp child
+    // inherits the parent environment, and env values are never re-parsed as
+    // code (injection-safe, so no shell-quoting concerns). The variables are
+    // cleared immediately after the spawn returns.
+    _putenv_s("PIPER_DL_URI", url.c_str());
+    _putenv_s("PIPER_DL_OUT", outStr.c_str());
     const char* argv[] = {
-        "powershell", "-NoProfile", "-Command", ps_script.c_str(),
-        url.c_str(), outStr.c_str(), nullptr,
+        "powershell", "-NoProfile", "-Command",
+        "Invoke-WebRequest -Uri $env:PIPER_DL_URI -OutFile $env:PIPER_DL_OUT",
+        nullptr,
     };
     int rc = piper_run_argv(argv);
+    _putenv_s("PIPER_DL_URI", "");
+    _putenv_s("PIPER_DL_OUT", "");
     return rc == 0;
 #else
     // Prefer curl, fall back to wget. Look up the binary on PATH locations

--- a/src/cpp/openjtalk_dictionary_manager.c
+++ b/src/cpp/openjtalk_dictionary_manager.c
@@ -40,15 +40,18 @@ static int verify_checksum(const char* file_path, const char* expected_sha256) {
     fprintf(stderr, "Verifying checksum...\n");
 
 #ifdef _WIN32
-    // PowerShell Get-FileHash. -Path is a parameter — the file path is
-    // passed via positional argument, not interpolated into a command
-    // string, so cmd.exe never sees it.
+    // PowerShell -Command does NOT bind trailing positional arguments to
+    // $args (only -File does), so the previous "-Path $args[0]" form left the
+    // path empty. Pass it via an environment variable instead: it is inherited
+    // by the child process and never re-parsed as code (injection-safe).
+    _putenv_s("PIPER_HASH_PATH", file_path);
     const char* const argv[] = {
         "powershell", "-NoProfile", "-Command",
-        "(Get-FileHash -Path $args[0] -Algorithm SHA256).Hash",
-        file_path, NULL,
+        "(Get-FileHash -Path $env:PIPER_HASH_PATH -Algorithm SHA256).Hash",
+        NULL,
     };
     spawn_rc = piper_capture_argv(argv, result, sizeof(result), &bytes_read);
+    _putenv_s("PIPER_HASH_PATH", "");
 #else
     // Probe for sha256sum / shasum at fixed paths (skip `which`, which
     // would re-introduce a shell sink that CodeQL flags).
@@ -360,12 +363,20 @@ static int download_and_extract_dictionary() {
 
 #ifdef _WIN32
     {
+        // PowerShell -Command does not bind positional args to $args; pass the
+        // URL / OutFile via environment variables (inherited by the child, not
+        // re-parsed as code) instead. See model_manager.cpp downloadFile() for
+        // the full rationale.
+        _putenv_s("PIPER_DL_URI", DICTIONARY_URL);
+        _putenv_s("PIPER_DL_OUT", archive_path);
         const char* const argv[] = {
             "powershell", "-NoProfile", "-Command",
-            "Invoke-WebRequest -Uri $args[0] -OutFile $args[1]",
-            DICTIONARY_URL, archive_path, NULL,
+            "Invoke-WebRequest -Uri $env:PIPER_DL_URI -OutFile $env:PIPER_DL_OUT",
+            NULL,
         };
         download_rc = piper_run_argv(argv);
+        _putenv_s("PIPER_DL_URI", "");
+        _putenv_s("PIPER_DL_OUT", "");
     }
 #else
     // Probe for curl / wget at fixed paths (avoids shell-based `which`).

--- a/src/cpp/tests/CMakeLists.txt
+++ b/src/cpp/tests/CMakeLists.txt
@@ -92,6 +92,10 @@ endif()
 # runtime when the fixture has not been generated.
 if(TARGET piper_common)
     list(APPEND TEST_SOURCES test_speaker_embedding_inference.cpp)
+    # v1.12.0 multi-codepoint phoneme leak (ɔɪ/œ̃/ɐ̃) regression guard. Uses
+    # `piper.hpp` + exercises parsePhonemizeConfig() / isSingleCodepoint() from
+    # piper.cpp, so it links the full library like test_speaker_embedding_inference.
+    list(APPEND TEST_SOURCES test_phonemize_config.cpp)
 endif()
 
 # Create test executables
@@ -322,6 +326,7 @@ foreach(test_source ${TEST_SOURCES})
     # links the full library to call loadVoice / phonemesToAudio against the
     # in-tree fixture model.
     if(${test_name} STREQUAL "test_speaker_embedding_inference" OR
+        ${test_name} STREQUAL "test_phonemize_config" OR
         ${test_name} STREQUAL "test_streaming")
         target_sources(${test_name} PRIVATE
             ../piper.cpp

--- a/src/cpp/tests/test_phonemize_config.cpp
+++ b/src/cpp/tests/test_phonemize_config.cpp
@@ -1,0 +1,101 @@
+// Regression guard for the v1.12.0 multi-codepoint phoneme leak (ɔɪ / œ̃ / ɐ̃).
+//
+// The HuggingFace-distributed tsukuyomi config.json carried these IPA tokens
+// as RAW multi-codepoint keys in phoneme_id_map instead of PUA-encoded single
+// codepoints. parsePhonemizeConfig() requires every key to be a single
+// codepoint (isSingleCodepoint), so loading that config threw / crashed the
+// C++ runtime on Windows. The canonical fix is to PUA-encode the keys (e.g.
+// œ̃ -> U+E063) before distribution; these tests pin both halves of the
+// contract so a future stale config or parser change is caught in CI.
+//
+//   ɔɪ = U+0254 U+026A  -> PUA U+E062
+//   œ̃  = U+0153 U+0303  -> PUA U+E063
+//   ɐ̃  = U+0250 U+0303  -> PUA U+E064
+// (PUA codepoints are the canonical values from
+//  src/python/g2p/piper_plus_g2p/data/pua.json.)
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+#include "../piper.hpp"
+#include "json.hpp"
+
+using json = nlohmann::json;
+
+namespace piper {
+// Free function defined in piper.cpp (intentionally not declared in piper.hpp).
+// Declared here so the test can exercise the config parser directly.
+void parsePhonemizeConfig(json &configRoot, PhonemizeConfig &phonemizeConfig);
+}  // namespace piper
+
+namespace {
+
+// UTF-8 encodings of the three IPA tokens that leaked as raw multi-codepoint
+// keys, plus their canonical PUA single-codepoint encodings.
+const std::string kOI = "\xC9\x94\xCA\xAA";       // ɔɪ  (U+0254 U+026A)
+const std::string kOEtilde = "\xC5\x93\xCC\x83";  // œ̃   (U+0153 U+0303)
+const std::string kAtilde = "\xC9\x90\xCC\x83";   // ɐ̃   (U+0250 U+0303)
+const std::string kPuaOI = "\xEE\x81\xA2";        // U+E062
+const std::string kPuaOEtilde = "\xEE\x81\xA3";   // U+E063
+const std::string kPuaAtilde = "\xEE\x81\xA4";    // U+E064
+
+}  // namespace
+
+// --- isSingleCodepoint predicate (the gate at piper.cpp's phoneme_id_map loop)
+
+TEST(PhonemizeConfigParse, RawMultiCodepointTokensAreNotSingleCodepoint) {
+    EXPECT_FALSE(piper::isSingleCodepoint(kOI));
+    EXPECT_FALSE(piper::isSingleCodepoint(kOEtilde));
+    EXPECT_FALSE(piper::isSingleCodepoint(kAtilde));
+}
+
+TEST(PhonemizeConfigParse, PuaEncodedTokensAreSingleCodepoint) {
+    EXPECT_TRUE(piper::isSingleCodepoint(kPuaOI));
+    EXPECT_TRUE(piper::isSingleCodepoint(kPuaOEtilde));
+    EXPECT_TRUE(piper::isSingleCodepoint(kPuaAtilde));
+}
+
+// --- parsePhonemizeConfig end-to-end behavior
+
+TEST(PhonemizeConfigParse, RawMultiCodepointKeyIsRejected) {
+    // Mirrors the broken v1.12.0 tsukuyomi config: a raw multi-codepoint IPA
+    // key in phoneme_id_map. The parser must reject it (throw) rather than
+    // silently mis-map it — this is exactly the failure Windows users hit.
+    json cfg = {
+        {"phoneme_type", "multilingual"},
+        {"phoneme_id_map",
+         {
+             {"_", {0}},
+             {"a", {10}},
+             {kOEtilde, {149}},  // œ̃ as raw multi-codepoint -> must throw
+         }},
+    };
+    piper::PhonemizeConfig pc;
+    EXPECT_THROW(piper::parsePhonemizeConfig(cfg, pc), std::runtime_error);
+}
+
+TEST(PhonemizeConfigParse, PuaEncodedConfigParsesAndMaps) {
+    // The corrected (PUA-encoded) form must parse cleanly and map each PUA
+    // codepoint to its id.
+    json cfg = {
+        {"phoneme_type", "multilingual"},
+        {"phoneme_id_map",
+         {
+             {"_", {0}},
+             {"a", {10}},
+             {kPuaOI, {94}},        // ɔɪ -> U+E062
+             {kPuaOEtilde, {149}},  // œ̃  -> U+E063
+             {kPuaAtilde, {153}},   // ɐ̃  -> U+E064
+         }},
+    };
+    piper::PhonemizeConfig pc;
+    ASSERT_NO_THROW(piper::parsePhonemizeConfig(cfg, pc));
+
+    auto it = pc.phonemeIdMap.find(static_cast<piper::Phoneme>(0xE063));
+    ASSERT_NE(it, pc.phonemeIdMap.end())
+        << "PUA codepoint U+E063 (œ̃) must be present in the id map";
+    ASSERT_FALSE(it->second.empty());
+    EXPECT_EQ(it->second[0], 149);
+}

--- a/src/cpp/tests/test_piper_proc_exec.cpp
+++ b/src/cpp/tests/test_piper_proc_exec.cpp
@@ -191,6 +191,66 @@ TEST(PiperProcExec, CaptureArgvNonexistentBinaryReturnsError) {
     EXPECT_LE(n, sizeof(buf));
 }
 
+#if defined(_WIN32)
+// Windows-only regression guard for the --download-model PowerShell bug.
+//
+// model_manager.cpp / openjtalk_dictionary_manager.c previously built
+// `powershell -NoProfile -Command "Invoke-WebRequest -Uri $args[0] ..."` and
+// passed the URL / OutFile as trailing positional argv elements. PowerShell's
+// -Command (unlike -File) does NOT bind positional arguments to $args, so
+// $args[0] was empty and Invoke-WebRequest failed with "argument is null or
+// empty", breaking model + dictionary downloads on Windows entirely.
+//
+// The fix passes those values via environment variables referenced as
+// $env:VAR. These two tests pin both halves of that fact so the regression
+// cannot silently return.
+//
+// Both use piper_run_argv (which spawns via _spawnvp directly) and assert on
+// the child *exit code*, NOT captured stdout: piper_capture_argv routes
+// through `cmd.exe /c` with per-arg quoting, whose outer-quote-stripping
+// mangles a multi-arg `powershell` command line. The real download path also
+// uses piper_run_argv, so this matches production.
+
+TEST(PiperProcExec, PowerShellCommandDoesNotBindPositionalArgsToDollarArgs) {
+    if (!piper_proc_exec_supported()) {
+        GTEST_SKIP();
+    }
+    // OLD (broken) pattern: the token is passed positionally. Under -Command
+    // $args[0] is NOT bound, so the comparison fails and the script exits 7.
+    const char* argv[] = {
+        "powershell", "-NoProfile", "-Command",
+        "if ($args[0] -eq 'PIPER_TOK') { exit 0 } else { exit 7 }",
+        "PIPER_TOK", nullptr,
+    };
+    int rc = piper_run_argv(argv);
+    EXPECT_NE(rc, 0)
+        << "PowerShell -Command must NOT bind positional args to $args (root "
+           "cause of the old --download-model failure); the $args[0] match "
+           "unexpectedly succeeded (rc=0).";
+}
+
+TEST(PiperProcExec, PowerShellEnvVarBindingDeliversValue) {
+    if (!piper_proc_exec_supported()) {
+        GTEST_SKIP();
+    }
+    // NEW (fixed) pattern: deliver the value via an environment variable and
+    // reference it as $env:VAR. The _spawnvp child inherits the parent
+    // environment, so the comparison succeeds and the script exits 0.
+    _putenv_s("PIPER_PROC_EXEC_TEST_VAL", "PIPER_TOK");
+    const char* argv[] = {
+        "powershell", "-NoProfile", "-Command",
+        "if ($env:PIPER_PROC_EXEC_TEST_VAL -eq 'PIPER_TOK') "
+        "{ exit 0 } else { exit 7 }",
+        nullptr,
+    };
+    int rc = piper_run_argv(argv);
+    _putenv_s("PIPER_PROC_EXEC_TEST_VAL", "");  // clear
+    EXPECT_EQ(rc, 0)
+        << "PowerShell must resolve $env:VAR from the inherited environment "
+           "(how the fixed download path passes URL/OutFile); rc=" << rc;
+}
+#endif
+
 #if !defined(_WIN32)
 // POSIX-only: shell metacharacters in argv must NOT be interpreted by a
 // shell — the whole point of argv-based exec. Pass a string with `;` and


### PR DESCRIPTION
## Summary

Windows で C++ `piper.exe` から `--download-model tsukuyomi` の 6lang モデルを動かすと、3 つの独立したバグが重なって音声生成に失敗する（0 byte WAV / `0xC0000409` crash）。本 PR はそのうちランタイム側のコードバグを修正し、3 バグすべてに再発防止のテスト/CI ゲートを追加する。3 バグは「実配布モデルを C++ ランタイムで（特に Windows で）text→WAV まで通す e2e テストが CI に存在しない」という共通の死角をすり抜けていた。

- **③ `--download-model` が Windows で機能不全（本 PR で修正）**: `powershell -Command "...-Uri $args[0]..."` は `-Command` が末尾位置引数を `$args` に束縛しないため URL/出力先が空になり失敗。model DL / 辞書 DL / 辞書ハッシュの 3 箇所を環境変数方式（`$env:VAR`）に修正。
- **② 配布 config の PUA 化漏れ（v1.12.0 リグレッション）**: 配布 config.json の `phoneme_id_map` に多コードポイント IPA 音素 `ɔɪ`/`œ̃`/`ɐ̃` が生のまま残り、C++ パーサが拒否して crash。C++ パーステストと配布 config 検証 CI ゲートを追加（HF artifact の再 push 自体は別途必要）。
- **① `speaker_embedding_mask` Missing Input（PR #443 で修正済み）**: 修正入りの公式 Windows バイナリが未リリースだった死角を埋めるため、release smoke と実モデル e2e を追加。

## Affected Components

- [x] C++ (`src/cpp/`)
- [x] CI/CD (`.github/workflows/`)
- [ ] Python (`src/python/`, `src/python_run/`)
- [ ] Rust (`src/rust/`)
- [ ] C# (`src/csharp/`)
- [ ] Go (`src/go/`)
- [ ] WASM/npm (`src/wasm/`)
- [ ] Documentation

## Type

- [x] Bug fix
- [x] CI/CD
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependencies

## Risk Level

- [x] patch (bug 修正 / 内部変更、 後方互換)
- [ ] minor (新機能、 非破壊)
- [ ] major (破壊的変更)

## Contract Impact

- [x] None

`docs/spec/*.toml` への変更なし。`inference-input-contract.toml` の既存定義（speaker_embedding mask 等）に準拠した実装・テスト追加のみ。

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| ③ Windows download 修正 | `model_manager.cpp` / `openjtalk_dictionary_manager.c` の 3 箇所で PowerShell の URL/出力先/ハッシュ対象パスを `$env:VAR` 経由に変更 | Windows で `--download-model` と辞書 DL/ハッシュ検証が "argument is null or empty" で失敗し続ける |
| ③ 回帰テスト | `test_piper_proc_exec.cpp` に Windows 限定 2 テスト: `-Command` が `$args` に束縛しないこと / `$env:` が値を届けることを実 PowerShell で pin | PowerShell の挙動誤解が再混入しても気付けない |
| ② C++ パーステスト | `test_phonemize_config.cpp`: 生多コードポイントキーを拒否、PUA エンコード済みキーを受理することを `parsePhonemizeConfig` で検証 | C++ パーサが壊れた config を黙って受理 or 正しい config を拒否する回帰を検知できない |
| ② 配布 config 検証ゲート | `pua-consistency.yml` に weekly + dispatch ジョブを追加し、HF 配布 config の `phoneme_id_map` が全て単一コードポイントか検証 | 再 export で多コードポイントキーが配布物に再混入しても誰も気付かない |
| ② config PUA 修正ツール | `scripts/fix_config_pua.py`: stdlib のみ・冪等で config を PUA 正規化（`pua.json` 参照） | stale config を引いたユーザー/CI が重い依存なしに即修正する手段がない |
| ① release smoke | `release-shared-lib.yml` に build-fixture + Windows smoke ジョブを追加し、実 release artifact の piper.exe で speaker_embedding モデルを合成検証。`release` の `needs` に接続 | ①修正前のバイナリ（v1.12.0 のような）を再びリリースしても gate がない |
| ① / ②③ e2e | `windows-cpp-e2e.yml`: weekly + dispatch で実 tsukuyomi を build→`--download-model`→config 正規化→JA 合成まで通す | 実配布モデル × C++ × Windows の交差点が無テストのまま（3 バグの共通死角） |

## 設計判断

- **③ は env 変数方式を採用**: `-Command` で位置引数を渡す当初実装は誤り。`-File` への切替や `-ArgumentList` も検討したが、既存の argv ベース exec（CodeQL の shell-injection 回避）を維持しつつ最小変更で済む `$env:VAR` 参照を選択。env 値はコードとして再パースされないため注入安全。spawn 後に即クリア。
- **② はランタイム自己修復を採らず config 修正で対応**: C++ に PUA 全表を焼き込めば config 無修正でも動かせるが、設計上 config は PUA エンコード済みが正であり、phonemizer 出力（PUA）と config キーの一致が動作の前提。よって正規の修正は配布 config の再生成＋再 push（リポジトリ側はその検証ゲートとローカル修正ツールを提供）。
- **配布 config 検証は weekly/dispatch 限定**: 壊れた artifact は HF 上にあり PR 時点のリポジトリからは見えない。毎 PR で HF を叩くと egress とフレークが増えるため、定期実行＋手動 dispatch（リリース前検証用）に限定。
- **e2e/smoke は非 PR 限定**: フル C++ ビルド + 約 40MB DL は重い。release-shared-lib は元々 PR で Windows をスキップするため、smoke も非 PR。e2e は weekly + dispatch。PR では既存の Linux/macOS ビルド smoke が早期検知を担う。
- **e2e の config 正規化は冪等な暫定措置**: 配布 config が HF で修正されれば `fix_config_pua.py` は no-op になり、`distributed-config-validator` ゲートが修正の維持を保証する。

## Test Plan

- [ ] `cmake -B build -G "Visual Studio 18 2026" -A x64 -DBUILD_TESTS=ON`（VS2026 環境）でビルドできる
- [ ] `ctest --test-dir build -R test_piper_proc_exec` が green（`PowerShell*` 2 テスト含む、Windows）
- [ ] `ctest --test-dir build -R test_phonemize_config` が green（4 テスト: 多コードポイント拒否 / PUA 受理）
- [ ] `python scripts/fix_config_pua.py <stale-config.json>` が 3 キー（ɔɪ/œ̃/ɐ̃）を U+E062/E063/E064 に修正し、再実行で no-op（冪等）
- [ ] `windows-cpp-e2e.yml` を `workflow_dispatch` で実行 → tsukuyomi の build→download→合成が green、RIFF WAV を artifact で確認
- [ ] `pua-consistency.yml` を `workflow_dispatch` で実行 → `distributed-config-validator` が現状の HF 配布 config の多コードポイントキーを検知して fail する（修正の forcing function として機能することを確認）
- [ ] 既存の `test_model_manager` / `test_download_utils` が引き続き green（`model_manager.cpp` 変更の非回帰）

## Checklist

- [x] Tests pass locally（`test_piper_proc_exec` / `test_phonemize_config` を Windows 実機で確認、`fix_config_pua.py` の fix/冪等/欠損を確認）
- [x] No GPL/LGPL deps added
- [ ] Documentation updated（コード/テスト/CI のみ。ユーザー向け手順は別途検討）

## Related Issues

Related: #385, #426（speaker_embedding/MB-iSTFT 推論の入力欠落。本 PR は同領域の Windows C++ ランタイム + 配布 config の積み残しを塞ぐ follow-up）
