### PR TITLE
chore(security): ignore pyo3 advisories blocked by rust-numpy

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -12,6 +12,9 @@ on:
       - "src/rust/**/Cargo.toml"
       - "src/rust/**/Cargo.lock"
       - "src/rust/Cargo.lock"
+      # cargo-audit の ignore リスト変更を PR 時に再監査する
+      # (.cargo/audit.toml を編集したら cargo-audit ジョブを走らせる)。
+      - "src/rust/**/audit.toml"
       - "src/wasm/**/package.json"
       - "src/wasm/**/package-lock.json"
       - "src/csharp/**/*.csproj"

--- a/src/rust/.cargo/audit.toml
+++ b/src/rust/.cargo/audit.toml
@@ -1,0 +1,23 @@
+# cargo-audit configuration for the piper-plus Rust workspace.
+#
+# `ignore` lists RUSTSEC advisories we have consciously accepted as
+# non-actionable for now. Each entry MUST document why it is safe and when it
+# can be removed. The Security Audit CI job (`.github/workflows/security-audit.yml`)
+# runs `cargo audit` from this directory, so this file gates that check.
+
+[advisories]
+ignore = [
+    # pyo3 0.24.2 — out-of-bounds read in PyList/PyTuple iterator nth/nth_back.
+    # pyo3 0.24.2 — missing Sync bound on PyCFunction::new_closure.
+    #
+    # Both are fixed only in pyo3 >= 0.29.0, but the `numpy` crate (rust-numpy)
+    # — including its main branch — still requires pyo3 ^0.28, so bumping pyo3
+    # to 0.29 is impossible without dropping the numpy dependency. Neither
+    # vulnerable API is reached by our binding (src/rust/piper-python): it does
+    # not call nth/nth_back on PyList/PyTuple iterators, nor PyCFunction::new_closure.
+    #
+    # REMOVE these two entries (and bump pyo3 -> 0.29 + numpy -> the matching
+    # release) once rust-numpy ships a pyo3 0.29-compatible version.
+    "RUSTSEC-2026-0176",
+    "RUSTSEC-2026-0177",
+]


### PR DESCRIPTION
## Summary

dev の `Security Audit` (cargo-audit) が pyo3 0.24.2 の 2 件の advisory で red のまま（#557 マージ前から、全 PR が影響）。クリーンな修正は pyo3 0.29 への bump だが、`numpy` クレート（rust-numpy）が released 版・main ブランチともに pyo3 `^0.28` を要求しており、numpy を使う限り pyo3 0.29 と共存できない。両 advisory の脆弱パスは当バインディングで未使用のため、`.cargo/audit.toml` で明示的に ignore して暫定対応する（rust-numpy が pyo3 0.29 対応版を出したら ignore 解除 + bump）。

- **RUSTSEC-2026-0176**: PyList/PyTuple iterator の `nth`/`nth_back` で out-of-bounds read。
- **RUSTSEC-2026-0177**: `PyCFunction::new_closure` の Sync 境界不足。
- どちらも `src/rust/piper-python` は呼び出していない（nth/nth_back・new_closure 未使用）。

## Affected Components

- [x] CI/CD (`.github/workflows/security-audit.yml` が読む `.cargo/audit.toml`)
- [ ] Python (`src/python/`, `src/python_run/`)
- [ ] Rust (`src/rust/` のコード変更なし)
- [ ] C# (`src/csharp/`)
- [ ] C++ (`src/cpp/`)
- [ ] Go (`src/go/`)
- [ ] WASM/npm (`src/wasm/`)
- [ ] Documentation

## Type

- [x] CI/CD
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependencies

## Risk Level

- [x] patch (audit 設定のみ、 コード変更なし、 documented risk acceptance)
- [ ] minor (新機能、 非破壊)
- [ ] major (破壊的変更)

## Contract Impact

- [x] None

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| cargo-audit ignore | `src/rust/.cargo/audit.toml` で RUSTSEC-2026-0176/0177 を理由付きで ignore | dev の Security Audit が pyo3 advisory で red のまま（全 PR が影響、ecosystem 都合で bump 不可） |
| audit path filter | security-audit.yml の PR trigger に `src/rust/**/audit.toml` を追加 | ignore リスト変更が PR 時に cargo-audit で再監査されない（dev に入るまで検証されない） |

## 設計判断

- **bump ではなく ignore を選択した理由**: 修正版 pyo3 0.29 は rust-numpy が（main でも）未対応で、numpy を使う限り物理的に共存不可。0.28 への bump では advisory は解消しない（修正は 0.29 のみ）。両脆弱パスは当バインディング未使用のため、リスク受容が妥当。
- **ignore の場所**: `.cargo/audit.toml` に集約し、local `cargo audit` と CI（`src/rust` で実行）で同一挙動。各 entry に「なぜ安全か」「いつ外すか（rust-numpy が pyo3 0.29 対応版を出したら）」をコメントで明記。
- **代替案（numpy 依存除去 + 0.29 bump）を採らない理由**: `audio_int16`/`audio_float32` が返す numpy 配列は Python 利用側の API。除去は破壊的変更で影響大。ecosystem が追いつくまでの暫定 ignore が低リスク・可逆。

## Test Plan

- [ ] `cd src/rust && cargo audit` が exit 0（pyo3 2 件が ignored、bincode/encoding の unmaintained warning は従来どおり pass）
- [ ] dev CI の `Security Audit / cargo-audit (Rust)` が green になる
- [ ] `cargo metadata` / 通常ビルドに影響しない（audit.toml は cargo-audit 専用）

## Checklist

- [x] Tests pass locally（`cargo audit` exit 0 をローカル確認）
- [x] No GPL/LGPL deps added
- [ ] Documentation updated（audit.toml 内コメントに removal trigger を記載）

## Related Issues

pyo3 advisory は #557 と無関係の pre-existing 問題。rust-numpy の pyo3 0.29 対応リリース後に ignore 解除 + bump で恒久対応予定。
