### PR TITLE
fix(tooling): skill 再呼び出しで /create-pr が常に deny される問題を修正

### DIFF
--- a/.claude/hooks/guard-bash.sh
+++ b/.claude/hooks/guard-bash.sh
@@ -148,11 +148,14 @@ is_in_skill() {
     | sed -nE 's|.*<command-name>/([a-z-]+)</command-name>.*|\1|p; s|.*"skill":"([^"]+)".*|\1|p')
   [ "$marker_skill" = "$skill_name" ] || return 1
   # marker 以降に user の new prompt があれば skill flow から抜けた → deny。
-  # Skill tool が invoke 直後に配信する skill body 本文 (`Base directory for
-  # this skill` を含む user-type メッセージ) は tool_result ではないため
-  # tool_use_id を持たないが、 user 入力でもないので除外する。
+  # ただし harness が生成する user-type メッセージは user 入力ではないので除外する:
+  #   - skill body 本文 (`Base directory for this skill` を含む)
+  #   - `"isMeta":true` が付く合成メッセージ。 同一セッションで skill を
+  #     再呼び出しすると `(Re-invocation of /<name> — ...)` という meta 行が
+  #     挿入され、 これを user prompt と誤判定すると 2 回目以降の
+  #     `/create-pr` が常に deny される
   local new_prompt_after
-  new_prompt_after=$(awk -v start="$marker_line" 'NR > start && /"type":"user"/ && !/"tool_use_id"/ && !/Base directory for this skill/' "$tpath" \
+  new_prompt_after=$(awk -v start="$marker_line" 'NR > start && /"type":"user"/ && !/"tool_use_id"/ && !/"isMeta":true/ && !/Base directory for this skill/' "$tpath" \
     | wc -l)
   [ "$new_prompt_after" -eq 0 ]
 }

