### PR TITLE
ci(release): drop redundant PyPI stub republish (piper-tts-plus)

### DIFF
--- a/.github/workflows/dev-create-release.yml
+++ b/.github/workflows/dev-create-release.yml
@@ -286,55 +286,6 @@ jobs:
           packages-dir: dist/
           skip-existing: true
 
-  # Publish stub package (piper-tts-plus -> piper-plus redirect)
-  publish_pypi_stub:
-    name: Publish PyPI Stub (piper-tts-plus)
-    needs: [publish_pypi]
-    if: |
-      always() &&
-      needs.publish_pypi.result == 'success'
-    runs-on: ubuntu-24.04
-    # Stub package has its own Trusted Publisher entry on PyPI (separate
-    # project name `piper-tts-plus`).
-    environment:
-      name: pypi-stub
-      url: https://pypi.org/p/piper-tts-plus
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-    steps:
-      - uses: actions/checkout@v6.0.3
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: '3.11'
-
-      - name: Install build tools
-        run: pip install build twine
-
-      - name: Copy VERSION for stub
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          echo "$VERSION" > VERSION
-          cp VERSION src/python_stub/VERSION
-
-      - name: Build stub package
-        working-directory: src/python_stub
-        run: python -m build
-
-      - name: Generate SLSA build provenance attestation (stub)
-        uses: actions/attest-build-provenance@v3.2.0
-        with:
-          subject-path: 'src/python_stub/dist/*'
-
-      - name: Publish stub to PyPI (Trusted Publisher)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: src/python_stub/dist/
-          skip-existing: true
-
   # C# CLI builds
   csharp-cli:
     name: Build C# CLI (${{ matrix.rid }})
@@ -704,7 +655,7 @@ jobs:
   release_summary:
     name: Release Summary
     runs-on: ubuntu-24.04
-    needs: [create_release, build_all, publish_pypi, publish_pypi_stub, publish_nuget, publish_crates, csharp-cli, rust-cli]
+    needs: [create_release, build_all, publish_pypi, publish_nuget, publish_crates, csharp-cli, rust-cli]
     if: always()
     steps:
       - name: Summary
@@ -718,7 +669,6 @@ jobs:
           echo "- Create Release: ${{ needs.create_release.result }}"
           echo "- Build All: ${{ needs.build_all.result }}"
           echo "- Publish PyPI: ${{ needs.publish_pypi.result }}"
-          echo "- Publish PyPI Stub: ${{ needs.publish_pypi_stub.result }}"
           echo "- Publish NuGet: ${{ needs.publish_nuget.result }}"
           echo "- Publish crates.io: ${{ needs.publish_crates.result }}"
           echo "- C# CLI: ${{ needs.csharp-cli.result }}"
@@ -728,7 +678,6 @@ jobs:
           echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
           echo "- C++/Python Build: ${{ needs.build_all.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- PyPI: ${{ needs.publish_pypi.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- PyPI Stub: ${{ needs.publish_pypi_stub.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- NuGet: ${{ needs.publish_nuget.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- crates.io: ${{ needs.publish_crates.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- C# CLI: ${{ needs.csharp-cli.result }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

`piper-tts-plus` is the pre-#289 PyPI name, kept only as an inactive rename-redirect (`Development Status :: 7 - Inactive`; its README says "All future releases will be published under the new name"). Its pyproject depends on unversioned `piper-plus`, so the already-published stub keeps redirecting `pip install piper-tts-plus` to the latest `piper-plus` with no per-release republish. The `publish_pypi_stub` job was therefore redundant churn and added a second PyPI Trusted Publisher requirement (`environment: pypi-stub`) that gated the release. This removes the job so only `piper-plus` (`environment: pypi`) needs a Trusted Publisher.

## Affected Components

- [ ] Python
- [ ] Rust
- [ ] C#
- [ ] C++
- [ ] Go
- [ ] WASM-npm
- [ ] Docker
- [x] CI/CD
- [ ] Documentation

## Type

- [x] CI/CD

## Risk Level

- [x] patch (bug fix / internal change)
- [ ] minor (new feature, non-breaking)
- [ ] major (breaking change)

## Contract Impact

- [x] None

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| `publish_pypi_stub` ジョブ削除 | 毎リリースの piper-tts-plus 再公開を停止 | inactive な旧名 stub を毎回再公開する冗長 job が残り、pypi-stub の Trusted Publisher 設定をリリースの前提にし続ける |
| `release_summary` 参照除去 | needs と echo 2箇所から publish_pypi_stub を削除 | 削除した job を needs に残すと dangling 参照で workflow が無効化 |

## 設計判断

- stub は既に PyPI 上に存在し `dependencies = ["piper-plus"]`(バージョン無指定)なので、再公開しなくても `pip install piper-tts-plus` は最新 piper-plus を解決する。redirect は維持される。
- `src/python_stub/` ディレクトリは削除しない(履歴・参照保全。再公開のみ停止)。
- 効果: リリースの failure 点が 1 つ減り、Trusted Publisher 設定が piper-plus 1 つだけで済む。

## Test Plan

- [ ] `actionlint` が pass(job 削除後も YAML 有効、`release_summary` に dangling `needs` なし)。
- [ ] `dev-create-release` を再 dispatch した際、`release_summary` が `publish_pypi_stub` を参照せずに完了する。
- [ ] 既存の `piper-tts-plus` PyPI ページが引き続き piper-plus への redirect として機能する(再公開しないため変化なし)。

## Checklist

- [x] Tests pass locally(該当なし: ワークフロー変更、再 dispatch で検証)
- [x] No GPL/LGPL deps
- [x] Documentation updated(該当なし)

## Related Issues

なし(#289 のパッケージ名統一の後始末。v1.13.0 リリース簡素化)
