### PR TITLE
ci(release): make iOS xcframework build byte-reproducible

### DIFF
--- a/.github/workflows/release-shared-lib.yml
+++ b/.github/workflows/release-shared-lib.yml
@@ -383,6 +383,14 @@ jobs:
             -DONNXRUNTIME_INCLUDE_DIR="${ORT_IOS_DIR}/include"
 
       - name: Build (iOS slice)
+        # ZERO_AR_DATE=1 makes Apple's `xcrun libtool -static` (the PiperPlusShared.cmake
+        # POST_BUILD merge, cmake/PiperPlusShared.cmake) zero the archive member mtimes
+        # and the global symbol-table timestamp, so libpiper_plus.a is byte-reproducible
+        # across runs of the same source. Required so the Package.swift binaryTarget
+        # checksum computed from a workflow_dispatch build still matches the tag-run
+        # rebuild (release job Gate 2 fails on any mismatch).
+        env:
+          ZERO_AR_DATE: "1"
         run: cmake --build build-ios --config Release -j$(sysctl -n hw.ncpu)
 
       - name: Verify slice arch
@@ -627,9 +635,17 @@ jobs:
       - name: Zip xcframework
         run: |
           set -euo pipefail
-          # zip -ry preserves symlinks (Apple frameworks rely on them in some
-          # configurations; harmless overhead for static-archive xcframeworks).
-          zip -ry libpiper_plus-ios.xcframework.zip piper_plus.xcframework
+          # Reproducible zip — the Package.swift binaryTarget checksum must survive the
+          # dispatch-build -> tag-build rebuild (the release job's Gate 2 compares the
+          # declared `let checksum` against a fresh sha256 of this zip and hard-fails on
+          # mismatch). `zip` stores a per-entry modification time, so we (1) normalise
+          # every entry's mtime to a fixed epoch (`touch -h`, not following symlinks),
+          # (2) feed a byte-sorted file list for a stable member order, and (3) pass -X
+          # to drop the platform extra field (uid/gid/hi-res time). -y keeps symlinks as
+          # symlinks (Apple framework layout). Combined with ZERO_AR_DATE on the .a build,
+          # the archive is byte-identical across runs of the same source.
+          find piper_plus.xcframework -exec touch -h -t 202001010000.00 {} +
+          find piper_plus.xcframework -print | LC_ALL=C sort | zip -X -y libpiper_plus-ios.xcframework.zip -@
           ls -la libpiper_plus-ios.xcframework.zip
           echo "sha256:"
           shasum -a 256 libpiper_plus-ios.xcframework.zip


### PR DESCRIPTION
## Summary

v1.13.0 is the first tag to ship `Package.swift` with a `binaryTarget` checksum. The `release` job in `release-shared-lib.yml` (Gate 2) hard-fails if the declared `let checksum` does not equal a fresh sha256 of the xcframework zip built at tag time. The build was non-deterministic, so a checksum computed from a pre-tag `workflow_dispatch` build would not survive the tag-run rebuild — forcing a re-tag cycle. This makes the iOS synthesis xcframework byte-reproducible so a single pre-tag checksum is stable.

## Affected Components

- [ ] Python
- [ ] Rust
- [ ] C#
- [ ] C++
- [ ] Go
- [ ] WASM-npm
- [ ] Docker
- [x] CI/CD
- [ ] Documentation

## Type

- [x] CI/CD

## Risk Level

- [x] patch (bug fix / internal change)
- [ ] minor (new feature, non-breaking)
- [ ] major (breaking change)

## Contract Impact

- [x] None

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| `ZERO_AR_DATE=1`(iOS build step) | `xcrun libtool -static` のアーカイブメンバ/シンボルテーブルの mtime をゼロ化 | `libpiper_plus.a` が実行ごとに変化し checksum 不一致 |
| 再現可能 zip(assemble-xcframework) | zip 前に mtime 固定 + メンバ名 sort + `zip -X -y` | zip の per-entry mtime/extra field が実行ごとに変化し checksum 不一致 |

## 設計判断

- synthesis xcframework のみを対象。`g2pChecksum` は v1.13.0 タグでは検証されない(`g2pVersion=1.14.0` ≠ tag)ため、g2p 経路(cargo+lipo)の決定化は本 PR の scope 外。
- `-y` で symlink を維持(Apple framework レイアウト)。`touch -h` で symlink 自体の mtime を固定(リンク先を辿らない)。
- 固定 epoch(2020-01-01)を使用。commit 由来の `SOURCE_DATE_EPOCH` だと checksum commit 前後で値が変わり cross-commit 再現性が壊れるため、定数を採用。

## Test Plan

- [ ] `workflow_dispatch` でこのブランチに対し本ワークフローを **2 回** 実行し、`assemble-xcframework` の「Zip xcframework」ステップが出力する sha256 が **完全一致** することを確認(再現性の実証)。
- [ ] 既存の `Verify slice arch` / `Verify symbol resolution` / xcframework 構造チェックが引き続き pass することを確認(zip 方式変更で構造が壊れていないこと)。
- [ ] `actionlint` が pass(YAML 構文)。

## Checklist

- [x] Tests pass locally(該当なし: iOS build は CI 専用、dispatch ×2 で検証)
- [x] No GPL/LGPL deps
- [x] Documentation updated(該当なし: ワークフロー内コメントで意図を明記)

## Related Issues

なし(v1.13.0 リリース準備の F2 blocker 解消)