--- a/.claude/hooks/test-guard-bash.sh
+++ b/.claude/hooks/test-guard-bash.sh
@@ -28,6 +28,13 @@ run() {
     if ! printf '%s' "$out" | grep -q "$want_output_grep"; then
       ok=0
     fi
+  # want_output_grep が空 = 「許可」 を期待するケース。 hook は deny する時だけ
+  # JSON を stdout に書き、 許可時は何も出力せずに exit 0 する。 exit code は
+  # deny でも 0 なので、 出力が空であることまで検査しないと許可ケースの
+  # assertion が全て空振りする (実際そうなっており、 /create-pr 再呼び出しの
+  # deny バグをこのハーネスが検出できなかった)。
+  elif [ -n "$out" ]; then
+    ok=0
   fi
   if [ "$ok" = 1 ]; then
     printf '  PASS  %s\n' "$label"
@@ -83,6 +90,22 @@ run "marker 後に user new prompt (拒否、 historical match 防止)" \
 
 run "marker 後に tool_result + user prompt 両方 (拒否)" \
   $'<command-name>/create-pr</command-name>\n{"type":"user","content":[{"tool_use_id":"toolu_01","type":"tool_result"}]}\n{"type":"user","content":"another task"}' \
+  "$(input_for 'gh pr create --base dev')" \
+  0 "permissionDecision.*deny"
+
+# 同一セッションで skill を再呼び出しすると harness が
+#   {"type":"user","message":{...},"isMeta":true}
+#   content = "(Re-invocation of /create-pr — ...)"
+# という合成行を挿入する。 これを user の new prompt と誤判定すると
+# 2 回目以降の /create-pr が常に deny される (セッション内で複数 PR を
+# 出すケースを丸ごと塞ぐ)。
+run "marker 後に skill 再呼び出しの isMeta 行 (許可)" \
+  $'{"name":"Skill","input":{"skill":"create-pr","args":""}}\n{"type":"user","message":{"role":"user","content":"(Re-invocation of /create-pr — the skill instructions were previously loaded; the arguments or dynamic output below are new.)"},"isMeta":true,"turnCompanion":true}' \
+  "$(input_for 'gh pr create --base dev')" \
+  0 ""
+
+run "marker 後に isMeta 行 + 実 user prompt (拒否は維持)" \
+  $'{"name":"Skill","input":{"skill":"create-pr","args":""}}\n{"type":"user","message":{"role":"user","content":"(Re-invocation of /create-pr — ...)"},"isMeta":true}\n{"type":"user","content":"another task"}' \
   "$(input_for 'gh pr create --base dev')" \
   0 "permissionDecision.*deny"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -824,6 +824,19 @@ repos:
         files: ^(cmake/ExternalDeps\.cmake|.*pyproject\.toml|.*requirements.*\.txt|scripts/check_openjtalk_version_sync\.py)$
         pass_filenames: false
 
+      # guard-bash.sh の振る舞いテスト。 既に shellcheck で syntax / lint は
+      # 見ているが、 hook の判定ロジックのバグ (「許可すべきものを deny する」)
+      # は shellcheck では原理的に検出できない。 実際 /create-pr の再呼び出しが
+      # 常に deny される回帰が素通りし、 セッション内で 2 本目以降の PR が
+      # 作れなくなっていた。 mock transcript を食わせる自己完結テストなので
+      # 依存なし・0.1 秒未満で回る。
+      - id: guard-bash-behaviour
+        name: guard-bash.sh 判定ロジックの振る舞いテスト
+        entry: bash .claude/hooks/test-guard-bash.sh
+        language: system
+        files: ^\.claude/hooks/(guard-bash|test-guard-bash)\.sh$
+        pass_filenames: false
+
       # Pytest skip-reason discipline. Skips without `reason=` accumulate as
       # silent technical debt — reviewers can't tell whether they're
       # permanent (missing optional dep), temporary (waiting on a fix), or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- 開発ツール: `.claude/hooks/guard-bash.sh` の `is_in_skill` が、 同一セッションで skill を再呼び出しした際に harness が挿入する `(Re-invocation of /<name> — ...)` メタ行 (`"isMeta":true`) を「新しいユーザー入力」と誤判定し、 **2 回目以降の `/create-pr` を常に deny** していた問題を修正 (1 セッションで複数 PR を出す流れが丸ごと塞がる)。 併せて `.claude/hooks/test-guard-bash.sh` の「許可」ケースが exit code しか見ておらず (hook は deny 時も exit 0 で JSON を stdout に出すため) **全て空振りしていた**のを、 出力が空であることまで検査するよう強化。 この振る舞いテストを pre-commit gate (`guard-bash-behaviour`) として登録し、 shellcheck では原理的に検出できない判定ロジックの回帰を commit 時点で捕まえるようにした
+
 - CI: `g2p-python-ci.yml` の `test extras` job で venv を workspace 内 (`.venv-extras/`) ではなく `${RUNNER_TEMP}/venv-extras` に作るよう変更。 当 job は `uv.lock` を経由せず PyPI から fresh resolve するため nltk 3.10.x を引くが、 3.10 で追加された `nltk/inisec.py` の `NLTKSafeImportFinder` が「解決先ファイルが cwd 配下に物理的に存在する」モジュールを一律ブロックするため、 workspace 内 venv だと site-packages 全体が誤検知され `import nltk` 自体が `ImportError: Blocked import of regex from current working directory` で失敗していた。 エラーメッセージが案内する `-P` / `PYTHONSAFEPATH=1` は判定基準が sys.path ではなくファイルの物理位置のため回避にならないことを実測で確認済み
 
 ## [2.0.0] - 2026-05-25


### PR DESCRIPTION
## Summary

`.claude/hooks/guard-bash.sh` の `is_in_skill` が、同一セッションで skill を再呼び出しした際に harness が挿入するメタ行を「新しいユーザー入力」と誤判定し、**2 回目以降の `/create-pr` を常に deny** していた。1 セッションで複数 PR を出す流れが丸ごと塞がる。併せて、テストハーネスの「許可」ケースが実質何も検査しておらず、この回帰を検出できなかった構造的な穴も塞ぐ。

## Affected Components

- [ ] Python
- [ ] Rust
- [ ] C#
- [ ] C++
- [ ] Go
- [ ] WASM/npm
- [ ] Docker
- [x] CI/CD
- [ ] Documentation

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] CI/CD
- [ ] Dependencies

## Risk Level

- [x] patch
- [ ] minor
- [ ] major

## Contract Impact

- [x] None

## 変更内容

### 根本原因

