### PR TITLE
fix(ci): move test-extras venv outside workspace for nltk 3.10 compat

### DIFF
--- a/.github/workflows/g2p-python-ci.yml
+++ b/.github/workflows/g2p-python-ci.yml
@@ -142,12 +142,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
       - uses: astral-sh/setup-uv@v6.8.0
-      - run: uv venv .venv-extras
-      - run: uv pip install --python .venv-extras "./src/python/g2p[${{ matrix.extra }}]"
+      # venv は workspace (= cwd) の外に作る。 この job は uv.lock を経由せず
+      # PyPI から fresh resolve するため nltk 3.10.x を引くが、 3.10 で追加された
+      # nltk/inisec.py の NLTKSafeImportFinder は「解決先ファイルが cwd 配下に
+      # 物理的に存在する」モジュールを一律 ImportError でブロックする。
+      # workspace 内に venv を置くと site-packages 全体が cwd 配下となり、
+      # regex 等の正規依存まで誤検知される。
+      # エラーメッセージが案内する `-P` / PYTHONSAFEPATH=1 は判定が sys.path では
+      # なくファイルの物理位置なので回避にならない (実測で確認済み)。
+      - run: uv venv "${RUNNER_TEMP}/venv-extras"
+      - run: uv pip install --python "${RUNNER_TEMP}/venv-extras" "./src/python/g2p[${{ matrix.extra }}]"
       - name: Download NLTK data (EN only)
         if: matrix.extra == 'en'
-        run: .venv-extras/bin/python -c "import nltk; nltk.download('averaged_perceptron_tagger_eng', quiet=True); nltk.download('cmudict', quiet=True)"
-      - run: .venv-extras/bin/python -c "from piper_plus_g2p import get_phonemizer; p = get_phonemizer('${{ matrix.extra }}'); print(p.phonemize('test'))"
+        run: |
+          "${RUNNER_TEMP}/venv-extras/bin/python" -c "import nltk; nltk.download('averaged_perceptron_tagger_eng', quiet=True); nltk.download('cmudict', quiet=True)"
+      - run: |
+          "${RUNNER_TEMP}/venv-extras/bin/python" -c "from piper_plus_g2p import get_phonemizer; p = get_phonemizer('${{ matrix.extra }}'); print(p.phonemize('test'))"
 
   publish:
     name: publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enforces this automatically.
 -->
 
+### Fixed
+
+- CI: `g2p-python-ci.yml` の `test extras` job で venv を workspace 内 (`.venv-extras/`) ではなく `${RUNNER_TEMP}/venv-extras` に作るよう変更。 当 job は `uv.lock` を経由せず PyPI から fresh resolve するため nltk 3.10.x を引くが、 3.10 で追加された `nltk/inisec.py` の `NLTKSafeImportFinder` が「解決先ファイルが cwd 配下に物理的に存在する」モジュールを一律ブロックするため、 workspace 内 venv だと site-packages 全体が誤検知され `import nltk` 自体が `ImportError: Blocked import of regex from current working directory` で失敗していた。 エラーメッセージが案内する `-P` / `PYTHONSAFEPATH=1` は判定基準が sys.path ではなくファイルの物理位置のため回避にならないことを実測で確認済み
+
 ## [2.0.0] - 2026-05-25
 
 Issue #527: Docker 全 image + CI workflow + ドキュメントを **Python 3.13 + CUDA 12.8 + Ubuntu 24.04** で完全統一する fully-aligned 戦略 migration。 新 GPU (T4 / RTX 6000 Ada / RTX 5090) サポート + TF32 / bf16-mixed default 化。


### PR DESCRIPTION
## Summary

`g2p-python-ci.yml` の `test extras` job が nltk 3.10 の新しい import ブロック機構により失敗する。 当 job は `uv.lock` を経由せず PyPI から fresh resolve するため、 nltk 3.10.1 を引いた時点で `import nltk` 自体が `ImportError` になり、 3 つの extra (ja / en / zh) のうち en が red になる。

この失敗は Dependabot PR #608 (python 依存 16 件) と #612 (GitHub Actions 8 件) の**両方**で発生しているが、 どちらの差分にも起因しない上流由来の横断的な破壊である。 両 PR に同じ修正を入れると後からマージする側が必ず conflict するため、 独立 PR として `dev` に先行投入する。

## Affected Components

- [ ] Python
- [ ] Rust
- [ ] C#
- [ ] C++
- [ ] Go
- [ ] WASM-npm
- [ ] Docker
- [x] CI/CD
- [ ] Documentation

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Dependencies

## Risk Level

- [x] patch
- [ ] minor
- [ ] major

