### PR TITLE
fix(ci): required status check gate の head_branch シェルインジェクションを塞ぐ

### DIFF
--- a/.github/workflows/required_status_check_gate.yml
+++ b/.github/workflows/required_status_check_gate.yml
@@ -51,6 +51,12 @@ jobs:
         Multi-Runtime RTF Benchmark,Memory regression (per-language),CodeQL,Parity Hub,PUA Consistency Gate
     steps:
       - uses: actions/checkout@v6.1.0
+        with:
+          # gate は workspace の scripts/ しか読まない。 check_required_gate.py は
+          # GITHUB_TOKEN env 経由で REST API を叩く (stdlib urllib のみ、 git は
+          # 呼ばない) ため credential helper は不要。 workflow_run は fork PR でも
+          # write context で走るので .git/config に token を残さない。
+          persist-credentials: false
 
       - uses: actions/setup-python@v6.2.0
         with:
@@ -58,17 +64,28 @@ jobs:
 
       - name: Resolve head_sha and PR number
         id: ctx
+        # workflow_run.head_branch は fork 側の branch 名 = 外部 contributor が
+        # 自由に決められる文字列で `$( )` / backtick を含められる。 run: に
+        # ${{ }} を直接展開すると script injection になるため、 pr-title-check /
+        # pr-body-validate と同じく env 経由で shell 変数として参照する。
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-            echo "pr=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-            echo "base_branch=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            echo "sha=${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+            echo "pr=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+            echo "base_branch=${PR_BASE_REF}" >> "$GITHUB_OUTPUT"
           else
-            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            echo "sha=${RUN_HEAD_SHA}" >> "$GITHUB_OUTPUT"
             # `workflow_run` doesn't carry the PR number directly; surface the
             # head branch so the next step can look it up if needed.
             echo "pr=" >> "$GITHUB_OUTPUT"
-            echo "base_branch=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+            echo "base_branch=${RUN_HEAD_BRANCH}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Aggregate spoke conclusions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enforces this automatically.
 -->
 
+### Security
+
+- CI: `Required Status Check Gate` (`.github/workflows/required_status_check_gate.yml`) に script injection があったのを修正。 `workflow_run` イベント経路で fork 側の branch 名 (`github.event.workflow_run.head_branch`) を `run:` ブロックへ直接展開しており、 git の ref 名は `$( )` や backtick を含められるため任意コマンドが実行可能だった。 `workflow_run` は fork PR 由来でも base repo の write context で発火し、 当 job は `pull-requests: write` を持つ。 さらに直前の `actions/checkout` が `persist-credentials: false` を指定していなかったため、 注入されたコマンドから `.git/config` 経由で `GITHUB_TOKEN` を回収できる状態だった (pwn-request パターン)。 同 repo 内の `pr-title-check.yml` / `pr-body-validate.yml` が既に採っている `env:` 経由で shell 変数として参照する形に統一し、 併せて checkout に `persist-credentials: false` を追加して多層防御とした (`check_required_gate.py` は stdlib `urllib` のみで `GITHUB_TOKEN` env から認証しており git credential helper を使わないことを確認済み)。 `.github/workflows/*.yml` の `run:` ブロック全件を走査し、 外部から制御可能な `github.event.*` フィールドを展開している箇所が他に無いことを確認済み
+
 ### Fixed
 
 - CI: distroless trial イメージ (`Dockerfile.cpu.distroless`) で `import onnxruntime` が SIGSEGV (exit 139) し、 `src/python/**` を触る全 PR がブロックされていた問題を修正。 ORT 1.29 が import 時に新設した device discovery (`device_discovery.cc`、 `/sys/devices` を走査して PCI bus ID を読む) が distroless の最小ファイルシステム上でクラッシュする。 本イメージ限定で `onnxruntime<1.29` に上限を設ける (canonical `Dockerfile.cpu` では ORT 1.29 が正常動作することを実測で確認済みのため、 そちらと通常のインストールは巻き込まない)。 シンボル欠落 / ライブラリ欠落 / インタプリタのパッチレベル差 / 実行ユーザー / seccomp はいずれも実測で棄却済み (根拠は Dockerfile のコメントに記録)。 併せて smoke test に `-X faulthandler` を追加し、 次に native crash が起きた際に `exit 139` だけでなく Python トレースバックが出るようにした。 「nonroot 65532 で動く」という誤ったコメントも実測値 (uid 0) に訂正


### PR DESCRIPTION
## Summary

`Required Status Check Gate` の `workflow_run` 経路で、 fork 側の branch 名 (`github.event.workflow_run.head_branch`) を `run:` ブロックへ直接展開しており、 fork から任意コマンドが実行できる状態だった。 同 repo 内で既に確立している env 経由参照の形へ統一し、 併せて checkout に `persist-credentials: false` を追加して token 回収経路も塞ぐ。

## Affected Components

- [ ] Python (src/python/, pyproject.toml)
- [ ] Rust (src/rust/)
- [ ] C# (src/csharp/)
- [ ] C++ (src/cpp/, CMakeLists.txt)
- [ ] Go (src/go/)
- [ ] WASM/npm (src/wasm/)
- [ ] Docker (docker/)
- [x] CI/CD (.github/workflows/)
- [ ] Documentation (docs/, README*)

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] CI/CD
- [ ] Dependencies