`is_in_skill` は「skill activation marker 以降に user の new prompt があれば skill flow を抜けた」と判定する (historical match 防止)。ところが同一セッションで skill を再呼び出しすると、harness が次の行を transcript に書く:

```json
{"type":"user","message":{"role":"user","content":"(Re-invocation of /create-pr — the skill instructions were previously loaded; the arguments or dynamic output below are new.)"},"isMeta":true,"turnCompanion":true}
```

この行は tool_result ではないので `"tool_use_id"` を持たず、skill body 本文でもないので `Base directory for this skill` にも一致しない。既存の除外条件を両方すり抜けて new prompt として数えられていた。

| 機能名 | 動作 | これがないと起こること |
|---|---|---|
| `"isMeta":true` の除外 | harness 生成の合成 user メッセージを new prompt 判定から除外 | 2 回目以降の `/create-pr` が常に deny され、1 セッションで複数 PR を出せない |
| 許可ケースの assertion 強化 | `want_output_grep` が空のとき「出力が空であること」まで検査 | hook は deny 時も `exit 0` で JSON を stdout に書くため、exit code だけ見る許可ケースは deny されても PASS になる (= 6 件の許可テストが全て空振り) |
| 再呼び出しケースのテスト追加 | isMeta 行のみなら許可 / isMeta 行 + 実 user prompt なら deny 維持 | 本バグの回帰、および「isMeta を除外しすぎて historical match 防止が壊れる」逆方向の回帰 |
| pre-commit gate `guard-bash-behaviour` | `guard-bash.sh` / `test-guard-bash.sh` 変更時に振る舞いテストを実行 | `.claude/hooks/*.sh` には shellcheck gate があるが、「許可すべきものを deny する」判定ロジックのバグは syntax lint では原理的に検出できない |

## 設計判断

- **`isMeta` を除外条件に選んだ理由**: transcript 上で実際のユーザー入力には `isMeta` が付かない (本セッションの transcript で実測: user 行 232 件中 `isMeta:true` は 5 件、いずれも harness 生成)。文言 (`Re-invocation of`) でマッチさせる案は harness のメッセージ変更で壊れるため採らなかった
- **historical match 防止を弱めていない**: 「isMeta 行の後に実 user prompt が続く」ケースは従来どおり deny することをテストで固定した
- **ハーネス側を先に直した理由**: 最初に回帰テストだけ追加したところ、修正前の hook でも緑になった。原因は許可ケースが exit code しか見ていなかったこと。テストが嘘をつく状態のまま hook を直しても、次の回帰はまた素通りする
- **shellcheck gate と重複しない**: 既存の shellcheck は syntax / quoting を見る静的検査で、今回のような判定ロジックの誤りは対象外。振る舞いテストを別 gate として足した

## Test Plan

- [ ] `bash .claude/hooks/test-guard-bash.sh` → `all green` (12 件)
- [ ] 回帰検出の確認: `git stash push -- .claude/hooks/guard-bash.sh && bash .claude/hooks/test-guard-bash.sh; git stash pop` → `marker 後に skill 再呼び出しの isMeta 行 (許可)` の 1 件だけが FAIL する (= 新テストが本バグを実際に捕まえている)
- [ ] ハーネス強化の確認: 上記 stash 状態で、強化前の `run()` に戻すと同じテストが PASS してしまうこと (許可ケースが空振りしていた証跡)
- [ ] `pre-commit run guard-bash-behaviour --files .claude/hooks/guard-bash.sh` → Passed
- [ ] `pre-commit run --files .claude/hooks/guard-bash.sh .claude/hooks/test-guard-bash.sh .pre-commit-config.yaml CHANGELOG.md` → exit 0 (shellcheck / yamllint と共存すること)
- [ ] 手動確認: 同一セッションで `/create-pr` を 2 回呼び、2 回目の `gh pr create` が deny されないこと
- [ ] 逆方向の手動確認: `/create-pr` 実行後に別の指示を出してから `gh pr create` を実行すると従来どおり deny されること

## Checklist

- [x] Tests pass locally (`test-guard-bash.sh` 12 件 all green、pre-commit exit 0)
- [x] No GPL/LGPL dependencies added
- [x] Documentation updated (`CHANGELOG.md`)

## Related Issues

なし。#616 関連の一連の修正 PR を出す途中で踏んだ独立の開発ツール不具合。