## Contract Impact

- [x] None

`docs/spec/*.toml` への影響なし。 CI workflow の venv 配置のみの変更で、 テスト対象のコード・データ・音素契約は一切変わらない。

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|---|---|---|
| test-extras venv の配置変更 | `uv venv .venv-extras` → `uv venv "${RUNNER_TEMP}/venv-extras"`。 install 先と 2 つの実行ステップの interpreter パスも追従 | nltk 3.10 の `NLTKSafeImportFinder` が site-packages 全体を「cwd 由来」と誤判定し、 `import nltk` が `ImportError: Blocked import of regex from current working directory` で失敗する |
| 判定基準の記録 (workflow コメント) | venv を cwd 外に置く理由と、 `-P` / `PYTHONSAFEPATH=1` が効かない事実をコメントで固定 | 次に同じ症状を見た人がエラーメッセージの案内どおり `-P` を試して時間を失う (メッセージの案内が実際には誤り) |

## 設計判断

- **根本原因**: nltk 3.10 で追加された `nltk/inisec.py` の `NLTKSafeImportFinder` は、 nltk 起因の import について「解決先ファイルの物理パスが `Path.cwd()` 配下にあるか」を判定してブロックする。 `sys.path` の内容ではなく**ファイルの物理位置**を見ている。 workspace 直下に venv を作ると site-packages 全体が cwd 配下になるため、 `regex` のような正規の依存まで巻き添えで弾かれる。 `regex` が実際に repo 直下にあるわけではない (`find . -maxdepth 2 -name 'regex*'` はヒットゼロ) — 上流の過剰検知である
- **`-P` / `PYTHONSAFEPATH=1` は採用しない**: エラーメッセージはこの 2 つを案内するが、 判定基準が `sys.path` ではないため実際には回避にならない。 nltk 3.10.1 を入れた最小プロジェクトで 4 案を実測して確認した (下記 Test Plan 参照)
- **`NLTK_DISABLE_IMPORT_SECURITY=1` は採用しない**: 実測では有効だが、 上流のセキュリティ機構を明示的に無効化することになる。 venv を移すだけで同じ結果が得られるため、 副作用の小さい方を選ぶ
- **この job だけを直す**: `uv run python -c "import nltk"` を使う他 3 workflow (`g2p-python-ci.yml:73` / `g2p-cross-platform-ci.yml:58` / `multi-runtime-rtf.yml:97`) も同じ条件 (in-project `.venv` が cwd 配下) を満たしており、 nltk が 3.10.x に上がった時点で同時に壊れる。 現在 green なのは root と `src/python/g2p` の `uv.lock` が nltk 3.9.4 を pin しているためである。 ただし今それらに手を入れると `UV_PROJECT_ENVIRONMENT` の変更が uv キャッシュ挙動に与える影響を CI 上で検証できないため、 本 PR は実際に赤い job のみを対象とし、 潜在リスクは別途 issue 化する
- **`uv.lock` に `nltk<3.10` を入れない**: 制約はユーザーが解決する依存にも効くため、 CI 都合の予防的 pin を配布パッケージ側に持ち込まない

## Test Plan

- [ ] `.github/workflows/g2p-python-ci.yml` が YAML として妥当: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/g2p-python-ci.yml'))"`
- [ ] CI 上で `test extras (ja)` / `test extras (en)` / `test extras (zh)` の 3 job がすべて green になる (修正前は en のみ red)
- [ ] 上流挙動の再現確認 — nltk 3.10.1 のみを依存に持つ最小プロジェクトを作り、 in-project `.venv` (cwd 配下) で以下を実行する:
  - `uv run python -c "import nltk"` → `ImportError: Blocked import of regex...` で失敗する (問題の再現)
  - `uv run python -P -c "import nltk"` → **同じ ImportError で失敗する** (`-P` が効かないことの確認)
  - `PYTHONSAFEPATH=1 uv run python -c "import nltk"` → **同じ ImportError で失敗する**
  - `UV_PROJECT_ENVIRONMENT=<cwd 外のパス> uv run python -c "import nltk"` → 成功する (本 PR が採る方針の有効性確認)
- [ ] CHANGELOG gate: `uv run --no-sync python scripts/check_changelog_format.py CHANGELOG.md` / `check_changelog_unreleased.py CHANGELOG.md` / `check_migration_xref.py` / `check_migration_changelog_parity.py` がすべて exit 0

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL deps
- [x] Documentation updated (CHANGELOG.md `[Unreleased] > ### Fixed`)

## Related Issues

なし。 Dependabot PR #608 / #612 の CI red を解消する前提修正。
