### PR TITLE
chore(android): local.properties を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,6 +272,10 @@ android/piper-plus-g2p/.cxx/
 android/piper-plus-g2p/build/
 android/.gradle/
 
+# Android SDK path — Gradle auto-generates this per machine on first build.
+# Machine-local absolute path, must never be committed.
+android/local.properties
+
 # Swift Package Manager: Package.resolved is auto-generated when SPM
 # resolves dependencies. piper-plus ships libraries (PiperPlus /
 # PiperPlusG2P), not an app, so we don't pin transitive dependency


### PR DESCRIPTION
## Summary

`android/local.properties` は Gradle が初回ビルド時にマシンごと自動生成する Android SDK パス設定ファイル (`sdk.dir=/Users/<user>/Library/Android/sdk`) だが、`.gitignore` に登録されておらず未追跡ファイルとして常に `git status` に残っていた。`android/` 配下の他の Gradle 生成物 (`.gradle/` / `build/` / `.cxx/` / `jniLibs/`) は既に ignore 済みで、本ファイルだけ漏れていたのを揃える。

## Affected Components

- [ ] Python (src/python/, pyproject.toml)
- [ ] Rust (src/rust/)
- [ ] C# (src/csharp/)
- [ ] C++ (src/cpp/, CMakeLists.txt)
- [ ] Go (src/go/)
- [ ] WASM/npm (src/wasm/)
- [ ] Docker (docker/)
- [ ] CI/CD (.github/workflows/)
- [ ] Documentation (docs/, README*)
- [x] Other: リポジトリ設定 (`.gitignore`) — Android build (`android/`)

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Dependencies

## Risk Level

- [x] **patch** — bug fix / internal refactor / docs only
- [ ] **minor** — new feature / additive API / no breaking change
- [ ] **major** — breaking change (API removal, schema migration, behavior reversal)

## Contract Impact

- [x] None (Python/runtime-internal change only)

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|--------|------|----------------------|
| `android/local.properties` の ignore 登録 | Gradle 生成の SDK パス設定ファイルを追跡対象外にする | 未追跡ファイルが常に `git status` に残り、他の変更に紛れて誤コミットされうる |
| ignore 理由の inline コメント | 「マシン固有の絶対パスを含むためコミット不可」を `.gitignore` 内に明記 | 将来 `!android/local.properties` で再包含する誤変更を招く |

## 設計判断

- **既存の Android ignore ブロックに隣接配置** — `android/.gradle/` の直後に置き、Gradle 生成物のまとまりを維持。既存ブロック冒頭のコメント (Issue #388: ファイル単位 ignore の理由) が示す方針とも整合する
- **ディレクトリ単位 ignore にしない** — `android/` 配下には `zh_en_loanword_matrix.json` mirror など sync gate 用のコミット対象ファイルが同居する。既存コメントが明示するとおり親ディレクトリ ignore + `!file` 再包含は git では機能しないため、ファイル単位 ignore を踏襲
- **`git rm --cached` は不要** — `git log --all -- android/local.properties` が 0 件で、本ファイルは過去に一度も追跡されていない。履歴からのパス除去や追跡解除は発生しない
- **`.gitignore` 単独変更に限定** — CHANGELOG / migration doc の各 gate は `CHANGELOG.md` / `docs/migration/*.md` を trigger 条件とするため対象外。開発者のローカル環境にのみ影響し、配布物・ランタイム挙動は不変

## Test Plan

- [ ] `git check-ignore -v android/local.properties` が `.gitignore:277:android/local.properties` にヒットする
- [ ] Android SDK 設定済み環境で `android/local.properties` が存在する状態で `git status --short` を実行し、当該ファイルが出力されない
- [ ] `git ls-files android/local.properties` が空 (追跡中ファイルを誤って ignore していない)
- [ ] `android/piper-plus-g2p/src/androidTest/assets/g2p_fixtures/zh_en_loanword_matrix.json` が引き続き追跡対象 (`git ls-files` にヒット) で、sync gate が壊れていない
- [ ] `pre-commit run --all-files` が pass

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL dependencies added ([License Policy](CONTRIBUTING.md#license-policy))
- [ ] Documentation updated (if applicable)

## Related Issues

なし
