### PR TITLE
ci(security): nltk GHSA-p4gq-832x-fm9v を抑止 + tracking issue #588

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -101,14 +101,17 @@ jobs:
         run: pip install pip-audit
       - name: Audit root requirements
         # PR は warning、schedule/push は fail。
-        # IGNORE 一覧 (`--ignore-vuln`) は理由付きで `docs/spec/pip-audit-ignores.toml`
-        # に集中管理。 一行 = 一 advisory + justification + 再評価条件。
+        # IGNORE 一覧 (`--ignore-vuln`) は本コメントブロックが single source。
+        # 一 advisory = 一行 + justification + 解除条件 + tracking issue 番号 を
+        # 明記する。 解除手順 (latest 確認 + 削除) の詳細は各 tracking issue 側。
         # 現在 ignore 中:
         #   - GHSA-p4gq-832x-fm9v (nltk ≤ 3.9.4, CVE-2026-54293) — nltk.data.load()
         #     URL-encoded path traversal。 piper-plus は g2p-en / g2pk2 経由で
         #     hardcoded path (`"cmudict"` 等 library-internal) のみ呼び出すため
-        #     attacker-controlled URL 経路が存在せず実エクスプロイト不可。 upstream
-        #     stable fix リリース時に解除 (3.9.4 が現時点 latest)。
+        #     attacker-controlled URL 経路が存在せず実エクスプロイト不可。
+        #     解除条件: upstream stable fix リリース (3.9.4 が現時点 latest)
+        #     または g2p-en / g2pk2 を nltk 非依存実装に置換。
+        #     tracking: #588
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           pip-audit --requirement <(uv pip compile pyproject.toml 2>/dev/null) --strict --vulnerability-service osv \
@@ -122,7 +125,7 @@ jobs:
         # により発覚)。`--requirement requirements.txt` で配布対象の production
         # 依存だけを対象にする。dev / gpu / webui は optional extras で
         # 配布 wheel には含まれないため audit 対象外。
-        # `--ignore-vuln` 一覧は root 側 step のコメントに集約。
+        # `--ignore-vuln` 一覧は root 側 step のコメントブロックが single source。
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         working-directory: src/python_run
         run: pip-audit --strict --vulnerability-service osv --requirement requirements.txt \

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -101,10 +101,20 @@ jobs:
         run: pip install pip-audit
       - name: Audit root requirements
         # PR は warning、schedule/push は fail。
+        # IGNORE 一覧 (`--ignore-vuln`) は理由付きで `docs/spec/pip-audit-ignores.toml`
+        # に集中管理。 一行 = 一 advisory + justification + 再評価条件。
+        # 現在 ignore 中:
+        #   - GHSA-p4gq-832x-fm9v (nltk ≤ 3.9.4, CVE-2026-54293) — nltk.data.load()
+        #     URL-encoded path traversal。 piper-plus は g2p-en / g2pk2 経由で
+        #     hardcoded path (`"cmudict"` 等 library-internal) のみ呼び出すため
+        #     attacker-controlled URL 経路が存在せず実エクスプロイト不可。 upstream
+        #     stable fix リリース時に解除 (3.9.4 が現時点 latest)。
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
-          pip-audit --requirement <(uv pip compile pyproject.toml 2>/dev/null) --strict --vulnerability-service osv || \
-          pip-audit --strict --vulnerability-service osv
+          pip-audit --requirement <(uv pip compile pyproject.toml 2>/dev/null) --strict --vulnerability-service osv \
+            --ignore-vuln GHSA-p4gq-832x-fm9v || \
+          pip-audit --strict --vulnerability-service osv \
+            --ignore-vuln GHSA-p4gq-832x-fm9v
       - name: Audit src/python_run
         # 引数なし `pip-audit --strict` は working-directory に依存せず runner の
         # グローバル Python 環境を audit してしまい、プリインストール pip 自体の
@@ -112,9 +122,11 @@ jobs:
         # により発覚)。`--requirement requirements.txt` で配布対象の production
         # 依存だけを対象にする。dev / gpu / webui は optional extras で
         # 配布 wheel には含まれないため audit 対象外。
+        # `--ignore-vuln` 一覧は root 側 step のコメントに集約。
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         working-directory: src/python_run
-        run: pip-audit --strict --vulnerability-service osv --requirement requirements.txt
+        run: pip-audit --strict --vulnerability-service osv --requirement requirements.txt \
+          --ignore-vuln GHSA-p4gq-832x-fm9v
 
   # Rust: cargo-audit
   # fail-on-severity 統一 (High 以上): cargo-audit はデフォルトで vulnerability


### PR DESCRIPTION
## Summary

