### PR TITLE
fix(ci): standalone CI stability fixes (Docker PEP 668 + C# race + C++ DFT tolerance)

### DIFF
--- a/docker/python-inference/Dockerfile.cpu
+++ b/docker/python-inference/Dockerfile.cpu
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # the python:3.13-slim-trixie default pip and bundled setuptools/wheel.
 # Run before uv install so the upgraded toolchain is what bootstraps
 # everything else.
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --break-system-packages --ignore-installed --upgrade pip setuptools wheel
 
 # Pin uv to the same major version range used by docker/wyoming/Dockerfile
 # (workspace-editable handling is uv version-sensitive).

--- a/docker/python-inference/Dockerfile.cpu.distroless
+++ b/docker/python-inference/Dockerfile.cpu.distroless
@@ -70,7 +70,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # setuptools / pip metadata) are copied verbatim into the final distroless
 # stage, so upgrading here propagates into the published image.
 # Issue #527: bumped from python:3.11-slim-bookworm + distroless debian12.
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --break-system-packages --ignore-installed --upgrade pip setuptools wheel
 
 # Pin uv to the same major version range used by the canonical
 # Dockerfile.cpu — workspace-editable handling is uv-version sensitive.

--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Upgrade pip / setuptools / wheel to clear Trivy supply-chain CVEs that
 # ride on the python:3.13.13-slim-trixie default toolchain.
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --break-system-packages --ignore-installed --upgrade pip setuptools wheel
 
 # Install uv
 RUN pip install --no-cache-dir uv

--- a/docker/webui/Dockerfile.distroless
+++ b/docker/webui/Dockerfile.distroless
@@ -52,7 +52,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # builder's site-packages (under /usr/local/lib/python3.13) is copied
 # verbatim into the distroless final stage, so upgrading here propagates
 # into the published image.
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --break-system-packages --ignore-installed --upgrade pip setuptools wheel
 
 # Pin uv. The canonical docker/webui/Dockerfile currently does an
 # unpinned `pip install uv`; pinning here is intentional drift to

--- a/docker/wyoming/Dockerfile
+++ b/docker/wyoming/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # builder stage's `/usr/local` is copied verbatim into the runtime stage
 # (see the `COPY --from=builder /usr/local /usr/local` instruction below),
 # so upgrading here propagates into the published image.
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --break-system-packages --ignore-installed --upgrade pip setuptools wheel
 
 # Pin uv to a known-good major version (workspace editable handling is uv version-sensitive)
 RUN pip install --no-cache-dir "uv>=0.9,<1"

--- a/src/csharp/PiperPlus.Cli/DotNetG2PEngine.cs
+++ b/src/csharp/PiperPlus.Cli/DotNetG2PEngine.cs
@@ -29,6 +29,15 @@ namespace PiperPlus.Cli;
 /// </remarks>
 internal sealed class DotNetG2PEngine : IJapaneseG2PEngine, IDisposable
 {
+    // Serialize MeCabTokenizer construction across threads.
+    // DotNetG2P.MeCab 1.8.x opens sys.dic with an exclusive FileShare during
+    // construction; concurrent ctor calls (e.g. ThreadLocal factory firing
+    // on every parallel worker's first Convert call) race on file-lock
+    // acquisition and throw IOException. Locking only the ctor keeps the
+    // per-thread engine isolation that follows — once each thread has its
+    // own tokenizer instance, Convert() runs in parallel without contention.
+    private static readonly object S_tokenizerCtorLock = new object();
+
     private readonly string _dictPath;
     private readonly ThreadLocal<G2PEngine> _threadLocalEngine;
 
@@ -43,7 +52,14 @@ internal sealed class DotNetG2PEngine : IJapaneseG2PEngine, IDisposable
         Environment.SetEnvironmentVariable("NAIST_JDIC_PATH", _dictPath);
 
         _threadLocalEngine = new ThreadLocal<G2PEngine>(
-            valueFactory: () => new G2PEngine(new MeCabTokenizer(_dictPath)),
+            valueFactory: () =>
+            {
+                // sys.dic file-lock race workaround for DotNetG2P.MeCab 1.8.x
+                lock (S_tokenizerCtorLock)
+                {
+                    return new G2PEngine(new MeCabTokenizer(_dictPath));
+                }
+            },
             trackAllValues: true);
     }
 

--- a/src/csharp/PiperPlus.Core/Config/DictionaryManager.cs
+++ b/src/csharp/PiperPlus.Core/Config/DictionaryManager.cs
@@ -46,6 +46,13 @@ public static class DictionaryManager
 
     private static readonly HttpClient S_httpClient = CreateHttpClient();
 
+    // Serializes concurrent EnsureDictionaryAsync calls so that parallel callers
+    // do not race on the download/extract path (which would corrupt sys.dic and
+    // other files due to overlapping FileStream writes). Process-lifetime,
+    // intentionally not disposed (Microsoft-recommended pattern for static
+    // SemaphoreSlim fields).
+    private static readonly SemaphoreSlim S_dictDownloadLock = new SemaphoreSlim(1, 1);
+
     private static HttpClient CreateHttpClient()
     {
         var client = new HttpClient
@@ -90,42 +97,64 @@ public static class DictionaryManager
     /// </exception>
     public static async Task<string> EnsureDictionaryAsync(CancellationToken ct = default)
     {
-        // 1. Try to find an existing dictionary
+        // 1. Lock-free fast path: if a dictionary is already present, return
+        //    immediately without acquiring the download lock. This keeps the
+        //    common "dict already exists" path contention-free for parallel
+        //    callers (e.g. SentenceParallelEncoder spawning N tasks).
         var existing = FindDictionary();
         if (existing is not null)
         {
             return existing;
         }
 
-        // 2. Check control flags
-        if (IsOfflineMode())
+        // 2. Serialize the slow path (download + extract). Multiple concurrent
+        //    callers must not race on the same archive/file writes — that was
+        //    the root cause of sys.dic corruption under 32-way parallel tests.
+        await S_dictDownloadLock.WaitAsync(ct).ConfigureAwait(false);
+        try
         {
-            throw new InvalidOperationException(
-                "OpenJTalk dictionary not found and offline mode is enabled (PIPER_OFFLINE_MODE=1). " +
-                "Please download the dictionary manually or set OPENJTALK_DICTIONARY_PATH.");
-        }
+            // 2a. Double-checked lookup inside the lock: another caller may
+            //     have completed the download while we were waiting.
+            existing = FindDictionary();
+            if (existing is not null)
+            {
+                return existing;
+            }
 
-        if (IsAutoDownloadDisabled())
+            // 2b. Check control flags
+            if (IsOfflineMode())
+            {
+                throw new InvalidOperationException(
+                    "OpenJTalk dictionary not found and offline mode is enabled (PIPER_OFFLINE_MODE=1). " +
+                    "Please download the dictionary manually or set OPENJTALK_DICTIONARY_PATH.");
+            }
+
+            if (IsAutoDownloadDisabled())
+            {
+                throw new InvalidOperationException(
+                    "OpenJTalk dictionary not found and auto-download is disabled (PIPER_AUTO_DOWNLOAD_DICT=0). " +
+                    "Please download the dictionary manually or set OPENJTALK_DICTIONARY_PATH.");
+            }
+
+            // 2c. Download to the data directory
+            var dataDir = GetDataDir();
+            var dictPath = Path.Join(dataDir, DictionaryDirName);
+
+            await DownloadAndExtractAsync(dataDir, ct).ConfigureAwait(false);
+
+            if (!IsValidDictionary(dictPath))
+            {
+                throw new InvalidOperationException(
+                    $"Dictionary download completed but validation failed. " +
+                    $"Expected directory with {string.Join(", ", RequiredFiles)} at: {dictPath}");
+            }
+
+            return dictPath;
+        }
+        finally
         {
-            throw new InvalidOperationException(
-                "OpenJTalk dictionary not found and auto-download is disabled (PIPER_AUTO_DOWNLOAD_DICT=0). " +
-                "Please download the dictionary manually or set OPENJTALK_DICTIONARY_PATH.");
+            S_dictDownloadLock.Release();
         }
-
-        // 3. Download to the data directory
-        var dataDir = GetDataDir();
-        var dictPath = Path.Join(dataDir, DictionaryDirName);
-
-        await DownloadAndExtractAsync(dataDir, ct).ConfigureAwait(false);
-
-        if (!IsValidDictionary(dictPath))
-        {
-            throw new InvalidOperationException(
-                $"Dictionary download completed but validation failed. " +
-                $"Expected directory with {string.Join(", ", RequiredFiles)} at: {dictPath}");
-        }
-
-        return dictPath;
     }
 
     /// <summary>

--- a/src/csharp/PiperPlus.runsettings
+++ b/src/csharp/PiperPlus.runsettings
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <RunConfiguration>
-    <MaxCpuCount>0</MaxCpuCount>
+    <!-- MaxCpuCount=1 (was 0 = unlimited) — VSTest spawns separate processes per
+         test assembly when > 1, and processes race on the OpenJTalk sys.dic
+         file lock during MeCabTokenizer ctor. In-process lock in
+         DotNetG2PEngine.cs handles intra-process races; cross-process race
+         on macOS is solved by serializing assemblies via MaxCpuCount=1.
+         (Ubuntu / Windows pass even with 0 because their FileShare semantics
+         tolerate the brief overlap window; macOS does not.) -->
+    <MaxCpuCount>1</MaxCpuCount>
     <ResultsDirectory>./TestResults</ResultsDirectory>
     <!-- Wall-clock cap for the entire test session (5 min). -->
     <TestSessionTimeout>300000</TestSessionTimeout>

--- a/src/python/piper_train/tools/prepare_bilingual_dataset.py
+++ b/src/python/piper_train/tools/prepare_bilingual_dataset.py
@@ -3,9 +3,9 @@
 
 Usage:
     uv run python prepare_bilingual_dataset.py \
-        --ja-dataset /data/piper/dataset-moe-speech-20speakers-v2/dataset.jsonl \
-        --en-input-dir /data/piper/ljspeech/LJSpeech-1.1 \
-        --output-dir /data/piper/dataset-bilingual-ja-en \
+        --ja-dataset "${JA_DATASET_DIR}/dataset.jsonl" \
+        --en-input-dir "${EN_LJSPEECH_DIR}" \
+        --output-dir "${OUTPUT_DIR}" \
         --sample-rate 22050 \
         --max-en-utterances 13000 \
         --workers 8

--- a/src/python/piper_train/tools/prepare_multilingual_dataset.py
+++ b/src/python/piper_train/tools/prepare_multilingual_dataset.py
@@ -14,12 +14,12 @@ Optimizations:
 
 Usage:
     .venv/bin/python prepare_multilingual_dataset.py \
-        --ja-en-dataset /data/piper/dataset-bilingual-ja-en-v4/dataset.jsonl \
-        --zh-aishell3 /data/piper/downloads/aishell3 \
-        --es-cml-tts /data/piper/downloads/cml_tts_dataset_spanish_v0.1 \
-        --fr-cml-tts /data/piper/downloads/cml_tts_dataset_french_v0.1 \
-        --pt-cml-tts /data/piper/downloads/cml_tts_dataset_portuguese_v0.1 \
-        --output-dir /data/piper/dataset-multilingual-6lang \
+        --ja-en-dataset "${JA_EN_DATASET}/dataset.jsonl" \
+        --zh-aishell3 "${DOWNLOADS_DIR}/aishell3" \
+        --es-cml-tts "${DOWNLOADS_DIR}/cml_tts_dataset_spanish_v0.1" \
+        --fr-cml-tts "${DOWNLOADS_DIR}/cml_tts_dataset_french_v0.1" \
+        --pt-cml-tts "${DOWNLOADS_DIR}/cml_tts_dataset_portuguese_v0.1" \
+        --output-dir "${OUTPUT_DIR}" \
         --sample-rate 22050 \
         --workers 30 \
         --gpu-spec-device cuda:0


### PR DESCRIPTION
## Summary

`release/ci-stability-fixes` — v2 ブランチで accumulated されていた **CI 安定化 / Docker / race fix** 系のうち、 dev base に対して **真に standalone** (zero-shot 機能や canonical default flip に依存しない) な 5 commit のみを cherry-pick。 Zero-Shot TTS 本体 (PR #222) の移植と canonical default flip (noise_scale 0.667→0.4 等) は dev base の current state では unbundlable なため、 後続の PR-B `release/zero-shot-tts` に統合予定。

## Cherry-pick scope (5 commits, +91/-39)

| commit | 内容 |
|---|---|
| `7685c76d` | Docker pip upgrade に `--break-system-packages --ignore-installed` を追加 (PEP 668 / Python 3.13 + Ubuntu 24.04 対応) |
| `608e4870` | C# OpenJTalk dictionary 並列ダウンロード race fix (`DictionaryManager.cs` semaphore 直列化) |
| `81001922` | C# MeCabTokenizer ctor を直列化 (DotNetG2P 1.8.x の sys.dic file-lock race 回避) |
| `bb4a7cd5` | VSTest `MaxCpuCount=1` で test assembly を直列化 (macOS の OpenJTalk file-lock race 回避) |
| `0dc8efd9` | piper-train tools の `/data/piper` docstring を env var placeholder 化 (PR #569 で削除された 2 ファイルのhunk は drop、 残る `prepare_{bilingual,multilingual}_dataset.py` のみ更新) |

### 当初 6 commits から drop

`d15d4a4f` (C++ test_speaker_encoder_parity の DFT tolerance 拡張) は cherry-pick 時の conflict 解決で `git checkout --theirs` を使った結果、 tolerance 拡張だけでなく `kMelNFft = 400` 等の前提変更 (de1f3aaf/571f0f77/3f57c182 依存) も拾ってしまい、 golden fixture (n_fft=512) と mismatch → cpp-tests 9 件 fail。 d15d4a4f は実は standalone ではなく上記 3 commit に依存していたため、 PR-A から drop し PR-B に統合予定。

## Affected Components

- [ ] Python (src/python/, pyproject.toml)
- [ ] Rust (src/rust/)
- [x] C# (src/csharp/) — 3 race fix commit
- [ ] C++ (src/cpp/, CMakeLists.txt)
- [ ] Go (src/go/)
- [ ] WASM/npm (src/wasm/)
- [x] Docker (docker/) — PEP 668 flag 追加 (webui / wyoming Dockerfile)
- [ ] CI/CD (.github/workflows/)
- [x] Documentation (docs/, README*) — piper-train tools docstring 2 ファイル

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Dependencies

## Risk Level

- [x] **patch** — bug fix / internal refactor / docs only
- [ ] **minor**
- [ ] **major**

Rationale: 全 commit が既存機能に対する race fix / Docker compatibility / docstring 微修正のみ。 user-visible API surface / default value 不変。

## Contract Impact

- [x] None (Python/runtime-internal change only)

(canonical default flip は本 PR では扱わない、 PR-B 統合予定)

## Test Plan

- pre-commit run --all-files
- C# unit tests (race fix 効果確認): `dotnet test src/csharp/PiperPlus.sln`
- Docker build (PEP 668 flag 確認): `docker build -f docker/webui/Dockerfile .`
- 全 CI matrix (300+ check) で green を確認

## 経緯と次の PR

- 元 commits: v2 branch (post-#569 → post-#222 timeframe)
- bundled merge 試行: PR #568 (cascade で 21+ fail、 close)
- PR-Migration: #569 (Python 3.13 + CUDA 12.8、 merged)
- 本 PR: 真に standalone な CI 安定化部分 (5 commits)
- 次回: PR-B `release/zero-shot-tts` — c644e9e2 (PR #222 zero-shot core) + canonical default flip (0.667→0.4 cross-runtime) + d15d4a4f + `docs/spec/inference-input-contract.toml` の split-by-export-mode 化 (192 CAM++ 新規 / 256 ECAPA legacy 維持)

## ultracode 調査経緯

本 PR は 2 回の ultracode workflow + adversarial review で計画。 最終 review が 5 件の deterministic blocker (PR-A 22-commit 案の internal inconsistency: golden fixture mismatch / ORT contract fixture drift / Go/Rust CLI default mismatch / doc-examples baseline drift / Go phantom test skip) を検出。 PR-A scope を 22 → 6 commits に縮小、 さらに d15d4a4f が実は standalone でないことが CI で判明し 6 → 5 commits に再縮小。

## Checklist

- [x] Tests pass locally (race fix の改善効果は CI で verify 予定)
- [x] No GPL/LGPL dependencies added
- [x] Documentation updated (piper-train tools docstring placeholder)

## Related Issues

- Refs PR #569 (PR-Migration: Python 3.13 + CUDA 12.8 を origin/dev に merge 済)
- Refs PR #568 (v2 bundled merge attempt, closed for cascade reasons)
- Refs PR #222 (Zero-Shot TTS, 後続 PR-B で個別移植)
- 本 PR merge は user 手動を維持
