### PR TITLE
feat(ci): HF Space deploy 前後の検証を追加 (BUILD_ERROR / RUNTIME_ERROR 即時検知)

### DIFF
--- a/.github/workflows/deploy-huggingface.yml
+++ b/.github/workflows/deploy-huggingface.yml
@@ -45,6 +45,22 @@ jobs:
             echo "Automatic deployment triggered by push to dev branch"
           fi
 
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: Pre-deploy gate -- README frontmatter schema
+        # Last-line defense before the bundle is uploaded. test-hf-space.yml
+        # also runs this gate on PRs touching huggingface-space/**, but a
+        # force-push to dev or a hand-edit on the web UI could still
+        # introduce a malformed frontmatter; fail fast here so we never
+        # ship a Space that will get rejected by HF as BUILD_ERROR or
+        # NO_APP_FILE.
+        run: |
+          pip install --quiet pyyaml
+          python scripts/check_hf_space_frontmatter.py
+
       - name: Prepare Space files
         run: |
           # Create a temporary directory for the Space
@@ -207,6 +223,27 @@ jobs:
           )
           print("Successfully deployed to Hugging Face Spaces")
           PYEOF
+
+      - name: Post-deploy verification -- wait for HF Space to reach RUNNING
+        # upload_folder succeeds the moment HF accepts the file commit, but
+        # the actual Docker build / Gradio launch happens asynchronously
+        # afterwards. If that pass enters BUILD_ERROR / RUNTIME_ERROR /
+        # CONFIG_ERROR / NO_APP_FILE, the upload step shows green and the
+        # broken Space sits unnoticed (this is exactly the failure mode
+        # that hid the 2026-06 sdk_version drift for weeks before a user
+        # opened the demo).
+        #
+        # This step polls HfApi.get_space_runtime and fails the workflow
+        # if the Space does not reach RUNNING within ~10 min. We cap the
+        # poll at 600s so a genuinely slow build is surfaced as an alert
+        # rather than letting the job time out at the 30-min job limit.
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          python scripts/verify_hf_space_runtime.py \
+            --space-id ayousanz/piper-plus-demo \
+            --timeout-seconds 600 \
+            --poll-interval-seconds 20
 
       - name: Deploy summary
         run: |

--- a/.github/workflows/test-hf-space.yml
+++ b/.github/workflows/test-hf-space.yml
@@ -38,6 +38,15 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: "Layer 0.5: README frontmatter schema"
+        # Catches BUILD_ERROR / CONFIG_ERROR / NO_APP_FILE causes the
+        # gradio-sync gate does not touch: missing app_file, missing sdk,
+        # unparseable YAML, app_file pointing to a file that does not
+        # exist in the Space directory.
+        run: |
+          pip install --quiet pyyaml
+          python scripts/check_hf_space_frontmatter.py
+
       - name: Prepare HF Space deployment directory
         run: |
           mkdir -p hf-space-deploy/models
@@ -115,6 +124,12 @@ jobs:
           pip install -r hf-space-deploy/requirements.txt
           python3 -c "import nltk; nltk.download('averaged_perceptron_tagger_eng', quiet=True); nltk.download('cmudict', quiet=True)"
 
+      - name: "Layer 2.1: pip check (dependency resolution)"
+        # `pip install` only warns on unresolved transitive conflicts; the
+        # HF Space build sometimes hits an actual ResolutionImpossible later
+        # when fresh deps are added on top. `pip check` surfaces those now.
+        run: pip check
+
       - name: "Layer 2.5: Import validation (with external deps)"
         working-directory: hf-space-deploy
         run: |
@@ -189,18 +204,29 @@ jobs:
           print(f'OK EN: {len(phoneme_ids)} phoneme IDs')
           "
 
-      - name: "Layer 5: App module import test"
+      - name: "Layer 5: App module import + Gradio interface instantiation"
         working-directory: hf-space-deploy
         run: |
           python3 -c "