dev の `Security Audit` workflow が `pip-audit (Python)` job で nltk 3.9.4 の `GHSA-p4gq-832x-fm9v` (CVE-2026-54293、 severity HIGH) を検知して連日 fail している。 upstream stable fix が未リリース (3.9.4 が現時点 latest) で bump 不能、 かつ実エクスプロイト経路がゼロ (詳細下記) のため、 `--ignore-vuln GHSA-p4gq-832x-fm9v` で抑止し、 上位 fix が出次第解除する tracking issue (#588) を発行する。

## Affected Components

- [ ] Python (training / src/python_run)
- [ ] Rust (piper-core / piper-cli / piper-python / piper-wasm)
- [ ] C# (PiperPlus.Core / PiperPlus.Cli)
- [ ] C++ (libpiper_plus / iOS / Android)
- [ ] Go (src/go)
- [ ] WASM / npm (src/wasm/openjtalk-web)
- [ ] Docker
- [x] CI / CD
- [ ] Documentation

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Dependencies

## Risk Level

- [x] Patch (CI workflow の audit 抑止 1 件追加のみ、 ランタイム / API / 配布物への影響なし)
- [ ] Minor (新機能 / 非破壊変更)
- [ ] Major (破壊的変更)

## Contract Impact

- [x] None — `docs/spec/*.toml` への影響なし。 dependency / 配布物 / API contract は不変

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|------------------------|
| `pip-audit ... --ignore-vuln GHSA-p4gq-832x-fm9v` を root requirements audit step に追加 | `pyproject.toml` の transitive dep (nltk 3.9.4) を audit 対象から除外 (advisory ID 単位) | `Security Audit / pip-audit (Python)` が dev / schedule / push で連日 fail し続け、 真の CVE 検知 signal が noise に埋もれる |
| 同 flag を `src/python_run` audit step にも追加 | `requirements.txt` 経由の transitive (g2p-en / g2pk2 → nltk) も同じ ignore で抑止 | step 2 が独立に fail する (現状の症状) |
| 抑止理由 / 解除条件を yaml コメントブロックに集約 | 「いつ / なぜ / どうやって解除するか」 が yaml と tracking issue の両方に明示される | 将来 maintainer がこの ignore を見て意図を読めず blanket-ignore に堕落する |

## 設計判断

- **抑止の正当性**: 脆弱性は `nltk.data.load()` の URL-encoded path traversal で **attacker-controlled URL を渡せる場合のみ** エクスプロイト可能。 piper-plus の利用経路は `g2p-en` / `g2pk2` 内で hardcoded path (`"cmudict"` 等 library-internal string) のみ。 ユーザー入力が `nltk.data.load()` に到達する経路が存在しないため実エクスプロイト不可。 advisory severity (HIGH) と本プロジェクトでの実 exposure (none) を分離して評価
- **ignore は advisory ID 単位 / 期限付き**: GHSA / CVE ID で point-exact に絞る。 nltk 全体や pip-audit 全体を黙らせる band-aid は不採用 (`feedback_no_band_aid_fixes`)。 解除条件 (upstream stable fix リリース / 代替実装) は #588 に明文化、 yaml コメントから参照
- **alternative の不採用理由**: (a) nltk bump → 該当 stable リリースなし、 (b) g2p-en / g2pk2 を nltk 非依存に置換 → 英語 / 韓国語 G2P の major refactor で本 PR の scope を超える (個別 issue 化が適切)、 (c) `continue-on-error: true` を schedule にも拡大 → 全 vuln を warning 化するため過剰抑止
- **license 影響なし**: dependency 追加 / 変更なし、 `feedback_no_license_change_deps` 抵触なし
- **tracking issue を本 PR と分離**: 「いつ解除するか」 の判断点は upstream リリースタイミング次第で長期的に open のため、 独立 issue (#588) で追跡。 PR merge 後も close しない

## Test Plan

- [ ] PR の `Security Audit / pip-audit (Python)` job が **success** (本 PR の真のテスト)
- [ ] PR の `Security Audit / pip-audit (Python)` job ログに `1 dependency was ignored (GHSA-p4gq-832x-fm9v)` 相当の line が出力されている (advisory ID が確実に hit して suppress された証跡)
- [ ] PR の `Security Audit / pip-audit (Python)` job ログに **他の vulnerability が新たに pass する** ことがない (suppress 範囲が広すぎない regression guard)
- [ ] `PYTHONUTF8=1 python -c "import yaml; yaml.safe_load(open('.github/workflows/security-audit.yml', encoding='utf-8'))"` で YAML 構文 OK
- [ ] `grep -c "GHSA-p4gq-832x-fm9v" .github/workflows/security-audit.yml` が `4` (root audit step + src/python_run audit step、 命令本体 2 + コメント 2)
- [ ] tracking issue #588 が open 状態で残っており、 解除条件 (upstream fix / 代替実装) が明示されている

## Checklist

- [x] Tests pass locally (YAML 構文 OK、 grep 4 件期待値一致)
- [x] No GPL / LGPL deps introduced (dependency 追加 / 変更なし)
- [x] Documentation updated (yaml 内コメントブロック + tracking issue #588 で運用ルール明文化)

## Related Issues

Closes #17 (本セッション内の判断待ちタスク — 抑止 + tracking で完了)
Related: #588 (suppression を解除するための tracking issue)
