### PR TITLE
feat(ci): post-rename hardening — legacy import ban + wheel data smoke + co-install e2e

### DIFF
--- a/.github/workflows/coinstall-smoke.yml
+++ b/.github/workflows/coinstall-smoke.yml
@@ -1,0 +1,263 @@
+name: "Co-install Smoke (piper-tts + piper-plus)"
+
+# ---------------------------------------------------------------------------
+# Co-install e2e smoke: verifies v2.0 rename (piper -> piper_plus) actually
+# achieves the "clean break" contract from
+# docs/design/piper-plus-module-rename-v2.md:
+#
+#   Upstream `piper-tts` (import piper / `piper` CLI) and our fork
+#   `piper-plus` (import piper_plus / `piper-plus` CLI) can be pip-installed
+#   into the SAME environment without any name collision, and each
+#   `import` / CLI resolves to the correct project.
+#
+# Regressions this catches:
+#   - Our wheel leaks a top-level `piper/` package (rename incomplete)
+#   - Our wheel installs a `piper` console script (entry-point collision)
+#   - `import piper` silently resolves to our fork (webui.py:23 class of bug
+#     called out in the rename design doc — "most silent, most dangerous")
+#   - `import piper_plus` fails after co-install (upstream shadows us)
+#   - `piper` / `piper-plus` CLI binaries missing or crash on --help
+#
+# Why a dedicated workflow and not a step in python-tests.yml:
+#   The whole point of this gate is a CLEAN venv with ONLY upstream +
+#   our wheel — no test extras, no editable installs, no pytest plugins.
+#   Any of those would mask real packaging bugs (e.g. `-e src/python_run`
+#   makes `import piper_plus` succeed even when the built wheel is
+#   broken). We build from src/python_run and install the built wheel.
+# ---------------------------------------------------------------------------
+
+# 最小権限: install / import / --help のみ、 PR / issue への書き込み不要。
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'src/python_run/**'
+      - 'pyproject.toml'
+      - '.github/workflows/coinstall-smoke.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'src/python_run/**'
+      - 'pyproject.toml'
+      - '.github/workflows/coinstall-smoke.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coinstall-smoke:
+    name: piper-tts + piper-plus in clean venv (Python 3.13)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.13'
+
+      # Pinned upstream version so a new piper-tts release cannot silently
+      # break this gate (or, worse, silently "fix" a real regression by
+      # coincidentally shipping a compatible layout). Bump manually after
+      # verifying the new release still exposes `piper` module + CLI.
+      # 1.3.0 = July 2025 stable, well after the upstream project's package
+      # layout stabilised; PyPI: https://pypi.org/project/piper-tts/1.3.0/
+      - name: Configure pinned versions
+        id: pins
+        run: |
+          echo "piper_tts_version=1.3.0" >> "$GITHUB_OUTPUT"
+
+      - name: Create clean venv
+        run: |
+          set -euxo pipefail
+          python -m venv coinstall-test-venv
+          # Upgrade pip / build inside the venv so the wheel build step
+          # below uses a modern PEP 517 frontend, but do NOT install
+          # anything else — this venv must stay minimal so a broken
+          # wheel cannot be masked by transitive test dependencies.
+          ./coinstall-test-venv/bin/python -m pip install --upgrade pip build
+
+      - name: Install upstream piper-tts (pinned)
+        run: |
+          set -euxo pipefail
+          ./coinstall-test-venv/bin/pip install \
+            "piper-tts==${{ steps.pins.outputs.piper_tts_version }}"
+
+      - name: Build piper-plus wheel from src/python_run
+        run: |
+          set -euxo pipefail
+          # `python -m build --wheel` runs PEP 517 build in an isolated
+          # environment so this does not pollute the co-install venv.
+          ./coinstall-test-venv/bin/python -m build --wheel src/python_run \
+            --outdir dist-coinstall
+          ls -la dist-coinstall/
+
+      - name: Install built piper-plus wheel into the same venv
+        run: |
+          set -euxo pipefail
+          # Glob-install the freshly-built wheel. There should be exactly
+          # one wheel in dist-coinstall/ (a single `python -m build`
+          # invocation on src/python_run). Fail loud if not.
+          wheels=(dist-coinstall/piper_plus-*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::expected exactly 1 piper_plus wheel, got ${#wheels[@]}: ${wheels[*]}"
+            exit 1
+          fi
+          ./coinstall-test-venv/bin/pip install "${wheels[0]}"
+
+      - name: Assert co-install semantics (Python imports)
+        run: |
+          ./coinstall-test-venv/bin/python <<'PY'
+          # Contract from docs/design/piper-plus-module-rename-v2.md:
+          #   (a) `import piper` succeeds AND resolves to upstream piper-tts
+          #       (i.e. its __file__ path does NOT contain 'piper_plus')
+          #   (b) `import piper_plus` succeeds AND resolves to our fork
+          #   (c) The two modules are distinct objects (no aliasing)
+          #   (d) site-packages/piper/ dir is upstream-owned — no leaked
+          #       files whose path suggests they came from our wheel
+          #
+          # Any failure = packaging regression. Print enough diagnostic
+          # detail so the PR author can see exactly which invariant broke.
+          import sys
+          from pathlib import Path
+
+          failures: list[str] = []
+
+          # (a) upstream import
+          try:
+              import piper
+          except Exception as e:
+              failures.append(f"(a) `import piper` failed: {type(e).__name__}: {e}")
+              piper = None  # type: ignore[assignment]
+          else:
+              piper_file = getattr(piper, "__file__", None)
+              print(f"piper.__file__ = {piper_file}")
+              if piper_file is None:
+                  failures.append("(a) `piper.__file__` is None — cannot verify origin")
+              elif "piper_plus" in str(piper_file):
+                  failures.append(
+                      f"(a) `import piper` resolved into our fork: {piper_file} "
+                      "(expected upstream piper-tts). Our wheel is leaking a "
+                      "top-level `piper/` package — rename is incomplete."
+                  )
+
+          # (b) our fork import
+          try:
+              import piper_plus
+          except Exception as e:
+              failures.append(f"(b) `import piper_plus` failed: {type(e).__name__}: {e}")
+              piper_plus = None  # type: ignore[assignment]
+          else:
+              plus_file = getattr(piper_plus, "__file__", None)
+              print(f"piper_plus.__file__ = {plus_file}")
+              if plus_file is None:
+                  failures.append("(b) `piper_plus.__file__` is None — cannot verify origin")
+              elif "piper_plus" not in str(plus_file):
+                  failures.append(
+                      f"(b) `import piper_plus` resolved to unexpected path: {plus_file}"
+                  )
+
+          # (c) distinct module objects
+          if piper is not None and piper_plus is not None:
+              if piper is piper_plus:
+                  failures.append(
+                      "(c) `piper` and `piper_plus` are the SAME module object — "
+                      "one of them is aliasing the other via sys.modules"
+                  )
+              else:
+                  print("piper and piper_plus are distinct module objects: ok")
+
+          # (d) site-packages/piper is upstream-owned only
+          # Locate the venv site-packages by asking sysconfig — this
+          # is what pip itself uses, so the path is authoritative.
+          import sysconfig
+          site_packages = Path(sysconfig.get_paths()["purelib"])
+          print(f"site-packages = {site_packages}")
+          piper_dir = site_packages / "piper"
+          if not piper_dir.is_dir():
+              failures.append(
+                  f"(d) expected {piper_dir} to exist (upstream piper-tts installs it), "
+                  "but it is missing — upstream install itself is broken"
+              )
+          else:
+              # A leak would look like: our wheel dropping a file into
+              # site-packages/piper/ that mentions our package name. A
+              # legitimate upstream file may mention 'piper' but not
+              # 'piper_plus'. This scan is a heuristic tripwire — cheap
+              # and unlikely to false-positive because upstream never
+              # references our fork's name.
+              leaked: list[Path] = []
+              for p in piper_dir.rglob("*"):
+                  if p.is_file() and "piper_plus" in p.name:
+                      leaked.append(p)
+              if leaked:
+                  failures.append(
+                      "(d) files with 'piper_plus' in their name found under "
+                      f"upstream's {piper_dir}: {[str(x) for x in leaked]}"
+                  )
+              else:
+                  print(f"(d) {piper_dir} contains no piper_plus-named files: ok")
+
+          if failures:
+              print("::error::co-install semantics violated:")
+              for f in failures:
+                  print(f"  - {f}")
+              sys.exit(1)
+          print("all co-install invariants (a)-(d) satisfied")
+          PY
+
+      - name: Assert upstream `piper --help` runs
+        run: |
+          set -euxo pipefail
+          # (e) upstream CLI still works after our wheel is installed.
+          # Some argparse-based tools exit non-zero on --help under
+          # certain configs; we assert success AND stdout non-empty so
+          # a broken entry-point script (e.g. our wheel shadowing) is
+          # caught even if the exit code accidentally passes.
+          out="$(./coinstall-test-venv/bin/piper --help 2>&1)"
+          echo "$out" | head -20
+          if [ -z "$out" ]; then
+            echo "::error::upstream 'piper --help' produced no output"
+            exit 1
+          fi
+
+      - name: Assert our `piper-plus --help` runs
+        run: |
+          set -euxo pipefail
+          # (f) our fork CLI. Same rationale as (e).
+          out="$(./coinstall-test-venv/bin/piper-plus --help 2>&1)"
+          echo "$out" | head -20
+          if [ -z "$out" ]; then
+            echo "::error::'piper-plus --help' produced no output"
+            exit 1
+          fi
+
+      - name: Dump venv layout on failure
+        if: failure()
+        run: |
+          set +e
+          echo "=== pip list ==="
+          ./coinstall-test-venv/bin/pip list
+          echo "=== venv bin/ ==="
+          ls -la coinstall-test-venv/bin/ || true
+          echo "=== site-packages/piper* ==="
+          ./coinstall-test-venv/bin/python - <<'PY'
+          import sysconfig
+          from pathlib import Path
+          sp = Path(sysconfig.get_paths()["purelib"])
+          for name in ("piper", "piper_plus"):
+              d = sp / name
+              print(f"--- {d} ---")
+              if d.is_dir():
+                  for p in sorted(d.rglob("*")):
+                      print(p.relative_to(sp))
+              else:
+                  print("(missing)")
+          PY

--- a/.github/workflows/dev-build-all.yml
+++ b/.github/workflows/dev-build-all.yml
@@ -187,6 +187,14 @@ jobs:
         run: |
           python -m build --wheel --outdir ../../dist/
 
+      # Gate 2 (Issue #590 / rename design §9): open the just-built wheel and
+      # verify (a) required package-data JSON files are bundled and (b) no
+      # stray top-level `piper/` directory leaked in — either regression is
+      # invisible to unit tests but breaks downstream co-install with the
+      # legacy `piper-tts` package on PyPI. ~1s, no extra deps.
+      - name: Verify wheel bundles required package-data (Gate 2)
+        run: python scripts/check_wheel_data_bundling.py --wheel dist/piper_plus-*.whl
+
       - name: List built wheels
         run: ls -la dist/
 

--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,9 @@ check_*.py
 !scripts/verify_hf_space_runtime.py
 # GitHub Pages post-deploy 404 detection gate
 !scripts/verify_pages_assets.py
+# Post-rename hardening gates (Issue #590 / follow-up to PR #598)
+!scripts/check_no_legacy_piper_imports.py
+!scripts/check_wheel_data_bundling.py
 create_comprehensive_*.py
 add_missing_*.py
 retrain_*.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -228,6 +228,22 @@ repos:
         files: ^(\.pre-commit-config\.yaml|scripts/check_precommit_file_regex\.py)$
         pass_filenames: false
 
+      # v2.0 `piper` -> `piper_plus` rename (commit b86df3f9) の carryover
+      # risk 対策 — Issue #590 / docs/design/piper-plus-module-rename-v2.md §9。
+      # `import piper` / `from piper import` が repo 内 .py に再侵入した場合、
+      # 我々の wheel と upstream `piper-tts` の同時 install 環境で silent に
+      # 上流モジュールへ解決されるため (webui.py 事案類型)、 grep-only の
+      # 軽量 gate として commit 時に fail-fast する。 `piper_train` /
+      # `piper_plus` / `piper_plus_g2p` / `piper_phonemize` / `piper_wyoming`
+      # は false-positive を避けるためスクリプト側 regex で除外。 doc / markdown
+      # / TOML は scope 外 (migration guide が legacy 形式を prose で引用可)。
+      - id: no-legacy-piper-imports
+        name: no legacy `import piper` / `from piper import` (v2.0 rename gate)
+        entry: uv run --no-sync python scripts/check_no_legacy_piper_imports.py
+        language: system
+        files: \.py$
+        pass_filenames: true
+
       # SSML subset 仕様 byte-for-byte 三方向 drift gate。
       # toml ↔ Python canonical ↔ JSON fixture が乖離していないか。
       # 既存 CI workflow を pre-commit 化、 PR 時点ではなく commit 時点で

--- a/scripts/check_no_legacy_piper_imports.py
+++ b/scripts/check_no_legacy_piper_imports.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Detect legacy ``import piper`` / ``from piper import`` references in sources.
+
+Background:
+    piper-plus v2.0 renamed the Python runtime module from ``piper`` to
+    ``piper_plus`` (see ``docs/design/piper-plus-module-rename-v2.md`` §9,
+    "co-install fallback risk", tracked in Issue #590). The bare top-level
+    ``piper`` module now belongs to upstream ``piper-tts`` on PyPI. If our
+    own sources still contain ``from piper import ...`` or ``import piper``
+    while both packages are installed in the same environment, Python
+    silently resolves the name to whichever wheel happens to win the
+    ``sys.path`` race — most often upstream ``piper-tts``. The failure
+    is silent, produces subtly different audio (different phonemizer,
+    different Voice class), and only surfaces when users open a bug
+    against us for behaviour that is actually upstream's.
+
+    §9 of the rename design flags this as the highest-severity carryover
+    risk from the rename. This gate is the static (compile-time) half of
+    the mitigation; a runtime co-install detection test is planned in
+    Phase 8.
+
+Detection rule (conservative — prefer false-negative over false-positive):
+
+- Matches ``import piper`` (with optional alias / comma / EOL / trailing
+  ``#comment``) but NOT ``import piper_train`` / ``import piper_plus`` /
+  ``import piper_plus_g2p`` / ``import piper_phonemize`` /
+  ``import piper_wyoming``.
+- Matches ``from piper import X`` and ``from piper.<submod> import X``
+  but NOT ``from piper_train import ...``.
+- Scope: repo-wide ``*.py`` files (executable Python only). Non-Python
+  formats — Markdown docs, TOML/JSON configs — are exempt; they may
+  legitimately quote ``import piper`` as prose (e.g., a migration guide
+  showing the deprecated form).
+- Skipped path prefixes: ``tests/fixtures/`` (synthetic parser fixtures)
+  and ``src/piper_phonemize_bundled/`` (vendored upstream mirror — outside
+  the rename contract). Gitignored trees (``.venv/``, ``target/``,
+  ``build/``, ``node_modules/``, ``__pycache__/``, ``dist/``) are
+  naturally excluded by ``git ls-files``.
+
+False-positive risks (documented so future contributors know when to
+extend ALLOWLIST vs. change the source):
+
+1. Docstrings / string literals that quote the legacy import form
+   (e.g., a migration-guide example embedded in a ``.py`` source). This
+   regex is line-based and cannot tell code from a string. Preferred
+   fix: extract the example into a Markdown file (docs/ is not scanned).
+   Fallback: add the file to ALLOWLIST with a justification comment.
+2. Tests that intentionally exercise co-install detection (planned in
+   Phase 8, ``tests/**/test_coinstall_*.py``). Add to ALLOWLIST when
+   introduced, not preemptively.
+3. This script itself: the regex source is a raw string, not a real
+   ``import piper`` statement, and does not match its own pattern
+   (branch 2 requires ``import\\s+piper`` at line start after optional
+   whitespace, while the source line here has the token embedded in a
+   quoted string). Verified by a full-repo dry run.
+
+Exit codes:
+    0  -- no legacy references found
+    1  -- references found; offending file:line printed to stderr
+
+Override:
+    Add the offending file to ALLOWLIST below with a justification.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+# Local import: shared UTF-8 stdout/stderr reconfiguration for Windows consoles
+# so gate output (arrows, dashes) doesn't UnicodeEncodeError on cp932/cp1252.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from platform_utils import force_utf8_output  # noqa: E402
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Single compiled regex; two branches OR'd together.
+#
+# Branch 1: ``from piper import X`` and ``from piper.<submod> import X``.
+#   ``piper`` must be followed by either ``.`` (submodule) or whitespace
+#   before ``import`` — a following ``_`` would make it ``piper_train``
+#   etc., which is what we want to ALLOW, so ``\s+`` (not ``\w``) after
+#   the optional submodule tail rejects that case naturally.
+#
+# Branch 2: ``import piper`` (with optional ``as alias`` / ``, other`` /
+#   comment / EOL).
+#   Negative lookahead ``(?![A-Za-z0-9_])`` after literal ``piper``
+#   rejects ``piper_train`` / ``piper_plus`` / ``piperclip`` / etc.
+LEGACY_IMPORT_RE = re.compile(
+    r"^\s*(?:"
+    r"from\s+piper(?:\.[A-Za-z_][A-Za-z0-9_.]*)?\s+import\b"
+    r"|"
+    r"import\s+piper(?![A-Za-z0-9_])"
+    r")"
+)
+
+# Path prefixes (POSIX-normalized) that are exempt from the check.
+# Add entries with a justification comment. Kept minimal on purpose —
+# broad skip lists silently accumulate escape hatches.
+SKIP_PREFIXES: tuple[str, ...] = (
+    # Synthetic Python fixtures for parser/lint testing may contain
+    # deliberately malformed or legacy import lines.
+    "tests/fixtures/",
+    # Vendored upstream mirror. This tree is not under the rename
+    # contract — it's a byte-for-byte copy of an external project.
+    "src/piper_phonemize_bundled/",
+)
+
+# Files explicitly allowed to keep the legacy import form. Document why
+# each entry exists. Additions should require code review.
+#
+# NOTE: Empty at introduction time. The repo-wide `git grep` sweep at
+# gate-authoring time returned zero hits, so no bootstrap entries were
+# needed. Future entries are expected to fall into the categories listed
+# in the module docstring under "False-positive risks".
+ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _is_python_file(path: Path) -> bool:
+    """Return True if ``path`` is a ``.py`` source file."""
+    return path.suffix == ".py"
+
+
+def _should_skip(rel_posix: str) -> bool:
+    """Return True if ``rel_posix`` matches a SKIP_PREFIX or ALLOWLIST entry."""
+    if rel_posix in ALLOWLIST:
+        return True
+    return any(rel_posix.startswith(p) for p in SKIP_PREFIXES)
+
+
+def _check_file(path: Path) -> list[tuple[int, str]]:
+    """Return list of ``(line_no, matched_line)`` legacy-import hits."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        # Rare binary-ish .py (generated resource files) — skip, matching
+        # the check_secret_path_reference.py convention.
+        return []
+    hits: list[tuple[int, str]] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        if LEGACY_IMPORT_RE.match(line):
+            hits.append((i, line.rstrip()))
+    return hits
+
+
+def _iter_repo_python_files() -> list[Path]:
+    """Enumerate tracked ``*.py`` files via ``git ls-files``.
+
+    Falls back to ``rglob`` with explicit ignore dirs when not in a git
+    checkout (e.g., release tarball), mirroring
+    ``scripts/check_secret_path_reference.py``.
+    """
+    try:
+        tracked = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "ls-files", "-z"],
+            capture_output=True,
+            check=True,
+        ).stdout.decode("utf-8", errors="replace")
+        return [REPO_ROOT / p for p in tracked.split("\0") if p and p.endswith(".py")]
+    except (OSError, subprocess.CalledProcessError):
+        _IGNORE_DIRS = {
+            "build",
+            ".venv",
+            "venv",
+            "node_modules",
+            "target",
+            "dist",
+            ".git",
+            "__pycache__",
+            ".mypy_cache",
+        }
+        return [
+            p
+            for p in REPO_ROOT.rglob("*.py")
+            if p.is_file()
+            and not _IGNORE_DIRS.intersection(p.relative_to(REPO_ROOT).parts)
+        ]
+
+
+def main(argv: list[str]) -> int:
+    force_utf8_output()
+
+    # pre-commit passes staged file paths as argv; if none given, do a
+    # full-repo sweep (manual invocation / release-time audit).
+    if argv:
+        paths = [Path(p) for p in argv]
+    else:
+        paths = _iter_repo_python_files()
+
+    failures: list[tuple[str, int, str]] = []
+    scanned = 0
+    for path in paths:
+        if not path.is_file():
+            continue
+        if not _is_python_file(path):
+            continue
+        try:
+            # as_posix() — forward slashes on every OS so SKIP_PREFIXES /
+            # ALLOWLIST entries (which use "/") match on Windows too.
+            rel = path.resolve().relative_to(REPO_ROOT).as_posix()
+        except ValueError:
+            rel = path.as_posix()
+        if _should_skip(rel):
+            continue
+        scanned += 1
+        for line_no, content in _check_file(path):
+            failures.append((rel, line_no, content))
+
+    if not failures:
+        print(
+            f"OK: scanned {scanned} *.py file(s); no legacy `import piper` / "
+            f"`from piper import` references found "
+            f"({len(ALLOWLIST)} files allowlisted, "
+            f"{len(SKIP_PREFIXES)} path prefix(es) skipped)."
+        )
+        return 0
+
+    print(
+        f"ERROR: {len(failures)} legacy `piper` import reference(s) found:",
+        file=sys.stderr,
+    )
+    for rel, line_no, content in failures:
+        print(f"  {rel}:{line_no}: {content}", file=sys.stderr)
+    print(
+        "\nWhy this fails: piper-plus v2.0 renamed the runtime module from "
+        "`piper` to `piper_plus`. The bare top-level `piper` module now "
+        "belongs to upstream `piper-tts` on PyPI. When both packages are "
+        "installed in the same environment (co-install), `from piper "
+        "import ...` silently resolves to whichever wheel wins the sys.path "
+        "race — typically upstream — and users see subtly wrong behaviour "
+        "that they attribute to piper-plus.",
+        file=sys.stderr,
+    )
+    print(
+        "\nSee: docs/design/piper-plus-module-rename-v2.md §9 "
+        "(silent fallback to upstream `piper-tts` PiperVoice) and "
+        "Issue #590.",
+        file=sys.stderr,
+    )
+    print(
+        "\nFix options:",
+        file=sys.stderr,
+    )
+    print(
+        "  - Rename to `piper_plus` (canonical): "
+        "`from piper_plus import PiperVoice`, `import piper_plus`.",
+        file=sys.stderr,
+    )
+    print(
+        "  - If the import is inside a docstring / string literal "
+        "(migration example, changelog snippet), extract it to a Markdown "
+        "file under `docs/` — Markdown is not scanned.",
+        file=sys.stderr,
+    )
+    print(
+        "  - If the file legitimately needs the legacy form (e.g., a "
+        "co-install detection test), add its repo-relative POSIX path to "
+        "ALLOWLIST in scripts/check_no_legacy_piper_imports.py with a "
+        "justification comment.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_wheel_data_bundling.py
+++ b/scripts/check_wheel_data_bundling.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Gate 2 — piper-plus wheel data bundling smoke test.
+
+Why this gate exists (Issue #590 rename design §9)
+--------------------------------------------------
+
+v2.0 renamed the top-level Python package ``piper`` → ``piper_plus`` in a
+single clean-break commit (b86df3f9). Two regression classes threaten that
+rename and are silently invisible to unit tests (they only bite downstream
+users at pip-install time):
+
+1. **Package-data drift.** ``piper_plus/voices.json`` and the two JSON
+   language-data files (``phonemize/data/zh_en_loanword.json`` /
+   ``phonemize/data/sv_function_words.json``) MUST be present inside the
+   built ``.whl`` archive; otherwise ``pip install piper-plus`` gives users
+   an import-time ``FileNotFoundError`` the first time they call
+   ``synthesize()``. The three paths live in three places at once —
+   ``src/python_run/pyproject.toml`` ``[tool.setuptools.package-data]``,
+   the on-disk file layout, and (implicitly) the runtime import path —
+   and any of them can drift independently. Existing lint/format gates
+   do not open the wheel.
+
+2. **Co-install safety after the piper→piper_plus rename.** If a stray
+   top-level ``piper/`` directory ever gets repackaged into the wheel
+   (e.g. an editable-install leftover, an accidental ``packages.find``
+   pattern change, or a symlink into the source tree), that wheel will
+   silently overwrite the legacy ``piper`` package on PyPI when a user
+   has both installed. The v2.0 rename design mandates a clean break —
+   the built wheel must contain **only** ``piper_plus/`` and its
+   sibling ``piper_plus-<ver>.dist-info/`` metadata.
+
+This script opens the built wheel with ``zipfile.ZipFile`` and asserts
+both invariants against the raw member name list. False-positive risks
+are minimized by the exact-match check for the three required files and
+the ``startswith("piper/")`` prefix (with the literal ``/``) for the
+forbidden check — ``piper_plus/`` does not match (``_`` != ``/``) and
+``piper_plus-<ver>.dist-info/`` does not match (``-`` != ``/``).
+
+Usage
+-----
+
+    # CI mode: point at the wheel produced by an earlier build step
+    python scripts/check_wheel_data_bundling.py --wheel dist/piper_plus-2.0.0-py3-none-any.whl
+
+    # Local mode: auto-discover the newest wheel in dist/, or build if missing
+    python scripts/check_wheel_data_bundling.py
+
+Exit codes
+----------
+
+* ``0`` — all three required files present, no top-level ``piper/`` member.
+* ``0`` — wheel could not be built locally within 120 s (skip with a
+  ``::warning::`` annotation; CI runs the gate against a pre-built wheel).
+* ``1`` — any required file missing OR any forbidden ``piper/`` member found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+from platform_utils import force_utf8_output
+
+
+force_utf8_output()
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The three required package-data files. Exact zipfile-member string match.
+# Keep in sync with src/python_run/pyproject.toml [tool.setuptools.package-data].
+REQUIRED_FILES: tuple[str, ...] = (
+    "piper_plus/voices.json",
+    "piper_plus/phonemize/data/zh_en_loanword.json",
+    "piper_plus/phonemize/data/sv_function_words.json",
+)
+
+# Anchor the glob to piper_plus-<digit> so sibling wheels
+# (piper_plus_g2p-*.whl) are not accidentally picked up. This matches the
+# convention in check_bundle_size.py where every distribution glob uses
+# a trailing "-[0-9]*" to exclude packages whose name shares the prefix.
+DIST_GLOB = "dist/piper_plus-[0-9]*.whl"
+
+# Local dev fallback: try to build the wheel once. Wall-clock 120 s is
+# generous — a warm src/python_run wheel build is ~10-20 s, a cold build
+# with a full uv resolver run is ~60 s. If we exceed this budget we
+# skip with a warning (CI is the authoritative gate).
+BUILD_TIMEOUT_SECONDS = 120
+
+
+def _resolve_wheel(explicit: str | None) -> Path | None:
+    """Return the wheel to inspect, or None if we should skip.
+
+    Resolution order:
+      1. ``--wheel`` if given.
+      2. Newest matching wheel in ``dist/`` by mtime.
+      3. Try ``uv build --wheel src/python_run --out-dir dist`` once, then
+         re-glob. On timeout / uv missing / build failure, return None so
+         the caller can print a skip warning and exit 0.
+    """
+    if explicit is not None:
+        candidates = sorted(glob.glob(explicit))
+        if not candidates:
+            print(
+                f"::error::--wheel path did not match any file: {explicit}",
+                file=sys.stderr,
+            )
+            return None
+        # If a glob was passed (e.g. dist/piper_plus-*.whl) prefer newest.
+        candidates.sort(key=os.path.getmtime)
+        chosen = Path(candidates[-1])
+        print(f"[check_wheel_data_bundling] using wheel: {chosen}", file=sys.stderr)
+        return chosen
+
+    matches = sorted(glob.glob(str(REPO_ROOT / DIST_GLOB)))
+    if matches:
+        matches.sort(key=os.path.getmtime)
+        chosen = Path(matches[-1])
+        print(
+            f"[check_wheel_data_bundling] auto-discovered wheel: {chosen}",
+            file=sys.stderr,
+        )
+        return chosen
+
+    # No wheel on disk — try one build. If uv is missing or the build
+    # exceeds the timeout, skip cleanly (this script is meant to be a fast
+    # sanity check; producing the wheel is CI's job).
+    print(
+        "[check_wheel_data_bundling] no wheel in dist/, attempting "
+        f"'uv build --wheel src/python_run --out-dir dist' (timeout "
+        f"{BUILD_TIMEOUT_SECONDS}s)...",
+        file=sys.stderr,
+    )
+    try:
+        subprocess.run(
+            [
+                "uv",
+                "build",
+                "--wheel",
+                "src/python_run",
+                "--out-dir",
+                "dist",
+            ],
+            cwd=REPO_ROOT,
+            timeout=BUILD_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError:
+        print(
+            "::warning::uv not installed locally; skipping wheel bundling "
+            "check. CI will run this gate against a fresh build.",
+            file=sys.stderr,
+        )
+        return None
+    except subprocess.TimeoutExpired:
+        print(
+            f"::warning::wheel not built within {BUILD_TIMEOUT_SECONDS}s; "
+            "skipping wheel bundling check. CI will run this gate against "
+            "a fresh build.",
+            file=sys.stderr,
+        )
+        return None
+
+    matches = sorted(glob.glob(str(REPO_ROOT / DIST_GLOB)))
+    if not matches:
+        print(
+            "::warning::wheel build completed but produced no matching "
+            f"{DIST_GLOB!s}; skipping. CI will run this gate against a "
+            "fresh build.",
+            file=sys.stderr,
+        )
+        return None
+    matches.sort(key=os.path.getmtime)
+    chosen = Path(matches[-1])
+    print(f"[check_wheel_data_bundling] built wheel: {chosen}", file=sys.stderr)
+    return chosen
+
+
+def _inspect_wheel(wheel_path: Path) -> tuple[list[str], list[str]]:
+    """Return (missing_required, unexpected_piper_members).
+
+    Uses zipfile member NAMES only — never inspects RECORD text or file
+    bodies. PKZIP guarantees forward slashes in member names, so no
+    OS-specific normalization is required.
+    """
+    with zipfile.ZipFile(wheel_path) as zf:
+        names = set(zf.namelist())
+
+    missing = [path for path in REQUIRED_FILES if path not in names]
+
+    # Forbidden: any member whose top-level directory is literally ``piper``.
+    # ``piper_plus/...`` and ``piper_plus-<ver>.dist-info/...`` do NOT
+    # match this prefix because both the underscore and the hyphen fail
+    # the ``startswith("piper/")`` literal-slash test.
+    unexpected = sorted(n for n in names if n.startswith("piper/"))
+
+    return missing, unexpected
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0] if __doc__ else "",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--wheel",
+        type=str,
+        default=None,
+        help=(
+            "Path (or glob) to a built .whl. If omitted, the newest "
+            f"{DIST_GLOB!s} is used; if none exists, one build attempt "
+            "is made via 'uv build --wheel src/python_run'."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    wheel_path = _resolve_wheel(args.wheel)
+    if wheel_path is None:
+        # A resolution warning (or explicit ::error::) has already been
+        # printed. For the explicit --wheel-not-found case we still want
+        # to fail; for the local skip case we want to exit 0. Distinguish
+        # by whether --wheel was passed.
+        if args.wheel is not None:
+            return 1
+        return 0
+
+    missing, unexpected = _inspect_wheel(wheel_path)
+
+    for path in missing:
+        print(f"::error::MISSING: {path}")
+    for member in unexpected:
+        print(f"::error::UNEXPECTED: piper/ found in wheel: {member}")
+
+    if missing or unexpected:
+        print(
+            f"\nERROR: {wheel_path.name} failed wheel bundling smoke — "
+            f"{len(missing)} missing required file(s), "
+            f"{len(unexpected)} unexpected piper/ member(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"[check_wheel_data_bundling] OK — {wheel_path.name}: "
+        f"{len(REQUIRED_FILES)}/{len(REQUIRED_FILES)} required files "
+        "present, 0 top-level piper/ members"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR #598 (piper→piper_plus rename v2.0) の post-merge hardening。 rename design v2.0 §9 が最高リスク項目として明示していた 3 種の regression パターン (silent fallback / package-data drift / co-install regression) に対する **継続的な CI 防御** を追加する。 audit で high 判定されたが rename PR の scope 外として意図的に deferred された 3 gate を、 一つの follow-up PR として提出する。

## Affected Components

- [x] CI-CD
- [x] Python

## Type

- [x] New feature

## Risk Level

- [ ] patch
- [x] minor
- [ ] major

新規 CI gate 追加のみ。 既存コード / 実装 / 契約は無変更、 破壊的変更なし。 誤検知した場合の失敗方向は保守的 (false negative 優先)、 pre-commit / CI ゲート追加による commit 時間は各 gate ~1-2s の増加のみ。

## Contract Impact

- [x] None

新規 gate 3 種は既存の `docs/spec/*.toml` 契約を参照 / 変更しない。 rename design (`docs/design/piper-plus-module-rename-v2.md` §9 / §10) の要求事項実装。

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| Gate 1: legacy `import piper` 検知 | `scripts/check_no_legacy_piper_imports.py` が repo 全 `*.py` を grep、 `from piper import X` / `import piper` (bare) を検出して file:line 出力 + exit 1。 `piper_train` / `piper_plus` / `piper_phonemize` 等は word-boundary で除外 | co-install 環境 (本家 piper-tts + 当 fork) で `from piper import ...` が silent に本家 PiperVoice へ fallback → 動作が微妙に異なるが ImportError なし → ユーザは piper-plus の bug として報告 (rename design §9「最も静かで危険」 と評価) |
| Gate 2: wheel package-data smoke | `scripts/check_wheel_data_bundling.py` が built `.whl` を `zipfile.ZipFile` で開き、 必須 3 files (`voices.json` / `zh_en_loanword.json` / `sv_function_words.json`) 同梱 + top-level `piper/` member 不在を assert | `pyproject.toml [tool.setuptools.package-data]` のキー rename 漏れで data file が wheel に同梱されず、 build success・実行時 `FileNotFoundError` になる。 rename design §9 で「高リスク」明示 |
| Gate 3: co-install e2e workflow | `.github/workflows/coinstall-smoke.yml` が clean venv で `pip install piper-tts==1.3.0` + built piper-plus wheel の co-install を実行、 `import piper` が upstream 解決 / `import piper_plus` が当 fork 解決 / モジュール別 object / `site-packages/piper/` に `piper_plus` 命名の leak なし / 両 CLI が動作 の 6 契約を assert | rename の主目的 (本家との pip 共存) を CI で構造的に検証する手段がなく、 v2.0 の存在意義が壊れても検知不能 |
| pre-commit + workflow wire | Gate 1 は `.pre-commit-config.yaml` に `local` hook、 Gate 2 は `.github/workflows/dev-build-all.yml` の `build_python_wheels` job で built wheel 直後に実行、 Gate 3 は独立 workflow (`on: pull_request` / `push` / `workflow_dispatch`) | gate があっても発火しないと意味なし。 既存の `check_*.py` hook 命名規則と workflow step 命名規則に沿わせる |

## 設計判断

- **保守的な false-positive 回避**: Gate 1 の regex は line-based で string literal / docstring の擬似 import を false-positive しうる。 `tests/fixtures/` と `src/piper_phonemize_bundled/` (vendored upstream) を SKIP_PREFIX、 明示 `ALLOWLIST` は空で bootstrap (post-PR #598 は 0 hits で clean)、 拡張点として docstring で文書化。 AST parse は over-engineering として却下。
- **Gate 2 の build 責務は CI 側**: local mode は既存 wheel の自動発見 or `uv build` fallback (120s timeout) を試み、 失敗時は skip + warning。 CI では `dev-build-all.yml` が build 済みの wheel に直接 gate を掛けるため信頼性が担保される。
- **Gate 3 の pin (piper-tts 1.3.0)**: upstream の新 release で silent に契約が変わる (or, worse, coincidentally regression を隠す) のを防ぐため明示 pin。 upstream の layout 変更を検知したら手動 bump。
- **Wire target の分業**: Gate 1 は grep-only で高速 → pre-commit hook (staged file only、 CI 側は既存の pre-commit workflow が all-files sweep)。 Gate 2 は wheel build 必須で遅い → CI-only、 pre-commit 化しない (既存 `check_bundle_size.py` と同じ pattern)。 Gate 3 は独立 workflow で trigger 自己完結。
- **平行検証 (adversarial verify)**: ultracode workflow (10 agent、 3 dimension × 4 phase) で 3 gate を並列設計・実装・adversarial verify。 各 gate が実際に検知すべき failure mode を捕捉することを local 実行で確認 (Gate 1: 445 .py scanned 0 hits、 Gate 2: 3/3 required present、 Gate 3: YAML schema valid)。
- **wire を 1 agent に集約**: 3 gate の pre-commit / workflow wire は共通ファイル (`.pre-commit-config.yaml` / `dev-build-all.yml`) を触るため sequential agent に集約、 file race を回避。
- **`.gitignore` の check_*.py 除外 allowlist 更新**: 既存の `check_*.py` は broad ignore に対する明示的な `!scripts/check_*.py` allowlist で管理されている慣習に沿い、 新規 2 script も同 allowlist に追加。 hidden gitignore による commit 抜けを回避 (feature branch 作成初回で気づいた)。

## Test Plan

- [ ] `git checkout feat/post-rename-hardening && uv run --no-sync python scripts/check_no_legacy_piper_imports.py` → exit 0、 `OK: scanned 445 *.py file(s)` (post-PR #598 clean state)
- [ ] `uv build --wheel src/python_run --out-dir dist && uv run --no-sync python scripts/check_wheel_data_bundling.py` → exit 0、 `OK: 3/3 required files present, 0 top-level piper/ members`
- [ ] `.github/workflows/coinstall-smoke.yml` の YAML schema valid (`python -c "import yaml; yaml.safe_load(open('.github/workflows/coinstall-smoke.yml'))"`)、 GitHub Actions parse エラーなし
- [ ] CI で `Co-install Smoke (piper-tts + piper-plus)` workflow が緑になる (実 pip install piper-tts + build piper-plus + co-install e2e 6 assertion 全 pass)
- [ ] `.github/workflows/dev-build-all.yml` の `build_python_wheels` job に `Verify wheel bundles required package-data (Gate 2)` step が追加され、 built wheel に対して pass する
- [ ] `.pre-commit-config.yaml` の `no-legacy-piper-imports` hook が `pre-commit run --all-files` で pass する
- [ ] Gate 1 に対する negative test: `echo "from piper import PiperVoice" > /tmp/x.py && uv run --no-sync python scripts/check_no_legacy_piper_imports.py /tmp/x.py` → exit 1、 stderr に file:line と rationale が出る
- [ ] Gate 2 に対する negative test: 空 wheel を作って script に食わせる → exit 1、 `::error::MISSING: piper_plus/voices.json` が出る

## Checklist

- [x] Tests pass locally
- [x] No GPL-LGPL deps
- [x] Documentation updated (rationale はスクリプト先頭 docstring、 pre-commit hook のコメント、 workflow のヘッダーコメントに集約)

## Related Issues

- Follow-up to #590 (rename design) / #598 (rename PR)
- Implements audit findings from PR #598 wf_ec9e1848 (3 High severity items deferred to follow-up)