-          # Verify app.py can be imported without errors
-          # (download_models will run but models already exist or will be skipped)
+          # Verify app.py can be imported AND its Gradio Blocks tree can be
+          # constructed. Previously this only ran 'import app', which does
+          # NOT exercise create_interface() -- a gradio API breaking change
+          # (renamed kwarg, removed component) would slip past until the
+          # actual Space tried to launch and entered RUNTIME_ERROR. By
+          # building the interface here we catch that class of regression
+          # at PR review time.
           import app
           assert hasattr(app, 'create_interface'), 'Missing create_interface'
           assert hasattr(app, 'synthesize_speech'), 'Missing synthesize_speech'
           assert hasattr(app, 'MODELS'), 'Missing MODELS'
           assert len(app.MODELS) == 6, f'Expected 6 models, got {len(app.MODELS)}'
-          print('OK app.py imports passed, 6 language models configured (trained model covers 6 langs; code supports 7 incl. sv)')
+
+          # Build the interface (does NOT launch -- no port binding, no
+          # network). This still resolves every gr.Component / gr.Blocks
+          # constructor and surfaces incompatible kwargs as TypeError.
+          iface = app.create_interface()
+          assert iface is not None, 'create_interface() returned None'
+          print('OK app.py imports + create_interface() runs cleanly')
           "
 
       - name: Summary

--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,9 @@ check_*.py
 !scripts/check_doc_examples.py
 # Swedish per-word LID sync gate (Issue #539)
 !scripts/check_swedish_lid_consistency.py
+# HF Space deploy hardening gates
+!scripts/check_hf_space_frontmatter.py
+!scripts/verify_hf_space_runtime.py
 create_comprehensive_*.py
 add_missing_*.py
 retrain_*.py