## Risk Level

- [x] **patch** — bug fix / internal refactor / docs only
- [ ] **minor** — new feature / additive API / no breaking change
- [ ] **major** — breaking change (API removal, schema migration, behavior reversal)

## Contract Impact

- [x] None (Python/runtime-internal change only)

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|---|---|---|
| `run:` ブロックの env 経由参照 | `Resolve head_sha and PR number` step が参照する 6 つの context 式をすべて step-level `env:` に移し、 shell 変数 (`"${RUN_HEAD_BRANCH}"` 等) として引用付きで参照する | `head_branch` に `$( )` / backtick を仕込んだ branch から fork PR を出すと、 gate job 内で任意コマンドが実行される。 git は ref 名にこれらの文字を許可するため、 特別な細工は不要 |
| checkout の `persist-credentials: false` | gate job の `actions/checkout` が `.git/config` に `GITHUB_TOKEN` を書き込まないようにする | 注入されたコマンドが `.git/config` から token を読み出せる。 当 job は `pull-requests: write` を持つため、 任意 PR へのコメント投稿・PR 改変が可能になる (pwn-request パターン) |

`workflow_run` は fork PR 由来のイベントでも base repo の write context で発火する点が本件の前提。 `pull_request` トリガーと異なり token は read-only にならない。

## 設計判断

- **env 経由に統一 (新規パターンを持ち込まない)** — `pr-title-check.yml:38` と `pr-body-validate.yml:43` が既に同じ形を採っており、 今回の :71 だけが例外だった。 独自の sanitize 関数や中間ファイルを挟むのではなく、 既存パターンへ寄せる形にした
- **`head_branch` 以外の 5 式もまとめて env へ移した** — `head.sha` (hex 固定長) / `pull_request.number` (整数) / `base.ref` (base repo 側の branch 名 = write 権限保持者のみ制御可) は単体では injection 経路にならないが、 1 つの `run:` 内に「env 経由の変数」と「直接展開」が混在していると、 後続の編集で安全な方をコピーする根拠が失われる。 全件を同じ形に揃えて、 この step には `${{ }}` を書かないという不変条件を成立させた
- **`persist-credentials: false` は多層防御として追加** — quoting 修正だけで injection 自体は塞がるが、 将来別の経路が生まれた場合の被害を token 回収不能な範囲に限定する。 `scripts/check_required_gate.py` が stdlib `urllib` のみを使い `GITHUB_TOKEN` env から認証している (`subprocess` / `git` / `gh` を一切呼ばない) ことを確認済みで、 credential helper への依存はない
- **全 workflow を走査して同種の箇所が無いことを確認した** — `.github/workflows/*.yml` の `run:` ブロック内で外部から制御可能な `github.event.*` フィールド (`workflow_run.head_branch` / `display_title` / `head_commit.message`、 `pull_request.title` / `body` / `head.ref` / `user.login`、 issue・comment・review の body、 `github.head_ref`) を展開している箇所を機械的に抽出したところ、 ヒットは本件 1 件のみだった。 他 workflow の `github.head_ref` は `concurrency: group:` 内 (workflow 式コンテキストであり shell ではない) のみ
- **同種の再発を検出する gate は本 PR に含めない** — 対象パターンを機械検出する gate は有用だが、 `.github/workflows/**` 全体に発火する新規 gate を security 修正と同一 PR に入れると、 既存の許容ヒット (write 権限保持者のみ制御可能な label 名の展開等) の allowlist 化まで巻き込んで PR が red になりうる。 修正を最短で着地させることを優先し、 gate 化は別 PR に切り出す

## Test Plan

- [ ] YAML として解析可能: `uv run --no-sync python -c "import yaml;yaml.safe_load(open('.github/workflows/required_status_check_gate.yml'));print('ok')"`
- [ ] 当該 workflow の `run:` ブロック内に `${{ }}` が 1 つも残っていないこと (本 PR の不変条件)
- [ ] actionlint / yamllint 通過: `uvx pre-commit run --files .github/workflows/required_status_check_gate.yml CHANGELOG.md` (`Lint GitHub Actions workflow files` / `yamllint` が Passed)
- [ ] `persist-credentials: false` の安全性: `grep -nE "GITHUB_TOKEN|subprocess|^import |^from " scripts/check_required_gate.py` で stdlib urllib のみ + `os.environ.get("GITHUB_TOKEN")` 認証であることを確認 (git credential helper 非依存)
- [ ] CHANGELOG ゲート通過: `uv run --no-sync python scripts/check_changelog_format.py`
- [ ] 本 PR 自身の `pull_request` トリガーで `Required Status Check Gate` が従来どおり緑になること (`pull_request` 分岐の実地確認)
- [ ] マージ後、 監視対象 spoke のいずれかが完了して `workflow_run` 分岐が実際に走った run を 1 件確認する (この分岐は PR の CI では実行されないため)

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL dependencies added ([License Policy](CONTRIBUTING.md#license-policy))
- [x] Documentation updated (if applicable)

## Related Issues

なし
