### PR TITLE
chore(spm): set Package.swift checksum for v1.13.0 xcframework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ import PackageDescription
 // v1.13.0 release lands; `swift package resolve` succeeds only against tags
 // where this manifest was updated to match a published release asset.
 let version = "1.13.0"
-let checksum = "0000000000000000000000000000000000000000000000000000000000000000"
+let checksum = "33870ebd45ac24685033901831d0910fdfb1c7f1acb5d1176966ba2239031552"
 
 // G2P-only artifact — produced by the same release workflow but as a
 // separate xcframework that does NOT depend on ONNX Runtime. Consumers


### PR DESCRIPTION
## Summary

Set the `Package.swift` synthesis xcframework `let checksum` to its real value for the v1.13.0 release (was the all-zero placeholder). The iOS xcframework build is now byte-reproducible (PR #561), and two independent `workflow_dispatch` builds produced an identical sha256, so this checksum will match the artifact rebuilt at the `v1.13.0` tag — the `release-shared-lib` job's Gate 2 (`checksum == sha256(asset)`) passes on the first tag attempt instead of forcing a re-tag.

## Affected Components

- [ ] Python
- [ ] Rust
- [ ] C#
- [ ] C++
- [ ] Go
- [ ] WASM-npm
- [ ] Docker
- [x] CI/CD
- [ ] Documentation

## Type

- [x] CI/CD

## Risk Level

- [x] patch (bug fix / internal change)
- [ ] minor (new feature, non-breaking)
- [ ] major (breaking change)

## Contract Impact

- [x] None

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| `let checksum` 確定 | synthesis xcframework の実 sha256 (`33870ebd…031552`) を設定 | placeholder のまま tag すると release-shared-lib Gate1(non-placeholder)で hard fail / SwiftPM resolve 不可 |

## 設計判断

- 値は再現性検証(PR #561 後の dispatch ×2 が同一 sha256)で確定済み。`let checksum` を埋めた commit は Package.swift のみ変更で xcframework ビルドに影響しないため、タグ時の再ビルドでも同値が再現し Gate 2 が一致する。
- `g2pChecksum` は placeholder のまま据え置き。`g2pVersion = 1.14.0` ≠ tag 1.13.0 のため release job が g2pChecksum 検証を skip する(Issue #387、v1.14.0 タグで確定予定)。
- checksum commit は tag が指す commit に載っている必要がある(SwiftPM は tag の git ref の manifest を解決)。post-tag 更新では解決されないため pre-tag で確定。

## Test Plan

- [ ] `v1.13.0` タグ push 時に release-shared-lib の「Verify Package.swift checksums match xcframework assets」ステップが pass(`33870ebd…` == 再ビルド zip の sha256)。
- [ ] タグ公開後、`swift package resolve` で `PiperPlus` binaryTarget が checksum 検証付きで解決できる。
- [ ] 「Verify Package.swift checksums are non-placeholder」ゲートが pass(all-zero でない 64-hex)。

## Checklist

- [x] Tests pass locally(該当なし: タグ時 CI ゲートで検証)
- [x] No GPL/LGPL deps
- [x] Documentation updated(該当なし)

## Related Issues

なし(v1.13.0 リリース F2 blocker 解消の最終ステップ。Issue #377 の SPM 配布経路)
