### PR TITLE
fix(ci): skip verify build in crates package-for-attestation step

### DIFF
--- a/.github/workflows/dev-create-release.yml
+++ b/.github/workflows/dev-create-release.yml
@@ -524,11 +524,20 @@ jobs:
         # exist on disk for attest-build-provenance. cargo publish below
         # repackages internally but produces byte-identical bundles when
         # the working tree is unchanged.
+        #
+        # --no-verify is REQUIRED here: the default verify build resolves
+        # internal deps against the crates.io index, but on a version bump the
+        # new versions are not published yet (e.g. packaging piper-plus 0.5.0
+        # fails with `failed to select a version for the requirement
+        # piper-plus-g2p = "^0.5.0"` because only 0.4.0/0.2.0 are on the index).
+        # We only need the .crate bundle for attestation here; the real
+        # `cargo publish` steps below verify in dependency order (g2p -> core ->
+        # cli) with index-propagation waits, so they resolve correctly.
         working-directory: src/rust
         run: |
-          cargo package -p piper-plus-g2p --allow-dirty
-          cargo package -p piper-plus --allow-dirty
-          cargo package -p piper-plus-cli --allow-dirty
+          cargo package -p piper-plus-g2p --allow-dirty --no-verify
+          cargo package -p piper-plus --allow-dirty --no-verify
+          cargo package -p piper-plus-cli --allow-dirty --no-verify
           echo "Packaged crates:"
           ls -lh target/package/*.crate
 


### PR DESCRIPTION
## Summary

The `publish_crates` job in `dev-create-release.yml` aborted before any `cargo publish` ran: the "Package crates (for attestation)" step uses `cargo package` with the default verify build, which resolves internal deps against the crates.io index. On a version bump the new versions are not published yet, so packaging `piper-plus 0.5.0` failed with `failed to select a version for the requirement piper-plus-g2p = "^0.5.0"` (index only had 0.4.0/0.2.0). Adding `--no-verify` to the attestation packaging skips the index-dependent verify build; the actual publish steps still verify in dependency order so they resolve the freshly-published deps. (No partial publish occurred — the job died before the publish steps.)

## Affected Components

- [ ] Python
- [ ] Rust
- [ ] C#
- [ ] C++
- [ ] Go
- [ ] WASM-npm
- [ ] Docker
- [x] CI/CD
- [ ] Documentation

## Type

- [x] CI/CD

## Risk Level

- [x] patch (bug fix / internal change)
- [ ] minor (new feature, non-breaking)
- [ ] major (breaking change)

## Contract Impact

- [x] None

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| attestation packaging に `--no-verify` | `.crate` バンドルだけ作り、index 依存の verify ビルドを飛ばす | バージョン bump 時に未公開の内部依存(piper-plus-g2p 0.5.0)を index に解決できず publish_crates が publish 前に全死 |

## 設計判断

- attestation 用の `cargo package` は SLSA provenance の `.crate` を作るのが目的で verify は不要。`--no-verify` でも `.crate` は生成されるので attestation は維持される。
- 実 publish ステップ(`cargo publish` を g2p→core→cli の依存順、間に index 伝播の sleep)は従来どおり verify する。各クレートが publish される時点で依存は既に index に存在するため解決できる。
- 最小変更(該当ステップの 3 行に flag 追加)に留め、リリースワークフローの挙動変更面を局所化。

## Test Plan

- [ ] `dev-create-release` を再 dispatch(version=1.13.0)し、`publish_crates` ジョブが成功(piper-plus-g2p / piper-plus / piper-plus-cli が crates.io に公開、または already-published を許容)。
- [ ] `actionlint` が pass(YAML 構文)。

## Checklist

- [x] Tests pass locally(該当なし: ワークフロー変更、再 dispatch で検証)
- [x] No GPL/LGPL deps
- [x] Documentation updated(該当なし: ステップ内コメントで意図を明記)

## Related Issues

なし(v1.13.0 リリース dispatch run 27493511391 で表面化した crates publish バグの修正)
