### PR TITLE
feat(train): Super-MAS Triton-GPU MAS accelerator (opt-in、 推論影響ゼロ)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,7 @@ B (FT) は A から `--devices 1`、`--base_lr 2e-5` (1/10 で catastrophic forg
 - **学習高速化** — Validation 頻度削減、DataLoader 最適化 (num_workers=2, pin_memory)、DDP `find_unused_parameters=True`。CLI: `--val-every-n-epochs`, `--limit-val-batches`, `--num-workers`, `--no-pin-memory`。
 - **WandB Audio Logging** (`vits/lightning.py:on_validation_epoch_end`) — Validation 時に音声サンプルアップロード。CLI: `--audio-log-epochs`, `--num-test-examples`。
 - **エネルギー VAD 高速キャッシュ** (`norm_audio/__init__.py`) — Silero ONNX VAD を numpy エネルギー VAD に置換、~25x 高速化 (~390ms → ~8ms/file)。
+- **Super-MAS Triton-GPU MAS accelerator** (`vits/monotonic_align/__init__.py`) — arXiv:2409.07704 (Park et al., 2024)。 CUDA tensor + `super_monotonic_align` package 利用可能時に Triton kernel に dispatch、 19-72x 高速化 (報告値)。 既存 Cython は CPU / package 未導入 / `PIPER_DISABLE_SUPER_MAS=1` 時のフォールバックとして温存。 推論経路への影響ゼロ (学習時 `SynthesizerTrn.forward` 内 1 箇所のみ呼び出し)。 Opt-in install: `pip install "piper-train[super-mas]"` (PyPI 非配布、 git+https のみ)。 algorithmic equivalence (upstream は bit-identical を明示保証しないが `max_neg_val` edge case 修正済)。
 
 ### ONNX エクスポート
 

--- a/src/python/piper_train/vits/monotonic_align/__init__.py
+++ b/src/python/piper_train/vits/monotonic_align/__init__.py
@@ -1,5 +1,30 @@
+"""Monotonic Alignment Search (MAS) with optional Triton-GPU acceleration.
+
+Dispatches to the Triton-GPU implementation provided by
+``super_monotonic_align`` (Park et al., 2024 — https://arxiv.org/abs/2409.07704)
+when both the package is installed and the input tensors are on CUDA.
+Otherwise falls back to the original Cython implementation with adaptive
+chunked processing (Issue #197).
+
+Super-MAS reports 19-72x speedup on GPU vs the Cython baseline. The output is
+algorithmically equivalent — the upstream README does not guarantee
+bit-identical floats — and the kernel additionally fixes a ``max_neg_val``
+edge case present in the original Glow-TTS implementation.
+
+Opt-in install (training-only, GPU-only):
+
+    pip install piper-train[super-mas]
+
+Disable at runtime via env (forces Cython for debugging / reproducibility):
+
+    PIPER_DISABLE_SUPER_MAS=1
+"""
+
+import os
+
 import numpy as np
 import torch
+
 
 try:
     from .core import maximum_path_c  # Cython or numba fallback
@@ -10,20 +35,52 @@ except ImportError:
 # When matrix size exceeds this, use batch_size=1
 _LARGE_MATRIX_THRESHOLD = 500000  # ~700x700
 
+# Super-MAS (Triton-GPU) optional accelerator
+# Env override is read at import time so process-wide settings are honoured
+# without affecting subsequent calls; tests that mock the dispatcher can
+# patch ``_super_mas_fn`` directly.
+_SUPER_MAS_DISABLED = os.environ.get("PIPER_DISABLE_SUPER_MAS", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+_super_mas_fn = None
+if not _SUPER_MAS_DISABLED:
+    try:
+        from super_monotonic_align import (
+            maximum_path as _super_mas_fn,  # type: ignore[import-not-found]
+        )
+    except ImportError:
+        _super_mas_fn = None
+
+
+def _use_super_mas(neg_cent: torch.Tensor) -> bool:
+    """Decide whether to dispatch to Super-MAS for this batch."""
+    if _super_mas_fn is None:
+        return False
+    if not neg_cent.is_cuda:
+        return False
+    return torch.cuda.is_available()
+
 
 def maximum_path(neg_cent, mask):
-    """Cython optimized version with adaptive chunked processing.
+    """Compute MAS (Monotonic Alignment Search).
 
-    Large batches or large matrices are automatically split into smaller
-    chunks to avoid memory/stack overflow in the Cython implementation.
+    Dispatches to the Triton-GPU implementation when CUDA tensors are passed
+    and ``super_monotonic_align`` is installed; otherwise falls back to the
+    Cython implementation with adaptive chunked processing.
 
     Args:
         neg_cent: [batch, t_t, t_s] tensor
         mask: [batch, t_t, t_s] tensor
 
     Returns:
-        Path tensor [batch, t_t, t_s]
+        Path tensor [batch, t_t, t_s] on the same device and dtype as
+        ``neg_cent``.
     """
+    if _use_super_mas(neg_cent):
+        return _maximum_path_super_mas(neg_cent, mask)
+
     device = neg_cent.device
     dtype = neg_cent.dtype
     batch_size, t_t, t_s = neg_cent.shape
@@ -41,10 +98,7 @@ def maximum_path(neg_cent, mask):
         for i in range(0, batch_size, max_chunk):
             chunk_end = min(i + max_chunk, batch_size)
             chunk_result = _maximum_path_core(
-                neg_cent[i:chunk_end],
-                mask[i:chunk_end],
-                device,
-                dtype
+                neg_cent[i:chunk_end], mask[i:chunk_end], device, dtype
             )
             results.append(chunk_result)
         return torch.cat(results, dim=0)
@@ -52,8 +106,22 @@ def maximum_path(neg_cent, mask):
     return _maximum_path_core(neg_cent, mask, device, dtype)
 
 
+def _maximum_path_super_mas(neg_cent, mask):
+    """Super-MAS Triton-GPU dispatch path.
+
+    The upstream kernel mutates ``value`` in place, so we clone it to keep
+    ``neg_cent`` immutable (matches the Cython contract used elsewhere in
+    the training loop). Inputs are cast to float32 / int32 as required and
+    the output is cast back to the caller's dtype.
+    """
+    value = neg_cent.detach().to(dtype=torch.float32).contiguous().clone()
+    attn_mask = mask.detach().to(dtype=torch.int32).contiguous()
+    path = _super_mas_fn(value, attn_mask, dtype=torch.float32)
+    return path.to(dtype=neg_cent.dtype)
+
+
 def _maximum_path_core(neg_cent, mask, device, dtype):
-    """Core implementation without chunking."""
+    """Core Cython implementation without chunking."""
     neg_cent_np = neg_cent.data.cpu().numpy().astype(np.float32)
     path = np.zeros(neg_cent_np.shape, dtype=np.int32)
     t_t_max = mask.sum(1)[:, 0].data.cpu().numpy().astype(np.int32)

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -97,8 +97,14 @@ test = [
 #
 # Disable at runtime with PIPER_DISABLE_SUPER_MAS=1 (forces Cython). PyPI
 # distribution does not exist upstream — install is git-only.
+#
+# Pinned to a specific commit SHA (not HEAD) for reproducibility and
+# supply-chain hygiene: every training run that uses this extra resolves to
+# the exact kernel revision validated against the piper-plus dispatcher.
+# Bump the SHA deliberately after re-validating MAS path equivalence against
+# the Cython baseline (see test_super_mas_dispatch.py).
 super-mas = [
-    "super-monotonic-align @ git+https://github.com/supertone-inc/super-monotonic-align.git",
+    "super-monotonic-align @ git+https://github.com/supertone-inc/super-monotonic-align.git@9bb1cb3a6fbab27bbe6e566827b9548010c5dd51",
 ]
 
 [project.scripts]

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -89,6 +89,18 @@ test = [
     "psutil>=5.9",
 ]
 
+# Optional Triton-GPU MAS accelerator (arXiv:2409.07704). Training-only,
+# CUDA-only. The base Cython MAS remains the default fallback path so this
+# extra is strictly opt-in:
+#
+#     pip install "piper-train[super-mas]"
+#
+# Disable at runtime with PIPER_DISABLE_SUPER_MAS=1 (forces Cython). PyPI
+# distribution does not exist upstream — install is git-only.
+super-mas = [
+    "super-monotonic-align @ git+https://github.com/supertone-inc/super-monotonic-align.git",
+]
+
 [project.scripts]
 piper-train = "piper_train.__main__:main"
 

--- a/src/python/tests/test_super_mas_dispatch.py
+++ b/src/python/tests/test_super_mas_dispatch.py
@@ -13,6 +13,8 @@ the optional dependency. The unit test scope is the dispatch logic.
 
 from __future__ import annotations
 
+import os
+import pathlib
 import subprocess
 import sys
 import textwrap
@@ -222,7 +224,18 @@ class TestEnvDisableImportTime:
     """
 
     def _run_import_check(self, env_value: str | None) -> dict:
-        """Run a subprocess that imports the module and reports state."""
+        """Run a subprocess that imports the module and reports state.
+
+        We inherit the *full* parent environment via ``os.environ.copy()`` so
+        that platform-specific magic variables (Windows ``SystemRoot``, Linux
+        ``LD_LIBRARY_PATH``, etc.) reach the child intact. A hand-built env
+        was used in an earlier draft but it (a) risked overriding Windows'
+        case-insensitive ``SystemRoot`` and (b) dropped the test session's
+        ``sys.path`` injection set by ``tests/conftest.py``, leaving the
+        subprocess unable to import ``piper_train`` outside an editable
+        install. PYTHONPATH is then prepended explicitly so the import works
+        regardless of how piper_train is installed.
+        """
         code = textwrap.dedent("""
             import json
             from piper_train.vits import monotonic_align as m
@@ -231,20 +244,16 @@ class TestEnvDisableImportTime:
                 "fn_is_none": m._super_mas_fn is None,
             }))
         """)
-        env = {"PYTHONIOENCODING": "utf-8", "SYSTEMROOT": ""}
-        # Inherit PATH and Python so the venv resolves; SystemRoot keeps
-        # Windows subprocess happy.
-        import os
-
-        env["PATH"] = os.environ.get("PATH", "")
-        # NOTE: Windows' magic variable is documented as "SystemRoot" (mixed
-        # case). ruff SIM112 prefers the upper-case form but Python's
-        # subprocess on Windows requires the actual name we read from
-        # os.environ, so we explicitly pass the case as-is.
-        sysroot = os.environ.get("SystemRoot")  # noqa: SIM112
-        if sysroot:
-            env["SystemRoot"] = sysroot  # noqa: SIM112
-        if env_value is not None:
+        env = os.environ.copy()
+        # Ensure src/python is on sys.path even if piper_train is not
+        # editable-installed (conftest.py only runs inside pytest, not in a
+        # fresh `python -c` subprocess).
+        src_python = str(pathlib.Path(__file__).resolve().parent.parent)
+        env["PYTHONPATH"] = src_python + os.pathsep + env.get("PYTHONPATH", "")
+        # Configure the toggle under test
+        if env_value is None:
+            env.pop("PIPER_DISABLE_SUPER_MAS", None)
+        else:
             env["PIPER_DISABLE_SUPER_MAS"] = env_value
 
         proc = subprocess.run(

--- a/src/python/tests/test_super_mas_dispatch.py
+++ b/src/python/tests/test_super_mas_dispatch.py
@@ -1,0 +1,148 @@
+"""Tests for the Super-MAS dispatcher in monotonic_align.
+
+Verifies the dispatcher routes correctly between the Triton-GPU
+``super_monotonic_align`` path (arXiv:2409.07704) and the Cython fallback
+without needing an actual CUDA device or the upstream package installed.
+The Cython fallback is also exercised end-to-end so the existing training
+contract (Issue #197) is preserved.
+
+The full GPU + Triton kernel path itself is intentionally not covered here —
+that is a benchmark/integration test that requires both a CUDA device and
+the optional dependency. The unit test scope is the dispatch logic.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+
+torch = pytest.importorskip("torch", reason="torch required for dispatch tests")
+
+try:
+    from piper_train.vits import monotonic_align
+except ImportError:
+    pytest.skip(
+        "piper_train.vits.monotonic_align not available",
+        allow_module_level=True,
+    )
+
+
+class TestDispatcherDecision:
+    """Confirm `_use_super_mas` predicate routes correctly."""
+
+    def test_cpu_tensor_always_falls_back(self):
+        """CPU tensors must always go through the Cython path."""
+        neg_cent = torch.randn(2, 16, 24)
+        with mock.patch.object(monotonic_align, "_super_mas_fn", lambda *a, **k: None):
+            assert monotonic_align._use_super_mas(neg_cent) is False
+
+    def test_no_super_mas_package_falls_back(self):
+        """When the optional package is not installed, _super_mas_fn is None."""
+        neg_cent = torch.randn(2, 16, 24)
+        with mock.patch.object(monotonic_align, "_super_mas_fn", None):
+            assert monotonic_align._use_super_mas(neg_cent) is False
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(),
+        reason="CUDA not available for GPU dispatch decision test",
+    )
+    def test_gpu_tensor_with_package_dispatches(self):
+        """CUDA tensor + installed package => Super-MAS path selected."""
+        neg_cent = torch.randn(2, 16, 24, device="cuda")
+        with mock.patch.object(
+            monotonic_align,
+            "_super_mas_fn",
+            lambda *a, **k: torch.zeros_like(a[0], dtype=torch.float32),
+        ):
+            assert monotonic_align._use_super_mas(neg_cent) is True
+
+
+class TestCythonFallbackCorrectness:
+    """End-to-end exercise of the dispatcher with Cython fallback only."""
+
+    def test_dispatch_returns_cython_when_no_super_mas(self):
+        """maximum_path produces a valid monotonic path via Cython."""
+        batch_size, t_t, t_s = 2, 12, 18
+        neg_cent = torch.randn(batch_size, t_t, t_s)
+        attn_mask = torch.ones(batch_size, t_t, t_s)
+
+        with mock.patch.object(monotonic_align, "_super_mas_fn", None):
+            result = monotonic_align.maximum_path(neg_cent, attn_mask)
+
+        assert result.shape == (batch_size, t_t, t_s)
+        assert result.device == neg_cent.device
+        # Binary path
+        assert torch.all((result == 0) | (result == 1))
+        # Monotonic: each row at most one 1
+        for b in range(batch_size):
+            row_sums = result[b].sum(dim=1)
+            assert torch.all(row_sums <= 1)
+
+    def test_disable_env_marker_class_attribute(self):
+        """`_SUPER_MAS_DISABLED` is exposed for runtime introspection.
+
+        Note: the value is read at import time, so this just verifies the
+        attribute exists and is bool. Tests that need to flip it use mock.
+        """
+        assert hasattr(monotonic_align, "_SUPER_MAS_DISABLED")
+        assert isinstance(monotonic_align._SUPER_MAS_DISABLED, bool)
+
+
+class TestSuperMASPathContract:
+    """Verify the Super-MAS dispatch helper itself with a mocked kernel.
+
+    We mock the upstream kernel so the test runs on CPU without Triton or a
+    GPU, but the wrapper logic (clone, dtype cast, device propagation) is
+    exercised end-to-end.
+    """
+
+    def test_clone_preserves_input(self):
+        """Wrapper must clone before calling upstream (upstream mutates input)."""
+        neg_cent = torch.randn(1, 8, 10)
+        snapshot = neg_cent.clone()
+
+        def fake_kernel(value, attn_mask, dtype=torch.float32):
+            # Simulate the upstream behaviour: mutate the input.
+            value.fill_(0)
+            return torch.ones(value.shape, dtype=dtype)
+
+        with mock.patch.object(monotonic_align, "_super_mas_fn", fake_kernel):
+            _ = monotonic_align._maximum_path_super_mas(
+                neg_cent, torch.ones_like(neg_cent)
+            )
+
+        # Original tensor must remain unchanged.
+        assert torch.allclose(neg_cent, snapshot)
+
+    def test_dtype_propagated_back(self):
+        """Output dtype must match input dtype (Cython contract parity)."""
+        neg_cent = torch.randn(1, 4, 6, dtype=torch.float64)
+
+        def fake_kernel(value, attn_mask, dtype=torch.float32):
+            return torch.ones(value.shape, dtype=torch.float32)
+
+        with mock.patch.object(monotonic_align, "_super_mas_fn", fake_kernel):
+            out = monotonic_align._maximum_path_super_mas(
+                neg_cent, torch.ones_like(neg_cent)
+            )
+
+        assert out.dtype == torch.float64
+
+    def test_int32_mask_passed_to_kernel(self):
+        """Wrapper must cast mask to int32 (Super-MAS contract)."""
+        neg_cent = torch.randn(1, 4, 6)
+        mask = torch.ones(1, 4, 6, dtype=torch.float32)
+        captured: dict = {}
+
+        def fake_kernel(value, attn_mask, dtype=torch.float32):
+            captured["mask_dtype"] = attn_mask.dtype
+            captured["value_dtype"] = value.dtype
+            return torch.zeros(value.shape, dtype=dtype)
+
+        with mock.patch.object(monotonic_align, "_super_mas_fn", fake_kernel):
+            _ = monotonic_align._maximum_path_super_mas(neg_cent, mask)
+
+        assert captured["mask_dtype"] == torch.int32
+        assert captured["value_dtype"] == torch.float32

--- a/src/python/tests/test_super_mas_dispatch.py
+++ b/src/python/tests/test_super_mas_dispatch.py
@@ -13,6 +13,9 @@ the optional dependency. The unit test scope is the dispatch logic.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import textwrap
 from unittest import mock
 
 import pytest
@@ -146,3 +149,135 @@ class TestSuperMASPathContract:
 
         assert captured["mask_dtype"] == torch.int32
         assert captured["value_dtype"] == torch.float32
+
+
+class TestPublicMaximumPathDispatch:
+    """Confirm ``maximum_path()`` actually routes through the Super-MAS path
+    when the predicate says so.
+
+    The individual helpers are covered above, but the integration point — the
+    ``if _use_super_mas(): return _maximum_path_super_mas(...)`` branch in the
+    public ``maximum_path()`` — is its own contract. We exercise it by
+    patching the predicate to return True and verifying the wrapper is the
+    one that produced the result (rather than falling through to Cython).
+    """
+
+    def test_dispatcher_invokes_super_mas_branch_when_predicate_true(self):
+        """When the predicate returns True, the wrapper is called once.
+
+        We do not need a real CUDA tensor — the predicate is the gate, and
+        we patch both it and the kernel. This isolates the wiring inside
+        ``maximum_path()`` from CUDA / Triton availability.
+        """
+        neg_cent = torch.randn(1, 8, 12)
+        mask = torch.ones(1, 8, 12)
+
+        sentinel = torch.zeros(1, 8, 12, dtype=torch.float32)
+        kernel_calls = []
+
+        def fake_kernel(value, attn_mask, dtype=torch.float32):
+            kernel_calls.append((value.shape, attn_mask.dtype))
+            return sentinel
+
+        with (
+            mock.patch.object(monotonic_align, "_use_super_mas", return_value=True),
+            mock.patch.object(monotonic_align, "_super_mas_fn", fake_kernel),
+        ):
+            out = monotonic_align.maximum_path(neg_cent, mask)
+
+        # Kernel was reached exactly once via the dispatcher branch
+        assert len(kernel_calls) == 1
+        # Output dtype matches caller's neg_cent dtype (Cython contract parity)
+        assert out.dtype == neg_cent.dtype
+        # Shape preserved
+        assert out.shape == neg_cent.shape
+
+    def test_dispatcher_skips_super_mas_branch_when_predicate_false(self):
+        """When the predicate returns False, the wrapper is never called."""
+        neg_cent = torch.randn(1, 8, 12)
+        mask = torch.ones(1, 8, 12)
+        kernel_calls = []
+
+        def fake_kernel(*args, **kwargs):
+            kernel_calls.append(args)
+            return torch.zeros_like(neg_cent)
+
+        with (
+            mock.patch.object(monotonic_align, "_use_super_mas", return_value=False),
+            mock.patch.object(monotonic_align, "_super_mas_fn", fake_kernel),
+        ):
+            out = monotonic_align.maximum_path(neg_cent, mask)
+
+        # Kernel was not reached — Cython branch handled it
+        assert len(kernel_calls) == 0
+        assert out.shape == neg_cent.shape
+
+
+class TestEnvDisableImportTime:
+    """Verify PIPER_DISABLE_SUPER_MAS=1 is honoured at import time.
+
+    The toggle is module-level (read once on import), so we re-import in a
+    fresh subprocess with the env var set. This is the only way to assert
+    the contract — patching the live module would test the wrong thing.
+    """
+
+    def _run_import_check(self, env_value: str | None) -> dict:
+        """Run a subprocess that imports the module and reports state."""
+        code = textwrap.dedent("""
+            import json
+            from piper_train.vits import monotonic_align as m
+            print(json.dumps({
+                "disabled": m._SUPER_MAS_DISABLED,
+                "fn_is_none": m._super_mas_fn is None,
+            }))
+        """)
+        env = {"PYTHONIOENCODING": "utf-8", "SYSTEMROOT": ""}
+        # Inherit PATH and Python so the venv resolves; SystemRoot keeps
+        # Windows subprocess happy.
+        import os
+
+        env["PATH"] = os.environ.get("PATH", "")
+        # NOTE: Windows' magic variable is documented as "SystemRoot" (mixed
+        # case). ruff SIM112 prefers the upper-case form but Python's
+        # subprocess on Windows requires the actual name we read from
+        # os.environ, so we explicitly pass the case as-is.
+        sysroot = os.environ.get("SystemRoot")  # noqa: SIM112
+        if sysroot:
+            env["SystemRoot"] = sysroot  # noqa: SIM112
+        if env_value is not None:
+            env["PIPER_DISABLE_SUPER_MAS"] = env_value
+
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+            check=False,
+        )
+        assert proc.returncode == 0, (
+            f"subprocess failed:\nstdout={proc.stdout}\nstderr={proc.stderr}"
+        )
+        import json
+
+        return json.loads(proc.stdout.strip().splitlines()[-1])
+
+    def test_env_unset_does_not_force_disable(self):
+        """Without the env var, the disable flag is False."""
+        state = self._run_import_check(env_value=None)
+        assert state["disabled"] is False
+        # _super_mas_fn may or may not be None (depends on whether the
+        # optional package is installed) — we only assert the flag here.
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE", "Yes"])
+    def test_env_truthy_disables_super_mas(self, value: str):
+        """Truthy env values force ``_super_mas_fn = None`` at import."""
+        state = self._run_import_check(env_value=value)
+        assert state["disabled"] is True
+        assert state["fn_is_none"] is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "", "anything-else"])
+    def test_env_non_truthy_does_not_disable(self, value: str):
+        """Non-truthy values leave the disable flag False."""
+        state = self._run_import_check(env_value=value)
+        assert state["disabled"] is False


### PR DESCRIPTION
## Summary

学習時の Monotonic Alignment Search (MAS) を Cython から Triton-GPU カーネル (Super-MAS, arXiv:2409.07704, Park et al., 2024) に opt-in で dispatch できるようにしました。 公式 docker stack (Python 3.13 + torch 2.11.0+cu128 + Triton 3.6.0) 上の RTX 4070 Ti SUPER 実測で **MAS 単独 38-187x** 高速化。 ただし MAS は 1 step 全体の **0.42 % しか占有しない** ことが実測で判明したため、 end-to-end の学習短縮効果は **約 0.37 %** とマージナル。 推論経路と ONNX グラフへの影響はゼロ、 既存 Cython は CPU / package 未導入 / 環境変数で disable 時のフォールバックとして温存。

## Affected Components

- [x] Python (src/python/, pyproject.toml)
- [ ] Rust (src/rust/)
- [ ] C# (src/csharp/)
- [ ] C++ (src/cpp/, CMakeLists.txt)
- [ ] Go (src/go/)
- [ ] WASM/npm (src/wasm/)
- [ ] Docker (docker/)
- [ ] CI/CD (.github/workflows/)
- [x] Documentation (docs/, README*)

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Dependencies

## Risk Level

- [ ] **patch** — bug fix / internal refactor / docs only
- [x] **minor** — new feature / additive API / no breaking change
- [ ] **major** — breaking change (API removal, schema migration, behavior reversal)

## Contract Impact

- [x] None (Python/runtime-internal change only)

推論経路への影響なし、 ONNX グラフ・cross-runtime contract に変更なし。 学習時 `SynthesizerTrn.forward` 内 1 箇所 (`models.py:964`) のみで dispatch される。

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|---|---|---|
| Super-MAS dispatcher | `super_monotonic_align.maximum_path` が利用可能 + CUDA tensor + `torch.cuda.is_available()` のすべて満たすときのみ Triton kernel に分岐、 それ以外は既存 Cython パスへフォールバック | 学習時 MAS が常に CPU Cython 実装で動作し、 GPU 学習で大規模バッチ時のボトルネックが解消されない |
| upstream の入力破壊への防御 | `_maximum_path_super_mas` 内で `value.clone()` してから kernel へ渡す。 入力 `neg_cent` は不変 | upstream は `value` を in-place 変更するため、 caller の `neg_cent` が壊れて学習 loop が破綻 |
| dtype / device 透過 | float32 化して kernel に渡し、 戻り値を caller の dtype に cast。 device は caller の tensor に従う | Cython パスとの契約 (shape / dtype / device 保持) が崩れ、 既存 callsite と非互換 |
| env による強制 disable | `PIPER_DISABLE_SUPER_MAS=1/true/yes/TRUE/Yes` で import 時に `_super_mas_fn = None` を強制。 再現性デバッグ / bit-identical 比較に利用 | A/B 比較やデバッグ時に Cython へ強制復帰できず原因切り分けができない |
| optional extra (commit SHA pin) | `pyproject.toml` に `super-mas = ["super-monotonic-align @ git+...@<sha>"]` を追加。 unpinned HEAD ではなく **特定 commit SHA** で pin (再現性 + supply-chain hygiene)。 `train` extra には含めず完全 opt-in | デフォルト install で git fetch が走り、 CI / Windows native などネットワーク制約環境で install 失敗。 unpinned だと再現性が崩れ過去 ckpt の bit-identical 再学習不能 |
| dispatcher テスト | `_use_super_mas` predicate / `_maximum_path_super_mas` wrapper / 公開 `maximum_path()` の if 分岐統合点 / env import-time 動作 (subprocess) を網羅。 subprocess test は `os.environ.copy()` で親 env 継承 + `PYTHONPATH` 明示 prepend | dispatcher の wiring 漏れや env が効かない regression を CI が検出できない。 hand-built env では Windows SystemRoot override や piper_train import 失敗のリスク |

## 設計判断

- **3 段安全網で opt-in を確実に**: (1) package 未導入 → Cython、 (2) CPU tensor → Cython (Windows native や CPU-only CI で安全)、 (3) `PIPER_DISABLE_SUPER_MAS=1` → 強制 Cython。 デフォルト挙動は完全に Cython 不変
- **PyPI 非配布のため `train` extra には含めず分離**: upstream は GitHub のみで配布。 git+https を `train` に混ぜると `pip install piper-train[train]` 時にネットワーク fetch が必須となり、 CI / offline 環境で fail する。 `[super-mas]` を独立 extra にすることで「明示的に opt-in した時のみ git+ install」となる
- **commit SHA で pin (HEAD 直追従を回避)**: upstream HEAD は将来移動するため、 unpinned 参照だと過去の学習 run の再現性が壊れる。 SHA pin により kernel revision を学習成果と紐付け、 bump は手動 re-validation 後にのみ行う運用に
- **bit-identical を主張しない**: upstream README は "algorithmic equivalence" のみ表明 (bit-identical は明示保証なし、 加えて `max_neg_val` edge case を修正済)。 docstring / CLAUDE.md でも「algorithmic equivalence」と明記して過剰な主張を避ける
- **`_use_super_mas` を independent predicate に切り出し**: maximum_path() 内に直接書かず関数化することで、 テスト時に predicate のみを mock 可能。 GPU 不在環境でも dispatcher 分岐の wiring を検証できる
- **`value.detach().to(float32).contiguous().clone()`**: upstream は `value` を in-place 変更するため clone 必須。 detach は autograd graph から切る (MAS は学習時 `torch.no_grad()` 配下で呼ばれるが明示する)、 contiguous は Triton kernel が strided memory を扱えない可能性に備える
- **subprocess test は `os.environ.copy()` ベース**: hand-built env では (a) Windows `SystemRoot` を case-insensitive で上書きする可能性、 (b) editable-install されていない piper_train を subprocess から見つけられない、 の 2 リスクがあった。 親 env 継承 + `PYTHONPATH` 明示 prepend で両方解消

## ベンチマーク

計測環境: RTX 4070 Ti SUPER (16GB Ada Lovelace) + WSL2 Ubuntu + Python 3.13.14 + torch 2.11.0+cu128 + Triton 3.6.0 (piper-plus 公式 docker stack と一致)

### MAS 単独 (synthetic, B=20, T=64-400, S=4T)

`triton.testing.do_bench(rep=50, warmup=5)`、 MAS のみの wall-time 比較。

| Shape (B, T, S) | Triton (ms) | Cython (ms) | Speedup |
|---|---:|---:|---:|
| (20, 64, 256) | 0.20 | 7.41 | **37.7x** |
| (20, 128, 512) | 1.00 | 66.61 | **66.5x** |
| (20, 192, 768) | 6.29 | 87.42 | 13.9x (※ outlier) |
| (20, 256, 1024) | 1.32 | 246.98 | **186.8x** |
| (20, 400, 1600) | 3.66 | 417.88 | **114.1x** |

- 頻出する T=64-128 範囲で 38-67x、 大行列 T=256-400 で 114-187x
- T=192 は単発測定の outlier (Triton autotune cache warm-up タイミング依存)

### End-to-end (実 SynthesizerTrn 1 step, B=8, T=128, T_y=512)

forward + backward + optimizer.step 1 step を Triton ON / Cython OFF で各 30 回計測 (warmup 15)。 MAS 呼び出しを patch して MAS 部分のみの wall-time も同時計測。

| 項目 | Triton ON | Cython OFF |
|---|---:|---:|
| MAS median | 1.69 ms | 15.90 ms |
| **MAS 占有率 (step 内)** | **0.027 %** | **0.42 %** |

実測値から計算した end-to-end 短縮: **0.42 % × (1 − 1/9.4) ≈ 0.37 %**

= 1 epoch 8h53m に対して **約 2 分短縮** にとどまる。 これは Glow-TTS 論文の「MAS は学習全体の 2% 未満」推定とも整合的 (実測ではむしろ更に低い 0.42%)。

**つまり: MAS 単独では大幅高速化するが、 学習 step 全体に占める MAS の割合が小さいため、 1 epoch wall-clock の短縮は実用上マージナル**。 大バッチ + 長文 dataset (T=400+) で MAS 占有率がわずかに上がる可能性はあるが、 桁が変わるほどではない。 本 PR の意義は wall-clock 短縮よりも (a) CPU↔GPU 転送オーバーヘッド除去、 (b) 大バッチ時の MAS スパイク解消、 (c) GPU bound にできる範囲を広げる、 にある。

## Test Plan

- [ ] `cd src/python && uv run --no-sync pytest tests/test_monotonic_align.py tests/test_super_mas_dispatch.py --no-cov -v` で 29 件 (既存 8 + 新規 21) すべて pass
- [ ] `uv run --no-sync ruff check src/python/piper_train/vits/monotonic_align/__init__.py src/python/tests/test_super_mas_dispatch.py` で lint clean
- [ ] `uv run --no-sync ruff format --check src/python/piper_train/vits/monotonic_align/__init__.py src/python/tests/test_super_mas_dispatch.py` で format clean
- [ ] 環境変数なしで `python -c "from piper_train.vits import monotonic_align; print(monotonic_align._SUPER_MAS_DISABLED)"` が `False` を返す
- [ ] `PIPER_DISABLE_SUPER_MAS=1` 環境で同コマンドが `True` を返し、 `_super_mas_fn is None` になる
- [ ] (GPU 環境で実施推奨) `pip install "piper-train[super-mas]"` 後に短い学習 step を回し、 既存 Cython 結果と SECS / loss が乖離しないことを確認 (本 PR の merge 後の follow-up でも可)

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL dependencies added ([License Policy](CONTRIBUTING.md#license-policy))
- [x] Documentation updated (if applicable)

## Related Issues

なし (`docs/research/architecture-replacement-survey-2026-06-27.md` §4.1.1 で adopt 推奨されていた候補の 1 件目)
