### PR TITLE
fix(pages): 残り 4 個の demo HTML にも favicon link を追加

### DIFF
--- a/src/wasm/openjtalk-web/test/multilingual-demo/multilingual.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/multilingual.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Multilingual TTS WebAssembly Demo</title>
+    <link rel="icon" type="image/svg+xml" href="../../assets/favicon.svg">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;

--- a/src/wasm/openjtalk-web/test/multilingual-demo/piper-espeak-complete.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/piper-espeak-complete.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Piper Multilingual Complete Demo</title>
+    <link rel="icon" type="image/svg+xml" href="../../assets/favicon.svg">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;

--- a/src/wasm/openjtalk-web/test/multilingual-demo/piper-espeak-english.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/piper-espeak-english.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Piper English TTS Demo</title>
+    <link rel="icon" type="image/svg+xml" href="../../assets/favicon.svg">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;

--- a/src/wasm/openjtalk-web/test/multilingual-demo/simple-multilingual.html
+++ b/src/wasm/openjtalk-web/test/multilingual-demo/simple-multilingual.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Simple Multilingual TTS Demo</title>
+    <link rel="icon" type="image/svg+xml" href="../../assets/favicon.svg">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;


### PR DESCRIPTION
## Summary

PR #585 で追加した GitHub Pages の pre-deploy gate が、 merge 後の初回デプロイ run #28370353050 で `<link rel="icon">` 不在を 4 件検出して deploy を停止 (deploy job は skip)。 gate が gate として正しく機能したケースで、 残り 4 つの demo HTML (PR #585 で見落としていたサブページ) に同じ favicon link を追加する follow-up。 gate を緩める band-aid は採用しない (`feedback_no_band_aid_fixes`)。

## Affected Components

- [ ] Python (training / src/python_run)
- [ ] Rust (piper-core / piper-cli / piper-python / piper-wasm)
- [ ] C# (PiperPlus.Core / PiperPlus.Cli)
- [ ] C++ (libpiper_plus / iOS / Android)
- [ ] Go (src/go)
- [x] WASM / npm (src/wasm/openjtalk-web)
- [ ] Docker
- [ ] CI / CD
- [ ] Documentation

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Dependencies

## Risk Level

- [x] Patch (bug fix / 内部改善のみ — 既存 API / output に影響なし)
- [ ] Minor (新機能 / 非破壊変更)
- [ ] Major (破壊的変更)

## Contract Impact

- [x] None — `docs/spec/*.toml` への影響なし。 HTML head に link 1 行追加のみで API / 音響パリティに変更なし

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|------------------------|
| `multilingual.html` に favicon link 追加 | `<link rel="icon" type="image/svg+xml" href="../../assets/favicon.svg">` を `<title>` 直下に挿入 | このページを開くと browser auto-fetch で `/favicon.ico` 404、 console noise + PR #585 で追加した pre-deploy gate が fail |
| `piper-espeak-complete.html` に同上 | 同上 | 同上 |
| `piper-espeak-english.html` に同上 | 同上 | 同上 |
| `simple-multilingual.html` に同上 | 同上 | 同上 |

## 設計判断

- **5 個全 HTML を統一**: PR #585 では root index (deploy 後の `index.html` / `404.html` / `multilingual-demo/index.html`) のみ favicon link を追加していた。 deploy step は `cp -r src/wasm/openjtalk-web/test/multilingual-demo/* deploy/multilingual-demo/` で **全** demo HTML を bundle に含めるため、 secondary HTMLs にも link を追加しないと console noise が残る
- **deploy 側 sed の path 書き換え**: source HTML は `../../assets/favicon.svg` (depth 2 から root)。 deploy workflow の `s|\.\./\.\./|../|g` で multilingual-demo/ subdir の場合 `../assets/favicon.svg` に書き換わり、 `https://ayutaz.github.io/piper-plus/assets/favicon.svg` に解決される (PR #585 で `index.html` で実証済の挙動)
- **gate を緩める band-aid は採らない**: PR #585 の gate を「primary HTML だけ検証」 に書き換える方が変更行数は少ないが、 console 404 を意図的に許容することになり gate の目的に反する。 secondary HTMLs を直す方が正しい (`feedback_no_band_aid_fixes`)
- **画一的な insert ポイント**: 全 4 ファイルとも `<meta name="viewport">` 直下、 同一の link 行。 機械的に検査可能で、 将来 demo HTML を追加した時の漏れも pre-deploy gate が catch する

## Test Plan

- [ ] `grep -L 'rel="icon"' src/wasm/openjtalk-web/test/multilingual-demo/*.html` の出力が空 (= 全 5 HTML に link あり)
- [ ] CI: `Deploy WebAssembly Demo to GitHub Pages` workflow の **Pre-deploy gate** が 0 件 MISSING で pass
- [ ] CI: **Post-deploy verification** が 13 アセット全て 2xx
- [ ] merge 後 `https://ayutaz.github.io/piper-plus/multilingual-demo/multilingual.html` をブラウザで開き console に `favicon.ico` 404 が出ないこと
- [ ] 同様に `piper-espeak-complete.html` / `piper-espeak-english.html` / `simple-multilingual.html` で 404 不在

## Checklist

- [x] Tests pass locally (`grep -L` で全 5 HTML カバレッジ確認済)
- [x] No GPL / LGPL deps introduced (HTML 1 行追加のみ)
- [x] Documentation updated (該当なし — spec 文書への影響なし)

## Related Issues

PR #585 follow-up (同 PR の pre-deploy gate が初稼働で検出した漏れの修正)