--- a/scripts/check_hf_space_frontmatter.py
+++ b/scripts/check_hf_space_frontmatter.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""HF Space README frontmatter schema gate.
+
+Hugging Face Spaces parses the YAML frontmatter at the top of ``README.md``
+to decide how to build and run the Space. A typo or missing field there is
+a common BUILD_ERROR cause that the build log surfaces as a misleading
+"cache miss" / generic error (the real reason is often only visible in the
+Space settings page).
+
+This gate catches the four most common drift patterns BEFORE the bundle is
+shipped to HF:
+
+  F1. A required field is missing
+      (HF rejects the build with no useful error)
+  F2. ``app_file:`` points to a file not present in ``huggingface-space/``
+      (HF returns NO_APP_FILE)
+  F3. The YAML itself is unparseable
+      (HF rejects with "could not parse README")
+  F4. ``sdk:`` is not one of the supported values
+      (HF returns CONFIG_ERROR)
+
+The gate is intentionally narrow: it does NOT enforce ``license:`` against
+HF's accepted list (HF updates that list independently of our repo and we
+do not want to false-positive a Dependabot-style license bump). It also
+does NOT cross-check ``sdk_version`` against ``requirements.txt`` -- that
+is handled by ``check_hf_space_gradio_sync.py``.
+
+Usage:
+    python scripts/check_hf_space_frontmatter.py
+
+Exit codes:
+    0 -- frontmatter is well-formed and self-consistent
+    1 -- one or more required fields missing, malformed, or inconsistent
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HF_SPACE_DIR = REPO_ROOT / "huggingface-space"
+README = HF_SPACE_DIR / "README.md"
+
+REQUIRED_FIELDS = ("title", "sdk", "sdk_version", "app_file")
+
+VALID_SDKS = ("gradio", "streamlit", "docker", "static")
+
+
+def _extract_frontmatter(readme_path: Path) -> tuple[dict | None, list[str]]:
+    """Return parsed frontmatter dict + list of errors.
+
+    A None dict + non-empty errors means the file is missing, has no
+    frontmatter delimiters, or fails YAML parse. Callers should treat both
+    cases the same way (gate must fail).
+    """
+    errors: list[str] = []
+    if not readme_path.exists():
+        errors.append(f"{readme_path.relative_to(REPO_ROOT)}: file does not exist")
+        return None, errors
+
+    text = readme_path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        errors.append(
+            f"{readme_path.relative_to(REPO_ROOT)}: file does not start with "
+            "`---` delimiter (HF Space requires YAML frontmatter at the top)"
+        )
+        return None, errors
+
+    end = text.find("\n---", 3)
+    if end < 0:
+        errors.append(
+            f"{readme_path.relative_to(REPO_ROOT)}: opening `---` found but no "
+            "closing `---` (frontmatter block is unterminated)"
+        )
+        return None, errors
+
+    frontmatter_text = text[3:end]
+    try:
+        data = yaml.safe_load(frontmatter_text)
+    except yaml.YAMLError as e:
+        errors.append(
+            f"{readme_path.relative_to(REPO_ROOT)}: frontmatter is not valid "
+            f"YAML: {e}"
+        )
+        return None, errors
+
+    if not isinstance(data, dict):
+        errors.append(
+            f"{readme_path.relative_to(REPO_ROOT)}: frontmatter parses to "
+            f"{type(data).__name__}, expected a mapping (key: value pairs)"
+        )
+        return None, errors
+
+    return data, errors
+
+
+def main() -> int:
+    data, errors = _extract_frontmatter(README)
+
+    if data is None:
+        # Parse failure -- emit the parse error(s) and stop. No point checking
+        # required fields if we could not parse the YAML at all.
+        print("HF Space frontmatter check FAILED:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    # F1: required fields present and non-empty
+    for field in REQUIRED_FIELDS:
+        value = data.get(field)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            errors.append(
+                f"frontmatter is missing required field `{field}:` (HF Space "
+                "cannot build without it)"
+            )
+
+    # F4: sdk must be one of HF's supported values
+    sdk = data.get("sdk")
+    if isinstance(sdk, str) and sdk not in VALID_SDKS:
+        errors.append(
+            f"`sdk: {sdk}` is not a recognized HF Space SDK. Allowed: "
+            f"{', '.join(VALID_SDKS)} (HF rejects unknown values with "
+            "CONFIG_ERROR)"
+        )
+
+    # F2: app_file must point to a file that exists in the Space directory
+    # (this directory is what `Prepare Space files` copies from). If it is
+    # missing here, the deploy bundle will be missing app.py and HF returns
+    # NO_APP_FILE at runtime.
+    app_file = data.get("app_file")
+    if isinstance(app_file, str) and app_file.strip():
+        target = HF_SPACE_DIR / app_file.strip()
+        if not target.exists():
+            errors.append(
+                f"`app_file: {app_file}` does not exist at "
+                f"{target.relative_to(REPO_ROOT)} -- HF Space will fail with "
+                "NO_APP_FILE after deploy"
+            )
+
+    if errors:
+        print("HF Space frontmatter check FAILED:")
+        for e in errors:
+            print(f"  - {e}")
+        print(
+            "\nTo fix: edit huggingface-space/README.md so the YAML "
+            "frontmatter has every required field and `app_file:` points to "
+            "an existing file."
+        )
+        return 1
+
+    print("OK: HF Space frontmatter is well-formed")
+    print(
+        f"     title={data.get('title')!r} sdk={data.get('sdk')} "
+        f"sdk_version={data.get('sdk_version')} app_file={data.get('app_file')}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_hf_space_runtime.py
+++ b/scripts/verify_hf_space_runtime.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Post-deploy HF Space runtime verification gate.
+
+After ``upload_folder`` succeeds, the deploy script currently treats that
+as a green deploy. But HF Space does the actual Docker build / Gradio
+launch ASYNCHRONOUSLY -- and that pass can still fail in ways the upload
+step never sees:
+
+  - BUILD_ERROR    -- pip install failed (e.g. gradio version drift, a
+                      yanked package, a system-library mismatch)
+  - CONFIG_ERROR   -- README frontmatter rejected
+  - RUNTIME_ERROR  -- the build produced a Docker image but app.py crashes
+                      at startup (model load fail / NLTK download fail /
+                      gradio API breakage)
+  - NO_APP_FILE    -- bundle missing the file pointed to by `app_file:`
+
+The 2026-06 incident (PR #583) was exactly this class of failure: the
+deploy workflow reported "Successfully deployed", but the Space was stuck
+in BUILD_ERROR for weeks before anyone noticed by manually opening the
+demo URL.
+
+This script closes the loop: poll ``HfApi.get_space_runtime`` after deploy
+and fail the workflow if the Space does not reach a healthy stage within
+a budget.
+
+Healthy stages (success): RUNNING, RUNNING_BUILDING, APP_STARTING
+                          (APP_STARTING / RUNNING_BUILDING are transient on
+                          the way to RUNNING and acceptable as final states
+                          if poll budget runs out -- the Space IS serving
+                          requests in those stages.)
+In-progress stages (continue polling): BUILDING
+Failure stages (exit immediately): BUILD_ERROR, RUNTIME_ERROR, CONFIG_ERROR,
+                                    NO_APP_FILE, PAUSED, STOPPED, DELETING
+
+Usage:
+    HF_TOKEN=... python scripts/verify_hf_space_runtime.py \\
+        --space-id ayousanz/piper-plus-demo \\
+        --timeout-seconds 600 \\
+        --poll-interval-seconds 20
+
+Exit codes:
+    0 -- Space reached a healthy stage within the budget
+    1 -- Space entered a failure stage, OR poll budget exhausted while
+         still BUILDING (the build is unusually slow -- worth investigating
+         manually even if it eventually succeeds)
+    2 -- usage / auth error (could not query the API at all)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+HEALTHY_STAGES = frozenset({"RUNNING", "RUNNING_BUILDING", "APP_STARTING"})
+IN_PROGRESS_STAGES = frozenset({"BUILDING"})
+# Anything else (BUILD_ERROR, RUNTIME_ERROR, CONFIG_ERROR, NO_APP_FILE,
+# PAUSED, STOPPED, DELETING) we treat as failure. We list the recognized
+# failure stages explicitly for the diagnostic message; unknown stages also
+# fail closed (safer than treating an unknown stage as healthy).
+KNOWN_FAILURE_STAGES = frozenset(
+    {"BUILD_ERROR", "RUNTIME_ERROR", "CONFIG_ERROR", "NO_APP_FILE", "PAUSED", "STOPPED", "DELETING"}
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument(
+        "--space-id",
+        required=True,
+        help="HF Space repo id (e.g. ayousanz/piper-plus-demo)",
+    )
+    p.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=600,
+        help="Maximum total wall-clock time to wait for a healthy stage. "
+        "Default 600 (10 min). Our normal build is 5-8 min; 10 min gives "
+        "headroom for HF queue contention without letting a truly broken "
+        "deploy hang the workflow.",
+    )
+    p.add_argument(
+        "--poll-interval-seconds",
+        type=int,
+        default=20,
+        help="Seconds between HF API polls. Default 20. Lower wastes API "
+        "budget; higher delays failure detection.",
+    )
+    p.add_argument(
+        "--allow-startup-grace-seconds",
+        type=int,
+        default=30,
+        help="Wait this long after upload before the FIRST poll. HF sometimes "
+        "takes a few seconds to register the upload and transition out of "
+        "the previous stage; polling immediately can return a stale RUNNING "
+        "stage from the prior deploy.",
+    )
+    return p.parse_args()
+
+
+def _get_stage(api, space_id: str) -> tuple[str, object]:
+    """Return (stage_string, raw_runtime_object).
+
+    Returns (\"\", None) if the API call fails -- caller decides whether to
+    retry or give up.
+    """
+    try:
+        runtime = api.get_space_runtime(space_id)
+    except Exception as e:  # noqa: BLE001 -- any API failure is "try again"
+        print(f"  (warning) get_space_runtime failed: {e}", flush=True)
+        return "", None
+    stage = getattr(runtime, "stage", "") or ""
+    return str(stage), runtime
+
+
+def main() -> int:
+    args = _parse_args()
+
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        print(
+            "ERROR: HF_TOKEN env var is required (set it to a token with "
+            "read access to the Space)",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        from huggingface_hub import HfApi
+    except ImportError:
+        print(
+            "ERROR: huggingface_hub is not installed (`pip install -U "
+            "huggingface_hub`)",
+            file=sys.stderr,
+        )
+        return 2
+
+    api = HfApi(token=token)
+
+    print(
+        f"Verifying HF Space '{args.space_id}' reaches a healthy stage "
+        f"within {args.timeout_seconds}s "
+        f"(poll every {args.poll_interval_seconds}s)..."
+    )
+
+    if args.allow_startup_grace_seconds > 0:
+        print(
+            f"  Waiting {args.allow_startup_grace_seconds}s for HF to register "
+            "the upload..."
+        )
+        time.sleep(args.allow_startup_grace_seconds)
+
+    deadline = time.monotonic() + args.timeout_seconds
+    last_stage = ""
+    poll_count = 0
+
+    while True:
+        poll_count += 1
+        stage, _runtime = _get_stage(api, args.space_id)
+        elapsed = int(args.timeout_seconds - max(0, deadline - time.monotonic()))
+
+        if stage:
+            if stage != last_stage:
+                print(f"  [{elapsed:>4}s, poll #{poll_count}] stage={stage}")
+                last_stage = stage
+            else:
+                print(f"  [{elapsed:>4}s, poll #{poll_count}] (still {stage})")
+        else:
+            print(f"  [{elapsed:>4}s, poll #{poll_count}] (transient API error)")
+
+        if stage in HEALTHY_STAGES:
+            print(
+                f"\nOK: HF Space reached healthy stage '{stage}' "
+                f"after {elapsed}s ({poll_count} polls)"
+            )
+            print(f"     Space URL: https://huggingface.co/spaces/{args.space_id}")
+            return 0
+
+        if stage in KNOWN_FAILURE_STAGES:
+            print(
+                f"\nFAIL: HF Space entered failure stage '{stage}' "
+                f"after {elapsed}s"
+            )
+            print(
+                "      Inspect the build / runtime log at "
+                f"https://huggingface.co/spaces/{args.space_id}?logs=build "
+                "(swap to ?logs=container for runtime errors)."
+            )
+            return 1
+
+        if stage and stage not in IN_PROGRESS_STAGES:
+            # Unknown stage -- log it but keep polling for a couple more
+            # cycles in case HF added a new transitional stage. Treat as
+            # failure if we reach the deadline still in this stage.
+            print(
+                f"      (warning: unrecognized stage '{stage}', "
+                "treating as in-progress for now)"
+            )
+
+        if time.monotonic() >= deadline:
+            print(
+                f"\nFAIL: timed out after {args.timeout_seconds}s with "
+                f"final stage='{stage or 'unknown'}'. A healthy build "
+                "completes in 5-8 minutes; this is unusually slow and "
+                "likely stuck. Check the Space build log."
+            )
+            return 1
+
+        time.sleep(args.poll_interval_seconds)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -3431,6 +3431,9 @@ inference-gpu = [
     { name = "soundfile" },
     { name = "uvicorn" },
 ]
+super-mas = [
+    { name = "super-monotonic-align" },
+]
 test = [
     { name = "coverage", extra = ["toml"] },
     { name = "mypy" },
@@ -3512,6 +3515,7 @@ requires-dist = [
     { name = "soundfile", marker = "extra == 'inference-gpu'", specifier = ">=0.12" },
     { name = "soundfile", marker = "extra == 'train'", specifier = ">=0.12" },
     { name = "soxr", marker = "extra == 'train'", specifier = ">=0.5.0" },
+    { name = "super-monotonic-align", marker = "extra == 'super-mas'", git = "https://github.com/supertone-inc/super-monotonic-align.git?rev=9bb1cb3a6fbab27bbe6e566827b9548010c5dd51" },
     { name = "tensorboard", marker = "extra == 'train'", specifier = ">=2.20.0" },
     { name = "torchmetrics", marker = "extra == 'train'", specifier = ">=1.9.0" },
     { name = "tqdm", marker = "extra == 'train'", specifier = ">=4.66" },
@@ -3523,7 +3527,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'inference-gpu'", specifier = ">=0.46.0" },
     { name = "wandb", marker = "extra == 'train'", specifier = ">=0.26.1" },
 ]
-provides-extras = ["train", "inference", "inference-gpu", "test"]
+provides-extras = ["train", "inference", "inference-gpu", "test", "super-mas"]
 
 [[package]]
 name = "platformdirs"
@@ -4803,6 +4807,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/da/279d12cab13f2affa9edd0ad4d5631573f4de07a020ad89a4ad0195f1d7c/SudachiPy-0.6.10-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7455e5cbb4c2cf9294c82345c9d46b344774b4eb23eca917f305ed716d8d5168", size = 3033253, upload-time = "2025-01-10T07:15:06.674Z" },
     { url = "https://files.pythonhosted.org/packages/66/ed/36eabf79eb81c38d477b77a5ab8fd62c8a4814a82c845f079f0c3b78ff18/SudachiPy-0.6.10-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38d0de9e840ac8d199e714a40506792ea5237d0db0c966da16d51fbc74a508d6", size = 1730534, upload-time = "2025-01-10T07:15:09.348Z" },
 ]
+
+[[package]]
+name = "super-monotonic-align"
+version = "1.0.0"
+source = { git = "https://github.com/supertone-inc/super-monotonic-align.git?rev=9bb1cb3a6fbab27bbe6e566827b9548010c5dd51#9bb1cb3a6fbab27bbe6e566827b9548010c5dd51" }
 
 [[package]]
 name = "sympy"


### PR DESCRIPTION
## Summary

PR #583 で sdk_version drift の症状を解消したが、 同様の事故が「別の原因」で再発したときに気付けない構造上の穴を埋める。 既存 deploy ワークフローは `upload_folder` 成功で 0 exit するため、 HF Space が BUILD_ERROR / RUNTIME_ERROR / CONFIG_ERROR / NO_APP_FILE に陥っていても workflow は green になっていた (2026-06 incident で誰も気付けなかった根本理由)。 deploy 前後に 4 層の検証を追加し、 「workflow green = Space は実際に動いている」 を成立させる。

## Affected Components

- [ ] Python
- [ ] Rust
- [ ] C#
- [ ] C++
- [ ] Go
- [ ] WASM-npm
- [ ] Docker
- [x] CI/CD
- [ ] Documentation

## Type

- [x] CI/CD
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependencies

## Risk Level

- [x] patch (内部の CI 補強のみ。 runtime / artifact / public API には触れない)
- [ ] minor
- [ ] major

## Contract Impact

- [x] None (spec TOML / public API / artifact format に変更なし)

## 変更内容

| 機能 | 動作 | これがないと起こること |
|------|------|----------------------|
| `scripts/check_hf_space_frontmatter.py` (F1-F4) | README YAML frontmatter の schema gate。 必須フィールド (title/sdk/sdk_version/app_file)、 app_file の実在、 sdk の妥当性、 YAML parse 可能性を検証 | `app_file:` typo / sdk typo / 必須フィールド削除 / YAML 構文破壊 → HF が CONFIG_ERROR / NO_APP_FILE / 汎用 BUILD_ERROR を返すが事前検知できない |
| `scripts/verify_hf_space_runtime.py` (F5、 universal safety net) | upload 後に `HfApi.get_space_runtime` を ~10min poll、 RUNNING/RUNNING_BUILDING/APP_STARTING のいずれかに到達するか BUILD_ERROR 等で fail するかを判定。 standalone 実行可能 | upload は成功して workflow green、 しかし HF Space は壊れたまま → 2026-06 と同じ「数週間誰も気付かない」事象が再発 |
| `test-hf-space.yml`: Layer 0.5 (frontmatter check) | PR 段階で frontmatter の整合性を強制 | dev 直 push / GitHub web 編集による frontmatter drift が CI を通過する |
| `test-hf-space.yml`: Layer 2.1 (`pip check`) | requirements インストール後の dependency conflict 検出 | `pip install` は warning だけ出して exit 0 のことがあり、 HF 側の本番 resolve が ResolutionImpossible になっても気付かない |
| `test-hf-space.yml`: Layer 5 強化 | `import app` だけでなく `create_interface()` まで実行し Gradio Blocks 構築を検証 | gradio の API 破壊変更 (kwarg 名変更、 component 削除) が `import` 時には現れず、 HF Space launch 時に RUNTIME_ERROR となる |
| `deploy-huggingface.yml`: pre-deploy frontmatter gate | upload 直前の最終防衛線 | dev 直 push で frontmatter が壊れていても upload してしまう |
| `deploy-huggingface.yml`: post-deploy runtime verification (10 min) | upload 後に Space が RUNNING に到達するまで poll | 上記 F5 の核心。 これがないと、 どの pre-deploy gate も漏らした問題 (HF 側の build キャッシュ汚染、 system library mismatch、 NLTK ダウンロード失敗 等) が完全にすり抜ける |

## 設計判断

- **post-deploy verification を最大の投資先にした理由**: 個別の gate (frontmatter / pip check / Gradio build) は既知の failure mode しか塞げないが、 runtime 状態の poll は HF 側でしか発生しない未知の failure mode (system lib mismatch、 build cache 汚染、 yanked package、 NLTK サーバ down 等) もすべて捕まえる universal safety net。
- **healthy stage に APP_STARTING / RUNNING_BUILDING を含めた**: これらは RUNNING への遷移途中だが既に HTTP request を返している = 実質ユーザーから見て稼働中。 タイムアウト時にこの状態でも green と判定することで「実際は動くのに workflow だけ red」 を防ぐ。
- **timeout を 600s に設定**: 通常 build 5-8 分 + HF queue 待ちで余裕。 これより長いと「動いてはいるが build hang」 として alert したい (workflow 全体の 30 min 上限内に収める)。
- **frontmatter gate で `license:` を検証しない**: HF は accepted license リストを独自に更新するため、 こちら側で hardcode 検証すると Dependabot 由来の license bump で false-positive する。 BUILD_ERROR 寄与度も低いため省略。
- **gradio sync gate との独立性**: frontmatter gate は `sdk_version` の値同士の比較はしない (PR #583 の gate が担当)。 役割分担を明示することで「両方 fail」 のときに原因切り分けが容易。
- **PR #583 とのコンフリクト回避**: 本 PR は dev 直 base で frontmatter gate と post-deploy gate を独立に追加。 PR #583 が先にマージされても rebase で Set up Python step が dedup されるだけで、 ロジックの衝突なし。
- **bundle completeness check (app.py の import を AST 解析して deploy step の `cp` invocations と突き合わせる) は後送り**: 価値はあるが既存の import validation step である程度カバーされており、 まず universal safety net を入れる方が ROI が高い。

## Test Plan

- [ ] `python scripts/check_hf_space_frontmatter.py` (正常 README で OK + 4 failure mode injection で全て exit 1)
- [ ] `python scripts/verify_hf_space_runtime.py --help` (usage 表示)
- [ ] `unset HF_TOKEN; python scripts/verify_hf_space_runtime.py --space-id ayousanz/piper-plus-demo --timeout-seconds 5` (rc=2 で usage error)
- [ ] PR CI の `test-hf-space` job で Layer 0.5 / 2.1 / 5 拡張が PASS
- [ ] PR CI 全体が green
- [ ] (post-merge) dev push 後の Deploy to Hugging Face Spaces workflow で post-deploy 検証 step が走り、 Space が RUNNING になることを実環境で確認

## Checklist

- [x] Tests pass locally (frontmatter gate 4 failure mode + 正常 PASS、 runtime script usage error rc=2、 ruff lint/format pass)
- [x] No GPL/LGPL deps (PyYAML BSD-3, huggingface_hub Apache-2.0)
- [x] Documentation updated (script の docstring に設計判断・exit code 規約・運用ガイドを記述)

## Related Issues

なし (PR #583 のフォローアップとして自発提案)。 ユーザー指示: 「今後同じような問題が起きないように事前に hf のデプロイおよび動作保証を CI もしくはデプロイ前後で確認ができるものがほかにないかを調査及び検証をして必要であれば、 新規の追加及び更新の対応を進めてください」
